### PR TITLE
nec/pc6001.cpp: 52 new dumps

### DIFF
--- a/hash/fm7_cass.xml
+++ b/hash/fm7_cass.xml
@@ -1904,7 +1904,7 @@ Titles, serial #s, publishers and release dates taken from:
 
 <!-- This should have contained 3 tapes, according to Oh!FM-7. Who's wrong? -->
 	<software name="mephius">
-		<description>Star Arthur Densetsu I - Wakusei Mephius</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TE-17"/>
@@ -1918,7 +1918,7 @@ Titles, serial #s, publishers and release dates taken from:
 	</software>
 
 	<software name="ankosei">
-		<description>Star Arthur Densetsu II - Ankoku Seiun</description>
+		<description>Star Arthur Densetsu II: Ankoku Seiun</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TE-25"/>
@@ -1942,7 +1942,7 @@ Titles, serial #s, publishers and release dates taken from:
 	</software>
 
 	<software name="ter4001">
-		<description>Star Arthur Densetsu III - Terra 4001</description>
+		<description>Star Arthur Densetsu III: Terra 4001</description>
 		<year>1984</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TET-43"/>

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -12292,7 +12292,7 @@ Right/left cursor keys select tape baud rate 1200/2400 respectively.
 	<software name="skygaldo">
 		<description>Skygaldo (Japan)</description>
 		<year>1986</year>
-		<publisher>Magical Zoo</publisher>
+		<publisher>MagicalZoo</publisher>
 		<info name="serial" value="MXMH21052" />
 		<info name="alt_title" value="スカイギャルド" />
 		<info name="gtin" value="04988614000011"/>

--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -9896,7 +9896,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="mephius">
-		<description>Legends of Star Arthur - Planet Mephius (Japan)</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius (Japan)</description>
 		<year>1985</year>
 		<publisher>T&amp;E Soft</publisher>
 		<info name="serial" value="TET-55"/>

--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -7114,7 +7114,7 @@ license:CC0-1.0
 	<software name="gldngrv2">
 		<description>Golden Grave II (Japan)</description>
 		<year>1985</year>
-		<publisher>Magical Zoo</publisher>
+		<publisher>MagicalZoo</publisher>
 		<info name="alt_title" value="続・黄金の墓 スフィンクスの謎"/>
 		<info name="serial" value="MXMH21037"/>
 		<info name="usage" value="Load with CLOAD + RUN. Requires a Japanese system"/>
@@ -12325,7 +12325,7 @@ license:CC0-1.0
 	<software name="ougon">
 		<description>Ougon no Haka (Japan)</description>
 		<year>1984</year>
-		<publisher>Magical Zoo</publisher>
+		<publisher>MagicalZoo</publisher>
 		<info name="serial" value="MXMH21002"/>
 		<info name="usage" value="Load with CLOAD + RUN. Requires a Japanese system."/>
 
@@ -12395,7 +12395,7 @@ license:CC0-1.0
 	<software name="outroyd">
 		<description>Outroyd (Japan)</description>
 		<year>1985</year>
-		<publisher>Magical Zoo</publisher>
+		<publisher>MagicalZoo</publisher>
 		<info name="serial" value="MXMH21047"/>
 		<info name="usage" value="Load with CLOAD + RUN"/>
 
@@ -12409,7 +12409,7 @@ license:CC0-1.0
 	<software name="outroyda" cloneof="outroyd">
 		<description>Outroyd (Japan, alt loader)</description>
 		<year>1985</year>
-		<publisher>Magical Zoo</publisher>
+		<publisher>MagicalZoo</publisher>
 		<info name="serial" value="MXMH21047"/>
 		<info name="usage" value="Load with BLOAD&quot;CAS:&quot;,R"/>
 

--- a/hash/mz2500_flop.xml
+++ b/hash/mz2500_flop.xml
@@ -267,10 +267,13 @@ Old note: hangs at title screen due of a PIT bug (timer irq dies)
 		</part>
 	</software>
 
-	<software name="lizard">
+	<software name="lizard" supported="partial">
 		<description>Lizard</description>
 		<year>1985</year>
 		<publisher>クリスタルソフト (Xtal Soft)</publisher>
+		<notes><![CDATA[
+Colors looks washed, perhaps wants upper bank only
+]]></notes>
 		<info name="alt_title" value="リザード"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="697008">
@@ -580,6 +583,7 @@ Cuts off top of player jumps with first capture (verify)
 		<description>Triton</description>
 		<year>198?</year>
 		<publisher>ザインソフト (Sein Soft)</publisher>
+		<info name="alt_title" value="トリトーン"/>
 
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="545840">

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -816,7 +816,7 @@ Optional [tape] load and save for construction mode
 		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 1, Page 2"/>
 		<info name="developer" value="Kunihisa Ogawa"/>
-ì		<part name="snap" interface="pc6001_snap">
+		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="2543">
 				<rom name="bound ball.cas" size="2543" crc="18385973" sha1="f2806d4e1e3adee3165d698a40d6c69e2dfe4cf1" offset="0" />
 			</dataarea>
@@ -1044,7 +1044,7 @@ Crashes on [tape] loading (regression)
         <year>2005</year>
 		<publisher>&lt;homebrew&gt;</publisher>
         <info name="usage" value="Mode 1, Page 2"/>
-		<!-- "the author and roadist" -->
+		<!-- "the author and roadist"? -->
         <info name="author" value="Sakai"/>
 		<info name="developer" value="Hashi"/>
 

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -40,9 +40,10 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 
 	<software name="amazon" supported="partial">
 		<description>The Amazon</description>
-		<year>19??</year>
-		<publisher>T. Katayama</publisher>
+		<year>198?</year>
+		<publisher>Image Soft</publisher>
 		<info name="usage" value="Mode 2, Page 3" />
+		<info name="developer" value="T. Katayama" />
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="15260">
 				<rom name="amazon.cas" size="15260" crc="0b154850" sha1="a616b6d8852bea0fae27241ab7a0d5c81014e0e0"/>
@@ -56,7 +57,7 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 	<software name="ax1" supported="partial">
 		<description>AX-1</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 Arabian Rhapsody: pc6001mk2 draws without border colors (verify)
 ]]></notes>
@@ -97,7 +98,7 @@ Arabian Rhapsody: pc6001mk2 draws without border colors (verify)
 	<software name="ax2" supported="no">
 		<description>AX-2</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 Nostromo, Dual Alien: MAME crash with pc6001
 Steal Alien: returns back to BASIC in pc6001
@@ -139,7 +140,7 @@ Steal Alien: returns back to BASIC in pc6001
 	<software name="ax3" supported="no">
 		<description>AX-3</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 All games but Demo: punts back to How Many Pages in pc6001 (and crashes MAME with ram 64K)
 Cosmic Revo: invisible charset in pc6001
@@ -181,7 +182,7 @@ Cosmic Revo: invisible charset in pc6001
 	<software name="ax4" supported="no">
 		<description>AX-4</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 Black Hole: non-functional [keyboard] and [joystick] inputs in pc6001
 ]]></notes>
@@ -222,7 +223,7 @@ Black Hole: non-functional [keyboard] and [joystick] inputs in pc6001
 	<software name="ax5" supported="no">
 		<description>AX-5</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 Olion: crashes MAME when pressing 'S' key in pc6001
 ]]></notes>
@@ -258,7 +259,7 @@ Olion: crashes MAME when pressing 'S' key in pc6001
 	<software name="ax6" supported="no">
 		<description>AX-6</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 Demo: [CRTKILL] should corrupt video when AY-based speech plays back (cfr. real HW refs)
 ]]></notes>
@@ -299,7 +300,7 @@ Demo: [CRTKILL] should corrupt video when AY-based speech plays back (cfr. real 
 	<software name="ax7" supported="no">
 		<description>AX-7</description>
 		<year>1983</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 The Asterodian: [VDG] glitch for ASCII text in title (verify)
 ]]></notes>
@@ -340,7 +341,7 @@ The Asterodian: [VDG] glitch for ASCII text in title (verify)
 	<software name="ax8" supported="partial">
 		<description>AX-8</description>
 		<year>1984</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<info name="usage" value="Mode 2, Page 1"/>
 		<info name="alt_title" value="ギャラクシーミッション"/>
 
@@ -361,7 +362,7 @@ The Asterodian: [VDG] glitch for ASCII text in title (verify)
 	<software name="ax9" supported="no">
 		<description>AX-9</description>
 		<year>1984</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 3D Flight Simulator: non-functional [keyboard] in gameplay
 Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at same time (verify)
@@ -397,7 +398,7 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 	<software name="ax10" supported="partial">
 		<description>AX-10</description>
 		<year>1985</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<info name="usage" value="Mode 2, Page 1 for Outlaw and The Seven Bibles, Mode 2, Page 2 for Pop Hand and Risuning"/>
 
 		<part name="snap1" interface="pc6001_snap">
@@ -501,6 +502,23 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 		</part>
 	</software>
 
+	<software name="genmatai" supported="no">
+		<description>Genma Taisen</description>
+		<year>1983</year>
+		<publisher>ポニカ (PonyCa)</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="developer" value="Y. Takahashi"/>
+		<info name="alt_title" value="幻魔大戦"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="40577">
+				<rom name="genma taisen.cas" size="40577" crc="71531000" sha1="205eab089cf3e495a87514ff2633ea753a76c42c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="holyswrd" supported="no">
 		<description>Holy Sword</description>
 		<year>1983</year>
@@ -590,6 +608,102 @@ Has optional [tape] loading for extra stages
 		</part>
 	</software>
 
+	<software name="mysterhm" supported="no">
+		<description>Mystery House</description>
+		<year>198?</year>
+		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+"Press HELP to display a list of words used" (?)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<!-- from LIST -->
+		<info name="developer" value="N. Minami"/>
+		<info name="alt_title" value="ミステリーハウス"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="20271">
+				<rom name="mystery house.cas" size="20271" crc="90f6463d" sha1="baab3298cafc9d751cc52e60f0923c96ccc86fde" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mysterh2" supported="no">
+		<description>Mystery House II</description>
+		<year>198?</year>
+		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<notes><![CDATA[
+[tape] fails loading after title
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<!-- from LIST -->
+		<info name="developer" value="I. Harada"/>
+		<info name="alt_title" value="ミステリーハウスII"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="73164">
+				<rom name="mystery house ii.cas" size="73164" crc="452a36af" sha1="d19f79465d80a2d1875a6cfc9fbb487d9ace606e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nanakin" supported="partial">
+		<description>Nana-chan no Kinjirareta Asobi</description>
+		<year>198?</year>
+		<publisher>パックスソフトニカ (Pax Softonica)</publisher>
+		<notes><![CDATA[
+[tape] has extra audio track, not hooked up
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1. After loading select Y for joystick, which should be in port 2"/>
+		<info name="developer" value="Yutaka"/>
+		<info name="alt_title" value="ナナちゃんの禁じられた遊び"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="8928">
+				<rom name="nana-chan no kinjirareta asobi (6001).cas" size="8928" crc="7a266047" sha1="152926cc1b3feac1adf8185ff908237e5cf02768" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ougon" supported="no">
+		<description>Ougon no Haka</description>
+		<year>1983</year>
+		<publisher>マジカルズゥ (MagicalZoo)</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 3"/>
+		<info name="alt_title" value="黄金の墓"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="39810">
+				<rom name="ougon no haka.cas" size="39810" crc="ee70a0d5" sha1="54103efa59e713130072cce178edeb83a5039b61" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ponyca2" supported="partial">
+		<description>PonyCa 2 Game Series: Galac Convoy &amp; Shooting Invaders</description>
+		<year>1982</year>
+		<publisher>ポニカ (PonyCa)</publisher>
+		<notes><![CDATA[
+Both games: wants [keyboard] shift+S to start a game (verify)
+]]></notes>
+		<info name="usage" value="Mode 1, Page 2 for both games"/>
+		<info name="developer" value="Rhodus"/>
+		<info name="alt_title" value="ポニカ 2 ゲームシリーズ：ギャラクコンボイ&amp;シューティングインベーダーズ"/>
+		<!-- tape serial: K28A5014 -->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Galac Convoy"/>
+			<dataarea name="snap" size="5241">
+				<rom name="ponyca 2 game series (galac convoy).p6" size="5241" crc="c37e0349" sha1="d860e9b0d6351272240a009db2ef37ee5ab744b6" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Shooting Invaders"/>
+			<dataarea name="snap" size="4478">
+				<rom name="ponyca 2 game series (shooting invaders).p6" size="4478" crc="24ccf028" sha1="88cdc330fb3b837325b275a6979ee0ad8681904b" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="portopia" supported="no">
 		<description>Portopia Renzoku Satsujin Jiken</description>
 		<year>1983</year>
@@ -633,6 +747,7 @@ Not extensively tested (language barrier)
 		</part>
 	</software>
 
+	<!-- NOTE: unrelated with pyramid above, prequel of this is actually MIA -->
 	<software name="pyramid2" supported="partial">
 		<description>Pyramid II</description>
 		<year>1983</year>
@@ -664,11 +779,33 @@ Optional [tape] user levels load and save
 		</part>
 	</software>
 
+	<!-- .cas version known to exist, sha1=d43bf96cdb570e708fb4eed25b250a1f4615123e -->
+	<software name="slendisl" supported="partial">
+		<description>Slender Island</description>
+		<year>1983</year>
+		<publisher>パックスソフトニカ (Pax Softonica)</publisher>
+		<info name="usage" value="Mode 2, Page 2. Load part 2 before issuing RUN command"/>
+		<info name="developer" value="Onion Soft"/>
+		<info name="alt_title" value="スレンダーアイランド"/>
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Part 1"/>
+			<dataarea name="snap" size="14778">
+				<rom name="slender island (part 1).p6" size="14778" crc="a34e6254" sha1="63cf79580bce9e9f345ea7317dc78f4ad98a6d25" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Part 2"/>
+			<dataarea name="snap" size="7009">
+				<rom name="slender island (part 2) .p6" size="7009" crc="267a0772" sha1="83fe28232f6b0471a1e271026986894380769003" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- TODO: did ASCII really released this in standalone form? -->
 	<software name="spcenemy" supported="partial">
 		<description>Space Enemy</description>
 		<year>1982</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<info name="usage" value="Mode 4, Page 3 - PC-6001 requires N60 Extended BASIC cartridge" />
 		<info name="alt_title" value="スペース・エネミー"/>
 		<sharedfeat name="requirement" value="pc6001_cart:n60basic"/>
@@ -758,6 +895,21 @@ Requires multiple space presses to actually start a game
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="41774">
 				<rom name="tiny xevious 2.cas" size="41774" crc="966c3a54" sha1="b69d633c7fa4b81c6b3113c2118ce1ffc83f050c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tsu4mj" supported="partial">
+		<description>Ultra Yonin Mahjong</description>
+		<year>198?</year>
+		<publisher>ツクモ (Tsukumo)</publisher>
+		<info name="usage" value="Mode 2, Page 1"/>
+		<info name="developer" value="A. Taguchi"/>
+		<!-- spelled as "うるとら 四人麻雀" on title screen -->
+		<info name="alt_title" value="ウルトラ4人麻雀"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="16755">
+				<rom name="ultra yonin mahjong.cas" size="16755" crc="d2762c19" sha1="4b4bc0efa24e7ed690d4b9824a62045a0c4c1b6e" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -853,6 +1005,123 @@ Optional [tape] user level load and save
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="3526">
 				<rom name="fruit panic append.p6" size="3526" crc="e2243bdc" sha1="21962c50d7934510b8cdf8812775301cdf93c76c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="packboy" supported="partial">
+		<description>Pack'n Boy</description>
+		<year>1982?</year>
+		<publisher>コムパック (Compac)</publisher>
+		<notes><![CDATA[
+Covermount for an unknown I/O magazine issue (cover: PC6-401, tape: PC60-401)
+Playfield has no line on top (btanb)
+]]></notes>
+		<info name="usage" value="Mode 1, Page 2"/>
+		<info name="alt_title" value="パックンボーイ"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="6961">
+				<rom name="pack'n boy.cas" size="6961" crc="5f289e3c" sha1="a5d4d7e855de5e6402311d798ccd271d6ed10cab" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+
+	<software name="p6note1" supported="partial">
+		<description>PC-6000 Note No. 1</description>
+		<year>1983</year>
+		<publisher>アスキー (ASCII)</publisher>
+		<notes><![CDATA[
+4 vartst: requires [keyboard] shift key held
+]]></notes>
+		<info name="usage" value="Mode 1, Page 2 for Biorhythm and Cassette Label Maker. Mode 1, Page 1 for everything else"/>
+		<info name="alt_title" value="PC-6000 Note No. 1 スターコマンドΣ"/>
+
+		<!--
+		Tape labels actually are:
+		(1) comand
+		(2) satan 1
+		(3) biorsm
+		(4) vartst
+		(5) t-ment
+		(6) lavelm
+		(7) satan 2
+		These are the actual filenames present on tape
+		-->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="1. Star Command Sigma"/>
+			<dataarea name="snap" size="11692">
+				<rom name="pc-6001 note no. 1 (star command sigma).p6" size="11692" crc="ae28b3c9" sha1="c3a09c5356b4b86a1b26a49ddf258dc0e8607c18" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="2. Space Satan 1"/>
+			<dataarea name="snap" size="3735">
+				<rom name="pc-6001 note no. 1 (space satan 1).p6" size="3735" crc="527eb7ca" sha1="39fe4a7304f08ab8acfd4a3e3d011441ca80f291" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="3. Biorhythm"/>
+			<dataarea name="snap" size="1998">
+				<rom name="pc-6001 note no. 1 (biorhythm).p6" size="1998" crc="c4481df9" sha1="3d4c2c78794268ea15fbb829900b822b401bdd17" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="4. Eigo no Fukisoku Doushi Test"/>
+			<dataarea name="snap" size="3577">
+				<rom name="pc-6001 note no. 1 (eigo no fukisoku doushi test).p6" size="3577" crc="94a13573" sha1="e77cbbb3ca15dbbafa79f85db078731b8587e084" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="5. Tournament-sen Jitsuryoku Hantei"/>
+			<dataarea name="snap" size="2131">
+				<rom name="pc-6001 note no. 1 (tournament-sen jitsuryoku hantei).p6" size="2131" crc="093f4ab9" sha1="c022e00e058cc8ba5516109a5fd6c7426acea2f1" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap6" interface="pc6001_snap">
+			<feature name="part_id" value="6. Cassette Label Maker"/>
+			<dataarea name="snap" size="2095">
+				<rom name="pc-6001 note no. 1 (cassette label maker).p6" size="2095" crc="cc120263" sha1="085b6b835eb14adbb71c19d36bd368b8ba87c4b2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap7" interface="pc6001_snap">
+			<feature name="part_id" value="7. Space Satan 2"/>
+			<dataarea name="snap" size="9034">
+				<rom name="pc-6001 note no. 1 (space satan 2).p6" size="9034" crc="b635450a" sha1="474129b8c6438b7911f99768bcf762e4aeb282b2" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spaceinv" supported="partial">
+		<description>Space Invaders</description>
+		<year>1982?</year>
+		<publisher>コムパック (Compac)</publisher>
+		<notes><![CDATA[
+Covermount for an unknown I/O magazine issue
+Title mispells as Space Inverders, which looks just a typo.
+]]></notes>
+		<info name="usage" value="Mode 1, Page 2"/>
+		<info name="alt_title" value="スペース・インベーダー"/>
+		<!-- "Both sides A and B are recorded" -->
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="6346">
+				<rom name="space inverders.cas" size="6346" crc="bbf51641" sha1="6d3c5d5e42df56d1d0480934eb88877f24bd6f67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spcmouse" supported="no">
+		<description>Space Mouse</description>
+		<year>198?</year>
+		<publisher>Wonder Soft</publisher>
+		<notes><![CDATA[
+Released as covermount under GTX(II)-3 and Paperware PC-6001(1)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2. Issue a CLEAR 10,&amp;hd5ff before CLOAD"/>
+		<info name="author" value="Akihisa Kanda"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="12084">
+				<rom name="space mouse.cas" size="12084" crc="43ad22db" sha1="f049c05a51f04bea67217913442ca113087e07cc" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1039,21 +1308,21 @@ Crashes on [tape] loading (regression)
 	</software>
 
 	<!-- original game released by Technopolis? -->
-    <software name="tinygolf" supported="partial">
-        <description>Tiny Golf</description>
-        <year>2005</year>
+	<software name="tinygolf" supported="partial">
+		<description>Tiny Golf</description>
+		<year>2005</year>
 		<publisher>&lt;homebrew&gt;</publisher>
-        <info name="usage" value="Mode 1, Page 2"/>
+		<info name="usage" value="Mode 1, Page 2"/>
 		<!-- "the author and roadist"? -->
-        <info name="author" value="Sakai"/>
+		<info name="author" value="Sakai"/>
 		<info name="developer" value="Hashi"/>
 
-        <part name="snap" interface="pc6001_snap">
-            <dataarea name="snap" size="443">
-                <rom name="tiny golf.cas" size="443" crc="4fa3c1e0" sha1="52090848c51c19fabb5f64c3d83df0319b61dcfa" offset="0" />
-            </dataarea>
-        </part>
-    </software>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="443">
+				<rom name="tiny golf.cas" size="443" crc="4fa3c1e0" sha1="52090848c51c19fabb5f64c3d83df0319b61dcfa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
 
 
 </softwarelist>

--- a/hash/pc6001_cass.xml
+++ b/hash/pc6001_cass.xml
@@ -25,6 +25,19 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 
 <!-- !Games -->
 
+	<software name="3dastfir" supported="partial">
+		<description>3D Asteroid Fire</description>
+		<year>1982</year>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
+		<info name="usage" value="Mode 2, Page 4"/>
+		<info name="alt_title" value="３Ｄアステロイドファイヤー"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="6903">
+				<rom name="3d asteroid fire.cas" size="6903" crc="354b9fb6" sha1="0e535fcc35fa1c6d4f1b8c2154e1bad9920807d3" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="amazon" supported="partial">
 		<description>The Amazon</description>
 		<year>19??</year>
@@ -33,18 +46,6 @@ Once in BASIC, enter CLOAD then press ENTER, then RUN then ENTER once loading co
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="15260">
 				<rom name="amazon.cas" size="15260" crc="0b154850" sha1="a616b6d8852bea0fae27241ab7a0d5c81014e0e0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="amita" supported="partial">
-		<description>Amita</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="usage" value="Mode 1, Page 2" />
-		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="2755">
-				<rom name="amita.cas" size="2755" crc="fbb5ec19" sha1="dc49c616fb7822f21ca895bbb5f3b16924d306d8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -64,7 +65,7 @@ Arabian Rhapsody: pc6001mk2 draws without border colors (verify)
 		<part name="snap1" interface="pc6001_snap">
 			<feature name="part_id" value="Demonstration"/>
 			<dataarea name="snap" size="13510">
-				<rom name="ax-1 (demo) {m1p1}.cas" size="13510" crc="5a7a7321" sha1="1086d76df3e03427b0181e704186f827828ab011" offset="0" />
+				<rom name="ax-1 (demo).cas" size="13510" crc="5a7a7321" sha1="1086d76df3e03427b0181e704186f827828ab011" offset="0" />
 			</dataarea>
 		</part>
 		<part name="snap2" interface="pc6001_snap">
@@ -427,8 +428,8 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 
 	<software name="brkthru" supported="partial">
 		<description>Break Through</description>
-		<year>19??</year>
-		<publisher>Compac</publisher>
+		<year>198?</year>
+		<publisher>コムパック (Compac)</publisher>
 		<info name="usage" value="Mode 2, Page 2" />
 		<info name="alt_title" value="ブレイク・スルー"/>
 		<part name="snap" interface="pc6001_snap">
@@ -441,7 +442,7 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 	<software name="doordoor" supported="partial">
 		<description>Door Door</description>
 		<year>1984</year>
-		<publisher>Enix</publisher>
+		<publisher>エニックス (Enix)</publisher>
 		<info name="usage" value="Mode 2, Page 2" />
 		<info name="alt_title" value="ドアドア"/>
 		<part name="snap" interface="pc6001_snap">
@@ -454,7 +455,7 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 	<software name="earthbnd" supported="partial">
 		<description>Earthbound</description>
 		<year>1984</year>
-		<publisher>Xtal Soft</publisher>
+		<publisher>クリスタルソフト (Xtal Soft)</publisher>
 		<info name="usage" value="Mode 2, Page 2" />
 		<info name="alt_title" value="アースバウンド"/>
 		<part name="snap" interface="pc6001_snap">
@@ -464,10 +465,33 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 		</part>
 	</software>
 
+	<software name="eformn" supported="no">
+		<description>Eformn</description>
+		<year>1984</year>
+		<publisher>システムソフト (SystemSoft)</publisher>
+		<notes><![CDATA[
+[VDG] swaps gfx mode mid-scanline (gameplay area uses SCREEN 4)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Easy"/>
+			<dataarea name="snap" size="25883">
+				<rom name="eformn (easy).cas" size="25883" crc="565ff19f" sha1="f4a0eb96defae89304a41bd78ea61489b320bc09" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Normal"/>
+			<dataarea name="snap" size="25884">
+				<rom name="eformn (normal).cas" size="25884" crc="f3709f1a" sha1="a08a1c3e2dc5e42b5661a97d3fc632632363334f" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="eggy" supported="partial">
 		<description>Eggy</description>
 		<year>1984</year>
-		<publisher>Bothtec</publisher>
+		<publisher>ボーステック (Bothtec)</publisher>
 		<info name="usage" value="Mode 2, Page 1" />
 		<info name="alt_title" value="エギー"/>
 		<part name="snap" interface="pc6001_snap">
@@ -477,15 +501,20 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 		</part>
 	</software>
 
-	<software name="headon" supported="partial">
-		<description>Head On</description>
-		<year>1982</year>
-		<publisher>ASCII</publisher>
-		<info name="usage" value="Mode 1, Page 1" />
-		<info name="alt_title" value="ヘッド・オン"/>
+	<software name="holyswrd" supported="no">
+		<description>Holy Sword</description>
+		<year>1983</year>
+		<!-- spelled as X'tal Soft on title -->
+		<publisher>クリスタルソフト (Xtal Soft)</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="author" value="K. Tomi"/>
+		<info name="alt_title" value="聖なる剣"/>
 		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="5711">
-				<rom name="head on.cas" size="5711" crc="91f7d594" sha1="e64442f2c32f0a7b6c62e1adcc4555fcc8149b66"/>
+			<dataarea name="snap" size="18167">
+				<rom name="holy sword.cas" size="18167" crc="6a84aa38" sha1="df470de4f4df0f5b935877500f7b8d72c359a4c8" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -493,7 +522,7 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 	<software name="jintori" supported="partial">
 		<description>Jintori Game</description>
 		<year>19??</year>
-		<publisher>Hudson Soft</publisher>
+		<publisher>ハドソン (Hudson Soft)</publisher>
 		<info name="usage" value="Mode 1, Page 2" />
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="1766">
@@ -502,10 +531,87 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 		</part>
 	</software>
 
+	<software name="ledzone" supported="partial">
+		<description>Led Zone</description>
+		<year>1983?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<info name="usage" value="Mode 2, Page 3"/>
+		<info name="developer" value="Keigo Kobayashi"/>
+		<info name="alt_title" value="レッドゾーン"/>
+		<part name="snap" interface="pc6001_snap">
+			<feature name="part_id" value="6001"/>
+			<dataarea name="snap" size="9727">
+				<rom name="led zone (6001).cas" size="9727" crc="450a4b45" sha1="93d75f164b4b5a0f93d491ac00ea7fa2893a431e" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ldrun" supported="partial">
+		<description>Lode Runner</description>
+		<!-- MCMLXXXIV -->
+		<year>1984</year>
+		<publisher>システムソフト (SystemSoft)</publisher>
+		<notes><![CDATA[
+Has optional [tape] loading for extra stages
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="alt_title" value="ロードランナー"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="72130">
+				<rom name="lode runner.p6" size="72130" crc="454d46a2" sha1="0d472ca72dc7d2d3dfb41b8d74ff790963d4317d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="magfield" supported="partial">
+		<description>Magnetic Field</description>
+		<year>1983</year>
+		<publisher>エニックス (Enix)</publisher>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="alt_title" value="マグネチックフィールド"/>
+		<info name="developer" value="A. Hideyuki"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="15666">
+				<rom name="magnetic field.cas" size="15666" crc="55ad4690" sha1="d1d68f25a546963284c20d8f5850ba0564785fa5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="miyushou" supported="partial">
+		<!-- Capitalized as THE on title -->
+		<description>Miyuki the Shoubushi</description>
+		<year>1983</year>
+		<publisher>パックスソフトニカ (Pax Softonica)</publisher>
+		<info name="usage" value="Mode 2, Page 3"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="11845">
+				<rom name="miyuki the shoubushi.cas" size="11845" crc="27b5fc89" sha1="fe4334e48599497e5f008c678afca094895112fe" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="portopia" supported="no">
+		<description>Portopia Renzoku Satsujin Jiken</description>
+		<year>1983</year>
+		<publisher>エニックス (Enix)</publisher>
+		<notes><![CDATA[
+[tape] throws an UL error at second loading (regression after bus request)
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 1"/>
+		<info name="developer" value="Yuji Horii"/>
+		<info name="alt_title" value="ポートピア連続殺人事件"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="28596">
+				<rom name="portopia renzoku satsujin jiken.cas" size="28596" crc="5437dcc5" sha1="7536663a4463107d0841a83f8894012c6b7e35e1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="proracer" supported="partial">
 		<description>Pro Racer</description>
 		<year>19??</year>
-		<publisher>Hudson Soft</publisher>
+		<publisher>ハドソン (Hudson Soft)</publisher>
 		<info name="usage" value="Mode 1, Page 2" />
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="8504">
@@ -523,6 +629,37 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="15263">
 				<rom name="pyramid.cas" size="15263" crc="7d3b4628" sha1="e1be45b435d599d3f7444f159c538e093ba63f3f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pyramid2" supported="partial">
+		<description>Pyramid II</description>
+		<year>1983</year>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
+		<notes><![CDATA[
+Optional [tape] user levels load and save
+]]></notes>
+		<info name="usage" value="Mode 4, Page 3. Select 3 to start game when prompted to"/>
+		<info name="alt_title" value="ピラミッドII"/>
+		<sharedfeat name="requirement" value="pc6001_cart:n60basic"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="18752">
+				<rom name="pyramid 2.cas" size="18752" crc="dcce31b0" sha1="2dff557da3e489e64a57d2205c5ea940e2062344" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="raigrwup" supported="partial">
+		<description>Raita no Growing Up</description>
+		<year>1983</year>
+		<publisher>エニックス (Enix)</publisher>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="developer" value="Hiroaki Shimada"/>
+		<info name="alt_title" value="雷太のグローイングアップ"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="12803">
+				<rom name="raita no growing up.cas" size="12803" crc="2819fc55" sha1="731fb27e5b0446599360bfd046f21f7b4dab957a" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -545,7 +682,7 @@ Blue Sky: [keyboard] doesn't allow hitting directions and space/shift key at sam
 	<software name="sharrier" supported="no">
 		<description>Space Harrier</description>
 		<year>198?</year>
-		<publisher>Dempa</publisher>
+		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
 		<notes><![CDATA[
 Very sensitive with [sub] irq triggers
 [keyboard] joy triggers doesn't work properly (select F1 after loading), cannot move down
@@ -562,14 +699,15 @@ Very sensitive with [sub] irq triggers
 		</part>
 	</software>
 
-	<software name="suprball" supported="partial">
-		<description>Super Ball</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="usage" value="Mode 2, Page 2" />
+	<software name="stardest" supported="partial">
+		<description>Star Destroyer</description>
+		<year>1983</year>
+		<publisher>T&amp;E Soft</publisher>
+		<info name="usage" value="Mode 2, Page 3"/>
+		<info name="alt_title" value="スターデストロイヤー"/>
 		<part name="snap" interface="pc6001_snap">
-			<dataarea name="snap" size="18114">
-				<rom name="super ball.p6" size="18114" crc="a7923430" sha1="01cb476f5e127176290949ff273cac0c6ffe5c49"/>
+			<dataarea name="snap" size="10925">
+				<rom name="star destroyer.cas" size="10925" crc="5326525a" sha1="ce996a59bd6a29ff65435c38043f1ab06876b32a" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -577,7 +715,7 @@ Very sensitive with [sub] irq triggers
 	<software name="trickboy" supported="partial">
 		<description>Trick Boy</description>
 		<year>1982</year>
-		<publisher>T&amp;E Soft</publisher>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
 		<info name="usage" value="Mode 2, Page 2" />
 		<info name="alt_title" value="トリックボーイ"/>
 		<part name="snap" interface="pc6001_snap">
@@ -590,7 +728,7 @@ Very sensitive with [sub] irq triggers
 	<software name="txevious" supported="partial">
 		<description>Tiny Xevious</description>
 		<year>1984</year>
-		<publisher>Dempa Micomsoft</publisher>
+		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
 		<info name="usage" value="Mode 4, Page 2 - PC-6001 requires N60 Extended BASIC cartridge" />
 		<info name="alt_title" value="タイニーゼビウス"/>
 		<info name="developer" value="T. Matsushima"/>
@@ -606,10 +744,11 @@ Very sensitive with [sub] irq triggers
 		<description>Tiny Xevious 2</description>
 		<!-- 1984 08. -->
 		<year>1984</year>
-		<publisher>Dempa Micomsoft</publisher>
+		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
 		<notes><![CDATA[
 pc6001: Heavy [VDG] issues ([cart] RAM? works in pc6001mk2)
 [VDG] swaps gfx mode mid-scanline (text uses a different one)
+Requires multiple space presses to actually start a game
 ]]></notes>
 		<info name="usage" value="Mode 2, Page 2, has optional support for Mode 4" />
 		<info name="alt_title" value="タイニーゼビウス2"/>
@@ -623,13 +762,106 @@ pc6001: Heavy [VDG] issues ([cart] RAM? works in pc6001mk2)
 		</part>
 	</software>
 
+	<software name="zunou" supported="partial">
+		<description>Zunou 4989</description>
+		<year>1984</year>
+		<publisher>エニックス (Enix)</publisher>
+		<notes><![CDATA[
+Optional [tape] load and save for construction mode
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2"/>
+		<info name="developer" value="K. Ohashi"/>
+		<part name="snap" interface="pc6001_snap">
+			<feature name="part_id" value="6001"/>
+			<dataarea name="snap" size="11296">
+				<rom name="zunou 4989 (6001).cas" size="11296" crc="879ba9b4" sha1="e1d0e146322c1f0d10617c0929b8981a6c8f4e67" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 <!-- !Covermount -->
+
+	<software name="amidamu" supported="partial">
+		<description>Amida Mushi</description>
+		<!-- BasicMagazine 1988.4 -->
+		<year>1988</year>
+		<publisher>Mycom BASIC</publisher>
+		<info name="usage" value="Mode 1, Page 2"/>
+		<info name="developer" value="Kunihisa Ogawa"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="2755">
+				<rom name="amida mushi.cas" size="2755" crc="fbb5ec19" sha1="dc49c616fb7822f21ca895bbb5f3b16924d306d8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="astesc" supported="partial">
+		<description>Asteroid Escape</description>
+		<!-- BasicMagazine 1987.4 -->
+		<year>1987</year>
+		<publisher>Mycom BASIC</publisher>
+		<info name="usage" value="Mode 1, Page 1"/>
+		<info name="developer" value="Kaw"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="3173">
+				<rom name="asteroid escape.cas" size="3173" crc="d4e4438d" sha1="a2f54cd9d777df7d3086b52287e9c6a2d0404614" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="boundbal" supported="partial">
+		<description>Bound Ball</description>
+		<!-- BasicMagazine 1988.1 -->
+		<year>1988</year>
+		<publisher>Mycom BASIC</publisher>
+		<info name="usage" value="Mode 1, Page 2"/>
+		<info name="developer" value="Kunihisa Ogawa"/>
+ì		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="2543">
+				<rom name="bound ball.cas" size="2543" crc="18385973" sha1="f2806d4e1e3adee3165d698a40d6c69e2dfe4cf1" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- v1.0 known to exist -->
+	<software name="fruitpan" supported="no">
+		<description>Fruit Panic (v1.1)</description>
+		<!-- PiO 1986/10 -->
+		<year>1986</year>
+		<publisher>PiO</publisher>
+		<notes><![CDATA[
+[VDG] Doesn't draw title screen semigfxs in pc6001
+Optional [tape] user level load and save
+]]></notes>
+		<!-- TODO: does it really require the extended BASIC? It seem to load fine without as well -->
+		<info name="usage" value="Mode 3, Page 1"/>
+		<info name="developer" value="Kaw"/>
+
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="8385">
+				<rom name="fruit panic (v1.1).p6" size="8385" crc="9a140a48" sha1="dd6c29495f97881efd953966bed2d4db84671f8d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fruitpap" supported="no">
+		<description>Fruit Panic Append</description>
+		<year>1986</year>
+		<publisher>PiO</publisher>
+		<info name="usage" value="Mode 3, Page 1. Fruit Panic data tape, load that first, press 3 on title, swap with this image and load."/>
+		<info name="developer" value="Kaw"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="3526">
+				<rom name="fruit panic append.p6" size="3526" crc="e2243bdc" sha1="21962c50d7934510b8cdf8812775301cdf93c76c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="takeoff" supported="no">
 		<description>Take Off 6000</description>
 		<!-- BasicMagazine 1989.10 -->
 		<year>1989</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 [VDG] doesn't show avoidable objects in pc6001
 ]]></notes>
@@ -644,7 +876,136 @@ pc6001: Heavy [VDG] issues ([cart] RAM? works in pc6001mk2)
 
 <!-- !Homebrew -->
 
-	<!-- original as MyCom BASIC release -->
+	<software name="1scrprg" supported="no">
+		<description>1-Screen Programs</description>
+		<year>2009</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<notes><![CDATA[
+Miscellaneous BASIC programs, made between 2005 and 2009
+03 Tiny Typing: may warrant a CAPS from pc6001mk2 [keyboard]
+04 Puchi Deka: crashes in pc6001 (wants 16KB RAM?)
+05 Michinari: [VDG] doesn't draw text in pc6001
+06 Nuketashi: don't know what to do (draws a number sequence, verify thru readme/BASIC listing)
+07 Rendori: [VDG] doesn't draw semigraphics in pc6001
+08 P6 Navi: throws a SN error at 60
+09 At-tobi: not sure what to do (game reacts with [keyboard] space key)
+10 Atehate: may warrant a CAPS from pc6001mk2 [keyboard]
+12 Pirodori: [VDG] doesn't draw text in pc6001
+13 Mukudori: [VDG] doesn't draw text in pc6001
+15 Bunbetsu: not sure what to do (game reacts with [keyboard] space key)
+16 Ketsuraku: not sure what to do
+17 Tentori: not sure what to do
+]]></notes>
+		<info name="usage" value="Mode 1, Page 1"/>
+		<info name="developer" value="Kaw"/>
+		<!-- Tiny Typing Game -->
+		<info name="developer" value="Hashi"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="01 On-naji"/>
+			<dataarea name="snap" size="412">
+				<rom name="1-screen programs (01 on-naji).p6" size="412" crc="b4b8e8f7" sha1="6261e6a4621620f971ef94c5212648f773e78a17" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="02 Iroai"/>
+			<dataarea name="snap" size="407">
+				<rom name="1-screen programs (02 iroai).p6" size="407" crc="a21cd88b" sha1="cb7cb7e869ba1d767bb6f4a2898292a5d91dd3a7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="03 Tiny Typing Game"/>
+			<dataarea name="snap" size="290">
+				<rom name="1-screen programs (03 tiny typing game).p6" size="290" crc="5eb0d127" sha1="6b5360311a2b58ab4208b8eaf383b51b9ef2657f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="04 Puchi Deka"/>
+			<dataarea name="snap" size="367">
+				<rom name="1-screen programs (04 puchi deka).p6" size="367" crc="fb0c21b0" sha1="2f61a629939410ffb6a6f2b97585408303d238d3" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="05 Michinari"/>
+			<dataarea name="snap" size="432">
+				<rom name="1-screen programs (05 michinari).p6" size="432" crc="91b34d05" sha1="bfca14da2ef6ffd76011cdc96a5133c4323220ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap6" interface="pc6001_snap">
+			<feature name="part_id" value="06 Nuketashi"/>
+			<dataarea name="snap" size="403">
+				<rom name="1-screen programs (06 nuketashi).p6" size="403" crc="d9fe924c" sha1="e480699b67885cdd86889a022d141b0d9d1f1483" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap7" interface="pc6001_snap">
+			<feature name="part_id" value="07 Rendori"/>
+			<dataarea name="snap" size="423">
+				<rom name="1-screen programs (07 rendori).p6" size="423" crc="5a95dda3" sha1="c2c8f854f363c01dd1d2a059fa990f876ce7f832" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap8" interface="pc6001_snap">
+			<feature name="part_id" value="08 P6 Navi"/>
+			<dataarea name="snap" size="565">
+				<rom name="1-screen programs (08 p6 navi) {m5p2}.p6" size="565" crc="4387a394" sha1="5a9a783b7969d1f48053471a30a26919a941829f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap9" interface="pc6001_snap">
+			<feature name="part_id" value="09 At-tobi"/>
+			<dataarea name="snap" size="419">
+				<rom name="1-screen programs (09 at-tobi).p6" size="419" crc="8e66d62c" sha1="2bc9a35abcab189b52bee923fc5c0e95201786d7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap10" interface="pc6001_snap">
+			<feature name="part_id" value="10 Atehate"/>
+			<dataarea name="snap" size="392">
+				<rom name="1-screen programs (10 atehate).p6" size="392" crc="5010282f" sha1="0a0454687f2ce3658d46d135fb51f59ed4cb58d2" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap11" interface="pc6001_snap">
+			<feature name="part_id" value="11 Chika yori"/>
+			<dataarea name="snap" size="391">
+				<rom name="1-screen programs (11 chika yori).p6" size="391" crc="fa370664" sha1="d4ca344afae3943c880d4b3dda3b0af1384820ed" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap12" interface="pc6001_snap">
+			<feature name="part_id" value="12 Pirodori"/>
+			<dataarea name="snap" size="469">
+				<rom name="1-screen programs (12 pirodori).p6" size="469" crc="0e91912b" sha1="a0dd403f8f01b1f8b24f92fc3e69adfe9241179e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap13" interface="pc6001_snap">
+			<feature name="part_id" value="13 Mukudori"/>
+			<dataarea name="snap" size="393">
+				<rom name="1-screen programs (13 mukudori).p6" size="393" crc="14f3050d" sha1="9448e1dc7ec9230c5b67f296c3bb1a0870ac8c34" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap14" interface="pc6001_snap">
+			<feature name="part_id" value="14 Zendori"/>
+			<dataarea name="snap" size="399">
+				<rom name="1-screen programs (14 zendori).p6" size="399" crc="9038d123" sha1="698800c7e1a87937338f974c9e2839c8c01e238d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap15" interface="pc6001_snap">
+			<feature name="part_id" value="15 Bunbetsu"/>
+			<dataarea name="snap" size="441">
+				<rom name="1-screen programs (15 bunbetsu).p6" size="441" crc="67a0e7a0" sha1="bd3d607b869dd59e78a1bec440015109f5de52c4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap16" interface="pc6001_snap">
+			<feature name="part_id" value="16 Ketsuraku"/>
+			<dataarea name="snap" size="404">
+				<rom name="1-screen programs (16 ketsuraku).p6" size="404" crc="839c733b" sha1="c3ce74ba8d508f38793a8d7ec0ca7a6e9634194a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap17" interface="pc6001_snap">
+			<feature name="part_id" value="17 Tentori"/>
+			<dataarea name="snap" size="423">
+				<rom name="1-screen programs (17 tentori).p6" size="423" crc="6c0a3e36" sha1="502ddcb6bf43b03f9c6f016ab73cbb2ad1e13913" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- original as Mycom BASIC release -->
 	<!-- preview version known to exist -->
 	<software name="fdot2" supported="partial">
 		<description>F-Dot 2</description>
@@ -660,5 +1021,39 @@ pc6001: Heavy [VDG] issues ([cart] RAM? works in pc6001mk2)
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="suprball" supported="no">
+		<description>Super Ball</description>
+		<year>19??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<notes><![CDATA[
+Crashes on [tape] loading (regression)
+]]></notes>
+		<info name="usage" value="Mode 2, Page 2" />
+		<info name="developer" value="Afoxai"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="18114">
+				<rom name="super ball.p6" size="18114" crc="a7923430" sha1="01cb476f5e127176290949ff273cac0c6ffe5c49"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- original game released by Technopolis? -->
+    <software name="tinygolf" supported="partial">
+        <description>Tiny Golf</description>
+        <year>2005</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+        <info name="usage" value="Mode 1, Page 2"/>
+		<!-- "the author and roadist" -->
+        <info name="author" value="Sakai"/>
+		<info name="developer" value="Hashi"/>
+
+        <part name="snap" interface="pc6001_snap">
+            <dataarea name="snap" size="443">
+                <rom name="tiny golf.cas" size="443" crc="4fa3c1e0" sha1="52090848c51c19fabb5f64c3d83df0319b61dcfa" offset="0" />
+            </dataarea>
+        </part>
+    </software>
+
 
 </softwarelist>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -125,7 +125,7 @@ Requires user [tape] saving, prompts user after character creation
 	<software name="bokosuka" supported="partial">
 		<description>Bokosuka Wars</description>
 		<year>1985</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<info name="usage" value="Mode 5, Page 3, BASIC" />
 		<info name="alt_title" value="ボコスカウォーズ"/>
 		<part name="snap" interface="pc6001_snap">
@@ -151,7 +151,7 @@ Requires user [tape] saving, prompts user after character creation
 	<software name="castle" supported="partial">
 		<description>The Castle</description>
 		<year>1986</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<info name="usage" value="Mode 5, Page 2, BASIC"/>
 		<info name="alt_title" value="ザ・キャッスル"/>
 
@@ -165,7 +165,7 @@ Requires user [tape] saving, prompts user after character creation
 	<software name="castleex" supported="no">
 		<description>Castle Excellent</description>
 		<year>1986?</year>
-		<publisher>ASCII</publisher>
+		<publisher>アスキー (ASCII)</publisher>
 		<notes><![CDATA[
 [gfx] wrong scan draw for title screen copyright text, bad dump?
 [keyboard] has input problems, keeps going to the left
@@ -561,6 +561,40 @@ Eventually requires [tape] user load and save
 		</part>
 	</software>
 
+	<software name="nanakin" supported="partial">
+		<description>Nana-chan no Kinjirareta Asobi (mkII)</description>
+		<year>198?</year>
+		<publisher>パックスソフトニカ (Pax Softonica)</publisher>
+		<notes><![CDATA[
+[tape] has extra audio track, not hooked up
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Yutaka"/>
+		<info name="alt_title" value="ナナちゃんの禁じられた遊び"/>
+		<part name="snap" interface="pc6001_snap">
+			<feature name="part_id" value="mkii"/>
+			<dataarea name="snap" size="23841">
+				<rom name="nana-chan no kinjirareta asobi (mkii).cas" size="23841" crc="e844d56e" sha1="7dc8ddba2b9cbedb3d6023ce6b2bf50b77103133" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nobunaga" supported="no">
+		<description>Nobunaga no Yabou</description>
+		<year>198?</year>
+		<publisher>光栄 (Koei)</publisher>
+		<notes><![CDATA[
+Eventually requires [tape] user load and save
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="信長の野望"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="56435">
+				<rom name="nobunaga no yabou.cas" size="56435" crc="631ab2ab" sha1="c23176b401af93e4dae851a2cab52427c1cda325" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Original fanfun in pc8001_flop / pc8801_cass -->
 	<software name="nfanfun" supported="partial">
 		<description>New Fan Fun</description>
@@ -636,6 +670,19 @@ Holding left+shift on [keyboard] pauses game (verify)
 		</part>
 	</software>
 
+	<software name="profmj" supported="partial">
+		<description>Professional Mahjong (v2.1)</description>
+		<year>198?</year>
+		<publisher>シャノアール (Chat Noir)</publisher>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="プロフェッショナル麻雀"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="25940">
+				<rom name="professional mahjong.cas" size="25940" crc="425239ec" sha1="08029af982ddfce8701f50b8e7e1058164bd560d" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="punchbal" supported="no">
 		<description>Punch Ball Mario Bros.</description>
 		<year>1983</year>
@@ -668,6 +715,19 @@ Not extensively tested (language barrier)
 		</part>
 	</software>
 
+	<software name="sorekuru" supported="partial">
+		<description>Soreyuke! Kurukuru</description>
+		<year>1984</year>
+		<publisher>パックスソフトニカ (Pax Softonica)</publisher>
+		<info name="usage" value="Mode 5, Page 3, MONITOR R-0 then G8800"/>
+		<info name="developer" value="T. Hotaka"/>
+		<info name="alt_title" value="それゆけ! くるくる"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="76076">
+				<rom name="soreyuke kurukuru.p6" size="76076" crc="4255facf" sha1="6d42c0c2406b4ee8a84f29044e98ca442c795d69" offset="0" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="mephius" supported="no">
 		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
@@ -790,6 +850,20 @@ Eventually requires [tape] load and save
 		</part>
 	</software>
 
+	<software name="suidokoz" supported="partial">
+		<description>Suidou Kozou</description>
+		<year>1983?</year>
+		<publisher>Hot-B</publisher>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Gamu"/>
+		<info name="alt_title" value="水道小僧"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="27110">
+				<rom name="suidou kozou.cas" size="27110" crc="edf9e6ba" sha1="a3226018595b6f3b3e1ad5a260673d91df0a343c" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="tforce" supported="partial">
 		<description>Thunder Force</description>
 		<year>1985</year>
@@ -803,21 +877,21 @@ Eventually requires [tape] load and save
 		</part>
 	</software>
 
-    <software name="tritorn" supported="no">
-        <description>Tritorn</description>
-        <year>198?</year>
+	<software name="tritorn" supported="no">
+		<description>Tritorn</description>
+		<year>198?</year>
 		<publisher>ザインソフト (Sein Soft)</publisher>
 		<notes><![CDATA[
 Eventually requires [tape] load and save
 ]]></notes>
-        <info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
 		<info name="alt_title" value="トリトーン"/>
-        <part name="snap" interface="pc6001_snap">
-            <dataarea name="snap" size="45145">
-                <rom name="tritorn.cas" size="45145" crc="82ce5954" sha1="38564e29591c800d2dd92485250af204a4dafdbb" offset="0" />
-            </dataarea>
-        </part>
-    </software>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="45145">
+				<rom name="tritorn.cas" size="45145" crc="82ce5954" sha1="38564e29591c800d2dd92485250af204a4dafdbb" offset="0" />
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="vegcrash" supported="partial">
 		<description>Vegetable Crash</description>

--- a/hash/pc6001mk2_cass.xml
+++ b/hash/pc6001mk2_cass.xml
@@ -27,6 +27,9 @@ If usage specifies MONITOR:
 - Enter MON then press ENTER to enter the Monitor.
 - Type R-0 (- is entered automatically) then press ENTER.
 
+Known undumped list:
+- Golf Island ゴルフアイランド (original 2 tapes version)
+
 -->
 <softwarelist name="pc6001mk2_cass" description="NEC PC-6001mkII cassette snapshots">
 
@@ -35,7 +38,7 @@ If usage specifies MONITOR:
 	<software name="3dgolfsv" supported="no">
 		<description>3D Golf Simulation: Super Version</description>
 		<year>1984?</year>
-		<publisher>T&amp;E Soft</publisher>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
 		<notes><![CDATA[
 Requires [keyboard] key repeat (verify)
 ]]></notes>
@@ -57,6 +60,30 @@ Requires [keyboard] key repeat (verify)
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="43303">
 				<rom name="american truck.cas" size="43303" crc="8b50ad46" sha1="aec8ba495b058f775b5f7bb418d430bd4ad7e0da" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="aspic" supported="no">
+		<description>Aspic</description>
+		<year>198?</year>
+		<publisher>クリスタルソフト (Xtal Soft)</publisher>
+		<notes><![CDATA[
+Requires [tape] scenario saving for a new game
+Side B use is unclear (required later?)
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="アスピック"/>
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="snap" size="47749">
+				<rom name="aspic (side a).cas" size="47749" crc="c89af7dd" sha1="d2af5424f477d63de8d5d1027f08610de4fe6f7e" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="snap" size="13107">
+				<rom name="aspic (side b).cas" size="13107" crc="b35eb02b" sha1="5ce96b9646f333e269a4378db90c9ca7ccccd5d2" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -156,10 +183,12 @@ No BGM sound
 
 	<software name="chackpop" supported="partial">
 		<description>Chack 'n Pop</description>
+		<!-- '84 Oct on title screen -->
 		<year>1984</year>
-		<publisher>Nidecom Carry</publisher>
+		<publisher>ニデコム (Nidecom)</publisher>
 		<info name="usage" value="Mode 5, Page 1, BASIC" />
 		<info name="alt_title" value="ちゃっくんぽっぷ"/>
+		<info name="developer" value="Carry Lab" />
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="46630">
 				<rom name="chack 'n pop.cas" size="46630" crc="de769cca" sha1="3e35398d960442c98035db530c3226dda06ae12f"/>
@@ -174,6 +203,7 @@ No BGM sound
 		<publisher>Comix</publisher>
 		<notes><![CDATA[
 pc6001mk2sr: crashes at title screen
+Lack of [upd7752] voice during intro
 ]]></notes>
 		<info name="usage" value="Mode 5, Page 3, BASIC" />
 		<info name="alt_title" value="クリス愛の旅立ち"/>
@@ -187,7 +217,7 @@ pc6001mk2sr: crashes at title screen
 	<software name="daidasso" supported="partial">
 		<description>Dai Dassou</description>
 		<year>1985?</year>
-		<publisher>Carry Lab</publisher>
+		<publisher>キャリーラボ (Carry Lab)</publisher>
 		<info name="usage" value="Mode 5, Page 1, BASIC" />
 		<info name="alt_title" value="大脱走"/>
 		<part name="snap" interface="pc6001_snap">
@@ -255,7 +285,7 @@ Unsupported [tape] saving, other chapters requires an user tape
 	<software name="doordoor" supported="partial">
 		<description>Door Door Mk. II</description>
 		<year>1984</year>
-		<publisher>Enix</publisher>
+		<publisher>エニックス (Enix)</publisher>
 		<info name="usage" value="Mode 5, Page 3, BASIC" />
 		<info name="alt_title" value="ドアドアmkII"/>
 		<part name="snap" interface="pc6001_snap">
@@ -268,7 +298,7 @@ Unsupported [tape] saving, other chapters requires an user tape
 	<software name="dsbubble" supported="partial">
 		<description>Dr. Slump Bubble Daisakusen</description>
 		<year>1984</year>
-		<publisher>Enix</publisher>
+		<publisher>エニックス (Enix)</publisher>
 		<info name="usage" value="Mode 5, Page 3, MONITOR" />
 		<info name="developer" value="K. Okamoto" />
 		<info name="alt_title" value="スランプ バブル大作戦"/>
@@ -292,6 +322,32 @@ Unsupported [tape] saving, other chapters requires an user tape
 		</part>
 	</software>
 
+	<software name="frontlin" supported="partial">
+		<description>Front Line</description>
+		<year>198?</year>
+		<publisher>ニデコム (Nidecom)</publisher>
+		<info name="usage" value="Mode 5, Page 1, BASIC"/>
+		<info name="alt_title" value="フロントライン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="28812">
+				<rom name="front line.cas" size="28812" crc="271f38c4" sha1="6ac866a27ea6ce46b3305016226933d974cf81b7" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="galaxian" supported="partial">
+		<description>Galaxian</description>
+		<year>198?</year>
+		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
+		<info name="usage" value="Mode 5, Page 2, MONITOR R-0 then G9000"/>
+		<info name="alt_title" value="ギャラクシアン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="58391">
+				<rom name="galaxian.cas" size="58391" crc="fcc4fa9c" sha1="cef6d2fc21b3fa042950655fc133a34a50dc5fa8" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="grobda" supported="partial">
 		<description>Grobda</description>
 		<year>198?</year>
@@ -309,17 +365,18 @@ Unsupported [tape] saving, other chapters requires an user tape
 		</part>
 	</software>
 
-	<software name="hisya" supported="partial">
-		<description>Hisya</description>
-		<year>198?</year>
-		<publisher>Carry Lab</publisher>
+	<software name="hisha" supported="partial">
+		<description>Hisha</description>
+		<year>1985?</year>
+		<publisher>キャリーラボ (Carry Lab)</publisher>
 		<notes><![CDATA[
 Optional [tape] saving and loading
 ]]></notes>
 		<info name="usage" value="Mode 5, Page 1, BASIC" />
+		<info name="alt_title" value="飛車"/>
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="30124">
-				<rom name="hisya.cas" size="30124" crc="c3d88ac6" sha1="c6a857cf88f1205b4dfff00e063739752992a7fc"/>
+				<rom name="hisha.cas" size="30124" crc="c3d88ac6" sha1="c6a857cf88f1205b4dfff00e063739752992a7fc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -361,7 +418,7 @@ Prompts for a [tape] save at startup
 	<software name="hydlide" supported="no">
 		<description>Hydlide</description>
 		<year>198?</year>
-		<publisher>T&amp;E Soft</publisher>
+		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
 		<notes><![CDATA[
 Unsupported [tape] save
 ]]></notes>
@@ -387,11 +444,128 @@ Unsupported [tape] save
 		</part>
 	</software>
 
+	<software name="jelda" supported="partial">
+		<description>Jelda</description>
+		<year>1984</year>
+		<publisher>キャリーラボ (Carry Lab)</publisher>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="alt_title" value="ジェルダ"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="25238">
+				<rom name="jelda.cas" size="25238" crc="33be8325" sha1="b728124d4fe6bf6d821160b021b760777e7582c9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="karuizaw" supported="no">
+		<description>Karuizawa Yuukai Annai</description>
+		<year>198?</year>
+		<publisher>エニックス (Enix)</publisher>
+		<notes><![CDATA[
+Eventually requires [tape] loading and saving
+Not extensively tested (language barrier)
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="軽井沢誘拐案内"/>
+		<!-- TODO: are these two tapes? -->
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Side A - Ch. 1"/>
+			<dataarea name="snap" size="23080">
+				<rom name="karuizawa yuukai annai (side a - ch. 1).cas" size="23080" crc="09cdd251" sha1="1e861c60b41e337f59778fdf60f871b1c39413b4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Side B - Ch. 2+3"/>
+			<dataarea name="snap" size="44016">
+				<rom name="karuizawa yuukai annai (side b - ch. 2+3).cas" size="44016" crc="33c06466" sha1="9c291edeed04c538462331853ce6edf39f5b6575" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Side B2 - Ch. 3"/>
+			<dataarea name="snap" size="8580">
+				<rom name="karuizawa yuukai annai (side b2 - ch. 3).cas" size="8580" crc="2c765117" sha1="433237251bae874a874dd71a6a978c2025351c12" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Side C - Ch. 4"/>
+			<dataarea name="snap" size="34566">
+				<rom name="karuizawa yuukai annai (side c - ch. 4).cas" size="34566" crc="d66eadfd" sha1="cc72b3e268d2a205d28c8c05b5dc78448bbcb727" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Side D - Ch. 5+6"/>
+			<dataarea name="snap" size="77599">
+				<rom name="karuizawa yuukai annai (side d - ch. 5+6).cas" size="77599" crc="decd51bd" sha1="074ba981798ff351d3ea42d001a5737c1aaca09b" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap6" interface="pc6001_snap">
+			<feature name="part_id" value="Side D2 - Ch. 6"/>
+			<dataarea name="snap" size="39497">
+				<rom name="karuizawa yuukai annai (side d2 - ch. 6).cas" size="39497" crc="9c1ccc52" sha1="18b2f474539bf270e257e54fcc5cb42110be3cd0" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap7" interface="pc6001_snap">
+			<feature name="part_id" value="Side D3 - RPG"/>
+			<dataarea name="snap" size="2500">
+				<rom name="karuizawa yuukai annai (side d3 - rpg).cas" size="2500" crc="82917330" sha1="585b4806bdded5a637bc5727064843d8c2e9d7bd" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nausicaa" supported="no">
+		<description>Kaze no Tani no Nausicaä</description>
+		<year>1984</year>
+		<publisher>テクノポリスソフト (Technopolis Soft)</publisher>
+		<notes><![CDATA[
+Loads a non-scene 1 after first playthrough ([tape]? bad dump?)
+]]></notes>
+		<info name="usage" value="Mode 5, Page 1 to load the demo. Mode 5, Page 3 CLOAD&quot;GAME to load the game."/>
+		<info name="developer" value="Me.Her.House"/>
+		<info name="alt_title" value="風の谷のナウシカ"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="57805">
+				<rom name="kaze no tani no nausicaa.p6" size="57805" crc="c3120c49" sha1="a030689b8027e43e189166213a11fd86f8368110" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ledzone" supported="partial">
+		<description>Led Zone (mkII)</description>
+		<year>198?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="developer" value="Keigo Kobayashi"/>
+		<info name="alt_title" value="レッドゾーン"/>
+		<part name="snap" interface="pc6001_snap">
+			<feature name="part_id" value="mkii"/>
+			<dataarea name="snap" size="16559">
+				<rom name="led zone (mkii).cas" size="16559" crc="14a58210" sha1="3a0ad9f38ec7277db534f790c3bc91c496c2b4e9" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lizard" supported="no">
+		<description>Lizard</description>
+		<year>1984</year>
+		<publisher>クリスタルソフト (Xtal Soft)</publisher>
+		<notes><![CDATA[
+Eventually requires [tape] user load and save
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="リザード"/>
+		<info name="author" value="Chihiro.F"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="40671">
+				<rom name="lizard.cas" size="40671" crc="cb9d2f73" sha1="92bd14d1ced8cb6c20c30b148d80709e367768b0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Original fanfun in pc8001_flop / pc8801_cass -->
 	<software name="nfanfun" supported="partial">
 		<description>New Fan Fun</description>
 		<year>1984</year>
-		<publisher>Enix</publisher>
+		<publisher>エニックス (Enix)</publisher>
 		<notes><![CDATA[
 [psg] sounds very aliased
 ]]></notes>
@@ -494,6 +668,128 @@ Not extensively tested (language barrier)
 		</part>
 	</software>
 
+
+	<software name="mephius" supported="no">
+		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
+		<year>1984?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+Eventually requires [tape] load and save
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="alt_title" value="スターアーサー伝説 Ⅰ -惑星メフィウス-"/>
+
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 1"/>
+			<dataarea name="snap" size="28362">
+				<rom name="legends of star arthur 1 - planet mephius (tape 1).cas" size="28362" crc="53589958" sha1="3df544bab8e2e4a31083161ddb2733be9bd3e8d7" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 2 Side A"/>
+			<dataarea name="snap" size="38417">
+				<rom name="legends of star arthur 1 - planet mephius (tape 2 side a) {m5p3}.cas" size="38417" crc="ba718296" sha1="d6f720295bab57afac5a5a1c0684c341f10be4a4" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 2 Side B"/>
+			<dataarea name="snap" size="8326">
+				<rom name="legends of star arthur 1 - planet mephius (tape 2 side b) {m5p3}.cas" size="8326" crc="4dd24f1c" sha1="654e09eac252f3ba5b5e48fe178ff6218ed66c5d" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 3 Side A"/>
+			<dataarea name="snap" size="34282">
+				<rom name="legends of star arthur 1 - planet mephius (tape 3 side a) {m5p3}.cas" size="34282" crc="c098c637" sha1="1f199c1adca26e309aceabd7b16942f1b1b0b72a" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 3 Side B"/>
+			<dataarea name="snap" size="7079">
+				<rom name="legends of star arthur 1 - planet mephius (tape 3 side b) {m5p3}.cas" size="7079" crc="07284e34" sha1="0436126aa742645dade3d71b5976325894575eaa" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ankosei" supported="no">
+		<description>Star Arthur Densetsu II: Ankoku Seiun</description>
+		<year>1984</year>
+		<publisher>T&amp;E Soft</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+Eventually requires [tape] load and save
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, BASIC"/>
+		<info name="alt_title" value="スターアーサー伝説 Ⅱ -暗黒星雲-"/>
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="tape 1"/>
+			<dataarea name="snap" size="83853">
+				<rom name="legends of star arthur 2 - dark nebula (tape 1).cas" size="83853" crc="825da3b3" sha1="17978c8acc7a9bf97097b62f37b2be89194e78cd" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 2 Side A"/>
+			<dataarea name="snap" size="77741">
+				<rom name="legends of star arthur 2 - dark nebula (tape 2 side a) {m5p3}.cas" size="77741" crc="4f084f5a" sha1="3055c272bbebb0da9dc7df447898fbd5b63267ac" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 2 Side B"/>
+			<dataarea name="snap" size="52374">
+				<rom name="legends of star arthur 2 - dark nebula (tape 2 side b) {m5p3}.cas" size="52374" crc="f48a3fbd" sha1="157e3f6d872531082203b9da6b0e35791d16d96f" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 3 Side A"/>
+			<dataarea name="snap" size="81756">
+				<rom name="legends of star arthur 2 - dark nebula (tape 3 side a) {m5p3}.cas" size="81756" crc="112fda98" sha1="9571923af78f16f415052683caa6acc98832b696" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap5" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 3 Side B"/>
+			<dataarea name="snap" size="54518">
+				<rom name="legends of star arthur 2 - dark nebula (tape 3 side b) {m5p3}.cas" size="54518" crc="2c3149cc" sha1="454b83547e368962017684d69b58c3a8a391b6f5" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ter4001" supported="no">
+		<description>Star Arthur Densetsu III: Terra 4001</description>
+		<year>1984?</year>
+		<publisher>T&amp;E Soft</publisher>
+		<notes><![CDATA[
+Not extensively tested (language barrier)
+Eventually requires [tape] load and save
+]]></notes>
+		<info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="スターアーサー伝説 III -テラ4001-"/>
+		<part name="snap1" interface="pc6001_snap">
+			<feature name="part_id" value="tape 1 side a"/>
+			<dataarea name="snap" size="63417">
+				<rom name="legends of star arthur 3 - terra 4001 (tape 1 side a).cas" size="63417" crc="4d6850ab" sha1="f3ada792697894cede22b6844e9d506edc982d87" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap2" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 1 Side B"/>
+			<dataarea name="snap" size="3014">
+				<rom name="legends of star arthur 3 - terra 4001 (tape 1 side b) {m5p2}.cas" size="3014" crc="e1462597" sha1="1a9bd5027a415c8b155e2c8e7f20b48e8fdcca27" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap3" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 2"/>
+			<dataarea name="snap" size="42400">
+				<rom name="legends of star arthur 3 - terra 4001 (tape 2) {m5p2}.cas" size="42400" crc="d95a2b6d" sha1="106d3bf5be1e90ebd0e0f003604d38e7394cf528" offset="0" />
+			</dataarea>
+		</part>
+		<part name="snap4" interface="pc6001_snap">
+			<feature name="part_id" value="Tape 3"/>
+			<dataarea name="snap" size="41736">
+				<rom name="legends of star arthur 3 - terra 4001 (tape 3) {m5p2}.cas" size="41736" crc="b1fe9d81" sha1="ac3c41246a2274ba64b8b78171c3f67f0dc2cde0" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="tforce" supported="partial">
 		<description>Thunder Force</description>
 		<year>1985</year>
@@ -507,6 +803,22 @@ Not extensively tested (language barrier)
 		</part>
 	</software>
 
+    <software name="tritorn" supported="no">
+        <description>Tritorn</description>
+        <year>198?</year>
+		<publisher>ザインソフト (Sein Soft)</publisher>
+		<notes><![CDATA[
+Eventually requires [tape] load and save
+]]></notes>
+        <info name="usage" value="Mode 5, Page 2, BASIC"/>
+		<info name="alt_title" value="トリトーン"/>
+        <part name="snap" interface="pc6001_snap">
+            <dataarea name="snap" size="45145">
+                <rom name="tritorn.cas" size="45145" crc="82ce5954" sha1="38564e29591c800d2dd92485250af204a4dafdbb" offset="0" />
+            </dataarea>
+        </part>
+    </software>
+
 	<software name="vegcrash" supported="partial">
 		<description>Vegetable Crash</description>
 		<year>198?</year>
@@ -516,6 +828,23 @@ Not extensively tested (language barrier)
 		<part name="snap" interface="pc6001_snap">
 			<dataarea name="snap" size="11027">
 				<rom name="vegetable crash.cas" size="11027" crc="7a0569d1" sha1="932d219a2eae516d57575511a0bdb2a96bd8fa6d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="victnine" supported="no">
+		<description>Victorious Nine</description>
+		<!-- 19850614 on title screen -->
+		<year>1985</year>
+		<publisher>ニデコム (Nidecom)</publisher>
+		<notes><![CDATA[
+Pitching doesn't trigger from neither [joystick] nor [keyboard]
+]]></notes>
+		<info name="usage" value="Mode 5, Page 1, BASIC"/>
+		<info name="alt_title" value="ビクトリアスナイン"/>
+		<part name="snap" interface="pc6001_snap">
+			<dataarea name="snap" size="53500">
+				<rom name="victorious nine.cas" size="53500" crc="efc7906d" sha1="a80974dd8e1f37d7333f4d0f254e84e5913f1bc3" offset="0" />
 			</dataarea>
 		</part>
 	</software>
@@ -546,12 +875,30 @@ Not extensively tested (language barrier)
 		</part>
 	</software>
 
+	<software name="zunou" supported="partial">
+		<description>Zunou 4989 (mkII)</description>
+		<year>1984</year>
+		<publisher>エニックス (Enix)</publisher>
+		<notes><![CDATA[
+Loads twice after hooking up [cassette] deck (verify)
+Optional [tape] load and save for construction mode
+]]></notes>
+		<info name="usage" value="Mode 5, Page 3, MONITOR"/>
+		<info name="developer" value="K. Ohashi"/>
+		<part name="snap" interface="pc6001_snap">
+			<feature name="part_id" value="mkii"/>
+			<dataarea name="snap" size="11810">
+				<rom name="zunou 4989 (mkii).cas" size="11810" crc="e8db6d09" sha1="c53591627f28641333b8e58f7d9f064644658d0a" offset="0" />
+			</dataarea>
+		</part>
+	</software>
+
 <!-- !Covermount -->
 
 	<software name="vitalamp" supported="partial">
 		<description>Vital Lamp</description>
 		<year>198?</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 5, Page 2, BASIC"/>
 		<info name="developer" value="Kazuhisa Honda"/>
 		<part name="snap" interface="pc6001_snap">

--- a/hash/pc6001mk2_flop.xml
+++ b/hash/pc6001mk2_flop.xml
@@ -4,10 +4,47 @@
 license:CC0-1.0
 
 Mode 5 PC-6001mkII/PC-6601 floppy disks. They autoboot at startup.
+
+Known undumped list:
+- Colony Odyssey II Taiketsu-hen コロニーオデッセイ対決編 PS66-102F
+
 -->
 <softwarelist name="pc6001mk2_flop" description="NEC PC-6001mkII/PC-6601 disk images">
 
 <!-- !Games -->
+
+	<software name="colonody" supported="no">
+		<description>Colony Odyssey Bouken-hen</description>
+		<year>1983</year>
+		<publisher>NEC</publisher>
+		<notes><![CDATA[
+Fails when mounted, requires mods in MSX .dsk identify
+Eventually uses [upd7752] voice
+]]></notes>
+		<info name="alt_title" value="コロニーオデッセイ冒険篇"/>
+
+		<!-- No. 1~3 for this chapter, No. 4~6 for the sequel -->
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="No. 1" />
+			<dataarea name="flop" size="163840">
+				<rom name="colony odyssey bouken-hen (6601) (disk 1).dsk" size="163840" crc="457bfc89" sha1="63078643aa88080b96ed6b26d6db705e918b0553"/>
+			</dataarea>
+		</part>
+
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="No. 2" />
+			<dataarea name="flop" size="163840">
+				<rom name="colony odyssey bouken-hen (6601) (disk 2).dsk" size="163840" crc="75eeb13e" sha1="5e99c5dd94da47864696edf3d29990dc304d89fd"/>
+			</dataarea>
+		</part>
+
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="No. 3" />
+			<dataarea name="flop" size="163840">
+				<rom name="colony odyssey bouken-hen (6601) (disk 3).dsk" size="163840" crc="f6c1f0b4" sha1="056def87674aee46fe8e41337907e5a4573f522c"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="hudson3" supported="no">
 		<description>Hudson Soft Best Hit Game Pack 3</description>
@@ -34,16 +71,52 @@ pc6601: "d88: Floppy disk has excess of heads for this drive that will be discar
 	<!-- v1.0 known to exist (same with no sound) -->
 	<software name="asalt" supported="yes">
 		<description>Asalt (v1.1, prototype)</description>
-		<year>19??</year>
+		<!-- 2009/06/07 -->
+		<year>2009</year>
 		<publisher>&lt;homebrew&gt;</publisher>
 		<notes><![CDATA[
 Looks a tech demo (time doesn't run down, has no enemies, has 1 stage)
 ]]></notes>
+		<info name="developer" value="Kaw"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="153008">
 				<rom name="asalt (v1.1).d88" size="153008" crc="5649ace5" sha1="4e972be3d60979d1d6c27fb1dc83b623d8157c8b"/>
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="spcblufz" supported="no">
+		<description>Space Bluster FZ</description>
+		<!-- 2011/03/20 -->
+		<!-- In-game says 1986 (from the original MZ-700 version?) -->
+		<year>2011</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<notes><![CDATA[
+pc6601: crashes after loading
+]]></notes>
+		<info name="developer" value="Kaw"/>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="153008">
+				<rom name="space bluster fz.d88" size="153008" crc="69f716e8" sha1="e78f3962cdce1774fb3ccad1092544df926db7a3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spcblufzp" cloneof="spcblufz" supported="no">
+		<description>Space Bluster FZ (preview)</description>
+		<year>20??</year>
+		<publisher>&lt;homebrew&gt;</publisher>
+		<notes><![CDATA[
+pc6601: crashes after loading
+Crashes if pressing [keyboard] shift (verify, possibly part of the "preview version")
+]]></notes>
+		<info name="developer" value="Kaw"/>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="153008">
+				<rom name="space bluster fz (preview ver).d88" size="153008" crc="3b302903" sha1="f6f33ccfa292bcf1f4c8d1d83e657497fe6f232d"/>
+			</dataarea>
+		</part>
+	</software>
+
 
 </softwarelist>

--- a/hash/pc6001mk2sr_cass.xml
+++ b/hash/pc6001mk2sr_cass.xml
@@ -4,6 +4,10 @@
 license:CC0-1.0
 
 Mode 6 PC-6001mkIISR/PC-6601SR cassette snapshots. They specifically needs N66SR BASIC
+
+Known undumped list:
+- Plazma Line プラズマライン 66SR version (i.e. using cyan rather than purple for OSD)
+
 -->
 <softwarelist name="pc6001mk2sr_cass" description="NEC PC-6001mkIISR/PC-6601SR cassette snapshots">
 

--- a/hash/pc6001mk2sr_cass.xml
+++ b/hash/pc6001mk2sr_cass.xml
@@ -13,7 +13,7 @@ Mode 6 PC-6001mkIISR/PC-6601SR cassette snapshots. They specifically needs N66SR
 		<description>9-gyou no Michi</description>
 		<!-- BasicMagazine 1992.2 -->
 		<year>1992</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6"/>
 		<info name="developer" value="Hiroshi Hashizume"/>
 		<part name="snap" interface="pc6001_snap">
@@ -79,7 +79,7 @@ Doesn't draw any GFX just [VDG] if pressing any [keyboard] input, in turn receiv
 		<description>Jewels</description>
 		<!-- "1987/4/12" according to LIST -->
 		<year>1987</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6. Hold space while pushing towards a block to use a bomb."/>
 		<info name="developer" value="Hiroshi Hashizume"/>
 		<part name="snap" interface="pc6001_snap">
@@ -93,7 +93,7 @@ Doesn't draw any GFX just [VDG] if pressing any [keyboard] input, in turn receiv
 		<description>Living Armor</description>
 		<!-- according to LIST -->
 		<year>1992</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 ]]></notes>
@@ -118,7 +118,7 @@ Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 		<description>Lizard Quest</description>
 		<!-- BasicMagazine 1987.4 -->
 		<year>1987</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6"/>
 		<info name="developer" value="Taro Kondo"/>
 		<part name="snap" interface="pc6001_snap">
@@ -132,7 +132,7 @@ Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 		<description>Lizard Quest II: Shitennou no Houfuku</description>
 		<!-- BasicMagazine 1987.10 -->
 		<year>1987</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6"/>
 		<info name="developer" value="Taro Kondo"/>
 		<part name="snap" interface="pc6001_snap">
@@ -146,9 +146,7 @@ Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 		<description>Lizard Quest III: Shi no Kami Gaabarian</description>
 		<!-- BasicMagazine 1988.4 -->
 		<year>1988</year>
-		<publisher>MyCom BASIC</publisher>
-		<notes><![CDATA[
-]]></notes>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6"/>
 		<info name="developer" value="Taro Kondo"/>
 
@@ -163,7 +161,7 @@ Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 		<description>Lizard Quest IV: Gold Lizard</description>
 		<!-- BasicMagazine 1988.11 -->
 		<year>1988</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<info name="usage" value="Mode 6"/>
 		<info name="developer" value="Taro Kondo"/>
 		<part name="snap" interface="pc6001_snap">
@@ -177,7 +175,7 @@ Doesn't boot, throws a ?SN Error at 37376 when loading part 2 (should be at 10)
 		<description>The Order</description>
 		<!-- BasicMagazine 1991.1 -->
 		<year>1991</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 Timer looks off (verify)
 Unclear about how to win at game.
@@ -195,7 +193,7 @@ Unclear about how to win at game.
 		<description>Pakuridius: '88 Dragon Breath</description>
 		<!-- According to LIST -->
 		<year>1988</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 [VDG] title screen scrolling is weird (verify)
 ]]></notes>
@@ -212,7 +210,7 @@ Unclear about how to win at game.
 		<description>Satan</description>
 		<!-- BasicMagazine 1988.12 -->
 		<year>1988</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 Oddly scrolls horizontally during fights (verify)
 ]]></notes>
@@ -229,7 +227,7 @@ Oddly scrolls horizontally during fights (verify)
 		<description>Wu-m Wakarannou</description>
 		<!-- BasicMagazine 1988.1 -->
 		<year>1988</year>
-		<publisher>MyCom BASIC</publisher>
+		<publisher>Mycom BASIC</publisher>
 		<notes><![CDATA[
 Unclear how to win, [keyboard] missing inputs?
 ]]></notes>

--- a/hash/pc6001mk2sr_flop.xml
+++ b/hash/pc6001mk2sr_flop.xml
@@ -7,6 +7,26 @@ Mode 6 PC-6001mkIISR/PC-6601SR floppy disks. They autoboot at startup.
 -->
 <softwarelist name="pc6001mk2sr_flop" description="NEC PC-6001mkIISR/PC-6601SR disk images">
 
+<!-- !Games -->
+
+	<software name="golfisl" supported="no">
+		<!-- TODO: pinpoint if this is normal or "Special" version -->
+		<!-- All covers seems to have the suffix -->
+		<description>Golf Island (66SR)</description>
+		<year>1985?</year>
+		<publisher>テクノソフト (Tecno Soft)</publisher>
+		<notes><![CDATA[
+[FDC] should autoboot from pc6601sr
+]]></notes>
+		<info name="alt_title" value="ゴルフアイランド"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="305328">
+				<rom name="golf island (66sr).d88" size="305328" crc="d4573555" sha1="52953b7c9831726919eae91082b25c21e0bd1d58"/>
+			</dataarea>
+		</part>
+	</software>
+
+
 <!-- !Utilities -->
 
 <!--

--- a/hash/pc6001mk2sr_flop.xml
+++ b/hash/pc6001mk2sr_flop.xml
@@ -41,7 +41,7 @@ Autoboot program
 Autoboot program menu
 Japanese word processor example sentences
 
-Acts as a Disk BIOS for further loading
+Acts as a Disk BIOS for further loading. .dsk alt format known to exist
 -->
 	<software name="sruty" supported="no">
 		<description>PC-6601SR Utility Disk</description>

--- a/hash/pc8001mk2_flop.xml
+++ b/hash/pc8001mk2_flop.xml
@@ -15,7 +15,7 @@ Bon Bon, Bon Bon, Compaq, Aug 83, Aug 83,
 四次元の家, 4 Dimension House, Prosumer, Nov 83,
 (these are unconfirmed if being specifically for PC-8001mkII or works on vanilla PC-8001 too)
 クイズダービー, Quiz Derby, Takara, Dec 83, (based off the TBS show)
-タンクトップ, Tank Top, Magical Zoo, Dec 83,
+タンクトップ, Tank Top, MagicalZoo, Dec 83,
 グラフィック雀球, <Graphic Mahjong?> , ストラッドフォード, Dec 83, (description clearly claims to be a mahjong)
 
 -->

--- a/hash/pc8801_cass.xml
+++ b/hash/pc8801_cass.xml
@@ -806,7 +806,7 @@ kanji name, romaji name, manufacturer, release date in %MMM %YY format, notes
 	</software>
 
 	<software name="wakumeph" supported="no">
-		<description>Star Arthur Densetsu I - Wakusei Mephius (alt)</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->

--- a/hash/pc8801_cass.xml
+++ b/hash/pc8801_cass.xml
@@ -1299,7 +1299,7 @@ kanji name, romaji name, manufacturer, release date in %MMM %YY format, notes
 	<software name="ultraymj" supported="no">
 		<description>Ultra Yonin Mahjong</description>
 		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>ツクモ (Tsukumo)</publisher>
 		<info name="alt_title" value="ウルトラ四人麻雀"/>
 		<part name="cass" interface="pc8801_cass">
 			<dataarea name="cass" size="25537">

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -24469,12 +24469,12 @@ Should be supported by [PC8001mkIISR] too
 	</software>
 
 	<software name="nausicaa">
-		<description>Nausicaä Adventure Game</description>
+		<description>Kaze no Tani no Nausicaä</description>
 		<year>1984</year>
 		<publisher>徳間書店 (Tokuma Shoten Publishing)</publisher>
 		<!-- PC8801 -->
 		<info name="release" value="198406xx"/>
-		<info name="alt_title" value="風の谷のナウシカ (Kaze no Tani no Naushika)"/>
+		<info name="alt_title" value="風の谷のナウシカ"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="348592">
 				<rom name="nausicaa.d88" size="348592" crc="fc9976be" sha1="24425dc8fa34e0636a7f7b246ceeef21dd459631"/>
@@ -32966,7 +32966,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 	</software>
 
 	<software name="mephius">
-		<description>Star Arthur Densetsu I - Wakusei Mephius</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->
@@ -32980,7 +32980,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 	</software>
 
 	<software name="mephiusa" cloneof="mephius">
-		<description>Star Arthur Densetsu I - Wakusei Mephius (alt)</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius (alt)</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->
@@ -32994,7 +32994,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 	</software>
 
 	<software name="mephiush1" cloneof="mephius">
-		<description>Star Arthur Densetsu I - Wakusei Mephius (Fixed)</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius (fixed)</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->
@@ -33008,7 +33008,8 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 	</software>
 
 	<software name="mephiush2" cloneof="mephius">
-		<description>Star Arthur Densetsu I - Wakusei Mephius (patched works through the end)</description>
+		<!-- TODO: understand what the note claims -->
+		<description>Star Arthur Densetsu I: Wakusei Mephius (patched works through the end)</description>
 		<year>1983</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->
@@ -33034,7 +33035,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 
 	<!-- Omake: run "SHUGYO" for a first person spaceship mini-game (eventually seen in the actual game too?) -->
 	<software name="ankosei" supported="yes">
-		<description>Star Arthur Densetsu II - Ankoku Seiun</description>
+		<description>Star Arthur Densetsu II: Ankoku Seiun</description>
 		<year>1984</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->
@@ -33051,7 +33052,7 @@ ExtractDisk  [02]"A DISK          " -> "sorcerian music library_02.d88"
 
 	<!-- Omake: run "SHUGYO" for a first person spaceship mini-game (eventually seen in the actual game too?) -->
 	<software name="ankoseia" cloneof="ankosei" supported="yes">
-		<description>Star Arthur Densetsu II - Ankoku Seiun (alt)</description>
+		<description>Star Arthur Densetsu II: Ankoku Seiun (alt)</description>
 		<year>1984</year>
 		<publisher>T&amp;E Soft</publisher>
 		<!-- PC8801 -->

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -43176,6 +43176,7 @@ Cannot install, gets stuck at "please insert disk and press mouse" prompt, tests
 		<year>1986</year>
 		<publisher>アスキー (ASCII)</publisher>
 		<info name="alt_title" value="ザ・スクリーマー" />
+		<info name="developer" value="MagicalZoo" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1265664">
 				<rom name="the screamer (1985)(magical zoo).fdi" size="1265664" crc="86f2163d" sha1="2d73222c8e7372f32b529798d0da60b36c875053" offset="0" />

--- a/hash/smc777.xml
+++ b/hash/smc777.xml
@@ -1054,9 +1054,9 @@ Bad colors on title screen. Happens if mouse is in port 2 (btanb)
 	</software>
 
 	<software name="tsu4mj">
-		<description>Tsukumo Ultra 4-nin Mahjong</description>
+		<description>Ultra Yonin Mahjong</description>
 		<year>198?</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>ツクモ (Tsukumo)</publisher>
 		<notes><![CDATA[
 Standalone version of MAHJONG.COM in compinv
 ]]></notes>

--- a/hash/x1_cass.xml
+++ b/hash/x1_cass.xml
@@ -1462,7 +1462,7 @@ Titles, publishers and release dates taken from:
 	</software>
 
 	<software name="mephius" supported="no">
-		<description>Star Arthur Densetsu I - Wakusei Mephius</description>
+		<description>Star Arthur Densetsu I: Wakusei Mephius</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="惑星メフィウス"/>


### PR DESCRIPTION
* hash/pc6001_cass.xml: rename and identify "amita" as "amidamu"
* hash/pc6001_cass.xml: remove headon, part of AX-6 set

New working software list items
-------------------------------
pc6001_cass: 3D Asteroid Fire, Asteroid Escape, Bound Ball, Led Zone, Lode Runner, Magnetic Field, Miyuki the Shoubushi, Nana-chan no Kinjirareta Asobi, Pack'n Boy, PC-6000 Note No. 1, PonyCa 2 Game Series: Galac Convoy & Shooting Invaders, Pyramid II, Raita no Growing Up, Slender Island, Space Mouse, Star Destroyer, Tiny Golf, Ultra Yonin Mahjong, Zunou 4989 [Neo Kobe] 
pc6001mk2_cass: Front Line, Galaxian, Jelda, Led Zone (mkII), Nana-chan no Kinjirareta Asobi (mkII), Professional Mahjong, Soreyuke! Kurukuru, Suidou Kozou, Zunou 4989 (mkII) [Neo Kobe]

New software list items marked not working
------------------------------------------
pc6001_cass: 1-Screen Programs, Eformn, Fruit Panic (v1.1), Fruit Panic Append, Genma Taisen, Holy Sword, Mystery House, Mystery House II, Ougon no Haka, Portopia Renzoku Satsujin Jiken [Neo Kobe] 
pc6001mk2_cass: Aspic, Karuizawa Yuukai Annai, Kaze no Tani no Nausicaa, Lizard, Nobunaga no Yabou, Star Arthur Densetsu I: Wakusei Mephius, Star Arthur Densetsu II: Ankoku Seiun, Star Arthur Densetsu III: Terra 4001, Tritorn, Victorious Nine [Neo Kobe] 
pc6001mk2_flop: Colony Odyssey Bouken-hen, Space Bluster FZ [Neo Kobe] 
pc6001mk2sr_flop: Golf Island (66SR) [Neo Kobe]
