### PR TITLE
s3000.cpp - Set floppy state as HD if it is HD

### DIFF
--- a/src/mame/akai/s3000.cpp
+++ b/src/mame/akai/s3000.cpp
@@ -380,7 +380,7 @@ void s3000_state::floppy_led_cb(floppy_image_device *, int state)
 uint8_t s3000_state::fdc_hc365_r()
 {
 	const auto imagedev = m_floppy->get_device();
-	return (imagedev->floppy_is_hd() ? 0x04 : 0x00) | imagedev->dskchg_r();
+	return (imagedev->floppy_is_hd() ? 0x00 : 0x04) | imagedev->dskchg_r();
 }
 
 static constexpr uint8_t s3000_memory_magic[9*8] =


### PR DESCRIPTION
I have dumped a couple disks to MFI which refused to load. According to the comment the bits should be set

```
// bit 2 = /HDD (high density if 0, double density if 1)
```

so I think the HD conditional got flipped. With this change both my S900 DD and S1000 HD disks load.