### PR TITLE
xerox/xerox820.cpp: mark bigboard5 as working

### DIFF
--- a/src/mame/xerox/xerox820.cpp
+++ b/src/mame/xerox/xerox820.cpp
@@ -1458,7 +1458,7 @@ ROM_END
 
 //    YEAR  NAME      PARENT    COMPAT  MACHINE      INPUT     CLASS             INIT        COMPANY                       FULLNAME                          FLAGS
 COMP( 1980, bigboard, 0,        0,      bigboard,    xerox820, bigboard_state,   empty_init, "Digital Research Computers", "Big Board",                      0 )
-COMP( 1980, bigboard5,bigboard, 0,      bigboard5,   xerox820, bigboard_state,   empty_init, "Digital Research Computers", "Big Board (5.25\" drives)",      MACHINE_NOT_WORKING )
+COMP( 1980, bigboard5,bigboard, 0,      bigboard5,   xerox820, bigboard_state,   empty_init, "Digital Research Computers", "Big Board (5.25\" drives)",      0 )
 COMP( 1981, x820,     bigboard, 0,      xerox820,    xerox820, xerox820_state,   empty_init, "Xerox",                      "Xerox 820",                      MACHINE_NO_SOUND_HW )
 COMP( 1982, mk82,     bigboard, 0,      bigboard,    xerox820, bigboard_state,   empty_init, "Scomar",                     "MK-82",                          0 )
 COMP( 1983, x820ii,   0,        0,      xerox820ii,  xerox820, xerox820ii_state, empty_init, "Xerox",                      "Xerox 820-II (8\" floppy)",      0 )


### PR DESCRIPTION
The Big Board 5.25" variant (`bigboard5`) has been flagged `MACHINE_NOT_WORKING` since it was added, but it boots CP/M correctly from the Xerox 820 software list.

`bigboard5()` calls `xerox820()`, so the machine already inherits `SOFTWARE_LIST(config, "flop_list").set_original("xerox820")`. The `cpm` entry (`130s22100ds_cpmrev3.imd` — Xerox 820 CP/M rev 3.000, 40 tracks x 18 sectors x 128 bytes FM) is single-density 5.25" media matching what the SA-400 field modification used.

```
mame bigboard5 cpm
```

The ROM monitor comes up, `B` loads CP/M from drive A, and the system reaches the `A>` prompt:

```
... system monitor 3.3 ...

* B

COPYRIGHT (C) 1981, XEROX CORPORATION

CP/M REG. TM 2.2  SY 3.00  2-294 BS0066226

A>
```

`DIR` reads the directory correctly, and a Ctrl-C warm boot reloads the CCP from the reserved tracks and returns to the prompt — so both the cold-boot path (ROM monitor sector read) and the CBIOS warm-boot path work.

No 5.25" media existed in the tree to exercise this machine, which is likely why the flag was never revisited. The driver's existing form-factor handling already covers the variant: `disk_drvsel_w()` switches the FD1771 clock on the drive's form factor, and `bigboard5()` leaves it at the 5.25" 1 MHz rate.

Verified against a clean master build with no other local patches, on macOS/SDL3 x86-64. Full `-validate` passes.

Scope note: floppy and console only — I have not exercised the beeper or the serial port on this variant.

Claude Opus (via Claude Code) assisted with the boot verification and drafting; reviewed and validated by me.

