### PR TITLE
video/zeus2: Rendering improvements (solid fills, depth clear, translucency)

### DIFF
--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1763,8 +1763,9 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 	extra.depth_clear_enable = (m_state->m_renderRegs[0x14] & 0x000c00);
 	// 021e0e = blend with texture alpha for type 2, 020202 blend src / dst alpha
 	extra.blend_enable = ((m_state->m_renderRegs[0x40] == 0x020202) || (m_state->m_renderRegs[0x40] == 0x021e0e && (texmode & 0x3) == 2));
-	extra.srcAlpha = m_state->m_renderRegs[0x0c];
-	extra.dstAlpha = m_state->m_renderRegs[0x0d];
+	// Clamp translucency (1.8 fixed, 0x100=1.0) to 0x100: scale8() takes a uint8_t, so >=0x100 would truncate to near-black.
+	extra.srcAlpha = std::min<uint32_t>(m_state->m_renderRegs[0x0c], 0x100);
+	extra.dstAlpha = std::min<uint32_t>(m_state->m_renderRegs[0x0d], 0x100);
 	extra.texture_alpha = false;
 	extra.texture_rgb555 = false;
 	switch (texmode & 0x3) {

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -842,10 +842,12 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 				}
 				if (logit)
 					logerror(" -- Clearing buffer: numPixels: %08X addr: %08X reg51: %08X", numPixels, addr, m_zeusbase[0x51]);
+				// A depth clear of 0 (nearest) rejects all later depth-tested geometry; reset to far instead.
+				int32_t clearDepth = (m_fill_depth == 0) ? 0xffffff : m_fill_depth;
 				for (int count = 0; count < numPixels; count++) {
 					// Crusn wraps the frame buffer during fill so need to mask address
 					m_frameColor[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = m_fill_color;
-					m_frameDepth[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = m_fill_depth;
+					m_frameDepth[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = clearDepth;
 				}
 			}
 			break;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -838,7 +838,6 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 				if (m_zeusbase[0x50] & 0x10000) {
 					addr = 0x0;
 					numPixels = WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 8;
-					printf("Clearing buffer: numPixels: %08X addr: %08X reg50: %08X\n", numPixels, addr, m_zeusbase[0x50]);
 				}
 				if (logit)
 					logerror(" -- Clearing buffer: numPixels: %08X addr: %08X reg51: %08X", numPixels, addr, m_zeusbase[0x51]);
@@ -1751,7 +1750,9 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 	extra.tex_src = m_state->zeus_texbase;
 	int texmode = texdata & 0xffff;
 	extra.texwidth = 0x20 << ((texmode >> 2) & 3);
-	extra.solidcolor = 0;//m_zeusbase[0x00] & 0x7fff;
+	extra.solidcolor = m_state->m_zeusbase[0x00] & 0x7fff;
+	// Flat solid-color fill: texmode bits 10-11 both set (same as Zeus 1)
+	extra.solid_enable = ((texmode & 0x0c00) == 0x0c00);
 	extra.transcolor = (texmode & 0x180) ? 0 : 0x100;
 	extra.texbase = WAVERAM_BLOCK0_EXT(m_state->zeus_texbase);
 	extra.depth_min_enable = true;// (m_state->m_renderRegs[0x14] & 0x008000);
@@ -1803,6 +1804,27 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 *  Rasterizers
 *************************************/
 
+// Blend srcColor into a frame buffer pixel and update depth; shared by the solid-fill and textured paths.
+static inline void zeus2_write_pixel(uint32_t &colorpix, int32_t &depthpix, rgb_t srcColor,
+	bool blend_enable, int32_t srcAlpha, int32_t dstAlpha, bool depth_write_enable, int32_t depthVal)
+{
+	if (blend_enable) {
+		// If src alpha is 0 don't write
+		if (srcAlpha == 0x00)
+			return;
+		rgb_t dstColor = colorpix;
+		if (srcAlpha != 0x100)
+			srcColor.scale8(srcAlpha);
+		if (dstAlpha == 0x100)
+			srcColor += dstColor;
+		else
+			srcColor += dstColor.scale8(dstAlpha);
+	}
+	colorpix = srcColor;
+	if (depth_write_enable)
+		depthpix = depthVal; // Should limit to 24 bits
+}
+
 void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, const zeus2_poly_extra_data& object, int threadid)
 {
 	int32_t curz = extent.param[0].start;
@@ -1821,6 +1843,8 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 	int32_t dstAlpha = object.dstAlpha;
 	bool depth_write_enable = object.depth_write_enable;
 	int texwidth = object.texwidth;
+	// RGB555 solidcolor expanded to RGB32
+	uint32_t solidColor = ((object.solidcolor & 0x7c00) << 9) | ((object.solidcolor & 0x3e0) << 6) | ((object.solidcolor & 0x1f) << 3);
 	int x;
 
 	uint32_t addr = m_state->frame_addr_from_xy(0, scanline, true);
@@ -1861,7 +1885,11 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 			if (v0 < 0) v0 = 0;
 			int u1 = (u0 + 1);
 			int v1 = (v0 + 1);
-			if (object.texture_rgb555) {
+			if (object.solid_enable) {
+				zeus2_write_pixel(colorptr[x], depthptr[x], solidColor, object.blend_enable,
+					srcAlpha, dstAlpha, depth_write_enable, curDepthVal);
+			}
+			else if (object.texture_rgb555) {
 				// Rendering for textures with direct color
 				rgb_t srcColor = m_state->get_rgb555(texbase, v0, u0, texwidth);
 				colorptr[x] = srcColor;
@@ -1932,32 +1960,8 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 					uint32_t color2 = m_state->m_pal_table[texel2];
 					uint32_t color3 = m_state->m_pal_table[texel3];
 					rgb_t srcColor = rgbaint_t::bilinear_filter(color0, color1, color2, color3, curu, curv);
-					if (object.blend_enable) {
-						// Need to check if this is correct or use incoming dstAlpha
-						//dstAlpha = 0x100 - srcAlpha;
-
-						// If src alpha is 256 don't blend
-						if (1 || srcAlpha != 0x100) {
-							rgb_t dstColor = colorptr[x];
-							if (srcAlpha != 0x100)
-								srcColor.scale8(srcAlpha);
-							if (dstAlpha == 0x100)
-								srcColor += dstColor;
-							else
-								srcColor += dstColor.scale8(dstAlpha);
-						}
-						// If src alpha is 0 don't write
-						if (srcAlpha != 0x00) {
-							colorptr[x] = srcColor;
-							if (depth_write_enable)
-								depthptr[x] = curDepthVal; // Should limit to 24 bits
-						}
-					}
-					else {
-						colorptr[x] = srcColor;
-						if (depth_write_enable)
-							depthptr[x] = curDepthVal; // Should limit to 24 bits
-					}
+					zeus2_write_pixel(colorptr[x], depthptr[x], srcColor, object.blend_enable,
+						srcAlpha, dstAlpha, depth_write_enable, curDepthVal);
 				}
 			// Rendering for textures with transparent color
 			//} else {

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -29,6 +29,8 @@ zeus2_renderer::zeus2_renderer(zeus2_device *state)
 
 DEFINE_DEVICE_TYPE(ZEUS2, zeus2_device, "zeus2", "Midway Zeus2")
 
+uint8_t *zeus2_device::s_waveram_base = nullptr;
+
 zeus2_device::zeus2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, ZEUS2, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
@@ -75,6 +77,7 @@ void zeus2_device::device_start()
 {
 	/* allocate memory for "wave" RAM */
 	m_waveram = std::make_unique<uint32_t[]>(WAVERAM0_WIDTH * WAVERAM0_HEIGHT * 8/4);
+	s_waveram_base = reinterpret_cast<uint8_t *>(m_waveram.get());
 	m_frameColor = std::make_unique<uint32_t[]>(WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2);
 	m_frameDepth = std::make_unique<int32_t[]>(WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2);
 

--- a/src/devices/video/zeus2.h
+++ b/src/devices/video/zeus2.h
@@ -52,6 +52,7 @@ struct zeus2_poly_extra_data
 	uint32_t          tex_src;
 	bool            texture_alpha;
 	bool            texture_rgb555;
+	bool            solid_enable;
 	bool            blend_enable;
 	int32_t         zbuf_min;
 	bool            depth_min_enable;

--- a/src/devices/video/zeus2.h
+++ b/src/devices/video/zeus2.h
@@ -71,11 +71,15 @@ struct zeus2_poly_extra_data
 #define WAVERAM_BLOCK0(blocknum)                ((void *)((uint8_t *)m_waveram.get() + 8 * (blocknum)))
 #define WAVERAM_BLOCK0_EXT(blocknum)            ((void *)((uint8_t *)m_state->m_waveram.get() + 8 * (blocknum)))
 
-#define WAVERAM_PTR8(base, bytenum)             ((uint8_t *)(base) + BYTE4_XOR_LE(bytenum))
+// Texel addressing wraps within waveram: crusnexo puts textures near the end of the buffer
+// and addresses rows past it, so a fetch that runs off the end must continue from the start.
+#define WAVERAM_WRAP(base, bytenum)             (s_waveram_base + (uint32_t((uint8_t *)(base) - s_waveram_base + (bytenum)) & (WAVERAM0_WIDTH * WAVERAM0_HEIGHT * 8 - 1)))
+
+#define WAVERAM_PTR8(base, bytenum)             WAVERAM_WRAP(base, BYTE4_XOR_LE(bytenum))
 #define WAVERAM_READ8(base, bytenum)            (*WAVERAM_PTR8(base, bytenum))
 #define WAVERAM_WRITE8(base, bytenum, data)     do { *WAVERAM_PTR8(base, bytenum) = (data); } while (0)
 
-#define WAVERAM_PTR16(base, wordnum)            ((uint16_t *)(base) + BYTE_XOR_LE(wordnum))
+#define WAVERAM_PTR16(base, wordnum)            ((uint16_t *)WAVERAM_WRAP(base, 2 * BYTE_XOR_LE(wordnum)))
 #define WAVERAM_READ16(base, wordnum)           (*WAVERAM_PTR16(base, wordnum))
 #define WAVERAM_WRITE16(base, wordnum, data)    do { *WAVERAM_PTR16(base, wordnum) = (data); } while (0)
 
@@ -142,6 +146,7 @@ public:
 	bool m_useZOffset;
 
 	std::unique_ptr<uint32_t[]> m_waveram;
+	static uint8_t *s_waveram_base;     // m_waveram start, for WAVERAM_WRAP
 	std::unique_ptr<uint32_t[]> m_frameColor;
 	std::unique_ptr<int32_t[]> m_frameDepth;
 	uint32_t m_pal_table[0x100];


### PR DESCRIPTION
This PR improves the following Cruis'n Exotica rendering items:

**1. Guard fast clear**
The fast-clear path wrote the fill depth verbatim into the depth buffer. A fill depth of 0 clears the buffer to the nearest plane, which then rejects every quad drawn afterwards. The clear now substitutes the far value (0xffffff) when the fill depth is 0.
This fixes the black overlay sticking when finishing races.

**2. Add untextured solid-color quads**
Quads whose texmode has bits 10-11 both set are flat solid-color fills that use register 0x00 as an RGB555 color, with no texture (same as Zeus 1). Zeus 2 previously ignored this and textured those quads, drawing wrong textures as a consequence.
This fixes the Cruis'n Exotica attract-mode flag girl appearing three times behind herself.

**3. Clamp translucency factors**
Translucency factors in render regs 0x0c/0x0d are 1.8 fixed-point (0x100 = 1.0) and can exceed 0x100. They are passed to rgb_t::scale8(), whose argument is a uint8_t, so a factor of 0x100 or above would overflow, scaling colors to almost black.
This fixes the random brightness of the cars.

Master:
<img width="375" alt="0000" src="https://github.com/user-attachments/assets/68255557-896d-4b62-81e7-157fe82cbf22" /><img width="375" alt="0011" src="https://github.com/user-attachments/assets/0de0bf60-de49-4671-9b5a-ca26c7bb98e0" />

PR:
<img width="375" alt="0025" src="https://github.com/user-attachments/assets/58ee89fa-8beb-4341-b00c-74069fefb770" /><img width="375" alt="0046" src="https://github.com/user-attachments/assets/3009463a-382c-41e3-8149-b3b8673c23a3" />

- fix MT8615 (Zeus2 side)

Assisted by Claude Opus 4.8. Human polished and regression tested on The Grid and Skins Game.