### PR TITLE
sega/model1: Clip wireframe lines to the viewport (fixes wingwar boot lockup from #15597)

### DIFF
--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -216,11 +216,52 @@ void model1_state::fill_line(bitmap_rgb32 &bitmap, view_t *view, int color, int3
 
 // Draw a solid line between two screen points (integer Bresenham).  Wireframe
 // primitives reach the rasterizer as a degenerate quad with two coincident
-// vertex pairs (A,A,B,B); fill_quad only touches one pixel per scanline, so a
-// near-horizontal wire would collapse to a handful of dots.  Drawing the line
-// directly restores the full span (e.g. the Star Wars Arcade target box).
-static void draw_wireframe_line(bitmap_rgb32 &bitmap, int x1, int y1, int x2, int y2, uint32_t color, bool moire)
+// vertex pairs (A,A,B,B); the scanline filler only touches one pixel per row,
+// collapsing near-horizontal wires to dots (e.g. the Star Wars Arcade target
+// box).  The endpoints come from the unclipped projection and can be garbage
+// (a degenerate projection yields inf/NaN, which float->int conversion turns
+// into INT32_MIN on x86 hosts), so clip the segment to the viewport first,
+// like fill_slope() does for the filler - unclipped, wingwar hung during boot
+// walking a ~2^31-pixel line.
+static void draw_wireframe_line(bitmap_rgb32 &bitmap, const rectangle &clip, int x1, int y1, int x2, int y2, uint32_t color, bool moire)
 {
+	// Liang-Barsky clip against the viewport rectangle (doubles hold every
+	// int32 exactly, so in-range endpoints pass through unchanged)
+	const double lx1 = x1, ly1 = y1;
+	const double cdx = double(x2) - lx1, cdy = double(y2) - ly1;
+	const double p[4] = { -cdx, cdx, -cdy, cdy };
+	const double q[4] = { lx1 - clip.min_x, clip.max_x - lx1, ly1 - clip.min_y, clip.max_y - ly1 };
+	double t0 = 0.0, t1 = 1.0;
+	for (int i = 0; i < 4; i++)
+	{
+		if (p[i] == 0.0)
+		{
+			if (q[i] < 0.0)
+				return; // parallel to this edge and outside it
+		}
+		else
+		{
+			const double t = q[i] / p[i];
+			if (p[i] < 0.0)
+				t0 = std::max(t0, t);
+			else
+				t1 = std::min(t1, t);
+		}
+	}
+	if (t0 > t1)
+		return; // entirely outside the viewport
+
+	if (t1 < 1.0)
+	{
+		x2 = int(std::lround(lx1 + t1 * cdx));
+		y2 = int(std::lround(ly1 + t1 * cdy));
+	}
+	if (t0 > 0.0)
+	{
+		x1 = int(std::lround(lx1 + t0 * cdx));
+		y1 = int(std::lround(ly1 + t0 * cdy));
+	}
+
 	int dx = std::abs(x2 - x1), dy = std::abs(y2 - y1);
 	int sx = x1 < x2 ? 1 : -1, sy = y1 < y2 ? 1 : -1;
 	int err = dx - dy;
@@ -277,7 +318,8 @@ void model1_state::fill_quad(bitmap_rgb32 &bitmap, view_t *view, const quad_t& q
 		}
 		if (ndist == 2)
 		{
-			draw_wireframe_line(bitmap, ax, ay, bx, by, color & ~MOIRE, (color & MOIRE) != 0);
+			// clip to the viewport, exactly like the scanline filler below does
+			draw_wireframe_line(bitmap, rectangle(view->x1, view->x2, view->y1, view->y2), ax, ay, bx, by, color & ~MOIRE, (color & MOIRE) != 0);
 			return;
 		}
 	}


### PR DESCRIPTION
## What this fixes

The wingwar gray-screen boot lockup reported by @Osso13 in the #15597 comments: MAME stops responding during boot on some Windows machines and has to be killed.

## Why we believe this is the problem

1. **wingwar generates NaN screen coordinates while booting.** An instrumented run shows 50+ NaN screen coordinates coming out of `project_point()` during a normal boot: a z slightly above 0 passes the `z > 0` guard, `x/z` becomes inf, and the boot-time viewport zoom is still 0, so `inf * 0 = NaN`.

2. **float->int conversion of NaN/inf is undefined behaviour and host-dependent.** x86 (`cvttss2si`) yields `0x80000000` (INT32_MIN); arm64 maps NaN to 0 and saturates +/-inf. This explains the platform split in the report: the hang shows on (some) x86 Windows machines while macOS hosts were always fine. Confirmed with UBSan: a stock master build instrumented with `-fsanitize=float-cast-overflow` traps inside `project_point()` ("Floating-point to integer conversion overflowed") seconds into a factory wingwar boot, on a host where the hang itself never manifests.

3. **INT32_MIN vertices trigger the wireframe path added by #15597.** All-NaN vertices collapse into identical (INT32_MIN, INT32_MIN) pairs, i.e. exactly two distinct vertices, so `draw_wireframe_line()` walks a ~2^31-pixel Bresenham whose `abs()` / `2 * err` terms overflow, and `screen_update` never returns. This is consistent with the observation that commenting out the `RENDER_BELOW_HUD` pass avoids the hang: both passes walk the same display list, but only the below-HUD pass pushes and rasterizes geometry.

4. **Reproduced deterministically.** Mimicking the x86 conversion semantics inside `project_point()` on an arm64 host makes stock master hang during the wingwar boot, stuck here:

   ```
   screen_device::update_partial
    model1_state::screen_update_model1
     model1_state::tgp_render (RENDER_BELOW_HUD)
      model1_state::draw_objects
       model1_state::fill_quad   <- spinning in the inlined wireframe Bresenham
   ```

   Disabling only the wireframe branch removes the hang; reverting only the unconditional direct-poly projection does not — the unbounded wireframe walk is the sole trigger.

5. **Why this never happened before #15597:** degenerate quads used to fall through to the scanline filler, and `fill_slope()`/`fill_line()` clamp every span to the viewport, so the exact same garbage vertices stayed bounded and invisible.

## The fix

Give the line rasterizer the same property the scanline filler always had: Liang-Barsky clip the segment to the viewport before walking it. In-view lines are untouched (doubles represent every int32 exactly, so unclipped endpoints pass through unchanged); garbage endpoints are clipped or rejected, so the walk is bounded by the viewport size.

## Verification

- With the x86-conversion mimic harness: master hangs at the wingwar boot, this branch completes.
- Deterministic attract snapshots (`-str`) of vf, vr, vformula, swa, wingwar and netmerc are pixel-identical to master, except ~10 px in wingwar where a wire used to leak past the bottom viewport edge into the HUD strip and now stops at the edge like every other primitive.
- The Star Wars Arcade target box and the other #15597 wireframe fixes still render correctly.

@Osso13 it would be great if you could confirm on the machine where you reproduced the original hang.

Claude Fable 5 (Anthropic) was used in the investigation and development of this fix.
