### PR TITLE
video/zeus2: Fix Cruis'n Exotica road rendering

### DIFF
--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1569,23 +1569,6 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 	// AYp = (AZ * M12) + (AY * M11) + (AX * M10) + TY
 	// AXp = (AZ * M02) + (AY * M01) + (AX * M00) + TX
 
-	// Fast HSR Removal
-	if (1)
-	{
-		float PZr;
-
-		int8_t normal[3];
-		normal[0] = databuffer[0] >> 0;
-		normal[1] = databuffer[0] >> 8;
-		normal[2] = databuffer[0] >> 16;
-
-		PZr = normal[0] * m_state->zeus_matrix[2][0] + normal[1] * m_state->zeus_matrix[2][1] + normal[2] * m_state->zeus_matrix[2][2] + m_state->zeus_trans[3];
-
-		//m_state->logerror("norm: %i %i %i PZr: %f\n", normal[0], normal[1], normal[2], PZr);
-		if (PZr >= 0)
-			return;
-	}
-
 	/* extract raw x,y,z */
 	if (m_state->m_atlantis) {
 			// Atlantis quad 14

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1677,6 +1677,7 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 		vert[i].p[2] += (texdata >> 16);
 		vert[i].p[1] *= 256.0f;
 		vert[i].p[2] *= 256.0f;
+		vert[i].p[3] = 0.0f;
 
 
 
@@ -1693,13 +1694,13 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 			unknownFloat[0], unknownFloat[1], unknownFloat[2], unknownFloat[3]);
 	}
 
-	// Z Clipping, done before clamp to 0
+	// Near-plane clip straddling quads instead of rejecting them (which dropped the nearest
+	// crusnexo road segment), matching the Zeus 1 renderer.
 	float clipVal = reinterpret_cast<float&>(m_state->m_zeusbase[0x78]);
-	for (int i = 0; i < 4; i++)
-	{
-		if (vert[i].p[0] < clipVal)
-			return;
-	}
+	z2_poly_vertex clipvert[8];
+	int numverts = zclip_if_less<4>(4, vert, clipvert, clipVal);
+	if (numverts < 3)
+		return;
 
 	float xOrigin = reinterpret_cast<float&>(m_state->m_zeusbase[0x6a]);
 	float yOrigin = reinterpret_cast<float&>(m_state->m_zeusbase[0x6b]);
@@ -1708,38 +1709,36 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 	float zRound = (m_state->m_system == m_state->CRUSNEXO) ? 2.0f : 0.5f;
 
 	float oozBase = 1 << m_state->m_zeusbase[0x6c];
-	float ooz;
-	for (int i = 0; i < 4; i++)
+	for (int i = 0; i < numverts; i++)
 	{
 		// Clamp to zero if negative
-		if (vert[i].p[0] < 0)
-			vert[i].p[0] = 0.0f;
+		if (clipvert[i].p[0] < 0)
+			clipvert[i].p[0] = 0.0f;
 
-		ooz = oozBase / (vert[i].p[0] + zRound);
+		float ooz = oozBase / (clipvert[i].p[0] + zRound);
 
-		if (1) {
-			//vert[i].p[0] += reinterpret_cast<float&>(m_state->m_zeusbase[0x63]);
-			vert[i].x *= ooz;
-			vert[i].y *= ooz;
-			//vert[i].p[0] = ooz;
-		}
+		clipvert[i].x *= ooz;
+		clipvert[i].y *= ooz;
+		// Perspective-correct texturing: carry u/z, v/z and 1/z for the per-pixel divide.
+		clipvert[i].p[1] *= ooz;
+		clipvert[i].p[2] *= ooz;
+		clipvert[i].p[3] = ooz;
 
-		vert[i].x += xOrigin;
-		vert[i].y += yOrigin;
+		clipvert[i].x += xOrigin;
+		clipvert[i].y += yOrigin;
 		// The Grid adds zoffset for objects with no light
 		if (m_state->m_useZOffset)
-			vert[i].p[0] += m_state->zeus_light[2];
+			clipvert[i].p[0] += m_state->zeus_light[2];
 
-		//clipvert[i].p[0] *= 65536.0f * 16.0f;
-		vert[i].p[0] *= 4096.0f * 1.0f;  // 12.12
+		clipvert[i].p[0] *= 4096.0f;  // 12.12
 
 		if (logextra & logit)
-			m_state->logerror("\t\t\tTranslated=(%f,%f, %f) scale = %f\n", (double)vert[i].x, (double)vert[i].y, (double)vert[i].p[0], ooz);
+			m_state->logerror("\t\t\tTranslated=(%f,%f, %f) scale = %f\n", (double)clipvert[i].x, (double)clipvert[i].y, (double)clipvert[i].p[0], ooz);
 	}
 	// Slow HSR
 	// ((AYs - BYs) * (BXs - CXs)) - ((AXs - BXs) * (BYs - CYs))
 	if (1) {
-		float slowHSR = ((vert[0].y - vert[1].y) * (vert[1].x - vert[2].x) - (vert[0].x - vert[1].x) * (vert[1].y - vert[2].y));
+		float slowHSR = ((clipvert[0].y - clipvert[1].y) * (clipvert[1].x - clipvert[2].x) - (clipvert[0].x - clipvert[1].x) * (clipvert[1].y - clipvert[2].y));
 		if (slowHSR >= 0)
 			return;
 	}
@@ -1793,9 +1792,7 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 		break;
 	}
 
-	//if (numverts == 3)
-	//  render_triangle<4>(m_state->zeus_cliprect, render_delegate(&zeus2_renderer::render_poly_8bit, this), vert[0], vert[1], vert[2]);
-	render_polygon<4, 4>(m_state->zeus_cliprect, render_delegate(&zeus2_renderer::render_poly_8bit, this), vert);
+	render_triangle_fan<4>(m_state->zeus_cliprect, render_delegate(&zeus2_renderer::render_poly_8bit, this), numverts, clipvert);
 }
 
 
@@ -1807,13 +1804,14 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, const zeus2_poly_extra_data& object, int threadid)
 {
 	int32_t curz = extent.param[0].start;
-	int32_t curu = extent.param[1].start;
-	int32_t curv = extent.param[2].start;
-	//  int32_t curi = extent.param[3].start;
+	// Perspective-correct texturing: params 1/2 hold u/z and v/z, param 3 holds 1/z.
+	float curupz = extent.param[1].start;
+	float curvpz = extent.param[2].start;
+	float curooz = extent.param[3].start;
 	int32_t dzdx = extent.param[0].dpdx;
-	int32_t dudx = extent.param[1].dpdx;
-	int32_t dvdx = extent.param[2].dpdx;
-	//  int32_t didx = extent.param[3].dpdx;
+	float dupzdx = extent.param[1].dpdx;
+	float dvpzdx = extent.param[2].dpdx;
+	float doozdx = extent.param[3].dpdx;
 	const void *texbase = object.texbase;
 	//const void *palbase = object.palbase;
 	uint16_t transcolor = object.transcolor;
@@ -1851,8 +1849,14 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 				depth_pass = false;
 		}
 		if (depth_pass) {
-			int u0 = (curu >> 8);// &(texwidth - 1);
-			int v0 = (curv >> 8);// &255;
+			// Perspective divide for texel coords; clamp guards the clipped near edge.
+			float oozInv = 1.0f / curooz;
+			int32_t curu = (int32_t)(curupz * oozInv);
+			int32_t curv = (int32_t)(curvpz * oozInv);
+			int u0 = (curu >> 8);
+			int v0 = (curv >> 8);
+			if (u0 < 0) u0 = 0;
+			if (v0 < 0) v0 = 0;
 			int u1 = (u0 + 1);
 			int v1 = (v0 + 1);
 			if (object.texture_rgb555) {
@@ -1968,9 +1972,9 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 			}
 		}
 		curz += dzdx;
-		curu += dudx;
-		curv += dvdx;
-		//      curi += didx;
+		curupz += dupzdx;
+		curvpz += dvpzdx;
+		curooz += doozdx;
 	}
 }
 


### PR DESCRIPTION
This PR fixes the Cruis'n Exotica road rendering in two ways:

**1. Road disappearing** 
The "Fast HSR Removal" pre-cull code block tested only the view-space Z of the polygon normal (normal * matrix_row2).  For near-horizontal surfaces such as the road, the sign flips at shallow viewing angles and whole road quads that genuinely face the camera got culled. Removing this fast block so the slow path always ran, made the road pop in.

**2. Nearest road segment missing** 
Quads straddling the near plane were rejected outright, dropping the closest road strip, causing black bands at the bottom of the screen. They are now clipped against the near plane and drawn as a triangle fan, matching what midzeus_v.cpp already does. Filling that geometry exposed affine-texturing warping on the steeply foreshortened near road, so perspective correction was added.

Master:
<img width="375" alt="crusnexo_A2" src="https://github.com/user-attachments/assets/953e7938-1de6-4538-8ccc-435738b4e9fb" /><img width="375" alt="crusnexo_B2" src="https://github.com/user-attachments/assets/380f2183-8e1f-4825-a62c-5e3ceb20b785" />

PR:
<img width="375" alt="crusnexo_A1" src="https://github.com/user-attachments/assets/b281ec69-e5e4-4b0a-9c30-6fd91f6244a2" /><img width="375" alt="crusnexo_B1" src="https://github.com/user-attachments/assets/fa755078-04ae-423c-ba02-2a02350e9f84" />

Assisted by Claude Opus 4.8. Human polished and regression tested on The Grid and Midway Skins, which also improved.