### PR TITLE
debugger/debuggdbstub.cpp: Add rp2a03g as m6502 alias to enable NES/Famicom debug

### DIFF
--- a/src/osd/modules/debugger/debuggdbstub.cpp
+++ b/src/osd/modules/debugger/debuggdbstub.cpp
@@ -666,6 +666,7 @@ static const std::map<std::string, const gdb_register_map &> gdb_register_maps =
 	{ "m6510",      gdb_register_map_m6502 },
 	{ "m65ce02",    gdb_register_map_m6502 },
 	{ "rp2a03",     gdb_register_map_m6502 },
+	{ "rp2a03g",    gdb_register_map_m6502 },
 	{ "w65c02",     gdb_register_map_m6502 },
 	{ "w65c02s",    gdb_register_map_m6502 },
 	{ "m6809",      gdb_register_map_m6809 },


### PR DESCRIPTION
This change restores remote debug for NES and Famicom systems, via `-debug -debugger gdbstub`.

This was previously added by PR #7440 (released in [MAME 0.227](https://github.com/mamedev/mame/releases/tag/mame0227), December 2020), but I believe was broken by PR #10299 (released in [MAME 0.248](https://github.com/mamedev/mame/releases/tag/mame0248), September 2022), which discriminated between different steppings of the NES CPU in order to improve audio accuracy.

The small number of machines which shipped with the original stepping kept the old CPU name and can be debugged, where more common (later) NES/Famicom variants were switched over to a new CPU type that has a "G" suffix, which the debugger does not know about.

Both chips have a standard set of 6502 registers and are interchangeable for debug purposes.

### Current situation

I'm using MAME installed from `apt` on Debian testing.

```
$ mame -version
0.288 (unknown)
```

Attempting this debug command causes a warning, then a segfault. Any iNES file will show the issue, the one here is [an open source homebrew game](https://github.com/mike42/8bit-table-tennis/releases/tag/v1.0) of mine so that this can be easily replicated.

```
$ mame nes -debug -debugger gdbstub -debugger_port 2159 -debugger_host 127.0.0.1 -window -nomouse  -cart table_tennis.nes
Ignoring MAME exception: gdbstub: cpuname rp2a03g not found in gdb stub descriptions

Fatal error: gdbstub: cpuname rp2a03g not found in gdb stub descriptions

Segmentation fault         mame nes -debug -debugger gdbstub -debugger_port 2159 -debugger_host 127.0.0.1 -window -nomouse -cart table_tennis.nes
```

I'm working around this by using the `famicomo` machine type, but want this to work for the more common variants of the console.

```
$ mame famicomo -debug -debugger gdbstub -debugger_port 2159 -debugger_host 127.0.0.1 -window -nomouse  -cart table_tennis.nes
gdbstub: listening on address 127.0.0.1 port 2159
```

### With fix

```
$ git show --oneline -s
d7fe70f3391 (HEAD -> master, origin/master, origin/HEAD) debugger/debuggdbstub.cpp: add rp2a03g as m6502 alias
$ ./mame nes -debug -debugger gdbstub -debugger_port 2159 -debugger_host 127.0.0.1 -window -nomouse -cart table_tennis.nes 
gdbstub: listening on address 127.0.0.1 port 2159
...
```

This is not a repeatable test, but I'm confident that debugging does work! I'm writing a tool which uses this debug interface, and this animation shows a breakpoints firing, and register values being shown correctly as I single-step the code. MAME is started with `mame nes` here (full command at the top of the screen is from a previous launch).

https://github.com/user-attachments/assets/fb3db76f-1ce8-453b-910a-2abd3bbde69b

This is my first MAME PR, apologies if any of the terminology is not quite correct. :smile:
