### PR TITLE
skeleton/micral.cpp: Emulate the floppy disk system — micral and questarm boot CP/M and QMOS (promoted to working)

### DIFF
--- a/src/mame/skeleton/micral.cpp
+++ b/src/mame/skeleton/micral.cpp
@@ -16,18 +16,21 @@ CRT8002, TMS9937 (=CRT5037), 4KB video RAM, 256x4 prom (7611);
 CDP6402 UART. Sound is a beeper.
 The keyboard has a uPD780C (=Z80) and 1KB of ROM.
 
-The FDC and HDC are unknown.
-No manuals, schematic or circuit description have been found.
+Reverse-engineered schematics of the whole machine (including the discrete
+floppy subsystem) and a commented disassembly of the boot ROM are available:
+https://forum.system-cfg.com/viewtopic.php?t=12786 (R2E Micral 8022 G thread)
+The HDC is still unknown.
 
 Commands must be in uppercase. Reboot to exit each command.
-Bx[,x]: ??
+Bd[,t]: boot from floppy drive d (track t; "B0" boots CP/M from drive 0,
+        "B0,8" boots Prologue/QMOS)
 Gxxxx : go (writes a jump @FFED then jumps to FFEB)
 T     : test
 *     : echo keystrokes
-enter : ??
+enter : boot drive 0 track 8
 
-Using generic keyboard via the uart for now. It's unknown how the real keyboard
-communicates with the main cpu.
+Using generic keyboard via the uart for now, the real keyboard MCU is not
+hooked up yet.
 
 FFF8/9 are used for sending instructions to the screen. FFF9 is command/status,
 and FFF8 is data. The codes 0-D seem to be for the CRT5037, but the results don't
@@ -35,23 +38,33 @@ make much sense. Code A0 is to write a byte to the current cursor position, and
 B0 is to get the status.
 
 Screen needs:
-- Scrolling
-- Proper character generator
-- To be properly understood
+- Proper character generator (currently borrowing the c10 chargen, BAD_DUMP)
 - According to the web, graphics are possible. A screenshot shows reverse video
   exists.
 
 Other things...
 - Beeper
-- 2 floppy drives
-- keyboard
-- unknown ports
+- The real keyboard MCU hookup
+- ST506 hard disk
 
 --------------------
 Honeywell Bull Questar/M
 
+The Questar/M is a rebadged Micral 80-22 (R2E had been acquired by Bull).
+Both machines boot CP/M 2.2 ("R2E 8021 57k CP/M vers 2.23", type B0 at the
+monitor prompt) and Prologue/QMOS (type B0,8) from the floppy images dumped
+from a surviving Questar/M.
+
 http://www.histoireinform.com/Histoire/+infos6/chr6inf3.htm
 https://www.esocop.org/docs/Questar.pdf
+
+Acknowledgements:
+- aquarius (forums.bannister.org) dumped the Questar/M BIOS ROM and the
+  CP/M and QMOS floppies, and reverse-engineered the hard-sectored track
+  format: https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=115424
+- rfka01 added the Questar/M BIOS to this driver.
+- The Micral 80-22G schematics and commented ROM disassembly published on
+  forum.system-cfg.com documented the floppy register interface.
 
 *********************************************************************************/
 
@@ -71,6 +84,103 @@ https://www.esocop.org/docs/Questar.pdf
 
 namespace {
 
+//**************************************************************************
+//  Floppy disk image device
+//
+//  Hard-sectored Tandon TM100-4: 80 cylinders, 2 sides, 16 sectors of
+//  256 bytes per side (logical sectors 0-15 = side 1, 16-31 = side 2),
+//  640K total.  Image format: raw decoded sector data, cylinder-major,
+//  32 x 256 bytes per cylinder (as produced by aquarius' kryoflux decode).
+//
+//  The FDC is discrete logic (see Micral 80-22G schematics, sheets 07-12):
+//  the CPU reads/writes the bit stream serially through 0xFFFF (one bit
+//  per access, bit 0, inverted on read), with drive/sector select at
+//  0xFFFD and a command register at 0xFFFE.  Media layout per sector:
+//  sync (00 00 05), then 00, track, sector, 256 data bytes and two
+//  checksum bytes (one's-complement running sum and second-order sum,
+//  cf. CP/M BIOS routine at F56C).
+//**************************************************************************
+
+class micral_floppy_device : public device_t, public device_image_interface
+{
+public:
+	micral_floppy_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+
+	virtual const char *image_type_name() const noexcept override { return "floppydisk"; }
+	virtual const char *image_brief_type_name() const noexcept override { return "flop"; }
+	virtual bool is_readable() const noexcept override { return true; }
+	virtual bool is_writeable() const noexcept override { return true; }
+	virtual bool is_creatable() const noexcept override { return false; }
+	virtual bool is_reset_on_load() const noexcept override { return false; }
+	virtual const char *file_extensions() const noexcept override { return "disk,img,bin"; }
+
+	virtual std::pair<std::error_condition, std::string> call_load() override
+	{
+		if (length() != DISK_SIZE)
+			return std::make_pair(image_error::INVALIDLENGTH, "Invalid image size (must be 655360 bytes)");
+		fseek(0, SEEK_SET);
+		if (fread(m_data.get(), DISK_SIZE) != DISK_SIZE)
+			return std::make_pair(image_error::UNSPECIFIED, "Error reading file");
+		m_loaded = true;
+		return std::make_pair(std::error_condition(), std::string());
+	}
+
+	virtual void call_unload() override
+	{
+		m_loaded = false;
+	}
+
+	bool loaded() const { return m_loaded; }
+
+	// 256 bytes of sector data, or nullptr
+	u8 *sector(u8 cyl, u8 sec)
+	{
+		if (!m_loaded || cyl >= 80 || sec >= 32)
+			return nullptr;
+		return &m_data[cyl * 32 * 256 + sec * 256];
+	}
+
+	void write_sector(u8 cyl, u8 sec, const u8 *src)
+	{
+		u8 *d = sector(cyl, sec);
+		if (!d)
+			return;
+		memcpy(d, src, 256);
+		if (!is_readonly())
+		{
+			fseek(cyl * 32 * 256 + sec * 256, SEEK_SET);
+			fwrite(src, 256);
+		}
+	}
+
+	static constexpr u32 DISK_SIZE = 80 * 32 * 256;
+
+protected:
+	virtual void device_start() override
+	{
+		m_data = make_unique_clear<u8[]>(DISK_SIZE);
+		save_pointer(NAME(m_data), DISK_SIZE);
+		save_item(NAME(m_loaded));
+	}
+
+private:
+	std::unique_ptr<u8[]> m_data;
+	bool m_loaded = false;
+};
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE(MICRAL_FLOPPY, micral_floppy_device, "micral_floppy", "Micral/Questar hard-sectored disk")
+
+namespace {
+
+micral_floppy_device::micral_floppy_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, MICRAL_FLOPPY, tag, owner, clock)
+	, device_image_interface(mconfig, *this)
+{
+}
+
+
 class micral_state : public driver_device
 {
 public:
@@ -83,6 +193,7 @@ public:
 		, m_p_chargen(*this, "chargen")
 		, m_uart(*this, "uart")
 		, m_crtc(*this, "crtc")
+		, m_flop(*this, "flop%u", 0U)
 	{ }
 
 	void micral(machine_config &config);
@@ -97,6 +208,17 @@ private:
 	void video_w(offs_t offset, u8 data);
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
+	// floppy
+	u8 fd_stat_r();
+	void fd_sel_w(u8 data);
+	void fd_cmd_w(u8 data);
+	u8 fd_data_r();
+	void fd_data_w(u8 data);
+	int fd_selected_drive() const;
+	void fd_build_stream();
+	void fd_commit_sector();
+	static void fd_chk_update(u8 &d, u8 &e, u8 a);
+
 	void io_kbd(address_map &map) ATTR_COLD;
 	void mem_kbd(address_map &map) ATTR_COLD;
 	void mem_map(address_map &map) ATTR_COLD;
@@ -104,6 +226,23 @@ private:
 	u16 s_curpos = 0U;
 	u8 s_command = 0U;
 	u8 s_data = 0U;
+	u8 s_reg6 = 23U;                 // CRT reg 6: last displayed data row (scroll offset)
+
+	// floppy state
+	u8 m_fd_sel = 0U;                // last write to 0xFFFD
+	u8 m_fd_cmd = 0U;                // last write to 0xFFFE
+	u8 m_fd_cyl[2] = { 0U, 0U };     // head position per drive
+	u8 m_fd_sec_latch = 0U;          // sector+side latched at seek time
+	bool m_fd_seek_done = false;     // status bit 0
+	u8 m_fd_stream[261]{};           // 00, track, sector, 256 data, chk1, chk2
+	int m_fd_bitpos = 0;             // -1 = pad bit, then 8 bits/byte MSB first
+	bool m_fd_reading = false;
+	bool m_fd_writing = false;       // write-start seen with data mode
+	bool m_fd_wr_synced = false;     // sync pattern (...000101) detected
+	u16 m_fd_wr_window = 0U;         // last written bits for sync hunt
+	u32 m_fd_wr_count = 0U;          // bits collected since sync
+	u8 m_fd_wr_buf[261]{};
+
 	std::unique_ptr<u8[]> m_vram;
 	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<cpu_device> m_maincpu;
@@ -113,6 +252,7 @@ private:
 	required_region_ptr<u8> m_p_chargen;
 	required_device<ay31015_device> m_uart;
 	required_device<crt5037_device> m_crtc;
+	required_device_array<micral_floppy_device, 2> m_flop;
 };
 
 u8 micral_state::status_r()
@@ -131,6 +271,222 @@ u8 micral_state::keyin_r()
 	u8 result = m_uart->receive();
 	m_uart->write_rdav(1);
 	return result;
+}
+
+//**************************************************************************
+//  Floppy
+//**************************************************************************
+
+// checksum pair update, exactly as CP/M BIOS routine at F56C:
+//   add a,d / adc a,0 / ld d,a / add a,e / adc a,0 / ld e,a
+void micral_state::fd_chk_update(u8 &d, u8 &e, u8 a)
+{
+	u16 t = u16(a) + d;
+	a = u8(t) + BIT(t, 8);
+	d = a;
+	t = u16(a) + e;
+	a = u8(t) + BIT(t, 8);
+	e = a;
+}
+
+int micral_state::fd_selected_drive() const
+{
+	if (BIT(m_fd_sel, 4))
+		return 0;
+	if (BIT(m_fd_sel, 5))
+		return 1;
+	return -1;
+}
+
+// FFFD read: bit 0 = sector found, bit 1 = track 0, bit 2 = write protected,
+// bit 3 = double sided drive, bit 4 = first command flag
+u8 micral_state::fd_stat_r()
+{
+	int drive = fd_selected_drive();
+	if (drive < 0 || !m_flop[drive]->loaded())
+		return 0x00;
+
+	u8 stat = 0x08;    // Tandon TM100-4 = double sided
+	if (m_fd_seek_done)
+		stat |= 0x01;
+	if (m_fd_cyl[drive] == 0)
+		stat |= 0x02;
+	if (m_flop[drive]->is_readonly())
+		stat |= 0x04;
+	return stat;
+}
+
+// FFFD write: bits 0-3 sector, bit 4 drive 0, bit 5 drive 1
+void micral_state::fd_sel_w(u8 data)
+{
+	m_fd_sel = data;
+}
+
+// FFFE write: bit 0 step direction, bit 1 step pulse, bit 2 ext pinout,
+// bit 3 motor, bit 4 data mode / clear bit counter, bit 5 sector seek,
+// bit 6 write start, bit 7 side select
+void micral_state::fd_cmd_w(u8 data)
+{
+	u8 prev = m_fd_cmd;
+	m_fd_cmd = data;
+
+	int drive = fd_selected_drive();
+
+	// step pulse (rising edge of bit 1)
+	if (BIT(data, 1) && !BIT(prev, 1) && drive >= 0)
+	{
+		if (BIT(data, 0))
+		{
+			if (m_fd_cyl[drive] < 79)
+				m_fd_cyl[drive]++;
+		}
+		else
+		{
+			if (m_fd_cyl[drive] > 0)
+				m_fd_cyl[drive]--;
+		}
+	}
+
+	// sector seek: the hard-sector logic finds the requested sector hole.
+	// Sector and side are latched here: the boot ROM drops the side bit
+	// from the command when it later switches to data mode (writes 1C).
+	if (BIT(data, 5))
+	{
+		m_fd_sec_latch = (m_fd_sel & 0x0f) | (BIT(data, 7) ? 0x10 : 0x00);
+		m_fd_seek_done = (drive >= 0 && m_flop[drive]->loaded());
+	}
+	else if (!BIT(data, 5) && BIT(prev, 5))
+		m_fd_seek_done = false;
+
+	// data mode (rising edge of bit 4): reset the serial bit counter
+	if (BIT(data, 4) && !BIT(prev, 4))
+	{
+		if (BIT(data, 6))
+		{
+			// write: hunt for the software-generated sync pattern
+			m_fd_writing = true;
+			m_fd_reading = false;
+			m_fd_wr_synced = false;
+			m_fd_wr_window = 0;
+			m_fd_wr_count = 0;
+		}
+		else
+		{
+			m_fd_reading = false;
+			m_fd_writing = false;
+			fd_build_stream();
+		}
+	}
+
+	// write start dropped: abort any write in progress
+	if (!BIT(data, 6) && BIT(prev, 6))
+		m_fd_writing = false;
+}
+
+// build the post-sync serial stream for the currently selected
+// drive / head position / sector / side
+void micral_state::fd_build_stream()
+{
+	int drive = fd_selected_drive();
+	if (drive < 0)
+		return;
+
+	u8 cyl = m_fd_cyl[drive];
+	u8 sec = m_fd_sec_latch;
+
+	u8 const *data = m_flop[drive]->sector(cyl, sec);
+	if (!data)
+		return;
+
+	m_fd_stream[0] = 0x00;    // rest of the sync field
+	m_fd_stream[1] = cyl;
+	m_fd_stream[2] = sec;
+	memcpy(&m_fd_stream[3], data, 256);
+
+	u8 d = cyl, e = cyl;
+	fd_chk_update(d, e, sec);
+	for (int i = 0; i < 256; i++)
+		fd_chk_update(d, e, data[i]);
+	m_fd_stream[259] = d;
+	m_fd_stream[260] = e;
+
+	m_fd_bitpos = -1;         // one pad bit before the first byte
+	m_fd_reading = true;
+}
+
+// FFFF read: one bit per access in bit 0 (inverted), bits 1-7 high
+u8 micral_state::fd_data_r()
+{
+	if (!m_fd_reading)
+		return 0xff;
+
+	if (m_fd_bitpos < 0)
+	{
+		if (!machine().side_effects_disabled())
+			m_fd_bitpos++;
+		return 0xfe;
+	}
+
+	if (m_fd_bitpos >= 261 * 8)
+		return 0xff;
+
+	u8 byte = m_fd_stream[m_fd_bitpos >> 3];
+	u8 bit = BIT(byte, 7 - (m_fd_bitpos & 7));
+	if (!machine().side_effects_disabled())
+		m_fd_bitpos++;
+	return 0xfe | (bit ^ 1);
+}
+
+// FFFF write: one bit per access in bit 0 (not inverted).  The software
+// writes a long run of zeros, the sync pattern 101 (making bytes 05 00
+// with the preceding zeros), then 00, track, sector, 256 data bytes and
+// two checksum bytes.
+void micral_state::fd_data_w(u8 data)
+{
+	if (!m_fd_writing)
+		return;
+
+	u8 bit = BIT(data, 0);
+
+	if (!m_fd_wr_synced)
+	{
+		m_fd_wr_window = (m_fd_wr_window << 1) | bit;
+		if ((m_fd_wr_window & 0x3f) == 0x05)    // ...000101
+		{
+			m_fd_wr_synced = true;
+			m_fd_wr_count = 0;
+		}
+		return;
+	}
+
+	if (m_fd_wr_count < 261 * 8)
+	{
+		u32 idx = m_fd_wr_count >> 3;
+		m_fd_wr_buf[idx] = (m_fd_wr_buf[idx] << 1) | bit;
+		m_fd_wr_count++;
+		if (m_fd_wr_count == 261 * 8)
+			fd_commit_sector();
+	}
+}
+
+void micral_state::fd_commit_sector()
+{
+	int drive = fd_selected_drive();
+	if (drive < 0)
+		return;
+
+	u8 cyl = m_fd_wr_buf[1];
+	u8 sec = m_fd_wr_buf[2];
+
+	u8 d = cyl, e = cyl;
+	fd_chk_update(d, e, sec);
+	for (int i = 0; i < 256; i++)
+		fd_chk_update(d, e, m_fd_wr_buf[3 + i]);
+	if (d != m_fd_wr_buf[259] || e != m_fd_wr_buf[260])
+		logerror("fd write: checksum mismatch on C%u S%u (%02X/%02X vs %02X/%02X)\n",
+				cyl, sec, m_fd_wr_buf[259], m_fd_wr_buf[260], d, e);
+
+	m_flop[drive]->write_sector(cyl, sec, &m_fd_wr_buf[3]);
 }
 
 u8 micral_state::video_r(offs_t offset)
@@ -154,6 +510,9 @@ void micral_state::video_w(offs_t offset, u8 data)
 		else
 		if (s_command == 0xa0)
 			m_vram[s_curpos] = s_data;
+		else
+		if ((s_command & 0xbf) == 0x06)    // reg 6: last displayed data row (hardware scroll)
+			s_reg6 = s_data & 0x1f;
 
 		//if (s_command < 0x10)
 			//m_crtc->write(s_command, s_data);
@@ -175,7 +534,9 @@ void micral_state::mem_map(address_map &map)
 	map(0xfffa, 0xfffa).r(FUNC(micral_state::keyin_r));
 	map(0xfffb, 0xfffb).r(FUNC(micral_state::unk_r));
 	map(0xfffc, 0xfffc).r(FUNC(micral_state::status_r));
-	map(0xfffd, 0xffff); // more unknown ports
+	map(0xfffd, 0xfffd).rw(FUNC(micral_state::fd_stat_r), FUNC(micral_state::fd_sel_w));
+	map(0xfffe, 0xfffe).w(FUNC(micral_state::fd_cmd_w));
+	map(0xffff, 0xffff).rw(FUNC(micral_state::fd_data_r), FUNC(micral_state::fd_data_w));
 }
 
 void micral_state::mem_kbd(address_map &map)
@@ -327,10 +688,14 @@ INPUT_PORTS_END
 
 uint32_t micral_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t sy=0,ma=0;
+	uint16_t sy=0;
+	uint8_t const top = (s_reg6 + 1) % 24;    // first displayed data row
 
 	for (uint8_t y = 0; y < 24; y++)
 	{
+		uint8_t const row = (top + y) % 24;
+		uint16_t const ma = row << 8;
+
 		for (uint8_t ra = 0; ra < 10; ra++)
 		{
 			uint16_t *p = &bitmap.pix(sy++);
@@ -342,7 +707,7 @@ uint32_t micral_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 				{
 					uint8_t chr = m_vram[x+ma];
 					gfx = m_p_chargen[(chr<<4) | ra ];
-					if (((s_curpos & 0xff)==x) && ((s_curpos >> 8)==y))
+					if (((s_curpos & 0xff)==x) && ((s_curpos >> 8)==row))
 						gfx ^= 0xff;
 				}
 				/* Display a scanline of a character */
@@ -356,13 +721,19 @@ uint32_t micral_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap
 				*p++ = BIT(gfx, 0);
 			}
 		}
-		ma+=256;
 	}
 	return 0;
 }
 
 void micral_state::machine_reset()
 {
+	m_fd_sel = 0;
+	m_fd_cmd = 0;
+	m_fd_seek_done = false;
+	m_fd_reading = false;
+	m_fd_writing = false;
+	s_reg6 = 23;
+
 	// no idea if these are hard-coded, or programmable
 	m_uart->write_xr(0);
 	m_uart->write_xr(1);
@@ -402,6 +773,20 @@ void micral_state::machine_start()
 	save_item(NAME(s_curpos));
 	save_item(NAME(s_command));
 	save_item(NAME(s_data));
+	save_item(NAME(s_reg6));
+	save_item(NAME(m_fd_sel));
+	save_item(NAME(m_fd_cmd));
+	save_item(NAME(m_fd_cyl));
+	save_item(NAME(m_fd_sec_latch));
+	save_item(NAME(m_fd_seek_done));
+	save_item(NAME(m_fd_stream));
+	save_item(NAME(m_fd_bitpos));
+	save_item(NAME(m_fd_reading));
+	save_item(NAME(m_fd_writing));
+	save_item(NAME(m_fd_wr_synced));
+	save_item(NAME(m_fd_wr_window));
+	save_item(NAME(m_fd_wr_count));
+	save_item(NAME(m_fd_wr_buf));
 }
 
 void micral_state::micral(machine_config &config)
@@ -443,6 +828,9 @@ void micral_state::micral(machine_config &config)
 	uart_clock.signal_handler().append(m_uart, FUNC(ay31015_device::write_rcp));
 
 	RS232_PORT(config, "rs232", default_rs232_devices, "keyboard");
+
+	MICRAL_FLOPPY(config, m_flop[0]);
+	MICRAL_FLOPPY(config, m_flop[1]);
 }
 
 ROM_START( micral )
@@ -475,5 +863,5 @@ ROM_END
 /* Driver */
 
 //    YEAR  NAME      PARENT  COMPAT  MACHINE  INPUT   CLASS         INIT         COMPANY           FULLNAME         FLAGS
-COMP( 1981, micral,   0,      0,      micral,  micral, micral_state, empty_init, "Bull R2E",       "Micral 80-22G", MACHINE_NO_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
-COMP( 1982, questarm, micral, 0,      micral,  micral, micral_state, empty_init, "Honeywell Bull", "Questar/M",     MACHINE_NO_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
+COMP( 1981, micral,   0,      0,      micral,  micral, micral_state, empty_init, "Bull R2E",       "Micral 80-22G", MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )
+COMP( 1982, questarm, micral, 0,      micral,  micral, micral_state, empty_init, "Honeywell Bull", "Questar/M",     MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
## What this does

Emulates the previously-missing floppy disk system of the Bull R2E Micral 80-22G / Honeywell Bull Questar/M (`skeleton/micral.cpp`), promoting both machines from skeletons to working: they now boot their two real operating systems from the surviving disk dumps.

- **CP/M 2.2** — type `B0` at the monitor → `R2E 8021 57k CP/M vers 2.23` → `A>` prompt; `DIR`, `DDT`, etc. work interactively.
- **Prologue/QMOS 1.A (22/10/82)** — type `B0,8` → QMOS banner and `->` prompt.

```
R2E 8021 57k CP/M vers 2.23

A>DIR
A: FORMAT   COM : PIP      COM : SUBMIT   COM : XSUB     COM
A: ED       COM : ASM      COM : DDT      COM : LOAD     COM
...
```

## Implementation notes

The FDC is discrete logic (no standard controller chip). The CPU talks to it through three memory-mapped registers:

- `0xFFFD` — drive/sector select (write) / status (read: sector found, track 0, write protect, double-sided)
- `0xFFFE` — command (step direction/pulse, motor, data mode + bit-counter clear, sector seek, write start, side select)
- `0xFFFF` — **bit-serial data**: one bit per access in bit 0, inverted on read; bytes are assembled MSB-first by the software

Per-sector stream after the hard-sector sync: `00 TT SS` + 256 data bytes + two checksum bytes. The checksum pair (left as unsolved in the 2019 forum thread) turned out to be a running one's-complement sum plus a second-order sum of the running sums, as implemented by the CP/M BIOS routine on the disk itself — the driver reproduces that algorithm exactly (`fd_chk_update`). The side bit is latched at sector-seek time because the boot ROM drops it from the command when it switches to data mode. Writing is also emulated (sync-pattern hunt + sector commit with write-back to the image), since CP/M is a read/write OS.

Also implemented: CRT register 6 hardware scrolling, which the OS console uses.

Media: a new in-driver `micral_floppy_device` image device (`-flop1`/`-flop2`) for the raw 640K decoded images (80 cyl × 32 sectors × 256 bytes). A software list for the two known disks can follow in a separate PR if desired.

## Sources and acknowledgements

- **aquarius** (forums.bannister.org) dumped the Questar/M BIOS and the CP/M/QMOS floppies and reverse-engineered the hard-sectored track format — this PR is the "it would be great if one of the devs could add the floppy system" from that thread, seven years later: https://forums.bannister.org/ubbthreads.php?ubb=showflat&Number=115424
- **rfka01** added the Questar/M BIOS to the driver back in 2019.
- The **forum.system-cfg.com** community published reverse-engineered Micral 80-22G schematics (including the full FD subsystem) and a commented disassembly of the boot ROM, which documented the register interface.
- **Robbbert** wrote the original skeleton driver this builds on.

The remaining checksum/protocol details were reverse-engineered for this PR from a disassembly of the CP/M BIOS contained on the disk dumps. All new code is original work submitted under the file's existing BSD-3-Clause license; no third-party code was copied.

## Testing

- `micral` and `questarm` × `B0` (CP/M) and `B0,8` (QMOS): all four combinations boot and reach their prompts (verified headless by dumping video RAM through the CRT ports, and interactively under SDL).
- Side-2 reads (logical sectors 16-31), track stepping, and multi-sector program loads (`DDT` loads and runs) exercised; `-validate` passes.
- Known limitations kept from the skeleton and documented in the header: keyboard still goes through the generic serial-keyboard hack (the real keyboard MCU is dumped but unwired), chargen is a BAD_DUMP borrowed from the C10, no beeper — hence `MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS`.

## AI assistance disclosure

Per the contribution guidelines: this change was developed with AI assistance — **Claude Fable 5 (model `claude-fable-5`, Anthropic)**, which performed the reverse engineering and wrote the driver code under the submitter's direction; the submitter reviewed and tested the result. The commit carries a `Co-Authored-By` trailer accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
