### PR TITLE
sega/model1: Return the latched count when reading a stopped timer (fixes vf hair physics regression from #15642)

### DIFF
--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -871,7 +871,8 @@ void model1_state::sound_ready_w(int state)
 u16 model1_state::timer_r(offs_t offset)
 {
 	u16 result = m_timer_val[offset];
-	if (m_irq0_timer[offset]->enabled())
+
+	if (m_timer_period[offset])
 	{
 		uint32_t ticks = m_irq0_timer[offset]->remaining().as_ticks(m_maincpu->clock());
 		result = ticks / 0x800;


### PR DESCRIPTION
## What this fixes

A regression I introduced in #15642, and I want to start with an apology for it: while making the GLUE timer emulation more faithful to the hardware, I broke Virtua Fighter's hair physics — Sarah's ponytail, Lau's braid and Kage's scarf disappear from the attract demos. My visual testing for that PR failed to catch it, and I'm sorry for the noise. 

## The Fix

I had mistaken the timer's enabled flag for the counter actually running; gate the live count read on the period register instead, so a parked timer returns the latched value.

Claude Fable 5 (Anthropic) was used in the investigation and development of this fix.
