### PR TITLE
dataeast/deco16ic.cpp: Make tilemap register/config into structs, Updates (in related drivers):

### DIFF
--- a/src/mame/dataeast/backfire.cpp
+++ b/src/mame/dataeast/backfire.cpp
@@ -38,13 +38,13 @@ public:
 	backfire_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_spriteram(*this, "spriteram%u", 1U, 0x1000U, ENDIANNESS_LITTLE),
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U, 0x800U, ENDIANNESS_LITTLE),
+		m_rowscroll(*this, "rowscroll_%u", 1U, 0x800U, ENDIANNESS_LITTLE),
 		m_mainram(*this, "mainram"),
 		m_left_priority(*this, "left_priority"),
 		m_right_priority(*this, "right_priority"),
 		m_maincpu(*this, "maincpu"),
 		m_sprgen(*this, "spritegen%u", 1U),
-		m_deco_tilegen(*this, "tilegen%u", 1U),
+		m_tilegen(*this, "tilegen%u", 1U),
 		m_eeprom(*this, "eeprom"),
 		m_adc(*this, "adc"),
 		m_palette(*this, "palette"),
@@ -56,8 +56,8 @@ public:
 
 private:
 	uint32_t control2_r();
-	template<int Layer> uint32_t pf_rowscroll_r(offs_t offset);
-	template<int Layer> void pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	template<int Layer> uint32_t rowscroll_r(offs_t offset);
+	template<int Layer> void rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	template<int Chip> uint32_t spriteram_r(offs_t offset);
 	template<int Chip> void spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t backfire_speedup_r();
@@ -68,14 +68,14 @@ private:
 	void vbl_interrupt(int state);
 	void irq_ack_w(uint32_t data);
 	void descramble_sound();
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	void backfire_map(address_map &map) ATTR_COLD;
 
 	/* memory pointers */
 	memory_share_array_creator<uint16_t, 2> m_spriteram;
-	memory_share_array_creator<uint16_t, 4> m_pf_rowscroll;
+	memory_share_array_creator<uint16_t, 4> m_rowscroll;
 	required_shared_ptr<uint32_t> m_mainram;
 	required_shared_ptr<uint32_t> m_left_priority;
 	required_shared_ptr<uint32_t> m_right_priority;
@@ -83,7 +83,7 @@ private:
 	/* devices */
 	required_device<cpu_device> m_maincpu;
 	required_device_array<decospr_device, 2> m_sprgen;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<adc0808_device> m_adc;
@@ -102,22 +102,22 @@ uint32_t backfire_state::screen_update_left(screen_device &screen, bitmap_ind16 
 
 	/* screen 1 uses pf1 as the foreground and pf3 as the background */
 	/* screen 2 uses pf2 as the foreground and pf4 as the background */
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0x100, cliprect);
 
 	if (m_left_priority[0] == 0)
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0], 0x2000/4);
 	}
 	else if (m_left_priority[0] == 2)
 	{
-		m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 		m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0], 0x2000/4);
 	}
 	else
@@ -133,22 +133,22 @@ uint32_t backfire_state::screen_update_right(screen_device &screen, bitmap_ind16
 
 	/* screen 1 uses pf1 as the foreground and pf3 as the background */
 	/* screen 2 uses pf2 as the foreground and pf4 as the background */
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0x500, cliprect);
 
 	if (m_right_priority[0] == 0)
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1], 0x2000/4);
 	}
 	else if (m_right_priority[0] == 2)
 	{
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 		m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1], 0x2000/4);
 	}
 	else
@@ -169,8 +169,8 @@ void backfire_state::eeprom_w(uint8_t data)
 
 /* map 32-bit writes to 16-bit */
 
-template<int Layer> uint32_t backfire_state::pf_rowscroll_r(offs_t offset){ return m_pf_rowscroll[Layer][offset] ^ 0xffff0000; }
-template<int Layer> void backfire_state::pf_rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask){ data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[Layer][offset]); }
+template<int Layer> uint32_t backfire_state::rowscroll_r(offs_t offset){ return m_rowscroll[Layer][offset] ^ 0xffff0000; }
+template<int Layer> void backfire_state::rowscroll_w(offs_t offset, uint32_t data, uint32_t mem_mask){ data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_rowscroll[Layer][offset]); }
 
 
 uint32_t backfire_state::pot_select_r(offs_t offset)
@@ -199,16 +199,16 @@ void backfire_state::spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask
 void backfire_state::backfire_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
-	map(0x100000, 0x10001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x110000, 0x111fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x114000, 0x115fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x120000, 0x120fff).rw(FUNC(backfire_state::pf_rowscroll_r<0>), FUNC(backfire_state::pf_rowscroll_w<0>));
-	map(0x124000, 0x124fff).rw(FUNC(backfire_state::pf_rowscroll_r<1>), FUNC(backfire_state::pf_rowscroll_w<1>));
-	map(0x130000, 0x13001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x140000, 0x141fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x144000, 0x145fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x150000, 0x150fff).rw(FUNC(backfire_state::pf_rowscroll_r<2>), FUNC(backfire_state::pf_rowscroll_w<2>));
-	map(0x154000, 0x154fff).rw(FUNC(backfire_state::pf_rowscroll_r<3>), FUNC(backfire_state::pf_rowscroll_w<3>));
+	map(0x100000, 0x10001f).rw(m_tilegen[0], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x110000, 0x111fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x114000, 0x115fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x120000, 0x120fff).rw(FUNC(backfire_state::rowscroll_r<0>), FUNC(backfire_state::rowscroll_w<0>));
+	map(0x124000, 0x124fff).rw(FUNC(backfire_state::rowscroll_r<1>), FUNC(backfire_state::rowscroll_w<1>));
+	map(0x130000, 0x13001f).rw(m_tilegen[1], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x140000, 0x141fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x144000, 0x145fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x150000, 0x150fff).rw(FUNC(backfire_state::rowscroll_r<2>), FUNC(backfire_state::rowscroll_w<2>));
+	map(0x154000, 0x154fff).rw(FUNC(backfire_state::rowscroll_r<3>), FUNC(backfire_state::rowscroll_w<3>));
 	map(0x160000, 0x161fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x170000, 0x177fff).ram().share(m_mainram);// main ram
 	map(0x180010, 0x180013).nopw(); // always 180010 ?
@@ -325,13 +325,12 @@ void backfire_state::irq_ack_w(uint32_t data)
 }
 
 
-DECO16IC_BANK_CB_MEMBER(backfire_state::bank_callback)
+int backfire_state::bank_callback(int bank)
 {
 	//  logerror("bank callback %04x\n",bank); // bit 1 gets set too?
-	bank = bank >> 4;
-	bank = (bank & 1) | ((bank & 4) >> 1) | ((bank & 2) << 1);
+	bank = (bank & 0x10) | ((bank & 0x40) >> 1) | ((bank & 0x20) << 1);
 
-	return bank * 0x1000;
+	return bank << 8;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(backfire_state::pri_callback)
@@ -381,33 +380,33 @@ void backfire_state::backfire(machine_config &config)
 	rscreen.set_screen_update(FUNC(backfire_state::screen_update_right));
 	rscreen.set_palette(m_palette);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_screen(m_lscreen);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x40);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(backfire_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(backfire_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_screen(m_lscreen);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x40);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(backfire_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(backfire_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_screen(m_lscreen);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x10);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x50);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(backfire_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(backfire_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(2);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(3);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_screen(m_lscreen);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x10);
+	m_tilegen[1]->set_col_bank<1>(0x50);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(backfire_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(backfire_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(2);
+	m_tilegen[1]->set_16x16_bank(3);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_backfire_spr1);
 	m_sprgen[0]->set_screen(m_lscreen);
@@ -418,11 +417,13 @@ void backfire_state::backfire(machine_config &config)
 	m_sprgen[1]->set_pri_callback(FUNC(backfire_state::pri_callback));
 
 	/* sound hardware */
-	SPEAKER(config, "speaker", 2).front();
+	// each screen paired with mono speakers
+	SPEAKER(config, "lspeaker").front_center();
+	SPEAKER(config, "rspeaker").front_center();
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", 28000000 / 2));
-	ymz.add_route(0, "speaker", 1.0, 0);
-	ymz.add_route(1, "speaker", 1.0, 1);
+	ymz.add_route(0, "lspeaker", 1.0, 0);
+	ymz.add_route(1, "rspeaker", 1.0, 1);
 }
 
 

--- a/src/mame/dataeast/backfire.cpp
+++ b/src/mame/dataeast/backfire.cpp
@@ -51,8 +51,8 @@ public:
 		m_lscreen(*this, "lscreen")
 	{ }
 
-	void backfire(machine_config &config);
-	void init_backfire();
+	void backfire(machine_config &config) ATTR_COLD;
+	void init_backfire() ATTR_COLD;
 
 private:
 	uint32_t control2_r();
@@ -67,7 +67,7 @@ private:
 	uint32_t screen_update_right(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void vbl_interrupt(int state);
 	void irq_ack_w(uint32_t data);
-	void descramble_sound();
+	void descramble_sound() ATTR_COLD;
 	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
@@ -328,9 +328,7 @@ void backfire_state::irq_ack_w(uint32_t data)
 int backfire_state::bank_callback(int bank)
 {
 	//  logerror("bank callback %04x\n",bank); // bit 1 gets set too?
-	bank = (bank & 0x10) | ((bank & 0x40) >> 1) | ((bank & 0x20) << 1);
-
-	return bank << 8;
+	return bitswap<3>(bank, 5, 6, 4) << 12;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(backfire_state::pri_callback)

--- a/src/mame/dataeast/boogwing.cpp
+++ b/src/mame/dataeast/boogwing.cpp
@@ -117,11 +117,11 @@ public:
 		, m_deco104(*this, "ioprot")
 		, m_deco_ace(*this, "deco_ace")
 		, m_screen(*this, "screen")
-		, m_deco_tilegen(*this, "tilegen%u", 1)
+		, m_tilegen(*this, "tilegen%u", 1)
 		, m_oki(*this, "oki%u", 1)
 		, m_sprgen(*this, "spritegen%u", 1)
 		, m_spriteram(*this, "spriteram%u", 1)
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1)
+		, m_rowscroll(*this, "rowscroll_%u", 1)
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
 	{ }
 
@@ -139,12 +139,12 @@ private:
 	required_device<deco104_device> m_deco104;
 	required_device<deco_ace_device> m_deco_ace;
 	required_device<screen_device> m_screen;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device_array<okim6295_device, 2> m_oki;
 	required_device_array<decospr_device, 2> m_sprgen;
 	required_device_array<buffered_spriteram16_device, 2> m_spriteram;
 
-	required_shared_ptr_array<u16, 4> m_pf_rowscroll;
+	required_shared_ptr_array<u16, 4> m_rowscroll;
 	required_shared_ptr<u16> m_decrypted_opcodes;
 
 	u16 m_priority = 0U;
@@ -158,8 +158,8 @@ private:
 	u16 ioprot_r(offs_t offset);
 	void ioprot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
-	DECO16IC_BANK_CB_MEMBER(bank_callback2);
+	int bank_callback(int bank);
+	int bank_callback2(int bank);
 
 	void audio_map(address_map &map) ATTR_COLD;
 	void main_map(address_map &map) ATTR_COLD;
@@ -416,7 +416,7 @@ void boogwing_state::mix(screen_device &screen, bitmap_rgb32 &bitmap, const rect
 
 u32 boogwing_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	u16 const flip = m_deco_tilegen[0]->pf_control_r(0);
+	u16 const flip = m_tilegen[0]->control_r(0);
 	u16 const priority = m_priority;
 
 	// sprites are flipped relative to tilemaps
@@ -428,8 +428,8 @@ u32 boogwing_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, c
 	m_sprgen[1]->draw_sprites(bitmap, cliprect, m_spriteram[1]->buffer(), 0x400);
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	// Draw playfields
 	bitmap.fill(m_deco_ace->pen(0x400), cliprect); // pen not confirmed
@@ -440,40 +440,40 @@ u32 boogwing_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, c
 	// bit&0x4 combines playfields
 	if ((priority & 0x7) == 0x5)
 	{
-		m_deco_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, m_temp_bitmap, cliprect, 0, 32);
+		m_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+		m_tilegen[1]->tilemap_12_combine_draw(screen, m_temp_bitmap, cliprect, 0, 32);
 	}
 	else if ((priority & 0x7) == 0x4)
 	{
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 32);
+		m_tilegen[1]->tilemap_12_combine_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+		m_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 32);
 	}
 	else if ((priority & 0x7) == 0x1 || (priority & 0x7) == 0x2)
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 8);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, m_temp_bitmap, cliprect, 0, 32);
+		m_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+		m_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 8);
+		m_tilegen[1]->tilemap_1_draw(screen, m_temp_bitmap, cliprect, 0, 32);
 	}
 	else if ((priority & 0x7) == 0x3)
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 8);
+		m_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+		m_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 8);
 
 		// This mode uses playfield 3 to shadow sprites & playfield 2 (instead of
 		// regular alpha-blending, the destination is inverted).  Not yet implemented.
 		m_alpha_tmap_bitmap.fill(0, cliprect);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, m_alpha_tmap_bitmap, cliprect, 0, 0); // 32
+		m_tilegen[1]->tilemap_1_draw(screen, m_alpha_tmap_bitmap, cliprect, 0, 0); // 32
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, m_temp_bitmap, cliprect, 0, 8);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 32);
+		m_tilegen[1]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+		m_tilegen[1]->tilemap_1_draw(screen, m_temp_bitmap, cliprect, 0, 8);
+		m_tilegen[0]->tilemap_2_draw(screen, m_temp_bitmap, cliprect, 0, 32);
 	}
 
 	mix(screen,bitmap,cliprect);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -517,19 +517,19 @@ void boogwing_state::main_map(address_map &map)
 //  map(0x24e6c0, 0x24e6c1).portr("DSW");
 //  map(0x24e138, 0x24e139).portr("SYSTEM");
 //  map(0x24e344, 0x24e345).portr("INPUTS");
-	map(0x24e000, 0x24efff).rw(FUNC(boogwing_state::ioprot_r), FUNC(boogwing_state::ioprot_w)).share("prot16ram"); // Protection device
+	map(0x24e000, 0x24efff).rw(FUNC(boogwing_state::ioprot_r), FUNC(boogwing_state::ioprot_w)); // Protection device
 
-	map(0x260000, 0x26000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x264000, 0x265fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x266000, 0x267fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x268000, 0x268fff).ram().share(m_pf_rowscroll[0]);
-	map(0x26a000, 0x26afff).ram().share(m_pf_rowscroll[1]);
+	map(0x260000, 0x26000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x264000, 0x265fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x266000, 0x267fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x268000, 0x268fff).ram().share(m_rowscroll[0]);
+	map(0x26a000, 0x26afff).ram().share(m_rowscroll[1]);
 
-	map(0x270000, 0x27000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
-	map(0x274000, 0x275fff).ram().w(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_w));
-	map(0x276000, 0x277fff).ram().w(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_w));
-	map(0x278000, 0x278fff).ram().share(m_pf_rowscroll[2]);
-	map(0x27a000, 0x27afff).ram().share(m_pf_rowscroll[3]);
+	map(0x270000, 0x27000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
+	map(0x274000, 0x275fff).ram().w(m_tilegen[1], FUNC(deco16ic_device::vram_w<0>));
+	map(0x276000, 0x277fff).ram().w(m_tilegen[1], FUNC(deco16ic_device::vram_w<1>));
+	map(0x278000, 0x278fff).ram().share(m_rowscroll[2]);
+	map(0x27a000, 0x27afff).ram().share(m_rowscroll[3]);
 
 	map(0x280000, 0x28000f).noprw(); // ?
 	map(0x282000, 0x282001).noprw(); // Palette setup?
@@ -696,14 +696,14 @@ void boogwing_state::sound_bankswitch_w(u8 data)
 }
 
 
-DECO16IC_BANK_CB_MEMBER(boogwing_state::bank_callback)
+int boogwing_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
-DECO16IC_BANK_CB_MEMBER(boogwing_state::bank_callback2)
+int boogwing_state::bank_callback2(int bank)
 {
-	int offset = ((bank >> 4) & 0x7) * 0x1000;
+	int offset = (bank & 0x70) << 8;
 	if ((bank & 0xf) == 0xa)
 		offset += 0x800; // strange - transporter level
 
@@ -738,31 +738,31 @@ void boogwing_state::boogwing(machine_config &config)
 
 	DECO_ACE(config, m_deco_ace);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0);
-	m_deco_tilegen[0]->set_pf2_col_bank(0);   // pf2 is non default
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0);
+	m_tilegen[0]->set_col_bank<1>(0);   // pf2 is non default
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
 	// no bank1 callback
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(boogwing_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	m_tilegen[0]->set_bank_callback<1>(FUNC(boogwing_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0);
-	m_deco_tilegen[1]->set_pf2_col_bank(16);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(boogwing_state::bank_callback2));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(boogwing_state::bank_callback2));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0);
+	m_tilegen[1]->set_col_bank<1>(16);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(boogwing_state::bank_callback2));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(boogwing_state::bank_callback2));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen[0], m_deco_ace, gfx_boogwing_spr1);
 	DECO_SPRITE(config, m_sprgen[1], m_deco_ace, gfx_boogwing_spr2);

--- a/src/mame/dataeast/captaven.cpp
+++ b/src/mame/dataeast/captaven.cpp
@@ -44,7 +44,7 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_sprgen(*this, "spritegen")
-		, m_deco_tilegen(*this, "tilegen%u", 1)
+		, m_tilegen(*this, "tilegen%u", 1)
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
 		, m_palette(*this, "palette")
@@ -52,7 +52,7 @@ public:
 		, m_ioprot(*this, "ioprot")
 		, m_ym2151(*this, "ymsnd")
 		, m_oki(*this, "oki%u", 1)
-		, m_pf_rowscroll32(*this, "pf%u_rowscroll32", 1)
+		, m_rowscroll32(*this, "rowscroll32_%u", 1)
 		, m_io_dsw(*this, "DSW%u", 1U)
 	{ }
 
@@ -71,7 +71,7 @@ private:
 	u32 _71_r();
 	u8 captaven_soundcpu_status_r();
 
-	template<int Chip> void pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template<int Chip> void rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
 	u32 spriteram_r(offs_t offset);
 	void spriteram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
@@ -79,8 +79,8 @@ private:
 	void pri_w(u32 data);
 
 	void tile_callback(u32 &tile, u32 &colour, int layer, bool is_8x8);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
-	DECOSPR_PRIORITY_CB_MEMBER(captaven_pri_callback);
+	int bank_callback(int bank);
+	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -90,7 +90,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
 	required_device<decospr_device> m_sprgen;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
@@ -100,14 +100,14 @@ private:
 	required_device_array<okim6295_device, 2> m_oki;
 
 	// we use the pointers below to store a 32-bit copy..
-	required_shared_ptr_array<u32, 4> m_pf_rowscroll32;
+	required_shared_ptr_array<u32, 4> m_rowscroll32;
 
 	required_ioport_array<3> m_io_dsw;
 
 	u32 m_pri = 0;
 	std::unique_ptr<u16[]> m_spriteram16;
 	std::unique_ptr<u16[]> m_spriteram16_buffered;
-	std::unique_ptr<u16[]> m_pf_rowscroll[4]{};
+	std::unique_ptr<u16[]> m_rowscroll[4]{};
 };
 
 
@@ -164,11 +164,11 @@ void captaven_state::video_start()
 
 	for (int i = 0; i < 4; i++)
 	{
-		const u32 size = m_pf_rowscroll32[i].length();
+		const u32 size = m_rowscroll32[i].length();
 
-		m_pf_rowscroll[i] = make_unique_clear<u16[]>(size);
+		m_rowscroll[i] = make_unique_clear<u16[]>(size);
 
-		save_pointer(NAME(m_pf_rowscroll[i]), size, i);
+		save_pointer(NAME(m_rowscroll[i]), size, i);
 	}
 	save_pointer(NAME(m_spriteram16), 0x2000/4);
 	save_pointer(NAME(m_spriteram16_buffered), 0x2000/4);
@@ -205,9 +205,9 @@ void captaven_state::buffer_spriteram_w(u32 data)
 }
 
 // tattass tests these as 32-bit ram, even if only 16-bits are hooked up to the tilemap chip - does it mirror parts of the dword?
-template <int TileMap> void captaven_state::pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_pf_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[TileMap][offset]); }
+template <int TileMap> void captaven_state::rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_rowscroll[TileMap][offset]); }
 
-DECOSPR_PRIORITY_CB_MEMBER(captaven_state::captaven_pri_callback)
+DECOSPR_PRIORITY_CB_MEMBER(captaven_state::pri_callback)
 {
 	if ((pri & 0x60) == 0x00)
 	{
@@ -239,37 +239,37 @@ void captaven_state::tile_callback(u32 &tile, u32 &colour, int layer, bool is_8x
 	}
 }
 
-DECO16IC_BANK_CB_MEMBER(captaven_state::bank_callback)
+int captaven_state::bank_callback(int bank)
 {
 	return (bank & 0x20) << 9;
 }
 
 u32 captaven_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	const u16 flip = m_deco_tilegen[0]->pf_control_r(0);
+	const u16 flip = m_tilegen[0]->control_r(0);
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(m_palette->pen(0x000), cliprect); // Palette index not confirmed
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_tilegen[0]->update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_tilegen[1]->update(m_rowscroll[2].get(), m_rowscroll[3].get());
 
 	// pf4 not used (because pf3 is in 8bpp mode)
 
 	if ((m_pri & 1) == 0)
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 	}
 	else
 	{
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 	}
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram16_buffered.get(), 0x400); // only low half of sprite ram is used?
 
@@ -298,17 +298,17 @@ void captaven_state::main_map(address_map &map)
 	map(0x168002, 0x168002).lr8(NAME([this] () { return m_io_dsw[2]->read(); }));
 	map(0x168003, 0x168003).r(FUNC(captaven_state::captaven_soundcpu_status_r));
 	map(0x178000, 0x178003).w(FUNC(captaven_state::pri_w));
-	map(0x180000, 0x18001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x180000, 0x18001f).rw(m_tilegen[0], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
 	// Mirror address - bug in program code
-	map(0x190000, 0x191fff).mirror(0x2000).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x194000, 0x195fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x1a0000, 0x1a3fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<0>)).share(m_pf_rowscroll32[0]);
-	map(0x1a4000, 0x1a5fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<1>)).share(m_pf_rowscroll32[1]);
-	map(0x1c0000, 0x1c001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1d0000, 0x1d1fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1d4000, 0x1d5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
-	map(0x1e0000, 0x1e3fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<2>)).share(m_pf_rowscroll32[2]);
-	map(0x1e4000, 0x1e5fff).ram().w(FUNC(captaven_state::pf_rowscroll_w<3>)).share(m_pf_rowscroll32[3]); // unused
+	map(0x190000, 0x191fff).mirror(0x2000).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x194000, 0x195fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x1a0000, 0x1a3fff).ram().w(FUNC(captaven_state::rowscroll_w<0>)).share(m_rowscroll32[0]);
+	map(0x1a4000, 0x1a5fff).ram().w(FUNC(captaven_state::rowscroll_w<1>)).share(m_rowscroll32[1]);
+	map(0x1c0000, 0x1c001f).rw(m_tilegen[1], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x1d0000, 0x1d1fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x1d4000, 0x1d5fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>)); // unused
+	map(0x1e0000, 0x1e3fff).ram().w(FUNC(captaven_state::rowscroll_w<2>)).share(m_rowscroll32[2]);
+	map(0x1e4000, 0x1e5fff).ram().w(FUNC(captaven_state::rowscroll_w<3>)).share(m_rowscroll32[3]); // unused
 }
 
 void captaven_state::sound_map(address_map &map)
@@ -563,33 +563,33 @@ void captaven_state::captaven(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_captaven);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_888, 2048);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x20);
+	m_tilegen[0]->set_col_bank<1>(0x30);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);    // pf3 is in 8bpp mode, pf4 is not used
-	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x00);
-	m_deco_tilegen[1]->set_tile_callback(FUNC(captaven_state::tile_callback));
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(captaven_state::bank_callback));
+	DECO16IC(config, m_tilegen[1]);    // pf3 is in 8bpp mode, pf4 is not used
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_col_bank<0>(0x04);
+	m_tilegen[1]->set_col_bank<1>(0x00);
+	m_tilegen[1]->set_col_mask<0>(0x03);
+	m_tilegen[1]->set_col_mask<1>(0x00);
+	m_tilegen[1]->set_tile_callback(FUNC(captaven_state::tile_callback));
+	m_tilegen[1]->set_bank_callback<0>(FUNC(captaven_state::bank_callback));
 	// no bank2 callback
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_captaven_spr);
-	m_sprgen->set_pri_callback(FUNC(captaven_state::captaven_pri_callback));
+	m_sprgen->set_pri_callback(FUNC(captaven_state::pri_callback));
 	m_sprgen->set_alt_format(true);
 
 	DECO146PROT(config, m_ioprot);

--- a/src/mame/dataeast/cbuster.cpp
+++ b/src/mame/dataeast/cbuster.cpp
@@ -78,12 +78,12 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_deco_tilegen(*this, "tilegen%u", 1U)
+		, m_tilegen(*this, "tilegen%u", 1U)
 		, m_palette(*this, "palette")
 		, m_spriteram(*this, "spriteram")
 		, m_soundlatch(*this, "soundlatch")
 		, m_sprgen(*this, "spritegen")
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1U)
+		, m_rowscroll(*this, "rowscroll_%u", 1U)
 	{ }
 
 	void init_twocrude();
@@ -99,14 +99,14 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<palette_device> m_palette;
 	required_device<buffered_spriteram16_device> m_spriteram;
 	required_device<generic_latch_8_device> m_soundlatch;
 	required_device<decospr_device> m_sprgen;
 
 	// memory pointers
-	required_shared_ptr_array<u16, 4> m_pf_rowscroll;
+	required_shared_ptr_array<u16, 4> m_rowscroll;
 
 	// misc
 	u16 m_prot = 0U;
@@ -115,7 +115,7 @@ private:
 	void prot_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u16 prot_r();
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	static rgb_t xbgr_888(u32 raw);
 	void main_map(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
@@ -159,35 +159,35 @@ rgb_t cbuster_state::xbgr_888(u32 raw)
 
 u32 cbuster_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	const u16 flip = m_deco_tilegen[0]->pf_control_r(0);
+	const u16 flip = m_tilegen[0]->control_r(0);
 
 	flip_screen_set(!BIT(flip, 7));
 	m_sprgen->set_flip_screen(!BIT(flip, 7));
 
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram->buffer(), 0x400);
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	// Draw playfields & sprites
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_sprgen->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0800, 0x0900, 0x100, 0x0ff);
 	m_sprgen->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0900, 0x0900, 0x500, 0x0ff);
 
 	if (m_pri)
 	{
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	}
 
 	m_sprgen->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0000, 0x0900, 0x100, 0x0ff);
 	m_sprgen->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0100, 0x0900, 0x500, 0x0ff);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -229,7 +229,8 @@ void cbuster_state::prot_w(offs_t offset, u16 data, u16 mem_mask)
 
 u16 cbuster_state::prot_r()
 {
-	LOGPROT("%04x : protection control read at 0bc004\n", m_maincpu->pc());
+	if (!machine().side_effects_disabled())
+		LOGPROT("%s : protection control read at 0bc004\n", machine().describe_context());
 	return m_prot;
 }
 
@@ -240,20 +241,20 @@ void cbuster_state::main_map(address_map &map)
 	map(0x000000, 0x07ffff).rom();
 	map(0x080000, 0x083fff).ram();
 
-	map(0x0a0000, 0x0a1fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x0a2000, 0x0a2fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x0a4000, 0x0a47ff).ram().share(m_pf_rowscroll[0]);
-	map(0x0a6000, 0x0a67ff).ram().share(m_pf_rowscroll[1]);
+	map(0x0a0000, 0x0a1fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x0a2000, 0x0a2fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x0a4000, 0x0a47ff).ram().share(m_rowscroll[0]);
+	map(0x0a6000, 0x0a67ff).ram().share(m_rowscroll[1]);
 
-	map(0x0a8000, 0x0a8fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x0aa000, 0x0aafff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x0ac000, 0x0ac7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x0ae000, 0x0ae7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x0a8000, 0x0a8fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x0aa000, 0x0aafff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x0ac000, 0x0ac7ff).ram().share(m_rowscroll[2]);
+	map(0x0ae000, 0x0ae7ff).ram().share(m_rowscroll[3]);
 
 	map(0x0b0000, 0x0b07ff).ram().share("spriteram");
 	map(0x0b4000, 0x0b4001).nopw();
-	map(0x0b5000, 0x0b500f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x0b6000, 0x0b600f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x0b5000, 0x0b500f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x0b6000, 0x0b600f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 	map(0x0b8000, 0x0b8fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x0b9000, 0x0b9fff).ram().w(m_palette, FUNC(palette_device::write16_ext)).share("palette_ext");
 	map(0x0bc000, 0x0bc001).portr("P1_P2").w(m_spriteram, FUNC(buffered_spriteram16_device::write));
@@ -388,7 +389,7 @@ GFXDECODE_END
 
 /******************************************************************************/
 
-DECO16IC_BANK_CB_MEMBER(cbuster_state::bank_callback)
+int cbuster_state::bank_callback(int bank)
 {
 	return (bank & 0x70) << 8;
 }
@@ -429,31 +430,31 @@ void cbuster_state::twocrude(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x20);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(cbuster_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(cbuster_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x20);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(cbuster_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(cbuster_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cbuster_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cbuster_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x30);
+	m_tilegen[1]->set_col_bank<1>(0x40);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cbuster_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cbuster_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_cbuster_spr);
 

--- a/src/mame/dataeast/cninja.cpp
+++ b/src/mame/dataeast/cninja.cpp
@@ -60,30 +60,32 @@ template<int Chip>
 void cninja_state::cninja_pf_control_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	m_screen->update_partial(m_screen->vpos());
-	m_deco_tilegen[Chip]->pf_control_w(offset, data, mem_mask);
+	m_tilegen[Chip]->control_w(offset, data, mem_mask);
 }
 
-
-uint16_t cninja_state::cninja_protection_region_0_104_r(offs_t offset)
+template <offs_t Base>
+uint16_t cninja_state::ioprot_r(offs_t offset)
 {
-	int const real_address = 0 + (offset * 2);
+	int const real_address = Base + (offset * 2);
 	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
+	uint16_t const data = m_ioprot->read_data(deco146_addr, cs);
 	return data;
 }
 
-void cninja_state::cninja_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+template <offs_t Base>
+void cninja_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int const real_address = 0 + (offset * 2);
+	int const real_address = Base + (offset * 2);
 	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
+	m_ioprot->write_data(deco146_addr, data, mem_mask, cs);
 }
 
 uint16_t cninja_state::cninjabl2_sprite_dma_r()
 {
-	m_spriteram[0]->copy();
+	if (!machine().side_effects_disabled())
+		m_spriteram[0]->copy();
 	return 0;
 }
 
@@ -93,16 +95,16 @@ void cninja_state::cninja_map(address_map &map)
 	map(0x000000, 0x0bffff).rom();
 
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
-	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).writeonly().share(m_pf_rowscroll[0]);
-	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
+	map(0x144000, 0x144fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x146000, 0x146fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x14c000, 0x14c7ff).writeonly().share(m_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
-	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x154000, 0x154fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x156000, 0x156fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x15c000, 0x15c7ff).ram().share(m_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_rowscroll[3]);
 
 	map(0x184000, 0x187fff).ram();
 	map(0x190000, 0x190007).m("irq", FUNC(deco_irq_device::map)).umask16(0x00ff);
@@ -110,7 +112,7 @@ void cninja_state::cninja_map(address_map &map)
 
 	map(0x1a4000, 0x1a47ff).ram().share("spriteram1");           /* Sprites */
 	map(0x1b4000, 0x1b4001).w(m_spriteram[0], FUNC(buffered_spriteram16_device::write)); /* DMA flag */
-	map(0x1bc000, 0x1bffff).rw(FUNC(cninja_state::cninja_protection_region_0_104_r), FUNC(cninja_state::cninja_protection_region_0_104_w)).share("prot16ram"); /* Protection device */
+	map(0x1bc000, 0x1bffff).rw(FUNC(cninja_state::ioprot_r<0>), FUNC(cninja_state::ioprot_w<0>)); /* Protection device */
 
 	map(0x308000, 0x308fff).nopw(); /* Bootleg only */
 }
@@ -122,16 +124,16 @@ void cninja_state::cninjabl_map(address_map &map)
 	map(0x138000, 0x1387ff).ram().share("spriteram1"); /* bootleg sprite-ram (sprites rewritten here in new format) */
 
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
-	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).writeonly().share(m_pf_rowscroll[0]);
-	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
+	map(0x144000, 0x144fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x146000, 0x146fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x14c000, 0x14c7ff).writeonly().share(m_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));    // not used / incorrect on this
-	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x154000, 0x154fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x156000, 0x156fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x15c000, 0x15c7ff).ram().share(m_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_rowscroll[3]);
 
 	map(0x17ff22, 0x17ff23).portr("DSW");
 	map(0x17ff28, 0x17ff29).portr("SYSTEM");
@@ -154,70 +156,28 @@ void cninja_state::cninjabl2_map(address_map &map)
 	map(0x1b4000, 0x1b4001).r(FUNC(cninja_state::cninjabl2_sprite_dma_r));
 }
 
-uint16_t cninja_state::edrandy_protection_region_8_146_r(offs_t offset)
-{
-	int const real_address = 0x1a0000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
-	return data;
-}
-
-void cninja_state::edrandy_protection_region_8_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	int const real_address = 0x1a0000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
-}
-
-uint16_t cninja_state::edrandy_protection_region_6_146_r(offs_t offset)
-{
-//  uint16_t realdat = deco16_60_prot_r(space,offset&0x3ff,mem_mask);
-
-	int const real_address = 0x198000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
-
-//  if ((realdat & mem_mask) != (data & mem_mask))
-//      printf("returned %04x instead of %04x (real address %08x)\n", data, realdat, real_address);
-
-	return data;
-}
-
-void cninja_state::edrandy_protection_region_6_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-//  deco16_60_prot_w(space,offset&0x3ff,data,mem_mask);
-
-	int const real_address = 0x198000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
-}
-
 void cninja_state::edrandy_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
 
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
-	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).ram().share(m_pf_rowscroll[0]);
-	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
+	map(0x144000, 0x144fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x146000, 0x146fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x14c000, 0x14c7ff).ram().share(m_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
-	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x154000, 0x154fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x156000, 0x156fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x15c000, 0x15c7ff).ram().share(m_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_rowscroll[3]);
 
 	map(0x188000, 0x189fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x194000, 0x197fff).ram(); /* Main ram */
-	map(0x198000, 0x19bfff).rw(FUNC(cninja_state::edrandy_protection_region_6_146_r), FUNC(cninja_state::edrandy_protection_region_6_146_w)).share("prot16ram"); /* Protection device */
-//  map(0x198000, 0x1987ff).rw(FUNC(cninja_state::edrandy_protection_region_6_146_r), FUNC(cninja_state::edrandy_protection_region_6_146_w)).share("prot16ram"); /* Protection device */
+	map(0x198000, 0x19bfff).rw(FUNC(cninja_state::ioprot_r<0x198000>), FUNC(cninja_state::ioprot_w<0x198000>)); /* Protection device */
+//  map(0x198000, 0x1987ff).rw(FUNC(cninja_state::ioprot_r<0x198000>), FUNC(cninja_state::ioprot_w<0x198000>)); /* Protection device */
 
-	map(0x1a0000, 0x1a3fff).rw(FUNC(cninja_state::edrandy_protection_region_8_146_r), FUNC(cninja_state::edrandy_protection_region_8_146_w));
+	map(0x1a0000, 0x1a3fff).rw(FUNC(cninja_state::ioprot_r<0x1a0000>), FUNC(cninja_state::ioprot_w<0x1a0000>));
 
 	map(0x1a4000, 0x1a4007).m("irq", FUNC(deco_irq_device::map)).umask16(0x00ff);
 	map(0x1ac000, 0x1ac001).w(m_spriteram[0], FUNC(buffered_spriteram16_device::write)); /* DMA flag */
@@ -235,22 +195,22 @@ void cninja_state::robocop2_map(address_map &map)
 	map(0x000000, 0x0fffff).rom();
 
 	map(0x140000, 0x14000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
-	map(0x144000, 0x144fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x146000, 0x146fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x14c000, 0x14c7ff).ram().share(m_pf_rowscroll[0]);
-	map(0x14e000, 0x14e7ff).ram().share(m_pf_rowscroll[1]);
+	map(0x144000, 0x144fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x146000, 0x146fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x14c000, 0x14c7ff).ram().share(m_rowscroll[0]);
+	map(0x14e000, 0x14e7ff).ram().share(m_rowscroll[1]);
 
 	map(0x150000, 0x15000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
-	map(0x154000, 0x154fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x156000, 0x156fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x15c000, 0x15c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x15e000, 0x15e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x154000, 0x154fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x156000, 0x156fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x15c000, 0x15c7ff).ram().share(m_rowscroll[2]);
+	map(0x15e000, 0x15e7ff).ram().share(m_rowscroll[3]);
 
 	map(0x180000, 0x1807ff).ram().share("spriteram1");
 //  map(0x18c000, 0x18c0ff).w(FUNC(cninja_state::cninja_loopback_w)) /* Protection writes */
 //  map(0x18c000, 0x18c7ff).r(m_ioprot, FUNC(deco146_device,robocop2_prot_r)) /* Protection device */
 //  map(0x18c064, 0x18c065).w(m_soundlatch, FUNC(generic_latch_8_device::write));
-	map(0x18c000, 0x18ffff).rw(FUNC(cninja_state::mutantf_protection_region_0_146_r), FUNC(cninja_state::mutantf_protection_region_0_146_w)).share("prot16ram"); /* Protection device */
+	map(0x18c000, 0x18ffff).rw(FUNC(cninja_state::ioprot_r<0>), FUNC(cninja_state::ioprot_w<0>)); /* Protection device */
 
 	map(0x198000, 0x198001).w(m_spriteram[0], FUNC(buffered_spriteram16_device::write)); /* DMA flag */
 	map(0x1a8000, 0x1a9fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
@@ -260,23 +220,6 @@ void cninja_state::robocop2_map(address_map &map)
 	map(0x1f8000, 0x1f8001).portr("DSW3"); /* Dipswitch #3 */
 }
 
-
-uint16_t cninja_state::mutantf_protection_region_0_146_r(offs_t offset)
-{
-	int const real_address = 0 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	uint16_t const data = m_ioprot->read_data( deco146_addr, cs );
-	return data;
-}
-
-void cninja_state::mutantf_protection_region_0_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	int const real_address = 0 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	m_ioprot->write_data( deco146_addr, data, mem_mask, cs );
-}
 
 uint16_t cninja_state::mutantf_71_r()
 {
@@ -292,21 +235,21 @@ void cninja_state::mutantf_map(address_map &map)
 	map(0x160000, 0x161fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x180000, 0x180001).w(FUNC(cninja_state::robocop2_priority_w));
 	map(0x180002, 0x180003).nopw(); /* VBL irq ack */
-	map(0x1a0000, 0x1a3fff).rw(FUNC(cninja_state::mutantf_protection_region_0_146_r), FUNC(cninja_state::mutantf_protection_region_0_146_w)).share("prot16ram"); /* Protection device */
+	map(0x1a0000, 0x1a3fff).rw(FUNC(cninja_state::ioprot_r<0>), FUNC(cninja_state::ioprot_w<0>)); /* Protection device */
 	map(0x1c0000, 0x1c0001).w(m_spriteram[0], FUNC(buffered_spriteram16_device::write)).r(FUNC(cninja_state::mutantf_71_r));
 	map(0x1e0000, 0x1e0001).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write));
 
 	map(0x300000, 0x30000f).w(FUNC(cninja_state::cninja_pf_control_w<0>));
-	map(0x304000, 0x305fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x306000, 0x307fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x308000, 0x3087ff).ram().share(m_pf_rowscroll[0]);
-	map(0x30a000, 0x30a7ff).ram().share(m_pf_rowscroll[1]);
+	map(0x304000, 0x305fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x306000, 0x307fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x308000, 0x3087ff).ram().share(m_rowscroll[0]);
+	map(0x30a000, 0x30a7ff).ram().share(m_rowscroll[1]);
 
 	map(0x310000, 0x31000f).w(FUNC(cninja_state::cninja_pf_control_w<1>));
-	map(0x314000, 0x315fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x316000, 0x317fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x318000, 0x3187ff).ram().share(m_pf_rowscroll[2]);
-	map(0x31a000, 0x31a7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x314000, 0x315fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x316000, 0x317fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x318000, 0x3187ff).ram().share(m_rowscroll[2]);
+	map(0x31a000, 0x31a7ff).ram().share(m_rowscroll[3]);
 
 	map(0xad00ac, 0xad00ff).nopr(); /* Reads from here seem to be a game code bug */
 }
@@ -413,7 +356,6 @@ void cninja_state::cninjabl2_oki_map(address_map &map)
 /**********************************************************************************/
 
 static INPUT_PORTS_START( edrandy )
-
 	PORT_START("INPUTS")
 	DATAEAST_2BUTTON
 
@@ -467,7 +409,6 @@ static INPUT_PORTS_START( edrandc )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( cninja )
-
 	PORT_START("INPUTS")
 	DATAEAST_2BUTTON
 
@@ -478,7 +419,6 @@ static INPUT_PORTS_START( cninja )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("screen", FUNC(screen_device::vblank))
 
 	PORT_START("DSW")   /* Dip switch bank 1 */
-
 	DATAEAST_COINAGE
 
 	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:7")
@@ -547,7 +487,6 @@ static INPUT_PORTS_START( robocop2 )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("screen", FUNC(screen_device::vblank))
 
 	PORT_START("DSW")   /* Dip switch bank 1 */
-
 	DATAEAST_COINAGE
 
 	PORT_DIPNAME( 0x0040, 0x0000, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:7")
@@ -604,7 +543,6 @@ static INPUT_PORTS_START( robocop2 )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( mutantf )
-
 	PORT_START("INPUTS")
 	DATAEAST_2BUTTON
 
@@ -615,7 +553,6 @@ static INPUT_PORTS_START( mutantf )
 	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER("screen", FUNC(screen_device::vblank))
 
 	PORT_START("DSW")   /* Dip switch bank 1 */
-
 	DATAEAST_COINAGE
 
 	PORT_DIPNAME( 0x0040, 0x0040, DEF_STR( Flip_Screen ) ) PORT_DIPLOCATION("SW1:7")
@@ -718,26 +655,21 @@ void cninja_state::cninjabl2_oki_bank_w(uint8_t data)
 
 /**********************************************************************************/
 
-DECO16IC_BANK_CB_MEMBER(cninja_state::cninja_bank_callback)
+int cninja_state::cninja_bank_callback(int bank)
 {
-	if ((bank >> 4) & 0xf)
+	if (bank & 0xf0)
 		return 0x0000; /* Only 2 banks */
 	return 0x1000;
 }
 
-DECO16IC_BANK_CB_MEMBER(cninja_state::robocop2_bank_callback)
+int cninja_state::robocop2_bank_callback(int bank)
 {
 	return (bank & 0x30) << 8;
 }
 
-DECO16IC_BANK_CB_MEMBER(cninja_state::mutantf_1_bank_callback)
+int cninja_state::mutantf_2_bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x3) << 12;
-}
-
-DECO16IC_BANK_CB_MEMBER(cninja_state::mutantf_2_bank_callback)
-{
-	return ((bank >> 5) & 0x1) << 14;
+	return (bank & 0x20) << 9;
 }
 
 // palette bits are not effected
@@ -799,29 +731,29 @@ void cninja_state::cninja(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
@@ -880,29 +812,29 @@ void cninja_state::stoneage(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
@@ -970,29 +902,29 @@ void cninja_state::cninjabl(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -1036,29 +968,29 @@ void cninja_state::edrandy(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::cninja_bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::cninja_bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
@@ -1116,31 +1048,31 @@ void cninja_state::robocop2(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(cninja_state::robocop2_bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<1>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::robocop2_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::robocop2_bank_callback));
-	m_deco_tilegen[1]->set_mix_callback(FUNC(cninja_state::robocop2_mix_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[1]->set_mix_callback(FUNC(cninja_state::robocop2_mix_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_cninja_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(cninja_state::pri_callback));
@@ -1195,31 +1127,31 @@ void cninja_state::mutantf(machine_config &config)
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 	BUFFERED_SPRITERAM16(config, m_spriteram[1]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(cninja_state::mutantf_1_bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(cninja_state::mutantf_2_bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x30);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(cninja_state::mutantf_2_bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(cninja_state::mutantf_1_bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(cninja_state::mutantf_1_bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x20);
+	m_tilegen[1]->set_col_bank<1>(0x40);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(cninja_state::robocop2_bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_mutantf_spr1);
 	m_sprgen[0]->set_alt_format(true);

--- a/src/mame/dataeast/cninja.h
+++ b/src/mame/dataeast/cninja.h
@@ -26,7 +26,7 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_ioprot(*this, "ioprot")
-		, m_deco_tilegen(*this, "tilegen%u", 1U)
+		, m_tilegen(*this, "tilegen%u", 1U)
 		, m_oki2(*this, "oki2")
 		, m_sprgen(*this, "spritegen%u", 1U)
 		, m_gfxdecode(*this, "gfxdecode")
@@ -34,7 +34,7 @@ public:
 		, m_palette(*this, "palette")
 		, m_soundlatch(*this, "soundlatch")
 		, m_spriteram(*this, "spriteram%u", 1U)
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1U)
+		, m_rowscroll(*this, "rowscroll_%u", 1U)
 		, m_okibank(*this, "okibank")
 	{ }
 
@@ -53,7 +53,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
 	optional_device<deco_146_base_device> m_ioprot;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	optional_device<okim6295_device> m_oki2;
 	optional_device_array<decospr_device, 2> m_sprgen;
 	required_device<gfxdecode_device> m_gfxdecode;
@@ -63,7 +63,7 @@ private:
 	optional_device_array<buffered_spriteram16_device, 2> m_spriteram;
 
 	/* memory pointers */
-	required_shared_ptr_array<uint16_t, 4> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 4> m_rowscroll;
 	optional_memory_bank m_okibank;
 
 	uint16_t m_priority = 0U;
@@ -82,25 +82,17 @@ private:
 	uint32_t screen_update_edrandy(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_robocop2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_mutantf(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void cninjabl_draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect );
+	void cninjabl_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(cninja_bank_callback);
-	DECO16IC_BANK_CB_MEMBER(robocop2_bank_callback);
-	DECO16IC_BANK_CB_MEMBER(mutantf_1_bank_callback);
-	DECO16IC_BANK_CB_MEMBER(mutantf_2_bank_callback);
+	int cninja_bank_callback(int bank);
+	int robocop2_bank_callback(int bank);
+	int mutantf_2_bank_callback(int bank);
 
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 	u16 robocop2_mix_callback(u16 p, u16 p2);
 
-	uint16_t edrandy_protection_region_6_146_r(offs_t offset);
-	void edrandy_protection_region_6_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t edrandy_protection_region_8_146_r(offs_t offset);
-	void edrandy_protection_region_8_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-
-	uint16_t mutantf_protection_region_0_146_r(offs_t offset);
-	void mutantf_protection_region_0_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t cninja_protection_region_0_104_r(offs_t offset);
-	void cninja_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	template <offs_t Base> uint16_t ioprot_r(offs_t offset);
+	template <offs_t Base> void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
 	uint16_t cninjabl2_sprite_dma_r();
 	void robocop2_priority_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);

--- a/src/mame/dataeast/cninja_v.cpp
+++ b/src/mame/dataeast/cninja_v.cpp
@@ -13,22 +13,22 @@
 
 VIDEO_START_MEMBER(cninja_state,cninja)
 {
-	m_deco_tilegen[0]->set_transmask(1, 0, 0x00ff, 0xff01);
+	m_tilegen[0]->set_transmask(1, 0, 0x00ff, 0xff01);
 }
 
 VIDEO_START_MEMBER(cninja_state,stoneage)
 {
 	/* The bootleg has broken scroll registers */
-	m_deco_tilegen[0]->set_scrolldx(3, 0, -10, -10); /* pf4 16x16 tilemap */
-	m_deco_tilegen[0]->set_scrolldx(1, 0, -10, -10); /* pf2 16x16 tilemap */
-	m_deco_tilegen[0]->set_scrolldx(0, 1, 2, 2); /* pf1 8x8 tilemap */
+	m_tilegen[0]->set_scrolldx(3, 0, -10, -10); /* pf4 16x16 tilemap */
+	m_tilegen[0]->set_scrolldx(1, 0, -10, -10); /* pf2 16x16 tilemap */
+	m_tilegen[0]->set_scrolldx(0, 1, 2, 2); /* pf1 8x8 tilemap */
 }
 
 /******************************************************************************/
 
 
 /* The bootleg sprites are in a different format! */
-void cninja_state::cninjabl_draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect )
+void cninja_state::cninjabl_draw_sprites(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	uint16_t *buffered_spriteram = m_spriteram[0]->buffer();
 	int offs;
@@ -128,30 +128,30 @@ void cninja_state::cninjabl_draw_sprites( screen_device &screen, bitmap_ind16 &b
 
 uint32_t cninja_state::screen_update_cninja(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	/* Draw playfields */
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(512, cliprect);
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 4);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 4);
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
 uint32_t cninja_state::screen_update_cninjabl2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	/* force layers to be enabled */
-	m_deco_tilegen[0]->set_enable(0, 1 );
-	m_deco_tilegen[0]->set_enable(1, 1 );
+	m_tilegen[0]->set_enable(0, 1);
+	m_tilegen[0]->set_enable(1, 1);
 
 	screen_update_cninja(screen, bitmap, cliprect);
 
@@ -160,88 +160,88 @@ uint32_t cninja_state::screen_update_cninjabl2(screen_device &screen, bitmap_ind
 
 uint32_t cninja_state::screen_update_cninjabl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 
 	/* force layers to be enabled */
-	m_deco_tilegen[1]->set_enable(0, 1 );
-	m_deco_tilegen[1]->set_enable(1, 1 );
+	m_tilegen[1]->set_enable(0, 1);
+	m_tilegen[1]->set_enable(1, 1);
 
 	flip_screen_set(BIT(flip, 7));
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	/* Draw playfields */
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(512, cliprect);
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 4);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 4);
 	cninjabl_draw_sprites(screen, bitmap, cliprect);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
 uint32_t cninja_state::screen_update_edrandy(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0, cliprect);
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
 uint32_t cninja_state::screen_update_robocop2(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 	uint16_t const priority = m_priority;
 
 	/* Update playfields */
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	/* Draw playfields */
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0x200, cliprect);
 
 	if ((priority & 4) == 0)
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
 
 	/* Switchable priority */
 	switch (priority & 0x8)
 	{
 		case 8:
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 			if (priority & 4)
-				m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 4);
 			else
-				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 			break;
 		default:
 		case 0:
 			if (priority & 4)
-				m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 2);
+				m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 2);
 			else
-				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+				m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 			break;
 	}
 
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -253,7 +253,7 @@ VIDEO_START_MEMBER(cninja_state,mutantf)
 
 uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 	uint16_t const priority = m_priority;
 
 	// sprites are flipped relative to tilemaps
@@ -261,8 +261,8 @@ uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32
 	m_sprgen[0]->set_flip_screen(!BIT(flip, 7));
 	m_sprgen[1]->set_flip_screen(!BIT(flip, 7));
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	/* Draw playfields */
 	bitmap.fill(0x400, cliprect); /* Confirmed */
@@ -282,9 +282,9 @@ uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32
 	The other bits may control alpha blend on the 2nd sprite chip, or
 	layer order.
 	*/
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 
 	if (priority & 1)
@@ -297,6 +297,6 @@ uint32_t cninja_state::screen_update_mutantf(screen_device &screen, bitmap_rgb32
 		m_sprgen[1]->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0000, 0x0000, 1024+768, 0x0ff, 0x80);  // fixed alpha of 0x80 for this layer?
 		m_sprgen[0]->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0000, 0x0000, 0x100, 0x1ff);
 	}
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }

--- a/src/mame/dataeast/darkseal.cpp
+++ b/src/mame/dataeast/darkseal.cpp
@@ -44,13 +44,13 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_palette(*this, "colors")
-		, m_deco_tilegen(*this, "tilegen%u", 1U)
+		, m_palette(*this, "palette")
+		, m_tilegen(*this, "tilegen%u", 1U)
 		, m_sprgen(*this, "spritegen")
 		, m_spriteram(*this, "spriteram")
 		, m_soundlatch(*this, "soundlatch")
-		, m_pf1_rowscroll(*this, "pf1_rowscroll")
-		, m_pf3_rowscroll(*this, "pf3_rowscroll")
+		, m_rowscroll_1(*this, "rowscroll_1")
+		, m_rowscroll_3(*this, "rowscroll_3")
 		, m_paletteram(*this, "palette")
 		, m_paletteram_ext(*this, "palette_ext")
 	{ }
@@ -72,13 +72,13 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
 	required_device<palette_device> m_palette;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<decospr_device> m_sprgen;
 	required_device<buffered_spriteram16_device> m_spriteram;
 	required_device<generic_latch_8_device> m_soundlatch;
 
-	required_shared_ptr<uint16_t> m_pf1_rowscroll;
-	required_shared_ptr<uint16_t> m_pf3_rowscroll;
+	required_shared_ptr<uint16_t> m_rowscroll_1;
+	required_shared_ptr<uint16_t> m_rowscroll_3;
 	required_shared_ptr<uint16_t> m_paletteram;
 	required_shared_ptr<uint16_t> m_paletteram_ext;
 };
@@ -129,21 +129,21 @@ void darkseal_state::palette_ext_w(offs_t offset, uint16_t data, uint16_t mem_ma
 
 uint32_t darkseal_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[1]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[1]->control_r(0);
 	flip_screen_set(!BIT(flip, 7));
 	m_sprgen->set_flip_screen(!BIT(flip, 7));
 
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	m_deco_tilegen[0]->pf_update(m_pf1_rowscroll, m_pf1_rowscroll);
-	m_deco_tilegen[1]->pf_update(m_pf3_rowscroll, m_pf3_rowscroll);
+	m_tilegen[0]->update(m_rowscroll_1, m_rowscroll_1);
+	m_tilegen[1]->update(m_rowscroll_3, m_rowscroll_3);
 
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram->buffer(), 0x400);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -174,17 +174,17 @@ void darkseal_state::main_map(address_map &map)
 	map(0x180008, 0x180009).w(m_soundlatch, FUNC(generic_latch_8_device::write)).umask16(0x00ff).cswidth(16);
 	map(0x18000a, 0x18000b).nopr().w(FUNC(darkseal_state::irq_ack_w));
 
-	map(0x200000, 0x201fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x203fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x240000, 0x24000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x200000, 0x201fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x203fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x240000, 0x24000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 
-	map(0x220000, 0x220fff).ram().share(m_pf1_rowscroll);
+	map(0x220000, 0x220fff).ram().share(m_rowscroll_1);
 	// pf2 & 4 rowscrolls are where? (maybe don't exist?)
-	map(0x222000, 0x222fff).ram().share(m_pf3_rowscroll);
+	map(0x222000, 0x222fff).ram().share(m_rowscroll_3);
 
-	map(0x260000, 0x261fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x262000, 0x263fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x2a0000, 0x2a000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
+	map(0x260000, 0x261fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x262000, 0x263fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x2a0000, 0x2a000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
 }
 
 /******************************************************************************/
@@ -292,7 +292,7 @@ static const gfx_layout charlayout =
 	8*8*2 // every char takes 8 consecutive bytes
 };
 
-static const gfx_layout seallayout =
+static const gfx_layout tilelayout =
 {
 	16,16,
 	RGN_FRAC(1,2),
@@ -305,12 +305,12 @@ static const gfx_layout seallayout =
 
 static GFXDECODE_START( gfx_darkseal )
 	GFXDECODE_ENTRY( "chars",   0, charlayout,    0, 16 )  // 8x8
-	GFXDECODE_ENTRY( "tiles1",  0, seallayout,  768, 16 )  // 16x16
-	GFXDECODE_ENTRY( "tiles2",  0, seallayout, 1024, 16 )  // 16x16
+	GFXDECODE_ENTRY( "tiles1",  0, tilelayout,  768, 16 )  // 16x16
+	GFXDECODE_ENTRY( "tiles2",  0, tilelayout, 1024, 16 )  // 16x16
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_darkseal_spr )
-	GFXDECODE_ENTRY( "sprites", 0, seallayout,  256, 32 )  // 16x16
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout,  256, 32 )  // 16x16
 GFXDECODE_END
 
 /******************************************************************************/
@@ -341,27 +341,27 @@ void darkseal_state::darkseal(machine_config &config)
 
 	BUFFERED_SPRITERAM16(config, m_spriteram);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x64);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x64);     // both these tilemaps need to be twice the y size of usual!
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x64);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x64);     // both these tilemaps need to be twice the y size of usual!
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x00);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x00);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_darkseal_spr);
 

--- a/src/mame/dataeast/dassault.cpp
+++ b/src/mame/dataeast/dassault.cpp
@@ -239,14 +239,14 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_subcpu(*this, "sub")
-		, m_deco_tilegen(*this, "tilegen%u", 1U)
+		, m_tilegen(*this, "tilegen%u", 1U)
 		, m_oki2(*this, "oki2")
 		, m_spriteram(*this, "spriteram%u", 1U)
 		, m_sprgen(*this, "spritegen%u", 1U)
 		, m_palette(*this, "palette")
 		, m_soundlatch(*this, "soundlatch")
-		, m_pf2_rowscroll(*this, "pf2_rowscroll")
-		, m_pf4_rowscroll(*this, "pf4_rowscroll")
+		, m_rowscroll_2(*this, "rowscroll_2")
+		, m_rowscroll_4(*this, "rowscroll_4")
 		, m_input(*this, { "P1_P2", "P3_P4", "DSW1", "DSW2", "SYSTEM" })
 	{ }
 
@@ -263,7 +263,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
 	required_device<cpu_device> m_subcpu;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<okim6295_device> m_oki2;
 	required_device_array<buffered_spriteram16_device, 2> m_spriteram;
 	required_device_array<decospr_device, 2> m_sprgen;
@@ -271,8 +271,8 @@ private:
 	required_device<generic_latch_8_device> m_soundlatch;
 
 	// memory pointers
-	required_shared_ptr<uint16_t> m_pf2_rowscroll;
-	required_shared_ptr<uint16_t> m_pf4_rowscroll;
+	required_shared_ptr<uint16_t> m_rowscroll_2;
+	required_shared_ptr<uint16_t> m_rowscroll_4;
 
 	required_ioport_array<5> m_input;
 
@@ -286,7 +286,7 @@ private:
 	void sound_bankswitch_w(uint8_t data);
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void mix_layer(bitmap_rgb32 &bitmap, bitmap_ind16 *sprite_bitmap, const rectangle &cliprect, uint16_t pri, uint16_t primask, uint16_t penbase, uint8_t alpha);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	void main_map(address_map &map) ATTR_COLD;
 	void sub_map(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
@@ -366,7 +366,7 @@ void dassault_state::mix_layer(bitmap_rgb32 &bitmap, bitmap_ind16 *sprite_bitmap
 // but if (for example) you walk to the side of the crates in the first part of the game you appear over them...
 uint32_t dassault_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
@@ -378,21 +378,21 @@ uint32_t dassault_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 	bitmap_ind16 *sprite_bitmap2 = &m_sprgen[1]->get_sprite_temp_bitmap();
 
 	// Update tilemaps
-	m_deco_tilegen[0]->pf_update(nullptr, m_pf2_rowscroll);
-	m_deco_tilegen[1]->pf_update(nullptr, m_pf4_rowscroll);
+	m_tilegen[0]->update(nullptr, m_rowscroll_2);
+	m_tilegen[1]->update(nullptr, m_rowscroll_4);
 
 	// Draw playfields/update priority bitmap
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(m_palette->pen(3072), cliprect);
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 
 	// The middle playfields can be swapped priority-wise
 	if ((m_priority & 3) == 0)
 	{
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0600, 0x0600, 0x400, 0xff); // 1
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2); // 2
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2); // 2
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0400, 0x0600, 0x400, 0xff); // 8
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 16); // 16
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 16); // 16
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0200, 0x0600, 0x400, 0xff); // 32
 		mix_layer(bitmap, sprite_bitmap2, cliprect, 0x0000, 0x0000, 0x800, 0x80); // 64?
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0000, 0x0600, 0x400, 0xff); // 128
@@ -401,19 +401,19 @@ uint32_t dassault_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 	else if ((m_priority & 3) == 1)
 	{
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0600, 0x0600, 0x400, 0xff); // 1
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2); // 2
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2); // 2
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0400, 0x0600, 0x400, 0xff); // 8
 		mix_layer(bitmap, sprite_bitmap2, cliprect, 0x0000, 0x0000, 0x800, 0x80); // 16?
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0200, 0x0600, 0x400, 0xff); // 32
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 64); // 64
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 64); // 64
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0000, 0x0600, 0x400, 0xff); // 128
 	}
 	else if ((m_priority & 3) == 3)
 	{
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0600, 0x0600, 0x400, 0xff); // 1
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2); // 2
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2); // 2
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0400, 0x0600, 0x400, 0xff); // 8
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 16); // 16
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 16); // 16
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0200, 0x0600, 0x400, 0xff); // 32
 		mix_layer(bitmap, sprite_bitmap2, cliprect, 0x0000, 0x0000, 0x800, 0x80); // 64?
 		mix_layer(bitmap, sprite_bitmap1, cliprect, 0x0000, 0x0600, 0x400, 0xff); // 128
@@ -423,7 +423,7 @@ uint32_t dassault_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 		// Unused
 	}
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -493,15 +493,15 @@ void dassault_state::main_map(address_map &map)
 	map(0x1c000c, 0x1c000d).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write));
 	map(0x1c000e, 0x1c000f).w(FUNC(dassault_state::control_w));
 
-	map(0x200000, 0x201fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x203fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x212000, 0x212fff).writeonly().share(m_pf2_rowscroll);
-	map(0x220000, 0x22000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
+	map(0x200000, 0x201fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x203fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x212000, 0x212fff).writeonly().share(m_rowscroll_2);
+	map(0x220000, 0x22000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
 
-	map(0x240000, 0x240fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x242000, 0x242fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x252000, 0x252fff).writeonly().share(m_pf4_rowscroll);
-	map(0x260000, 0x26000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x240000, 0x240fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x242000, 0x242fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x252000, 0x252fff).writeonly().share(m_rowscroll_4);
+	map(0x260000, 0x26000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 
 	map(0x3f8000, 0x3fbfff).ram(); // Main RAM
 	map(0x3fc000, 0x3fcfff).ram().share("spriteram2");
@@ -719,9 +719,9 @@ void dassault_state::sound_bankswitch_w(uint8_t data)
 	m_oki2->set_rom_bank(data & 1);
 }
 
-DECO16IC_BANK_CB_MEMBER(dassault_state::bank_callback)
+int dassault_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0xf) << 12;
+	return (bank & 0xf0) << 8;
 }
 
 void dassault_state::machine_reset()
@@ -762,31 +762,31 @@ void dassault_state::dassault(machine_config &config)
 	BUFFERED_SPRITERAM16(config, m_spriteram[0]);
 	BUFFERED_SPRITERAM16(config, m_spriteram[1]);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0);
-	m_deco_tilegen[0]->set_pf2_col_bank(16);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(dassault_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(dassault_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0);
+	m_tilegen[0]->set_col_bank<1>(16);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(dassault_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(dassault_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0);
-	m_deco_tilegen[1]->set_pf2_col_bank(16);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(dassault_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(dassault_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0);
+	m_tilegen[1]->set_col_bank<1>(16);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(dassault_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(dassault_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_dassault_spr1);
 	DECO_SPRITE(config, m_sprgen[1], m_palette, gfx_dassault_spr2);

--- a/src/mame/dataeast/dblewing.cpp
+++ b/src/mame/dataeast/dblewing.cpp
@@ -91,12 +91,12 @@ class dblewing_state : public driver_device
 public:
 	dblewing_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U),
+		m_rowscroll(*this, "rowscroll_%u", 1U),
 		m_spriteram(*this, "spriteram"),
 		m_decrypted_opcodes(*this, "decrypted_opcodes"),
 		m_maincpu(*this, "maincpu"),
 		m_audiocpu(*this, "audiocpu"),
-		m_deco_tilegen(*this, "tilegen"),
+		m_tilegen(*this, "tilegen"),
 		m_deco104(*this, "ioprot"),
 		m_sprgen(*this, "spritegen"),
 		m_soundlatch_pending(false)
@@ -108,14 +108,14 @@ public:
 
 private:
 	/* memory pointers */
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 	required_shared_ptr<uint16_t> m_spriteram;
 	required_shared_ptr<uint16_t> m_decrypted_opcodes;
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_audiocpu;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<deco104_device> m_deco104;
 	required_device<decospr_device> m_sprgen;
 
@@ -123,7 +123,7 @@ private:
 	void soundlatch_irq_w(int state);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	uint16_t ioprot_r(offs_t offset);
@@ -139,17 +139,17 @@ private:
 
 uint32_t dblewing_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(0, cliprect); /* not Confirmed */
 	screen.priority().fill(0);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	return 0;
 }
@@ -180,17 +180,17 @@ void dblewing_state::dblewing_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 
-	map(0x100000, 0x100fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x102000, 0x102fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x104000, 0x104fff).ram().share(m_pf_rowscroll[0]);
-	map(0x106000, 0x106fff).ram().share(m_pf_rowscroll[1]);
+	map(0x100000, 0x100fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x102000, 0x102fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x104000, 0x104fff).ram().share(m_rowscroll[0]);
+	map(0x106000, 0x106fff).ram().share(m_rowscroll[1]);
 
 //  map(0x280000, 0x2807ff).rw("ioprot104", FUNC(deco104_device::dblewing_prot_r), FUNC(deco104_device::dblewing_prot_w)).share("prot16ram");
-	map(0x280000, 0x283fff).rw(FUNC(dblewing_state::ioprot_r), FUNC(dblewing_state::ioprot_w)).share("prot16ram"); /* Protection device */
+	map(0x280000, 0x283fff).rw(FUNC(dblewing_state::ioprot_r), FUNC(dblewing_state::ioprot_w)); /* Protection device */
 
 	map(0x284000, 0x284001).ram();
 	map(0x288000, 0x288001).ram();
-	map(0x28c000, 0x28c00f).ram().w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
+	map(0x28c000, 0x28c00f).ram().w(m_tilegen, FUNC(deco16ic_device::control_w));
 	map(0x300000, 0x3007ff).ram().share("spriteram");
 	map(0x320000, 0x3207ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0xff0000, 0xff3fff).mirror(0xc000).ram();
@@ -331,9 +331,9 @@ static INPUT_PORTS_START( dblewing )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
 
-DECO16IC_BANK_CB_MEMBER(dblewing_state::bank_callback)
+int dblewing_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(dblewing_state::pri_callback)
@@ -369,18 +369,18 @@ void dblewing_state::dblewing(machine_config &config)
 	PALETTE(config, "palette").set_format(palette_device::xBGR_444, 2048/2);
 	GFXDECODE(config, "gfxdecode", "palette", gfx_dblewing);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(dblewing_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(dblewing_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(dblewing_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(dblewing_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, "palette", gfx_dblewing_spr);
 	m_sprgen->set_pri_callback(FUNC(dblewing_state::pri_callback));

--- a/src/mame/dataeast/deco16ic.cpp
+++ b/src/mame/dataeast/deco16ic.cpp
@@ -274,7 +274,7 @@ TILEMAP_MAPPER_MEMBER(deco16ic_device::scan_rows)
 	return (col & 0x1f) + ((row & 0x1f) << 5) + ((col & 0x20) << 5) + ((row & 0x20) << 6);
 }
 
-template <unsigned Which, bool is8x8>
+template <unsigned Which, bool Is8x8>
 TILE_GET_INFO_MEMBER(deco16ic_device::get_tile_info)
 {
 	u32 tile = m_vram[Which][tile_index];
@@ -297,9 +297,9 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_tile_info)
 
 	tile &= 0xfff;
 	if (!m_tile_cb.isnull())
-		m_tile_cb(tile, colour, Which, is8x8);
+		m_tile_cb(tile, colour, Which, Is8x8);
 
-	tileinfo.set(is8x8 ? m_8x8_gfx_bank : m_16x16_gfx_bank,
+	tileinfo.set(Is8x8 ? m_8x8_gfx_bank : m_16x16_gfx_bank,
 			tile + m_tmap[Which].m_bank,
 			(colour & m_tmap[Which].m_colour_mask) + m_tmap[Which].m_colour_bank,
 			flags);
@@ -490,7 +490,7 @@ void deco16ic_device::set_scrolldx(int tmap, int size, int dx, int dx_if_flipped
 /* cninjabl does not enable background layers */
 void deco16ic_device::set_enable(int tmap, int enable)
 {
-	m_tmap[tmap].m_control0 &= ~(1 << 7);
+	m_tmap[tmap].m_control0 &= ~(uint16_t(1) << 7);
 	m_tmap[tmap].m_control0 |= (enable & 1) << 7;
 }
 

--- a/src/mame/dataeast/deco16ic.cpp
+++ b/src/mame/dataeast/deco16ic.cpp
@@ -181,30 +181,16 @@ DEFINE_DEVICE_TYPE(DECO16IC, deco16ic_device, "deco16ic", "DECO 55 / 56 / 74 / 1
 deco16ic_device::deco16ic_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: device_t(mconfig, DECO16IC, tag, owner, clock)
 	, device_video_interface(mconfig, *this)
-	, m_pf1_data(nullptr)
-	, m_pf2_data(nullptr)
-	, m_pf12_control(nullptr)
-	, m_pf1_rowscroll_ptr(nullptr)
-	, m_pf2_rowscroll_ptr(nullptr)
-	, m_tile_cb(*this)
-	, m_bank1_cb(*this)
-	, m_bank2_cb(*this)
-	, m_mix_cb(*this)
-	, m_use_custom_pf1(0)
-	, m_use_custom_pf2(0)
-	, m_pf1_bank(0)
-	, m_pf2_bank(0)
-	, m_pf12_last_small(0)
-	, m_pf12_last_big(0)
-	, m_pf1_size(0)
-	, m_pf2_size(0)
-	, m_pf1_colour_bank(0)
-	, m_pf2_colour_bank(0)
-	, m_pf1_colourmask(0xf)
-	, m_pf2_colourmask(0xf)
-	, m_pf12_8x8_gfx_bank(0)
-	, m_pf12_16x16_gfx_bank(0)
 	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
+	, m_vram(*this, "vram_%u", 1U, 0x2000U, ENDIANNESS_BIG)
+	, m_control(*this, "control", 0x10U, ENDIANNESS_BIG)
+	, m_tmap{(*this), (*this)}
+	, m_tile_cb(*this)
+	, m_mix_cb(*this)
+	, m_last_small(0)
+	, m_last_big(0)
+	, m_8x8_gfx_bank(0)
+	, m_16x16_gfx_bank(0)
 {
 }
 
@@ -214,60 +200,57 @@ deco16ic_device::deco16ic_device(const machine_config &mconfig, const char *tag,
 
 void deco16ic_device::device_start()
 {
-	if(!m_gfxdecode->started())
+	if (!m_gfxdecode->started())
 		throw device_missing_dependencies();
 
 	m_tile_cb.resolve();
-	m_bank1_cb.resolve();
-	m_bank2_cb.resolve();
+	m_tmap[0].m_bank_cb.resolve();
+	m_tmap[1].m_bank_cb.resolve();
 	m_mix_cb.resolve();
 
-	int fullheight1 = 0;
-	int fullwidth1 = 0;
+	int fullheight1 = 32;
+	int fullwidth1 = 32;
 
-	int fullheight2 = 0;
-	int fullwidth2 = 0;
+	int fullheight2 = 32;
+	int fullwidth2 = 32;
 
-	if (m_pf1_size&DECO_32x64)
-		fullheight1 = 1;
+	if (m_tmap[0].m_size & DECO_32x64)
+		fullheight1 = 64;
 
-	if (m_pf1_size&DECO_64x32)
-		fullwidth1 = 1;
+	if (m_tmap[0].m_size & DECO_64x32)
+		fullwidth1 = 64;
 
-	if (m_pf2_size&DECO_32x64)
-		fullheight2 = 1;
+	if (m_tmap[1].m_size & DECO_32x64)
+		fullheight2 = 64;
 
-	if (m_pf2_size&DECO_64x32)
-		fullwidth2 = 1;
+	if (m_tmap[1].m_size & DECO_64x32)
+		fullwidth2 = 64;
 
-	m_pf1_tilemap_16x16 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco16ic_device::get_pf1_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco16ic_device::deco16_scan_rows)), 16, 16, fullwidth1 ? 64 : 32, fullheight1 ? 64 : 32);
-//  m_pf1_tilemap_8x8 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco16ic_device::get_pf1_tile_info_b)), TILEMAP_SCAN_ROWS, 8, 8, fullwidth1 ? 64 : 32, fullheight1 ? 64 : 32);
-	m_pf1_tilemap_8x8 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco16ic_device::get_pf1_tile_info_b)), TILEMAP_SCAN_ROWS, 8, 8, fullwidth1 ? 64 : 32, fullheight1 ? 64 : 32);
+	m_tmap[0].m_tilemap_16x16 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&deco16ic_device::get_tile_info<0, false>))), tilemap_mapper_delegate(*this, FUNC(deco16ic_device::scan_rows)), 16, 16, fullwidth1, fullheight1);
+	m_tmap[0].m_tilemap_8x8 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&deco16ic_device::get_tile_info<0, true>))), TILEMAP_SCAN_ROWS, 8, 8, fullwidth1, fullheight1);
 
-	m_pf2_tilemap_16x16 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco16ic_device::get_pf2_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco16ic_device::deco16_scan_rows)), 16, 16, fullwidth2 ? 64 : 32, fullheight2 ? 64 : 32);
-	m_pf2_tilemap_8x8 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco16ic_device::get_pf2_tile_info_b)), TILEMAP_SCAN_ROWS, 8, 8, fullwidth2 ? 64 : 32, fullheight2 ? 64 : 32);
+	m_tmap[1].m_tilemap_16x16 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&deco16ic_device::get_tile_info<1, false>))), tilemap_mapper_delegate(*this, FUNC(deco16ic_device::scan_rows)), 16, 16, fullwidth2, fullheight2);
+	m_tmap[1].m_tilemap_8x8 = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, NAME((&deco16ic_device::get_tile_info<1, true>))), TILEMAP_SCAN_ROWS, 8, 8, fullwidth2, fullheight2);
 
-	m_pf1_tilemap_8x8->set_transparent_pen(0);
-	m_pf2_tilemap_8x8->set_transparent_pen(0);
-	m_pf1_tilemap_16x16->set_transparent_pen(0);
-	m_pf2_tilemap_16x16->set_transparent_pen(0);
+	m_tmap[0].m_tilemap_8x8->set_transparent_pen(0);
+	m_tmap[1].m_tilemap_8x8->set_transparent_pen(0);
+	m_tmap[0].m_tilemap_16x16->set_transparent_pen(0);
+	m_tmap[1].m_tilemap_16x16->set_transparent_pen(0);
 
-	m_pf1_data = make_unique_clear<u16[]>(0x2000 / 2);
-	m_pf2_data = make_unique_clear<u16[]>(0x2000 / 2);
-	m_pf12_control = make_unique_clear<u16[]>(0x10 / 2);
+	save_item(STRUCT_MEMBER(m_tmap, m_use_custom_pf));
+	save_item(STRUCT_MEMBER(m_tmap, m_bank));
+	save_item(STRUCT_MEMBER(m_tmap, m_colour_bank));
+	save_item(STRUCT_MEMBER(m_tmap, m_colour_mask));
+	save_item(STRUCT_MEMBER(m_tmap, m_scrollx));
+	save_item(STRUCT_MEMBER(m_tmap, m_scrolly));
+	save_item(STRUCT_MEMBER(m_tmap, m_control0));
+	save_item(STRUCT_MEMBER(m_tmap, m_control1));
+	save_item(STRUCT_MEMBER(m_tmap, m_bankval));
 
-	save_item(NAME(m_use_custom_pf1));
-	save_item(NAME(m_use_custom_pf2));
-	save_item(NAME(m_pf1_bank));
-	save_item(NAME(m_pf2_bank));
-	save_item(NAME(m_pf12_8x8_gfx_bank));
-	save_item(NAME(m_pf12_16x16_gfx_bank));
-	save_item(NAME(m_pf12_last_small));
-	save_item(NAME(m_pf12_last_big));
-
-	save_pointer(NAME(m_pf1_data), 0x2000 / 2);
-	save_pointer(NAME(m_pf2_data), 0x2000 / 2);
-	save_pointer(NAME(m_pf12_control), 0x10 / 2);
+	save_item(NAME(m_8x8_gfx_bank));
+	save_item(NAME(m_16x16_gfx_bank));
+	save_item(NAME(m_last_small));
+	save_item(NAME(m_last_big));
 }
 
 //-------------------------------------------------
@@ -276,35 +259,37 @@ void deco16ic_device::device_start()
 
 void deco16ic_device::device_reset()
 {
-	m_pf1_bank = m_pf2_bank = 0;
-	m_pf12_last_small = m_pf12_last_big = -1;
-	m_use_custom_pf1 = m_use_custom_pf2 = 0;
-	m_pf1_rowscroll_ptr = nullptr;
-	m_pf2_rowscroll_ptr = nullptr;
+	m_tmap[0].m_bank = m_tmap[1].m_bank = 0;
+	m_last_small = m_last_big = -1;
+	m_tmap[0].m_use_custom_pf = m_tmap[1].m_use_custom_pf = false;
+	m_tmap[0].m_rowscroll_ptr = nullptr;
+	m_tmap[1].m_rowscroll_ptr = nullptr;
 }
 
 /*****************************************************************************************/
 
-TILEMAP_MAPPER_MEMBER(deco16ic_device::deco16_scan_rows)
+TILEMAP_MAPPER_MEMBER(deco16ic_device::scan_rows)
 {
 	/* logical (col,row) -> memory offset */
 	return (col & 0x1f) + ((row & 0x1f) << 5) + ((col & 0x20) << 5) + ((row & 0x20) << 6);
 }
 
-TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info)
+template <unsigned Which, bool is8x8>
+TILE_GET_INFO_MEMBER(deco16ic_device::get_tile_info)
 {
-	u32 tile = m_pf2_data[tile_index];
+	u32 tile = m_vram[Which][tile_index];
 	u32 colour = (tile >> 12) & 0xf;
 	u8 flags = 0;
 
-	if (tile & 0x8000)
+	if (BIT(tile, 15))
 	{
-		if ((m_pf12_control[6] >> 8) & 0x01)
+		const u8 shift = Which << 3;
+		if (BIT(m_control[6], shift + 0))
 		{
 			flags |= TILE_FLIPX;
 			colour &= 0x7;
 		}
-		if ((m_pf12_control[6] >> 8) & 0x02)
+		if (BIT(m_control[6], shift + 1))
 		{
 			flags |= TILE_FLIPY;
 			colour &= 0x7;
@@ -313,101 +298,11 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info)
 
 	tile &= 0xfff;
 	if (!m_tile_cb.isnull())
-		m_tile_cb(tile, colour, 1, false);
+		m_tile_cb(tile, colour, Which, is8x8);
 
-	tileinfo.set(m_pf12_16x16_gfx_bank,
-			tile + m_pf2_bank,
-			(colour & m_pf2_colourmask) + m_pf2_colour_bank,
-			flags);
-}
-
-TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info)
-{
-	u32 tile = m_pf1_data[tile_index];
-	u32 colour = (tile >> 12) & 0xf;
-	u8 flags = 0;
-
-	if (tile & 0x8000)
-	{
-		if ((m_pf12_control[6] >> 0) & 0x01)
-		{
-			flags |= TILE_FLIPX;
-			colour &= 0x7;
-		}
-		if ((m_pf12_control[6] >> 0) & 0x02)
-		{
-			flags |= TILE_FLIPY;
-			colour &= 0x7;
-		}
-	}
-
-	tile &= 0xfff;
-	if (!m_tile_cb.isnull())
-		m_tile_cb(tile, colour, 0, false);
-
-	tileinfo.set(m_pf12_16x16_gfx_bank,
-			tile + m_pf1_bank,
-			(colour & m_pf1_colourmask) + m_pf1_colour_bank,
-			flags);
-}
-
-TILE_GET_INFO_MEMBER(deco16ic_device::get_pf2_tile_info_b)
-{
-	u32 tile = m_pf2_data[tile_index];
-	u32 colour = (tile >> 12) & 0xf;
-	u8 flags = 0;
-
-	if (tile & 0x8000)
-	{
-		if ((m_pf12_control[6] >> 8) & 0x01)
-		{
-			flags |= TILE_FLIPX;
-			colour &= 0x7;
-		}
-		if ((m_pf12_control[6] >> 8) & 0x02)
-		{
-			flags |= TILE_FLIPY;
-			colour &= 0x7;
-		}
-	}
-
-	tile &= 0xfff;
-	if (!m_tile_cb.isnull())
-		m_tile_cb(tile, colour, 1, true);
-
-	tileinfo.set(m_pf12_8x8_gfx_bank,
-			tile + m_pf2_bank,
-			(colour & m_pf2_colourmask) + m_pf2_colour_bank,
-			flags);
-}
-
-TILE_GET_INFO_MEMBER(deco16ic_device::get_pf1_tile_info_b)
-{
-	u32 tile = m_pf1_data[tile_index];
-	u32 colour = (tile >> 12) & 0xf;
-	u8 flags = 0;
-
-	if (tile & 0x8000)
-	{
-		if ((m_pf12_control[6] >> 0) & 0x01)
-		{
-			flags |= TILE_FLIPX;
-			colour &= 0x7;
-		}
-		if ((m_pf12_control[6] >> 0) & 0x02)
-		{
-			flags |= TILE_FLIPY;
-			colour &= 0x7;
-		}
-	}
-
-	tile &= 0xfff;
-	if (!m_tile_cb.isnull())
-		m_tile_cb(tile, colour, 0, true);
-
-	tileinfo.set(m_pf12_8x8_gfx_bank,
-			tile + m_pf1_bank,
-			(colour & m_pf1_colourmask) + m_pf1_colour_bank,
+	tileinfo.set(is8x8 ? m_8x8_gfx_bank : m_16x16_gfx_bank,
+			tile + m_tmap[Which].m_bank,
+			(colour & m_tmap[Which].m_colour_mask) + m_tmap[Which].m_colour_bank,
 			flags);
 }
 
@@ -539,226 +434,167 @@ void deco16ic_device::custom_tilemap_draw(
 
 void deco16ic_device::set_transmask(int tmap, int group, u32 fgmask, u32 bgmask)
 {
-	switch (tmap)
-	{
-	case 0:
-		m_pf1_tilemap_16x16->set_transmask(group, fgmask, bgmask);
-		m_pf1_tilemap_8x8->set_transmask(group, fgmask, bgmask);
-		break;
-	case 1:
-		m_pf2_tilemap_16x16->set_transmask(group, fgmask, bgmask);
-		m_pf2_tilemap_8x8->set_transmask(group, fgmask, bgmask);
-		break;
-	}
+	m_tmap[tmap].m_tilemap_16x16->set_transmask(group, fgmask, bgmask);
+	m_tmap[tmap].m_tilemap_8x8->set_transmask(group, fgmask, bgmask);
 }
 
 /* robocop 2 can switch between 2 tilemaps at 4bpp, or 1 at 8bpp */
 void deco16ic_device::set_tilemap_colour_mask(int tmap, int mask)
 {
-	switch (tmap)
-	{
-	case 0: m_pf1_colourmask = mask; m_pf1_tilemap_16x16->mark_all_dirty(); m_pf1_tilemap_8x8->mark_all_dirty(); break;
-	case 1: m_pf2_colourmask = mask; m_pf2_tilemap_16x16->mark_all_dirty(); m_pf2_tilemap_8x8->mark_all_dirty(); break;
-	}
+	m_tmap[tmap].m_colour_mask = mask;
+	m_tmap[tmap].m_tilemap_16x16->mark_all_dirty();
+	m_tmap[tmap].m_tilemap_8x8->mark_all_dirty();
 }
 
 void deco16ic_device::set_tilemap_colour_bank(int tmap, int bank)
 {
-	switch (tmap)
+	if (m_tmap[tmap].m_colour_bank != bank)
 	{
-	case 0:
-		if (m_pf1_colour_bank != bank)
-		{
-			m_pf1_colour_bank = bank;
-			if (m_pf1_tilemap_16x16)
-				m_pf1_tilemap_16x16->mark_all_dirty();
-			if (m_pf1_tilemap_8x8)
-				m_pf1_tilemap_8x8->mark_all_dirty();
-		}
-		break;
-	case 1:
-		if (m_pf2_colour_bank != bank)
-		{
-			m_pf2_colour_bank = bank;
-			if (m_pf2_tilemap_16x16)
-				m_pf2_tilemap_16x16->mark_all_dirty();
-			if (m_pf2_tilemap_8x8)
-				m_pf2_tilemap_8x8->mark_all_dirty();
-		}
-		break;
+		m_tmap[tmap].m_colour_bank = bank;
+		if (m_tmap[tmap].m_tilemap_16x16)
+			m_tmap[tmap].m_tilemap_16x16->mark_all_dirty();
+		if (m_tmap[tmap].m_tilemap_8x8)
+			m_tmap[tmap].m_tilemap_8x8->mark_all_dirty();
 	}
 }
 
-void deco16ic_device::pf12_set_gfxbank(int small, int big)
+void deco16ic_device::set_gfxbank(int small, int big)
 {
-	if (m_pf12_last_big != big)
+	if (m_last_big != big)
 	{
-		if (m_pf1_tilemap_16x16)
-			m_pf1_tilemap_16x16->mark_all_dirty();
-		if (m_pf2_tilemap_16x16)
-			m_pf2_tilemap_16x16->mark_all_dirty();
+		if (m_tmap[0].m_tilemap_16x16)
+			m_tmap[0].m_tilemap_16x16->mark_all_dirty();
+		if (m_tmap[1].m_tilemap_16x16)
+			m_tmap[1].m_tilemap_16x16->mark_all_dirty();
 
-		m_pf12_last_big = big;
+		m_last_big = big;
 	}
-	m_pf12_16x16_gfx_bank = big;
+	m_16x16_gfx_bank = big;
 
-	if (m_pf12_last_small != small)
+	if (m_last_small != small)
 	{
-		if (m_pf1_tilemap_8x8)
-			m_pf1_tilemap_8x8->mark_all_dirty();
-		if (m_pf2_tilemap_8x8)
-			m_pf2_tilemap_8x8->mark_all_dirty();
+		if (m_tmap[0].m_tilemap_8x8)
+			m_tmap[0].m_tilemap_8x8->mark_all_dirty();
+		if (m_tmap[1].m_tilemap_8x8)
+			m_tmap[1].m_tilemap_8x8->mark_all_dirty();
 
-		m_pf12_last_small = small;
+		m_last_small = small;
 	}
-	m_pf12_8x8_gfx_bank = small;
+	m_8x8_gfx_bank = small;
 }
 
 /* stoneage has broken scroll registers, original tumble pop expects a 1 pixel offset */
 void deco16ic_device::set_scrolldx(int tmap, int size, int dx, int dx_if_flipped)
 {
-	switch (tmap)
-	{
-	case 0:
-		if (!size)
-			m_pf1_tilemap_16x16->set_scrolldx(dx, dx_if_flipped);
-		else
-			m_pf1_tilemap_8x8->set_scrolldx(dx, dx_if_flipped);
-		break;
-	case 1:
-		if (!size)
-			m_pf2_tilemap_16x16->set_scrolldx(dx, dx_if_flipped);
-		else
-			m_pf2_tilemap_8x8->set_scrolldx(dx, dx_if_flipped);
-		break;
-	}
+	if (!size)
+		m_tmap[tmap].m_tilemap_16x16->set_scrolldx(dx, dx_if_flipped);
+	else
+		m_tmap[tmap].m_tilemap_8x8->set_scrolldx(dx, dx_if_flipped);
 }
 
 /* cninjabl does not enable background layers */
 void deco16ic_device::set_enable(int tmap, int enable)
 {
 	int shift = (tmap & 1) ? 15 : 7;
-	m_pf12_control[5] &= ~(1 << shift);
-	m_pf12_control[5] |= (enable & 1) << shift;
+	m_control[5] &= ~(1 << shift);
+	m_control[5] |= (enable & 1) << shift;
 }
 
 
 /******************************************************************************/
 
-void deco16ic_device::pf1_data_w(offs_t offset, u16 data, u16 mem_mask)
+void deco16ic_device::vram_common_w(u8 index, offs_t offset, u16 data, u16 mem_mask)
 {
-	COMBINE_DATA(&m_pf1_data[offset]);
+	COMBINE_DATA(&m_vram[index][offset]);
 
-	m_pf1_tilemap_8x8->mark_tile_dirty(offset);
-//  if (offset < 0x800)
-		m_pf1_tilemap_16x16->mark_tile_dirty(offset);
+	m_tmap[index].m_tilemap_8x8->mark_tile_dirty(offset);
+	m_tmap[index].m_tilemap_16x16->mark_tile_dirty(offset);
 }
 
-void deco16ic_device::pf2_data_w(offs_t offset, u16 data, u16 mem_mask)
+u16 deco16ic_device::vram_common_r(u8 index, offs_t offset)
 {
-	COMBINE_DATA(&m_pf2_data[offset]);
-
-	m_pf2_tilemap_8x8->mark_tile_dirty(offset);
-//  if (offset < 0x800)
-		m_pf2_tilemap_16x16->mark_tile_dirty(offset);
+	return m_vram[index][offset];
 }
 
-u16 deco16ic_device::pf1_data_r(offs_t offset)
-{
-	return m_pf1_data[offset];
-}
-
-u16 deco16ic_device::pf2_data_r(offs_t offset)
-{
-	return m_pf2_data[offset];
-}
-
-void deco16ic_device::pf_control_w(offs_t offset, u16 data, u16 mem_mask)
+void deco16ic_device::control_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	// update until current scanline (inclusive if we're in hblank)
-	int ydelta = (screen().hpos() > screen().visible_area().right()) ? 0 : 1;
+	const int ydelta = (screen().hpos() > screen().visible_area().right()) ? 0 : 1;
 	screen().update_partial(screen().vpos() - ydelta);
 
-	COMBINE_DATA(&m_pf12_control[offset]);
+	data = COMBINE_DATA(&m_control[offset]);
+
+	switch (offset)
+	{
+		case 1:
+			m_tmap[0].m_scrollx = data;
+			break;
+		case 2:
+			m_tmap[0].m_scrolly = data;
+			break;
+		case 3:
+			m_tmap[1].m_scrollx = data;
+			break;
+		case 4:
+			m_tmap[1].m_scrolly = data;
+			break;
+		case 5:
+			if (ACCESSING_BITS_0_7)
+				m_tmap[0].m_control0 = data & 0xff;
+			if (ACCESSING_BITS_8_15)
+				m_tmap[1].m_control0 = (data >> 8) & 0xff;
+			break;
+		case 6:
+			if (ACCESSING_BITS_0_7)
+				m_tmap[0].m_control1 = data & 0xff;
+			if (ACCESSING_BITS_8_15)
+				m_tmap[1].m_control1 = (data >> 8) & 0xff;
+			break;
+		case 7:
+			if (ACCESSING_BITS_0_7)
+				m_tmap[0].m_bankval = data & 0xff;
+			if (ACCESSING_BITS_8_15)
+				m_tmap[1].m_bankval = (data >> 8) & 0xff;
+			break;
+	}
 }
 
-u16 deco16ic_device::pf_control_r(offs_t offset)
+u16 deco16ic_device::control_r(offs_t offset)
 {
-	return m_pf12_control[offset];
+	return m_control[offset];
 }
-
-
-u32 deco16ic_device::pf_control_dword_r(offs_t offset)
-{
-	return pf_control_r(offset) ^ 0xffff0000;
-}
-
-void deco16ic_device::pf_control_dword_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	pf_control_w(offset, data & 0xffff, mem_mask & 0xffff);
-}
-
-u32 deco16ic_device::pf1_data_dword_r(offs_t offset)
-{
-	return pf1_data_r(offset) ^ 0xffff0000;
-}
-
-void deco16ic_device::pf1_data_dword_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	pf1_data_w(offset, data & 0xffff, mem_mask & 0xffff);
-}
-
-u32 deco16ic_device::pf2_data_dword_r(offs_t offset)
-{
-	return pf2_data_r(offset) ^ 0xffff0000;
-}
-
-void deco16ic_device::pf2_data_dword_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	pf2_data_w(offset, data & 0xffff, mem_mask & 0xffff);
-}
-
 
 
 /*****************************************************************************************/
 
-static int deco16_pf_update(
-	tilemap_t *tilemap_8x8,
-	tilemap_t *tilemap_16x16,
-	const u16 *rowscroll_ptr,
-	const u16 scrollx,
-	const u16 scrolly,
-	const u16 control0,
-	const u16 control1,
-	const int tilemapsizes
-	)
+void deco16ic_device::deco16_tmap::update()
 {
-	int rows, cols, offs, use_custom = 0;
+	m_use_custom_pf = false;
 
 	/* Toggle between 8x8 and 16x16 modes (and master enable bit) */
-	if (BIT(control1, 7))
+	if (BIT(m_control1, 7))
 	{
-		if (tilemap_8x8)
-			tilemap_8x8->enable(BIT(control0, 7));
+		if (m_tilemap_8x8)
+			m_tilemap_8x8->enable(BIT(m_control0, 7));
 
-		if (tilemap_16x16)
-			tilemap_16x16->enable(0);
-
+		if (m_tilemap_16x16)
+			m_tilemap_16x16->enable(false);
 	}
 	else
 	{
-		if (tilemap_8x8)
-			tilemap_8x8->enable(0);
+		if (m_tilemap_8x8)
+			m_tilemap_8x8->enable(false);
 
-		if (tilemap_16x16)
-			tilemap_16x16->enable(BIT(control0, 7));
+		if (m_tilemap_16x16)
+			m_tilemap_16x16->enable(BIT(m_control0, 7));
 	}
 
 	/* Rowscroll enable */
-	if (rowscroll_ptr && (control1 & 0x60) == 0x40)
+	if (m_rowscroll_ptr && (m_control1 & 0x60) == 0x40)
 	{
+		int rows;
 		/* Several different rowscroll styles */
-		switch ((control0 >> 3) & 0xf)
+		switch ((m_control0 >> 3) & 0xf)
 		{
 			case 0:     rows = 512;     break;/* Every line of 512 height bitmap */
 			case 1:     rows = 256;     break;
@@ -772,162 +608,143 @@ static int deco16_pf_update(
 			default:    rows = 1;       break;
 		}
 
-		if (tilemap_16x16)
+		if (m_tilemap_16x16)
 		{
 			int numrows = rows;
 
 			// cap at tilemap size
-			if (numrows > tilemap_16x16->height())
-				numrows = tilemap_16x16->height();
+			if (numrows > m_tilemap_16x16->height())
+				numrows = m_tilemap_16x16->height();
 
-			tilemap_16x16->set_scroll_cols(1);
-			tilemap_16x16->set_scroll_rows(numrows);
-			tilemap_16x16->set_scrolly(0, scrolly);
+			m_tilemap_16x16->set_scroll_cols(1);
+			m_tilemap_16x16->set_scroll_rows(numrows);
+			m_tilemap_16x16->set_scrolly(0, m_scrolly);
 
-
-			for (offs = 0; offs < numrows; offs++)
-				tilemap_16x16->set_scrollx(offs, scrollx + rowscroll_ptr[offs]);
+			for (int offs = 0; offs < numrows; offs++)
+				m_tilemap_16x16->set_scrollx(offs, m_scrollx + m_rowscroll_ptr[offs]);
 		}
 
-		if (tilemap_8x8)
+		if (m_tilemap_8x8)
 		{
 			int numrows = rows;
 
 			// wolffang uses a larger 8x8 tilemap for the Japanese intro text, everything else seems to need this logic tho?
-			if (!(tilemapsizes & DECO_32x64))
+			if (!(m_size & deco16ic_device::DECO_32x64))
 				numrows = rows >> 1;
 
 			// cap at tilemap size
-			if (numrows > tilemap_8x8->height())
-				numrows = tilemap_8x8->height();
+			if (numrows > m_tilemap_8x8->height())
+				numrows = m_tilemap_8x8->height();
 
-			tilemap_8x8->set_scroll_cols(1);
-			tilemap_8x8->set_scroll_rows(numrows);
-			tilemap_8x8->set_scrolly(0, scrolly);
+			m_tilemap_8x8->set_scroll_cols(1);
+			m_tilemap_8x8->set_scroll_rows(numrows);
+			m_tilemap_8x8->set_scrolly(0, m_scrolly);
 
-			for (offs = 0; offs < numrows; offs++)
-				tilemap_8x8->set_scrollx(offs, scrollx + rowscroll_ptr[offs]);
+			for (int offs = 0; offs < numrows; offs++)
+				m_tilemap_8x8->set_scrollx(offs, m_scrollx + m_rowscroll_ptr[offs]);
 		}
 	}
-	else if (rowscroll_ptr && (control1 & 0x60) == 0x20)  /* Column scroll */
+	else if (m_rowscroll_ptr && (m_control1 & 0x60) == 0x20)  /* Column scroll */
 	{
 		/* Column scroll ranges from 8 pixel columns to 512 pixel columns */
-		int mask = (0x40 >> (control0 & 7)) - 1;
+		int mask = (0x40 >> (m_control0 & 7)) - 1;
 		if (mask == -1)
 			mask = 0;
 
-		cols = (8 << (control0 & 7)) & 0x3ff;
+		int cols = (8 << (m_control0 & 7)) & 0x3ff;
 		if (!cols)
 			cols = 1024;
 
 		cols = 1024 / cols;
 
-		if (tilemap_16x16)
+		if (m_tilemap_16x16)
 		{
-			tilemap_16x16->set_scroll_cols(cols);
-			tilemap_16x16->set_scroll_rows(1);
-			tilemap_16x16->set_scrollx(0, scrollx);
+			m_tilemap_16x16->set_scroll_cols(cols);
+			m_tilemap_16x16->set_scroll_rows(1);
+			m_tilemap_16x16->set_scrollx(0, m_scrollx);
 
-			for (offs = 0; offs < cols; offs++)
-				tilemap_16x16->set_scrolly(offs, scrolly + rowscroll_ptr[(offs & mask) + 0x200]);
+			for (int offs = 0; offs < cols; offs++)
+				m_tilemap_16x16->set_scrolly(offs, m_scrolly + m_rowscroll_ptr[(offs & mask) + 0x200]);
 		}
 
-		if (tilemap_8x8)
+		if (m_tilemap_8x8)
 		{
 			cols = cols / 2; /* Adjust because 8x8 tilemap is half the width of 16x16 */
 
-			tilemap_8x8->set_scroll_cols(cols);
-			tilemap_8x8->set_scroll_rows(1);
-			tilemap_8x8->set_scrollx(0, scrollx);
+			m_tilemap_8x8->set_scroll_cols(cols);
+			m_tilemap_8x8->set_scroll_rows(1);
+			m_tilemap_8x8->set_scrollx(0, m_scrollx);
 
-			for (offs = 0; offs < cols; offs++)
-				tilemap_8x8->set_scrolly(offs, scrolly + rowscroll_ptr[(offs & mask) + 0x200]);
+			for (int offs = 0; offs < cols; offs++)
+				m_tilemap_8x8->set_scrolly(offs, m_scrolly + m_rowscroll_ptr[(offs & mask) + 0x200]);
 		}
 	}
-	else if (control1 & 0x60)
+	else if (m_control1 & 0x60)
 	{
 		/* Simultaneous row & column scroll requested - use custom renderer */
-		use_custom = 1;
+		m_use_custom_pf = true;
 
-		if (tilemap_16x16)
+		if (m_tilemap_16x16)
 		{
-			tilemap_16x16->set_scroll_rows(1);
-			tilemap_16x16->set_scroll_cols(1);
-			tilemap_16x16->set_scrollx(0, scrollx);
-			tilemap_16x16->set_scrolly(0, scrolly);
+			m_tilemap_16x16->set_scroll_rows(1);
+			m_tilemap_16x16->set_scroll_cols(1);
+			m_tilemap_16x16->set_scrollx(0, m_scrollx);
+			m_tilemap_16x16->set_scrolly(0, m_scrolly);
 		}
 
-		if (tilemap_8x8)
+		if (m_tilemap_8x8)
 		{
-			tilemap_8x8->set_scroll_rows(1);
-			tilemap_8x8->set_scroll_cols(1);
-			tilemap_8x8->set_scrollx(0, scrollx);
-			tilemap_8x8->set_scrolly(0, scrolly);
-
+			m_tilemap_8x8->set_scroll_rows(1);
+			m_tilemap_8x8->set_scroll_cols(1);
+			m_tilemap_8x8->set_scrollx(0, m_scrollx);
+			m_tilemap_8x8->set_scrolly(0, m_scrolly);
 		}
-
 	}
 	else
 	{
-		if (tilemap_16x16)
+		if (m_tilemap_16x16)
 		{
-			tilemap_16x16->set_scroll_rows(1);
-			tilemap_16x16->set_scroll_cols(1);
-			tilemap_16x16->set_scrollx(0, scrollx);
-			tilemap_16x16->set_scrolly(0, scrolly);
+			m_tilemap_16x16->set_scroll_rows(1);
+			m_tilemap_16x16->set_scroll_cols(1);
+			m_tilemap_16x16->set_scrollx(0, m_scrollx);
+			m_tilemap_16x16->set_scrolly(0, m_scrolly);
 		}
 
-		if (tilemap_8x8)
+		if (m_tilemap_8x8)
 		{
-			tilemap_8x8->set_scroll_rows(1);
-			tilemap_8x8->set_scroll_cols(1);
-			tilemap_8x8->set_scrollx(0, scrollx);
-			tilemap_8x8->set_scrolly(0, scrolly);
+			m_tilemap_8x8->set_scroll_rows(1);
+			m_tilemap_8x8->set_scroll_cols(1);
+			m_tilemap_8x8->set_scrollx(0, m_scrollx);
+			m_tilemap_8x8->set_scrolly(0, m_scrolly);
 		}
 	}
 
-	return use_custom;
+	if (!m_bank_cb.isnull())
+	{
+		const int bank = m_bank_cb(m_bankval);
+
+		if (bank != m_bank)
+		{
+			if (m_tilemap_8x8)
+				m_tilemap_8x8->mark_all_dirty();
+			if (m_tilemap_16x16)
+				m_tilemap_16x16->mark_all_dirty();
+
+			m_bank = bank;
+		}
+	}
 }
 
-void deco16ic_device::pf_update(const u16 *rowscroll_1_ptr, const u16 *rowscroll_2_ptr)
+void deco16ic_device::update(const u16 *rowscroll_1_ptr, const u16 *rowscroll_2_ptr)
 {
-	int bank1, bank2;
-
 	/* Update scrolling and tilemap enable */
-	m_pf1_rowscroll_ptr = rowscroll_1_ptr;
-	m_pf2_rowscroll_ptr = rowscroll_2_ptr;
-	m_use_custom_pf2 = deco16_pf_update(m_pf2_tilemap_8x8, m_pf2_tilemap_16x16, rowscroll_2_ptr, m_pf12_control[3], m_pf12_control[4], m_pf12_control[5] >> 8, m_pf12_control[6] >> 8, m_pf2_size);
-	m_use_custom_pf1 = deco16_pf_update(m_pf1_tilemap_8x8, m_pf1_tilemap_16x16, rowscroll_1_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, m_pf1_size);
+	m_tmap[0].m_rowscroll_ptr = rowscroll_1_ptr;
+	m_tmap[1].m_rowscroll_ptr = rowscroll_2_ptr;
 
-	/* Update banking and global flip state */
-	if (!m_bank1_cb.isnull())
+	/* Update banking */
+	for (int i = 0; i < 2; i++)
 	{
-		bank1 = m_bank1_cb(m_pf12_control[7] & 0xff);
-
-		if (bank1 != m_pf1_bank)
-		{
-			if (m_pf1_tilemap_8x8)
-				m_pf1_tilemap_8x8->mark_all_dirty();
-			if (m_pf1_tilemap_16x16)
-				m_pf1_tilemap_16x16->mark_all_dirty();
-
-			m_pf1_bank = bank1;
-		}
-	}
-
-	if (!m_bank2_cb.isnull())
-	{
-		bank2 = m_bank2_cb(m_pf12_control[7] >> 8);
-
-		if (bank2 != m_pf2_bank)
-		{
-			if (m_pf2_tilemap_8x8)
-				m_pf2_tilemap_8x8->mark_all_dirty();
-			if (m_pf2_tilemap_16x16)
-				m_pf2_tilemap_16x16->mark_all_dirty();
-
-			m_pf2_bank = bank2;
-		}
+		m_tmap[i].update();
 	}
 }
 
@@ -940,10 +757,10 @@ void deco16ic_device::print_debug_info(bitmap_ind16 &bitmap)
     if (machine().input().code_pressed(KEYCODE_O))
         return;
 
-    if (m_pf12_control)
+    if (m_control)
     {
-        sprintf(buf,"%04X %04X %04X %04X\n", m_pf12_control[0], m_pf12_control[1], m_pf12_control[2], m_pf12_control[3]);
-        sprintf(&buf[strlen(buf)],"%04X %04X %04X %04X\n", m_pf12_control[4], m_pf12_control[5], m_pf12_control[6], m_pf12_control[7]);
+        sprintf(buf,"%04X %04X %04X %04X\n", m_control[0], m_control[1], m_control[2], m_control[3]);
+        sprintf(&buf[strlen(buf)],"%04X %04X %04X %04X\n", m_control[4], m_control[5], m_control[6], m_control[7]);
     }
     else
         sprintf(buf, "\n\n");
@@ -956,16 +773,16 @@ void deco16ic_device::print_debug_info(bitmap_ind16 &bitmap)
 template<class BitmapClass>
 void deco16ic_device::tilemap_1_draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	if (m_use_custom_pf1)
+	if (m_tmap[0].m_use_custom_pf)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_pf1_tilemap_8x8, m_pf1_tilemap_16x16, nullptr, nullptr, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0, 0, flags, priority, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect, m_tmap[0].m_tilemap_8x8, m_tmap[0].m_tilemap_16x16, nullptr, nullptr, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0, 0, flags, priority, pmask);
 	}
 	else
 	{
-		if (m_pf1_tilemap_8x8)
-			m_pf1_tilemap_8x8->draw(screen, bitmap, cliprect, flags, priority, pmask);
-		if (m_pf1_tilemap_16x16)
-			m_pf1_tilemap_16x16->draw(screen, bitmap, cliprect, flags, priority, pmask);
+		if (m_tmap[0].m_tilemap_8x8)
+			m_tmap[0].m_tilemap_8x8->draw(screen, bitmap, cliprect, flags, priority, pmask);
+		if (m_tmap[0].m_tilemap_16x16)
+			m_tmap[0].m_tilemap_16x16->draw(screen, bitmap, cliprect, flags, priority, pmask);
 	}
 }
 
@@ -979,16 +796,16 @@ void deco16ic_device::tilemap_1_draw(screen_device &screen, bitmap_rgb32 &bitmap
 template<class BitmapClass>
 void deco16ic_device::tilemap_2_draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	if (m_use_custom_pf2)
+	if (m_tmap[1].m_use_custom_pf)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_pf2_tilemap_8x8, m_pf2_tilemap_16x16, nullptr, nullptr, m_pf2_rowscroll_ptr, m_pf12_control[3], m_pf12_control[4], m_pf12_control[5] >> 8, m_pf12_control[6] >> 8, 0, 0, flags, priority, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect, m_tmap[1].m_tilemap_8x8, m_tmap[1].m_tilemap_16x16, nullptr, nullptr, m_tmap[1].m_rowscroll_ptr, m_control[3], m_control[4], m_control[5] >> 8, m_control[6] >> 8, 0, 0, flags, priority, pmask);
 	}
 	else
 	{
-		if (m_pf2_tilemap_8x8)
-			m_pf2_tilemap_8x8->draw(screen, bitmap, cliprect, flags, priority, pmask);
-		if (m_pf2_tilemap_16x16)
-			m_pf2_tilemap_16x16->draw(screen, bitmap, cliprect, flags, priority, pmask);
+		if (m_tmap[1].m_tilemap_8x8)
+			m_tmap[1].m_tilemap_8x8->draw(screen, bitmap, cliprect, flags, priority, pmask);
+		if (m_tmap[1].m_tilemap_16x16)
+			m_tmap[1].m_tilemap_16x16->draw(screen, bitmap, cliprect, flags, priority, pmask);
 	}
 }
 
@@ -1004,10 +821,10 @@ void deco16ic_device::tilemap_2_draw(screen_device &screen, bitmap_rgb32 &bitmap
 // Combines the output of two 4BPP tilemaps into an 8BPP tilemap
 void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_tmap[0].m_tilemap_16x16, nullptr, m_tmap[1].m_tilemap_16x16, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
 }
 
 void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_pf1_tilemap_16x16, nullptr, m_pf2_tilemap_16x16, m_pf1_rowscroll_ptr, m_pf12_control[1], m_pf12_control[2], m_pf12_control[5] & 0xff, m_pf12_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_tmap[0].m_tilemap_16x16, nullptr, m_tmap[1].m_tilemap_16x16, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
 }

--- a/src/mame/dataeast/deco16ic.cpp
+++ b/src/mame/dataeast/deco16ic.cpp
@@ -283,13 +283,12 @@ TILE_GET_INFO_MEMBER(deco16ic_device::get_tile_info)
 
 	if (BIT(tile, 15))
 	{
-		const u8 shift = Which << 3;
-		if (BIT(m_control[6], shift + 0))
+		if (BIT(m_tmap[Which].m_control1, 0))
 		{
 			flags |= TILE_FLIPX;
 			colour &= 0x7;
 		}
-		if (BIT(m_control[6], shift + 1))
+		if (BIT(m_tmap[Which].m_control1, 1))
 		{
 			flags |= TILE_FLIPY;
 			colour &= 0x7;
@@ -442,8 +441,7 @@ void deco16ic_device::set_transmask(int tmap, int group, u32 fgmask, u32 bgmask)
 void deco16ic_device::set_tilemap_colour_mask(int tmap, int mask)
 {
 	m_tmap[tmap].m_colour_mask = mask;
-	m_tmap[tmap].m_tilemap_16x16->mark_all_dirty();
-	m_tmap[tmap].m_tilemap_8x8->mark_all_dirty();
+	m_tmap[tmap].mark_both_all_dirty();
 }
 
 void deco16ic_device::set_tilemap_colour_bank(int tmap, int bank)
@@ -451,10 +449,7 @@ void deco16ic_device::set_tilemap_colour_bank(int tmap, int bank)
 	if (m_tmap[tmap].m_colour_bank != bank)
 	{
 		m_tmap[tmap].m_colour_bank = bank;
-		if (m_tmap[tmap].m_tilemap_16x16)
-			m_tmap[tmap].m_tilemap_16x16->mark_all_dirty();
-		if (m_tmap[tmap].m_tilemap_8x8)
-			m_tmap[tmap].m_tilemap_8x8->mark_all_dirty();
+		m_tmap[tmap].mark_both_all_dirty();
 	}
 }
 
@@ -495,9 +490,8 @@ void deco16ic_device::set_scrolldx(int tmap, int size, int dx, int dx_if_flipped
 /* cninjabl does not enable background layers */
 void deco16ic_device::set_enable(int tmap, int enable)
 {
-	int shift = (tmap & 1) ? 15 : 7;
-	m_control[5] &= ~(1 << shift);
-	m_control[5] |= (enable & 1) << shift;
+	m_tmap[tmap].m_control0 &= ~(1 << 7);
+	m_tmap[tmap].m_control0 |= (enable & 1) << 7;
 }
 
 
@@ -545,11 +539,28 @@ void deco16ic_device::control_w(offs_t offset, u16 data, u16 mem_mask)
 				m_tmap[1].m_control0 = (data >> 8) & 0xff;
 			break;
 		case 6:
+		{
+			u8 old_control1;
 			if (ACCESSING_BITS_0_7)
+			{
+				old_control1 = m_tmap[0].m_control1;
 				m_tmap[0].m_control1 = data & 0xff;
+				if ((old_control1 ^ m_tmap[0].m_control1) & 0x3)
+				{
+					m_tmap[0].mark_both_all_dirty();
+				}
+			}
 			if (ACCESSING_BITS_8_15)
+			{
+				old_control1 = m_tmap[1].m_control1;
 				m_tmap[1].m_control1 = (data >> 8) & 0xff;
+				if ((old_control1 ^ m_tmap[1].m_control1) & 0x3)
+				{
+					m_tmap[1].mark_both_all_dirty();
+				}
+			}
 			break;
+		}
 		case 7:
 			if (ACCESSING_BITS_0_7)
 				m_tmap[0].m_bankval = data & 0xff;
@@ -725,10 +736,7 @@ void deco16ic_device::deco16_tmap::update()
 
 		if (bank != m_bank)
 		{
-			if (m_tilemap_8x8)
-				m_tilemap_8x8->mark_all_dirty();
-			if (m_tilemap_16x16)
-				m_tilemap_16x16->mark_all_dirty();
+			mark_both_all_dirty();
 
 			m_bank = bank;
 		}
@@ -759,8 +767,8 @@ void deco16ic_device::print_debug_info(bitmap_ind16 &bitmap)
 
     if (m_control)
     {
-        sprintf(buf,"%04X %04X %04X %04X\n", m_control[0], m_control[1], m_control[2], m_control[3]);
-        sprintf(&buf[strlen(buf)],"%04X %04X %04X %04X\n", m_control[4], m_control[5], m_control[6], m_control[7]);
+        sprintf(buf,"%04X %04X %04X %04X\n", m_control[0], m_tmap[0].m_scrollx, m_tmap[0].m_scrolly, m_tmap[1].m_scrollx);
+        sprintf(&buf[strlen(buf)],"%04X %04X %04X %04X\n", m_tmap[1].m_scrolly, m_control[5], m_control[6], m_control[7]);
     }
     else
         sprintf(buf, "\n\n");
@@ -775,7 +783,14 @@ void deco16ic_device::tilemap_1_draw_common(screen_device &screen, BitmapClass &
 {
 	if (m_tmap[0].m_use_custom_pf)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_tmap[0].m_tilemap_8x8, m_tmap[0].m_tilemap_16x16, nullptr, nullptr, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0, 0, flags, priority, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect,
+				m_tmap[0].m_tilemap_8x8, m_tmap[0].m_tilemap_16x16,
+				nullptr, nullptr,
+				m_tmap[0].m_rowscroll_ptr,
+				m_tmap[0].m_scrollx, m_tmap[0].m_scrolly,
+				m_tmap[0].m_control0, m_tmap[0].m_control1,
+				0, 0,
+				flags, priority, pmask);
 	}
 	else
 	{
@@ -798,7 +813,14 @@ void deco16ic_device::tilemap_2_draw_common(screen_device &screen, BitmapClass &
 {
 	if (m_tmap[1].m_use_custom_pf)
 	{
-		custom_tilemap_draw(screen, bitmap, cliprect, m_tmap[1].m_tilemap_8x8, m_tmap[1].m_tilemap_16x16, nullptr, nullptr, m_tmap[1].m_rowscroll_ptr, m_control[3], m_control[4], m_control[5] >> 8, m_control[6] >> 8, 0, 0, flags, priority, pmask);
+		custom_tilemap_draw(screen, bitmap, cliprect,
+				m_tmap[1].m_tilemap_8x8, m_tmap[1].m_tilemap_16x16,
+				nullptr, nullptr,
+				m_tmap[1].m_rowscroll_ptr,
+				m_tmap[1].m_scrollx, m_tmap[1].m_scrolly,
+				m_tmap[1].m_control0, m_tmap[1].m_control1,
+				0, 0,
+				flags, priority, pmask);
 	}
 	else
 	{
@@ -821,10 +843,24 @@ void deco16ic_device::tilemap_2_draw(screen_device &screen, bitmap_rgb32 &bitmap
 // Combines the output of two 4BPP tilemaps into an 8BPP tilemap
 void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_tmap[0].m_tilemap_16x16, nullptr, m_tmap[1].m_tilemap_16x16, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect,
+			nullptr, m_tmap[0].m_tilemap_16x16,
+			nullptr, m_tmap[1].m_tilemap_16x16,
+			m_tmap[0].m_rowscroll_ptr,
+			m_tmap[0].m_scrollx, m_tmap[0].m_scrolly,
+			m_tmap[0].m_control0, m_tmap[0].m_control1,
+			0xf, 4,
+			flags, priority, pmask);
 }
 
 void deco16ic_device::tilemap_12_combine_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask)
 {
-	custom_tilemap_draw(screen, bitmap, cliprect, nullptr, m_tmap[0].m_tilemap_16x16, nullptr, m_tmap[1].m_tilemap_16x16, m_tmap[0].m_rowscroll_ptr, m_control[1], m_control[2], m_control[5] & 0xff, m_control[6] & 0xff, 0xf, 4, flags, priority, pmask);
+	custom_tilemap_draw(screen, bitmap, cliprect,
+			nullptr, m_tmap[0].m_tilemap_16x16,
+			nullptr, m_tmap[1].m_tilemap_16x16,
+			m_tmap[0].m_rowscroll_ptr,
+			m_tmap[0].m_scrollx, m_tmap[0].m_scrolly,
+			m_tmap[0].m_control0, m_tmap[0].m_control1,
+			0xf, 4,
+			flags, priority, pmask);
 }

--- a/src/mame/dataeast/deco16ic.h
+++ b/src/mame/dataeast/deco16ic.h
@@ -28,13 +28,13 @@ public:
 	static constexpr unsigned DECO_32x64 = 2;
 	static constexpr unsigned DECO_64x64 = 3;
 
+	using deco16_tile_cb_delegate = device_delegate<void (u32 &tile, u32 &colour, int layer, bool is_8x8)>;
+	using deco16_bank_cb_delegate = device_delegate<int (int bank)>;
+	using deco16_mix_cb_delegate = device_delegate<u16 (u16 p, u16 p2)>;
+
 	deco16ic_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	// configuration
-	typedef device_delegate<void (u32 &tile, u32 &colour, int layer, bool is_8x8)> deco16_tile_cb_delegate;
-	typedef device_delegate<int (int bank)> deco16_bank_cb_delegate;
-	typedef device_delegate<u16 (u16 p, u16 p2)> deco16_mix_cb_delegate;
-
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
 //  void set_palette_tag(const char *tag);
 	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
@@ -85,9 +85,9 @@ public:
 
 	void update(const u16 *rowscroll_1_ptr, const u16 *rowscroll_2_ptr);
 
-	template<class BitmapClass>
+	template <class BitmapClass>
 	void tilemap_1_draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
-	template<class BitmapClass>
+	template <class BitmapClass>
 	void tilemap_2_draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
 	void tilemap_1_draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
 	void tilemap_1_draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
@@ -114,7 +114,7 @@ public:
 	/* used by nslasher */
 	void set_tilemap_colour_bank(int tmap, int bank);
 
-	template<class BitmapClass>
+	template <class BitmapClass>
 	void custom_tilemap_draw(
 			screen_device &screen,
 			BitmapClass &bitmap,
@@ -135,7 +135,7 @@ public:
 			u8 pmask = 0xff);
 
 protected:
-	// device-level overrides
+	// device_t implementation overrides
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
@@ -207,7 +207,7 @@ private:
 	void vram_common_w(u8 index, offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	TILEMAP_MAPPER_MEMBER(scan_rows);
-	template <unsigned Which, bool is8x8> TILE_GET_INFO_MEMBER(get_tile_info);
+	template <unsigned Which, bool Is8x8> TILE_GET_INFO_MEMBER(get_tile_info);
 	template <unsigned Which> TILE_GET_INFO_MEMBER(get_tile_info_8x8);
 };
 

--- a/src/mame/dataeast/deco16ic.h
+++ b/src/mame/dataeast/deco16ic.h
@@ -16,61 +16,74 @@
 #include "tilemap.h"
 
 
-#define DECO_32x32  0
-#define DECO_64x32  1
-#define DECO_32x64  2
-#define DECO_64x64  3
-
 /***************************************************************************
     TYPE DEFINITIONS
 ***************************************************************************/
 
-typedef device_delegate<void (u32 &tile, u32 &colour, int layer, bool is_8x8)> deco16_tile_cb_delegate;
-typedef device_delegate<int (int bank)> deco16_bank_cb_delegate;
-typedef device_delegate<u16 (u16 p, u16 p2)> deco16_mix_cb_delegate;
-
 class deco16ic_device : public device_t, public device_video_interface
 {
 public:
+	static constexpr unsigned DECO_32x32 = 0;
+	static constexpr unsigned DECO_64x32 = 1;
+	static constexpr unsigned DECO_32x64 = 2;
+	static constexpr unsigned DECO_64x64 = 3;
+
 	deco16ic_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	// configuration
+	typedef device_delegate<void (u32 &tile, u32 &colour, int layer, bool is_8x8)> deco16_tile_cb_delegate;
+	typedef device_delegate<int (int bank)> deco16_bank_cb_delegate;
+	typedef device_delegate<u16 (u16 p, u16 p2)> deco16_mix_cb_delegate;
+
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
 //  void set_palette_tag(const char *tag);
 	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
-	template <typename... T> void set_bank1_callback(T &&... args) { m_bank1_cb.set(std::forward<T>(args)...); }
-	template <typename... T> void set_bank2_callback(T &&... args) { m_bank2_cb.set(std::forward<T>(args)...); }
 	template <typename... T> void set_mix_callback(T &&... args) { m_mix_cb.set(std::forward<T>(args)...); }
-	void set_pf1_size(int size) { m_pf1_size = size; }
-	void set_pf2_size(int size) { m_pf2_size = size; }
-	void set_pf1_col_mask(int mask) { m_pf1_colourmask = mask; }
-	void set_pf2_col_mask(int mask) { m_pf2_colourmask = mask; }
-	void set_pf1_col_bank(int bank) { m_pf1_colour_bank = bank; }
-	void set_pf2_col_bank(int bank) { m_pf2_colour_bank = bank; }
-	void set_pf12_8x8_bank(int bank) { m_pf12_8x8_gfx_bank = bank; }
-	void set_pf12_16x16_bank(int bank) { m_pf12_16x16_gfx_bank = bank; }
+	template <unsigned Which, typename... T> void set_bank_callback(T &&... args) { m_tmap[Which].m_bank_cb.set(std::forward<T>(args)...); }
+	template <unsigned Which> void set_size(int size) { m_tmap[Which].m_size = size; }
+	template <unsigned Which> void set_col_bank(int bank) { m_tmap[Which].m_colour_bank = bank; }
+	template <unsigned Which> void set_col_mask(int mask) { m_tmap[Which].m_colour_mask = mask; }
+	void set_8x8_bank(int bank) { m_8x8_gfx_bank = bank; }
+	void set_16x16_bank(int bank) { m_16x16_gfx_bank = bank; }
 
-	void pf1_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void pf2_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	template <unsigned Which> void vram_w(offs_t offset, u16 data, u16 mem_mask = ~0)
+	{
+		vram_common_w(Which, offset, data, mem_mask);
+	}
 
-	u16 pf1_data_r(offs_t offset);
-	u16 pf2_data_r(offs_t offset);
+	template <unsigned Which> u16 vram_r(offs_t offset)
+	{
+		return vram_common_r(Which, offset);
+	}
 
-	void pf_control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 pf_control_r(offs_t offset);
+	void control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 control_r(offs_t offset);
 
-	void pf1_data_dword_w(offs_t offset, u32 data, u32 mem_mask = ~0);
-	void pf2_data_dword_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template <unsigned Which> void vram32_w(offs_t offset, u32 data, u32 mem_mask = ~0)
+	{
+		mem_mask &= 0xffff;
+		vram_common_w(Which, offset, data, mem_mask);
+	}
 
-	u32 pf1_data_dword_r(offs_t offset);
-	u32 pf2_data_dword_r(offs_t offset);
+	template <unsigned Which> u32 vram32_r(offs_t offset)
+	{
+		return vram_common_r(Which, offset) | 0xffff0000;
+	}
 
-	void pf_control_dword_w(offs_t offset, u32 data, u32 mem_mask = ~0);
-	u32 pf_control_dword_r(offs_t offset);
+	void control32_w(offs_t offset, u32 data, u32 mem_mask = ~0)
+	{
+		mem_mask &= 0xffff;
+		control_w(offset, data, mem_mask);
+	}
+
+	u32 control32_r(offs_t offset)
+	{
+		return control_r(offset) | 0xffff0000;
+	}
 
 	void print_debug_info(bitmap_ind16 &bitmap);
 
-	void pf_update(const u16 *rowscroll_1_ptr, const u16 *rowscroll_2_ptr);
+	void update(const u16 *rowscroll_1_ptr, const u16 *rowscroll_2_ptr);
 
 	template<class BitmapClass>
 	void tilemap_1_draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int flags, u8 priority, u8 pmask = 0xff);
@@ -87,7 +100,7 @@ public:
 
 	/* used by robocop2 */
 	void set_tilemap_colour_mask(int tmap, int mask);
-	void pf12_set_gfxbank(int small, int big);
+	void set_gfxbank(int small, int big);
 
 	/* used by cninja */
 	void set_transmask(int tmap, int group, u32 fgmask, u32 bgmask);
@@ -96,7 +109,7 @@ public:
 	void set_scrolldx(int tmap, int size, int dx, int dx_if_flipped);
 
 	/* used by cninjabl */
-	void set_enable(int tmap, int enable );
+	void set_enable(int tmap, int enable);
 
 	/* used by nslasher */
 	void set_tilemap_colour_bank(int tmap, int bank);
@@ -127,50 +140,71 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 
 private:
+	// devices
+	required_device<gfxdecode_device> m_gfxdecode;
+
+	// memory pointers
+	memory_share_array_creator<u16, 2> m_vram;
+	memory_share_creator<u16> m_control;
+
 	// internal state
-	std::unique_ptr<u16[]> m_pf1_data;
-	std::unique_ptr<u16[]> m_pf2_data;
-	std::unique_ptr<u16[]> m_pf12_control;
+	struct deco16_tmap
+	{
+		deco16_tmap(deco16ic_device &owner)
+			: m_bank_cb(owner)
+			, m_rowscroll_ptr(nullptr)
+			, m_tilemap_16x16(nullptr)
+			, m_tilemap_8x8(nullptr)
+			, m_use_custom_pf(false)
+			, m_bank(0)
+			, m_size(0)
+			, m_colour_bank(0)
+			, m_colour_mask(0xf)
+		{
+		}
 
-	const u16 *m_pf1_rowscroll_ptr, *m_pf2_rowscroll_ptr;
+		// callbacks
+		deco16_bank_cb_delegate m_bank_cb;
 
-	tilemap_t *m_pf1_tilemap_16x16 = nullptr, *m_pf2_tilemap_16x16 = nullptr;
-	tilemap_t *m_pf1_tilemap_8x8 = nullptr, *m_pf2_tilemap_8x8 = nullptr;
+		// internal states
+		const u16 *m_rowscroll_ptr;
+		tilemap_t *m_tilemap_16x16;
+		tilemap_t *m_tilemap_8x8;
+
+		bool m_use_custom_pf;
+		s32 m_bank;
+		s32 m_size;
+		s32 m_colour_bank;
+		s32 m_colour_mask;
+
+		// registers
+		u16 m_scrollx;
+		u16 m_scrolly;
+		u8 m_control0;
+		u8 m_control1;
+		u8 m_bankval;
+
+		void update();
+	};
+
+	deco16_tmap m_tmap[2];
 
 	deco16_tile_cb_delegate m_tile_cb;
 
-	deco16_bank_cb_delegate m_bank1_cb;
-	deco16_bank_cb_delegate m_bank2_cb;
-
 	deco16_mix_cb_delegate m_mix_cb;
 
-	int m_use_custom_pf1, m_use_custom_pf2;
-	int m_pf1_bank, m_pf2_bank;
-	int m_pf12_last_small, m_pf12_last_big;
+	s32 m_last_small, m_last_big;
 
-	int m_pf1_size;
-	int m_pf2_size;
-	int m_pf1_colour_bank, m_pf2_colour_bank;
-	int m_pf1_colourmask, m_pf2_colourmask;
-	int m_pf12_8x8_gfx_bank, m_pf12_16x16_gfx_bank;
+	s32 m_8x8_gfx_bank, m_16x16_gfx_bank;
 
-	TILEMAP_MAPPER_MEMBER(deco16_scan_rows);
-	TILE_GET_INFO_MEMBER(get_pf2_tile_info);
-	TILE_GET_INFO_MEMBER(get_pf1_tile_info);
-	TILE_GET_INFO_MEMBER(get_pf2_tile_info_b);
-	TILE_GET_INFO_MEMBER(get_pf1_tile_info_b);
-	required_device<gfxdecode_device> m_gfxdecode;
+	u16 vram_common_r(u8 index, offs_t offset);
+	void vram_common_w(u8 index, offs_t offset, u16 data, u16 mem_mask = ~0);
+
+	TILEMAP_MAPPER_MEMBER(scan_rows);
+	template <unsigned Which, bool is8x8> TILE_GET_INFO_MEMBER(get_tile_info);
+	template <unsigned Which> TILE_GET_INFO_MEMBER(get_tile_info_8x8);
 };
 
 DECLARE_DEVICE_TYPE(DECO16IC, deco16ic_device)
-
-
-
-/***************************************************************************
-    DEVICE CONFIGURATION MACROS
-***************************************************************************/
-
-// function definition for a callback
-#define DECO16IC_BANK_CB_MEMBER(_name)     int _name(int bank)
 
 #endif // MAME_DATAEAST_DECO16IC_H

--- a/src/mame/dataeast/deco16ic.h
+++ b/src/mame/dataeast/deco16ic.h
@@ -185,6 +185,12 @@ private:
 		u8 m_bankval;
 
 		void update();
+
+		void mark_both_all_dirty()
+		{
+			m_tilemap_16x16->mark_all_dirty();
+			m_tilemap_8x8->mark_all_dirty();
+		}
 	};
 
 	deco16_tmap m_tmap[2];

--- a/src/mame/dataeast/dfruit2.cpp
+++ b/src/mame/dataeast/dfruit2.cpp
@@ -60,7 +60,7 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_hopper(*this, "hopper"),
 		m_palette(*this, "palette"),
-		m_deco_tilegen(*this, "tilegen"),
+		m_tilegen(*this, "tilegen"),
 		m_sprgen(*this, "sprgen"),
 		m_spriteram(*this, "spriteram", 0xe00, ENDIANNESS_BIG),
 		m_mainbank(*this, "mainbank")
@@ -77,7 +77,7 @@ private:
 	required_device<cpu_device> m_maincpu;
 	required_device<hopper_device> m_hopper;
 	required_device<palette_device> m_palette;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<decospr_device> m_sprgen;
 
 	memory_share_creator<u16> m_spriteram;
@@ -89,12 +89,10 @@ private:
 
 	uint8_t spriteram_r(offs_t offset);
 	void spriteram_w(offs_t offset, uint8_t data);
-	uint8_t tilegen_pf1_data_r(offs_t offset);
-	void tilegen_pf1_data_w(offs_t offset, uint8_t data);
-	uint8_t tilegen_pf2_data_r(offs_t offset);
-	void tilegen_pf2_data_w(offs_t offset, uint8_t data);
+	template <unsigned Which> uint8_t tilegen_vram_r(offs_t offset);
+	template <unsigned Which> void tilegen_vram_w(offs_t offset, uint8_t data);
 	void tilegen_control_w(offs_t offset, uint8_t data);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline_cb);
 	uint8_t bank_r();
@@ -111,11 +109,11 @@ uint32_t dfruit2_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 	screen.priority().fill(0, cliprect);
 
 	m_sprgen->set_flip_screen(true); // sprites are flipped relative to tilemaps
-	m_deco_tilegen->pf_update(nullptr, nullptr);
+	m_tilegen->update(nullptr, nullptr);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0xe00 / 2);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -140,44 +138,26 @@ void dfruit2_state::spriteram_w(offs_t offset, uint8_t data)
 		m_spriteram[offs] = (m_spriteram[offs] & 0x00ff) | (data << 8);
 }
 
-uint8_t dfruit2_state::tilegen_pf1_data_r(offs_t offset)
+template <unsigned Which>
+uint8_t dfruit2_state::tilegen_vram_r(offs_t offset)
 {
 	int const offs = offset >> 1;
 
 	if (!BIT(offset, 0))
-		return m_deco_tilegen->pf1_data_r(offs) & 0xff;
+		return m_tilegen->vram_r<Which>(offs) & 0xff;
 	else
-		return m_deco_tilegen->pf1_data_r(offs) >> 8;
+		return m_tilegen->vram_r<Which>(offs) >> 8;
 }
 
-void dfruit2_state::tilegen_pf1_data_w(offs_t offset, uint8_t data)
+template <unsigned Which>
+void dfruit2_state::tilegen_vram_w(offs_t offset, uint8_t data)
 {
 	int const offs = offset >> 1;
 
 	if (!BIT(offset, 0))
-		m_deco_tilegen->pf1_data_w(offs, data, 0x00ff);
+		m_tilegen->vram_w<Which>(offs, data, 0x00ff);
 	else
-		m_deco_tilegen->pf1_data_w(offs, data << 8, 0xff00);
-}
-
-uint8_t dfruit2_state::tilegen_pf2_data_r(offs_t offset)
-{
-	int const offs = offset >> 1;
-
-	if (!BIT(offset, 0))
-		return m_deco_tilegen->pf2_data_r(offs) & 0xff;
-	else
-		return m_deco_tilegen->pf2_data_r(offs) >> 8;
-}
-
-void dfruit2_state::tilegen_pf2_data_w(offs_t offset, uint8_t data)
-{
-	int const offs = offset >> 1;
-
-	if (!BIT(offset, 0))
-		m_deco_tilegen->pf2_data_w(offs, data, 0x00ff);
-	else
-		m_deco_tilegen->pf2_data_w(offs, data << 8, 0xff00);
+		m_tilegen->vram_w<Which>(offs, data << 8, 0xff00);
 }
 
 void dfruit2_state::tilegen_control_w(offs_t offset, uint8_t data)
@@ -185,17 +165,15 @@ void dfruit2_state::tilegen_control_w(offs_t offset, uint8_t data)
 	int const offs = offset >> 1;
 
 	if (!BIT(offset, 0))
-		m_deco_tilegen->pf_control_w(offs, data, 0x00ff);
+		m_tilegen->control_w(offs, data, 0x00ff);
 	else
-		m_deco_tilegen->pf_control_w(offs, data << 8, 0xff00);
-
+		m_tilegen->control_w(offs, data << 8, 0xff00);
 }
 
-DECO16IC_BANK_CB_MEMBER(dfruit2_state::bank_callback)
+int dfruit2_state::bank_callback(int bank)
 {
 	return (bank & 0xf0) << 8;
 }
-
 
 uint8_t dfruit2_state::bank_r()
 {
@@ -263,8 +241,8 @@ void dfruit2_state::program_map(address_map &map)
 	// map(0xb101, 0xb101).w();
 	map(0xb109, 0xb109).w(FUNC(dfruit2_state::b109_w));
 	map(0xc000, 0xc1ff).ram().w(m_palette, FUNC(palette_device::write8)).share("palette");
-	map(0xd000, 0xdfff).rw(FUNC(dfruit2_state::tilegen_pf2_data_r), FUNC(dfruit2_state::tilegen_pf2_data_w)); // SCREEN RAM CHECK NG if this range isn't mapped
-	map(0xe000, 0xefff).rw(FUNC(dfruit2_state::tilegen_pf1_data_r), FUNC(dfruit2_state::tilegen_pf1_data_w));
+	map(0xd000, 0xdfff).rw(FUNC(dfruit2_state::tilegen_vram_r<1>), FUNC(dfruit2_state::tilegen_vram_w<1>)); // SCREEN RAM CHECK NG if this range isn't mapped
+	map(0xe000, 0xefff).rw(FUNC(dfruit2_state::tilegen_vram_r<0>), FUNC(dfruit2_state::tilegen_vram_w<0>));
 	map(0xf000, 0xfdff).rw(FUNC(dfruit2_state::spriteram_r), FUNC(dfruit2_state::spriteram_w));
 	map(0xff08, 0xff08).rw(FUNC(dfruit2_state::bank_r), FUNC(dfruit2_state::bank_w));
 	map(0xfff0, 0xffff).ram();
@@ -401,18 +379,18 @@ void dfruit2_state::dfruit2(machine_config &config)
 
 	GFXDECODE(config, "gfxdecode", "palette", gfx_dfruit2);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x00);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(dfruit2_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(dfruit2_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x00);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(dfruit2_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(dfruit2_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, "sprgen", "palette", gfx_dfruit2_spr);
 

--- a/src/mame/dataeast/dietgo.cpp
+++ b/src/mame/dataeast/dietgo.cpp
@@ -50,12 +50,12 @@ class dietgo_state : public driver_device
 public:
 	dietgo_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1)
+		, m_rowscroll(*this, "rowscroll_%u", 1)
 		, m_spriteram(*this, "spriteram")
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_deco_tilegen(*this, "tilegen")
+		, m_tilegen(*this, "tilegen")
 		, m_deco104(*this, "ioprot104")
 		, m_sprgen(*this, "spritegen")
 	{ }
@@ -66,19 +66,19 @@ public:
 
 private:
 	// memory pointers
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 	required_shared_ptr<uint16_t> m_spriteram;
 	required_shared_ptr<uint16_t> m_decrypted_opcodes;
 
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<deco104_device> m_deco104;
 	required_device<decospr_device> m_sprgen;
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 
 	uint16_t ioprot_r(offs_t offset);
 	void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -90,16 +90,16 @@ private:
 
 uint32_t dietgo_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(256, cliprect); // not verified
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	return 0;
@@ -126,11 +126,11 @@ void dietgo_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 void dietgo_state::main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x200000, 0x20000f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
-	map(0x210000, 0x211fff).w(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_w));
-	map(0x212000, 0x213fff).w(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_w));
-	map(0x220000, 0x2207ff).writeonly().share(m_pf_rowscroll[0]);
-	map(0x222000, 0x2227ff).writeonly().share(m_pf_rowscroll[1]);
+	map(0x200000, 0x20000f).w(m_tilegen, FUNC(deco16ic_device::control_w));
+	map(0x210000, 0x211fff).w(m_tilegen, FUNC(deco16ic_device::vram_w<0>));
+	map(0x212000, 0x213fff).w(m_tilegen, FUNC(deco16ic_device::vram_w<1>));
+	map(0x220000, 0x2207ff).writeonly().share(m_rowscroll[0]);
+	map(0x222000, 0x2227ff).writeonly().share(m_rowscroll[1]);
 	map(0x280000, 0x2807ff).ram().share(m_spriteram);
 	map(0x300000, 0x300bff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0x340000, 0x343fff).rw(FUNC(dietgo_state::ioprot_r), FUNC(dietgo_state::ioprot_w)).share("prot16ram"); // Protection device
@@ -272,7 +272,7 @@ static GFXDECODE_START( gfx_dietgo_spr )
 	GFXDECODE_ENTRY( "sprites", 0, tile_16x16_layout, 512, 16 )    // Sprites (16x16)
 GFXDECODE_END
 
-DECO16IC_BANK_CB_MEMBER(dietgo_state::bank_callback)
+int dietgo_state::bank_callback(int bank)
 {
 	return (bank & 0x70) << 8;
 }
@@ -302,18 +302,18 @@ void dietgo_state::dietgo(machine_config &config)
 
 	GFXDECODE(config, "gfxdecode", "palette", gfx_dietgo);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(dietgo_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(dietgo_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(dietgo_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(dietgo_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, "palette", gfx_dietgo_spr);
 

--- a/src/mame/dataeast/dragngun.cpp
+++ b/src/mame/dataeast/dragngun.cpp
@@ -137,7 +137,7 @@ public:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_sprgen(*this, "c355spr")
-		, m_deco_tilegen(*this, "tilegen%u", 1)
+		, m_tilegen(*this, "tilegen%u", 1)
 		, m_spriteram(*this, "spriteram")
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
@@ -153,7 +153,7 @@ public:
 		, m_sprite_spritetile(*this, "look%u", 0)
 		, m_sprite_cliptable(*this, "spclip")
 		, m_sprite_indextable(*this, "spindex")
-		, m_pf_rowscroll32(*this, "pf%u_rowscroll32", 1)
+		, m_rowscroll32(*this, "rowscroll32_%u", 1)
 		, m_paletteram(*this, "paletteram")
 		, m_io_inputs(*this, "INPUTS")
 		, m_io_light_x(*this, "LIGHT%u_X", 0U)
@@ -192,7 +192,7 @@ protected:
 	u32 unk_video_r();
 	u32 lockload_gun_mirror_r(offs_t offset);
 
-	template<int Chip> void pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template<int Chip> void rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
 	void buffered_palette_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 	void palette_dma_w(u32 data);
@@ -208,8 +208,8 @@ protected:
 	bool sprite_mix_callback(u16 &dest, u8 &destpri, u16 colbase, u16 src, int srcpri, int pri);
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(bank_1_callback);
-	DECO16IC_BANK_CB_MEMBER(bank_2_callback);
+	int bank_1_callback(int bank);
+	int bank_2_callback(int bank);
 
 	void expand_sprite_data() ATTR_COLD;
 	void dragngun_init_common() ATTR_COLD;
@@ -228,7 +228,7 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
 	required_device<namco_c355spr_device> m_sprgen;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<buffered_spriteram32_device> m_spriteram;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
@@ -247,7 +247,7 @@ protected:
 	required_shared_ptr<u32> m_sprite_indextable;
 
 	// we use the pointers below to store a 32-bit copy..
-	required_shared_ptr_array<u32, 4> m_pf_rowscroll32;
+	required_shared_ptr_array<u32, 4> m_rowscroll32;
 	optional_shared_ptr<u32> m_paletteram;
 
 	optional_ioport m_io_inputs;
@@ -255,7 +255,7 @@ protected:
 	optional_ioport_array<2> m_io_light_y;
 
 	std::unique_ptr<u8[]> m_dirty_palette{};
-	std::unique_ptr<u16[]> m_pf_rowscroll[4]{};
+	std::unique_ptr<u16[]> m_rowscroll[4]{};
 
 	u32 m_sprite_ctrl = 0U;
 	u32 m_lightgun_port = 0;
@@ -363,11 +363,11 @@ void dragngun_state::video_start()
 {
 	for (int i = 0; i < 4; i++)
 	{
-		const u32 size = m_pf_rowscroll32[i].length();
+		const u32 size = m_rowscroll32[i].length();
 
-		m_pf_rowscroll[i] = make_unique_clear<u16[]>(size);
+		m_rowscroll[i] = make_unique_clear<u16[]>(size);
 
-		save_pointer(NAME(m_pf_rowscroll[i]), size, i);
+		save_pointer(NAME(m_rowscroll[i]), size, i);
 	}
 	m_dirty_palette = make_unique_clear<u8[]>(2048);
 
@@ -411,19 +411,19 @@ void dragngun_state::spriteram_dma_w(u32 data)
 }
 
 // tattass tests these as 32-bit ram, even if only 16-bits are hooked up to the tilemap chip - does it mirror parts of the dword?
-template <int TileMap> void dragngun_state::pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_pf_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[TileMap][offset]); }
+template <int TileMap> void dragngun_state::rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_rowscroll[TileMap][offset]); }
 
 u32 dragngun_state::unk_video_r()
 {
 	return machine().rand();
 }
 
-DECO16IC_BANK_CB_MEMBER(dragngun_state::bank_1_callback)
+int dragngun_state::bank_1_callback(int bank)
 {
 	return (bank & ~0xf) << 8;
 }
 
-DECO16IC_BANK_CB_MEMBER(dragngun_state::bank_2_callback)
+int dragngun_state::bank_2_callback(int bank)
 {
 	return (bank & ~0x1f) << 7;
 }
@@ -535,13 +535,13 @@ u32 dragngun_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, c
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(m_palette->pen(0x400), cliprect); // Palette index not confirmed
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_tilegen[0]->update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_tilegen[1]->update(m_rowscroll[2].get(), m_rowscroll[3].get());
 
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1); // it uses pf3 in 8bpp mode instead, like captaven
-	m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 8);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1); // it uses pf3 in 8bpp mode instead, like captaven
+	m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 8);
 
 	// zooming sprite draw is very slow, and sprites are buffered.. however, one of the levels attempts to use
 	// partial updates for every line, which causes things to be very slow... the sprites appear to support
@@ -666,16 +666,16 @@ void dragngun_state::common_map(address_map &map)
 	map(0x228000, 0x2283ff).ram().share(m_sprite_indextable); // sprite index (just a table 0x00-0xff here)
 	map(0x230000, 0x230003).w(FUNC(dragngun_state::spriteram_dma_w));
 
-	map(0x180000, 0x18001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x190000, 0x191fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x194000, 0x195fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x1a0000, 0x1a3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<0>)).share(m_pf_rowscroll32[0]);
-	map(0x1a4000, 0x1a5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<1>)).share(m_pf_rowscroll32[1]);
-	map(0x1c0000, 0x1c001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1d0000, 0x1d1fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1d4000, 0x1d5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w)); // unused
-	map(0x1e0000, 0x1e3fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<2>)).share(m_pf_rowscroll32[2]);
-	map(0x1e4000, 0x1e5fff).ram().w(FUNC(dragngun_state::pf_rowscroll_w<3>)).share(m_pf_rowscroll32[3]); // unused
+	map(0x180000, 0x18001f).rw(m_tilegen[0], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x190000, 0x191fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x194000, 0x195fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x1a0000, 0x1a3fff).ram().w(FUNC(dragngun_state::rowscroll_w<0>)).share(m_rowscroll32[0]);
+	map(0x1a4000, 0x1a5fff).ram().w(FUNC(dragngun_state::rowscroll_w<1>)).share(m_rowscroll32[1]);
+	map(0x1c0000, 0x1c001f).rw(m_tilegen[1], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x1d0000, 0x1d1fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x1d4000, 0x1d5fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>)); // unused
+	map(0x1e0000, 0x1e3fff).ram().w(FUNC(dragngun_state::rowscroll_w<2>)).share(m_rowscroll32[2]);
+	map(0x1e4000, 0x1e5fff).ram().w(FUNC(dragngun_state::rowscroll_w<3>)).share(m_rowscroll32[3]); // unused
 
 	map(0x300000, 0x3fffff).rom().region("maincpu", 0x100000);
 	map(0x420000, 0x420000).rw(FUNC(dragngun_state::eeprom_r), FUNC(dragngun_state::eeprom_w));
@@ -1020,31 +1020,31 @@ void dragngun_state::dragngun(machine_config &config)
 
 	BUFFERED_SPRITERAM32(config, m_spriteram);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(dragngun_state::bank_1_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(dragngun_state::bank_1_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x20);
+	m_tilegen[0]->set_col_bank<1>(0x30);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(dragngun_state::bank_1_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(dragngun_state::bank_1_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x04);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x03);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(dragngun_state::bank_2_callback));
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x04);
+	m_tilegen[1]->set_col_bank<1>(0x04);
+	m_tilegen[1]->set_col_mask<0>(0x03);
+	m_tilegen[1]->set_col_mask<1>(0x03);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(dragngun_state::bank_2_callback));
 	// no bank2 callback
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	namco_sprites(config);
 
@@ -1104,8 +1104,8 @@ void dragngun_state::lockloadu(machine_config &config)
 
 	m_deco_irq->lightgun_irq_callback().set("irq_merger", FUNC(input_merger_any_high_device::in_w<2>));
 
-	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);    // lockload definitely wants pf34 half width..
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_32x32);    // lockload definitely wants pf34 half width..
 
 	m_ym2151->port_write_handler().set(FUNC(dragngun_state::lockload_okibank_lo_w));
 }
@@ -1147,31 +1147,31 @@ void dragngun_state::lockload(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_dragngun);
 	PALETTE(config, m_palette).set_entries(2048);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(dragngun_state::bank_1_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(dragngun_state::bank_1_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x20);
+	m_tilegen[0]->set_col_bank<1>(0x30);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(dragngun_state::bank_1_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(dragngun_state::bank_1_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);    // lockload definitely wants pf34 half width..
-	m_deco_tilegen[1]->set_pf1_col_bank(0x04);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x04);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x03);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x03);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(dragngun_state::bank_2_callback));
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_32x32);    // lockload definitely wants pf34 half width..
+	m_tilegen[1]->set_col_bank<0>(0x04);
+	m_tilegen[1]->set_col_bank<1>(0x04);
+	m_tilegen[1]->set_col_mask<0>(0x03);
+	m_tilegen[1]->set_col_mask<1>(0x03);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(dragngun_state::bank_2_callback));
 	// no bank2 callback
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	namco_sprites(config);
 

--- a/src/mame/dataeast/dreambal.cpp
+++ b/src/mame/dataeast/dreambal.cpp
@@ -42,7 +42,7 @@ public:
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
 		m_deco104(*this, "ioprot104"),
-		m_deco_tilegen(*this, "tilegen"),
+		m_tilegen(*this, "tilegen"),
 		m_eeprom(*this, "eeprom")
 	{ }
 
@@ -54,85 +54,84 @@ private:
 	/* devices */
 	required_device<cpu_device> m_maincpu;
 	optional_device<deco104_device> m_deco104;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;
 
-	uint32_t screen_update_dreambal(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	int bank_callback(int bank);
 
-	uint16_t dreambal_protection_region_0_104_r(offs_t offset);
-	void dreambal_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t ioprot_r(offs_t offset);
+	void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
-	void dreambal_eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0)
+	void eeprom_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0)
 	{
-		if (data&0xfff8)
+		if (data & 0xfff8)
 		{
-			logerror("dreambal_eeprom_w unhandled data %04x %04x\n",data&0x0fff8, mem_mask);
+			logerror("%s: eeprom_w unhandled data %04x %04x\n", machine().describe_context(), data & 0x0fff8, mem_mask);
 		}
 
 		if (ACCESSING_BITS_0_7)
 		{
-			m_eeprom->clk_write(data &0x2 ? ASSERT_LINE : CLEAR_LINE);
-			m_eeprom->di_write(data &0x1);
-			m_eeprom->cs_write(data&0x4 ? ASSERT_LINE : CLEAR_LINE);
+			m_eeprom->clk_write(BIT(data, 1) ? ASSERT_LINE : CLEAR_LINE);
+			m_eeprom->di_write(BIT(data, 0));
+			m_eeprom->cs_write(BIT(data, 2) ? ASSERT_LINE : CLEAR_LINE);
 		}
 	}
-	void dreambal_map(address_map &map) ATTR_COLD;
+	void main_map(address_map &map) ATTR_COLD;
 };
 
 
-uint32_t dreambal_state::screen_update_dreambal(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+uint32_t dreambal_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t flip = m_deco_tilegen->pf_control_r(0);
+	const uint16_t flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
-	m_deco_tilegen->pf_update(nullptr, nullptr);
+	m_tilegen->update(nullptr, nullptr);
 
 	bitmap.fill(0, cliprect); /* not Confirmed */
 	screen.priority().fill(0);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 	return 0;
 }
 
 
-uint16_t dreambal_state::dreambal_protection_region_0_104_r(offs_t offset)
+uint16_t dreambal_state::ioprot_r(offs_t offset)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const int real_address = 0 + (offset * 2);
+	const int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	uint16_t data = m_deco104->read_data( deco146_addr, cs );
+	const uint16_t data = m_deco104->read_data(deco146_addr, cs);
 	return data;
 }
 
-void dreambal_state::dreambal_protection_region_0_104_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void dreambal_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int real_address = 0 + (offset *2);
-	int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
+	const int real_address = 0 + (offset * 2);
+	const int deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
-	m_deco104->write_data( deco146_addr, data, mem_mask, cs );
+	m_deco104->write_data(deco146_addr, data, mem_mask, cs);
 }
 
-void dreambal_state::dreambal_map(address_map &map)
+void dreambal_state::main_map(address_map &map)
 {
 //map.unmap_value_high();
 	map(0x000000, 0x07ffff).rom();
-	map(0x100000, 0x100fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
+	map(0x100000, 0x100fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
 	map(0x101000, 0x101fff).ram();
-	map(0x102000, 0x102fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
+	map(0x102000, 0x102fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
 	map(0x103000, 0x103fff).ram();
 
 	map(0x120000, 0x123fff).ram();
 	map(0x140000, 0x1403ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 
-	map(0x160000, 0x163fff).rw(FUNC(dreambal_state::dreambal_protection_region_0_104_r), FUNC(dreambal_state::dreambal_protection_region_0_104_w)).share("prot16ram"); /* Protection device */
+	map(0x160000, 0x163fff).rw(FUNC(dreambal_state::ioprot_r), FUNC(dreambal_state::ioprot_w)); /* Protection device */
 
-	map(0x161000, 0x16100f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
-
+	map(0x161000, 0x16100f).w(m_tilegen, FUNC(deco16ic_device::control_w));
 
 	map(0x180001, 0x180001).rw("oki", FUNC(okim6295_device::read), FUNC(okim6295_device::write));
 
@@ -140,7 +139,7 @@ void dreambal_state::dreambal_map(address_map &map)
 	map(0x163000, 0x163001).nopw(); // something on bit 1
 	map(0x164000, 0x164001).nopw(); // something on bit 1
 
-	map(0x165000, 0x165001).w(FUNC(dreambal_state::dreambal_eeprom_w)); // EEP Write?
+	map(0x165000, 0x165001).w(FUNC(dreambal_state::eeprom_w)); // EEP Write?
 
 	map(0x16c002, 0x16c00d).nopw(); // writes 0000 to 0005 on startup
 	map(0x1a0000, 0x1a0003).nopw(); // RS-232C status / data ports (byte access)
@@ -171,8 +170,8 @@ static const gfx_layout tile_16x16_layout =
 
 
 static GFXDECODE_START( gfx_dreambal )
-	GFXDECODE_ENTRY( "gfx1", 0, tile_8x8_layout,     0x000, 32 )    /* Tiles (8x8) */
-	GFXDECODE_ENTRY( "gfx1", 0, tile_16x16_layout,   0x000, 32 )    /* Tiles (16x16) */
+	GFXDECODE_ENTRY( "tiles", 0, tile_8x8_layout,     0x000, 32 )    /* Tiles (8x8) */
+	GFXDECODE_ENTRY( "tiles", 0, tile_16x16_layout,   0x000, 32 )    /* Tiles (16x16) */
 GFXDECODE_END
 
 static INPUT_PORTS_START( dreambal )
@@ -299,9 +298,9 @@ static INPUT_PORTS_START( dreambal )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
 
-DECO16IC_BANK_CB_MEMBER(dreambal_state::bank_callback)
+int dreambal_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 void dreambal_state::machine_start()
@@ -317,7 +316,7 @@ void dreambal_state::dreambal(machine_config &config)
 {
 	/* basic machine hardware */
 	M68000(config, m_maincpu, 28000000/2);
-	m_maincpu->set_addrmap(AS_PROGRAM, &dreambal_state::dreambal_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dreambal_state::main_map);
 	m_maincpu->set_vblank_int("screen", FUNC(dreambal_state::irq6_line_hold)); // 5 valid too?
 
 	/* video hardware */
@@ -326,7 +325,7 @@ void dreambal_state::dreambal(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500) /* not accurate */);
 	screen.set_size(64*8, 32*8);
 	screen.set_visarea(0*8, 40*8-1, 1*8, 31*8-1);
-	screen.set_screen_update(FUNC(dreambal_state::screen_update_dreambal));
+	screen.set_screen_update(FUNC(dreambal_state::screen_update));
 	screen.set_palette("palette");
 
 	PALETTE(config, "palette").set_format(palette_device::xBGR_444, 0x400/2);
@@ -339,18 +338,18 @@ void dreambal_state::dreambal(machine_config &config)
 	m_deco104->port_b_cb().set_ioport("SYSTEM");
 	m_deco104->port_c_cb().set_ioport("DSW");
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(dreambal_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(dreambal_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(dreambal_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(dreambal_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -359,12 +358,11 @@ void dreambal_state::dreambal(machine_config &config)
 }
 
 
-
 ROM_START( dreambal )
 	ROM_REGION( 0x80000, "maincpu", 0 )
 	ROM_LOAD16_WORD_SWAP( "mm_00-2.1c",    0x000000, 0x020000, CRC(257f6ad1) SHA1(7b232ce2d503e6f21286176974f6b74052f76d07) )
 
-	ROM_REGION( 0x80000, "gfx1", 0 )
+	ROM_REGION( 0x80000, "tiles", 0 )
 	ROM_LOAD( "mm_01-1.12b",    0x00000, 0x80000, CRC(dc9cc708) SHA1(03b8e6aa37e0107514a2498849208d2bd51a4163) )
 
 	ROM_REGION( 0x80000, "oki", 0 ) /* Oki samples */
@@ -373,7 +371,7 @@ ROM_END
 
 void dreambal_state::init_dreambal()
 {
-	deco56_decrypt_gfx(machine(), "gfx1");
+	deco56_decrypt_gfx(machine(), "tiles"); // 141
 }
 
 } // anonymous namespace

--- a/src/mame/dataeast/fghthist.cpp
+++ b/src/mame/dataeast/fghthist.cpp
@@ -389,9 +389,9 @@ void fghthist_common_state::buffer_spriteram_w(u32 data)
 }
 
 // tattass tests these as 32-bit ram, even if only 16-bits are hooked up to the tilemap chip - does it mirror parts of the dword?
-template <int TileMap> void fghthist_common_state::pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_pf_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_pf_rowscroll[TileMap][offset]); }
+template <int TileMap> void fghthist_common_state::rowscroll_w(offs_t offset, u32 data, u32 mem_mask) { COMBINE_DATA(&m_rowscroll32[TileMap][offset]); data &= 0x0000ffff; mem_mask &= 0x0000ffff; COMBINE_DATA(&m_rowscroll[TileMap][offset]); }
 
-DECOSPR_PRIORITY_CB_MEMBER( fghthist_state::fghthist_pri_callback )
+DECOSPR_PRIORITY_CB_MEMBER(fghthist_state::fghthist_pri_callback)
 {
 	u32 mask = GFX_PMASK_8; // under the text layer
 	if (extpri)
@@ -400,14 +400,14 @@ DECOSPR_PRIORITY_CB_MEMBER( fghthist_state::fghthist_pri_callback )
 	return mask;
 }
 
-DECO16IC_BANK_CB_MEMBER( fghthist_state::bank_callback )
+int fghthist_state::bank_callback(int bank)
 {
 	bank = (bank & 0x10) | ((bank & 0x40) >> 1) | ((bank & 0x20) << 1);
 
 	return bank << 8;
 }
 
-DECO16IC_BANK_CB_MEMBER( nslasher_state::bank_callback )
+int nslasher_state::bank_callback(int bank)
 {
 	return (bank & ~0xf) << 8;
 }
@@ -615,16 +615,16 @@ void fghthist_common_state::common_map(address_map &map)
 	map(0x000000, 0x0fffff).rom();
 	map(0x100000, 0x11ffff).ram();
 	map(0x140000, 0x140003).w(FUNC(fghthist_state::vblank_ack_w));
-	map(0x182000, 0x183fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x184000, 0x185fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x192000, 0x193fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<0>)).share(m_pf_rowscroll32[0]);
-	map(0x194000, 0x195fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<1>)).share(m_pf_rowscroll32[1]);
-	map(0x1a0000, 0x1a001f).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x1c2000, 0x1c3fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x1c4000, 0x1c5fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
-	map(0x1d2000, 0x1d3fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<2>)).share(m_pf_rowscroll32[2]);
-	map(0x1d4000, 0x1d5fff).ram().w(FUNC(fghthist_state::pf_rowscroll_w<3>)).share(m_pf_rowscroll32[3]);
-	map(0x1e0000, 0x1e001f).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
+	map(0x182000, 0x183fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x184000, 0x185fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x192000, 0x193fff).ram().w(FUNC(fghthist_state::rowscroll_w<0>)).share(m_rowscroll32[0]);
+	map(0x194000, 0x195fff).ram().w(FUNC(fghthist_state::rowscroll_w<1>)).share(m_rowscroll32[1]);
+	map(0x1a0000, 0x1a001f).rw(m_tilegen[0], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x1c2000, 0x1c3fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x1c4000, 0x1c5fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
+	map(0x1d2000, 0x1d3fff).ram().w(FUNC(fghthist_state::rowscroll_w<2>)).share(m_rowscroll32[2]);
+	map(0x1d4000, 0x1d5fff).ram().w(FUNC(fghthist_state::rowscroll_w<3>)).share(m_rowscroll32[3]);
+	map(0x1e0000, 0x1e001f).rw(m_tilegen[1], FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
 	map(0x200000, 0x207fff).rw(FUNC(fghthist_state::ioprot_r), FUNC(fghthist_state::ioprot_w)).umask32(0xffff0000).share("prot32ram"); // only maps on 16-bits
 }
 
@@ -643,7 +643,7 @@ void fghthist_state::fghthisto_map(address_map &map)
 {
 	map.unmap_value_high();
 	fghthist_common_map(map);
-//  map(0x000000, 0x001fff).rom().w(FUNC(fghthist_state::pf1_data_w)); // wtf??
+//  map(0x000000, 0x001fff).rom().w(FUNC(fghthist_state::vram_w<0>)); // wtf??
 	map(0x120020, 0x120021).lr16(NAME([this] () { return m_io_in[0]->read(); }));
 	map(0x120024, 0x120025).lr16(NAME([this] () { return m_io_in[1]->read(); }));
 	map(0x120028, 0x120028).r(FUNC(fghthist_state::eeprom_r));
@@ -953,31 +953,31 @@ void fghthist_state::fghthisto(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fghthist);
 	PALETTE(config, m_palette).set_entries(2048);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(fghthist_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(fghthist_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(fghthist_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(fghthist_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(fghthist_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(fghthist_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x20);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(fghthist_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(fghthist_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_fghthist_spr);
 	m_sprgen[0]->set_pri_callback(FUNC(fghthist_state::fghthist_pri_callback));
@@ -1064,32 +1064,32 @@ void nslasher_state::nslasher(machine_config &config)
 
 	DECO_ACE(config, m_deco_ace);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(nslasher_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(nslasher_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(nslasher_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(nslasher_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(nslasher_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(nslasher_state::bank_callback));
-	m_deco_tilegen[1]->set_mix_callback(FUNC(nslasher_state::mix_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x20);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(nslasher_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(nslasher_state::bank_callback));
+	m_tilegen[1]->set_mix_callback(FUNC(nslasher_state::mix_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_deco_ace, gfx_nslasher_spr1);
 	DECO_SPRITE(config, m_sprgen[1], m_deco_ace, gfx_nslasher_spr2);
@@ -1156,32 +1156,32 @@ void tattass_state::tattass(machine_config &config)
 
 	DECO_ACE(config, m_deco_ace);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(tattass_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(tattass_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(tattass_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(tattass_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x20);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(tattass_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(tattass_state::bank_callback));
-	m_deco_tilegen[1]->set_mix_callback(FUNC(tattass_state::mix_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x20);
+	m_tilegen[1]->set_col_bank<1>(0x30);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(tattass_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(tattass_state::bank_callback));
+	m_tilegen[1]->set_mix_callback(FUNC(tattass_state::mix_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen[0], m_deco_ace, gfx_nslasher_spr1);
 	DECO_SPRITE(config, m_sprgen[1], m_deco_ace, gfx_nslasher_spr2);

--- a/src/mame/dataeast/fghthist.h
+++ b/src/mame/dataeast/fghthist.h
@@ -31,14 +31,14 @@ protected:
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_sprgen(*this, "spritegen%u", 1)
-		, m_deco_tilegen(*this, "tilegen%u", 1)
+		, m_tilegen(*this, "tilegen%u", 1)
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
 		, m_eeprom(*this, "eeprom")
 		, m_ioprot(*this, "ioprot")
 		, m_ym2151(*this, "ymsnd")
 		, m_oki(*this, "oki%u", 1)
-		, m_pf_rowscroll32(*this, "pf%u_rowscroll32", 1)
+		, m_rowscroll32(*this, "rowscroll32_%u", 1)
 	{ }
 
 	virtual void video_start() override ATTR_COLD;
@@ -51,7 +51,7 @@ protected:
 	void volume_w(u8 data);
 	void vblank_ack_w(u32 data);
 
-	template<int Chip> void pf_rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
+	template<int Chip> void rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
 	template<int Chip> u32 spriteram_r(offs_t offset);
 	template<int Chip> void spriteram_w(offs_t offset, u32 data, u32 mem_mask = ~0);
@@ -68,7 +68,7 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
 	optional_device_array<decospr_device, 2> m_sprgen;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
@@ -77,12 +77,12 @@ protected:
 	optional_device_array<okim6295_device, 2> m_oki;
 
 	// we use the pointers below to store a 32-bit copy..
-	required_shared_ptr_array<u32, 4> m_pf_rowscroll32;
+	required_shared_ptr_array<u32, 4> m_rowscroll32;
 
 	u32 m_pri = 0;
 	std::unique_ptr<u16[]> m_spriteram16[2]{};
 	std::unique_ptr<u16[]> m_spriteram16_buffered[2]{};
-	std::unique_ptr<u16[]> m_pf_rowscroll[4]{};
+	std::unique_ptr<u16[]> m_rowscroll[4]{};
 };
 
 class fghthist_state : public fghthist_common_state
@@ -125,7 +125,7 @@ private:
 
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(fghthist_pri_callback);
 
 	void fghthist_common_map(address_map &map) ATTR_COLD;
@@ -164,7 +164,7 @@ protected:
 	void mix_nslasher(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, gfx_element *gfx0, gfx_element *gfx1, int mixAlphaTilemap);
 	u32 screen_update_nslasher(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	u16 mix_callback(u16 p, u16 p2);
 
 	void nslasher_common_map(address_map &map) ATTR_COLD;

--- a/src/mame/dataeast/fghthist_v.cpp
+++ b/src/mame/dataeast/fghthist_v.cpp
@@ -43,8 +43,8 @@ void fghthist_state::palette_dma_w(u32 data)
 // sprite and BG2/3 color banks are changeable at run time
 void nslasher_state::tilemap_color_bank_w(u8 data)
 {
-	m_deco_tilegen[1]->set_tilemap_colour_bank(0, ((data >> 0) & 7) << 4);
-	m_deco_tilegen[1]->set_tilemap_colour_bank(1, ((data >> 3) & 7) << 4);
+	m_tilegen[1]->set_tilemap_colour_bank(0, ((data >> 0) & 7) << 4);
+	m_tilegen[1]->set_tilemap_colour_bank(1, ((data >> 3) & 7) << 4);
 }
 
 void nslasher_state::sprite1_color_bank_w(u8 data)
@@ -63,11 +63,11 @@ void fghthist_common_state::video_start()
 {
 	for (int i = 0; i < 4; i++)
 	{
-		const u32 size = m_pf_rowscroll32[i].length();
+		const u32 size = m_rowscroll32[i].length();
 
-		m_pf_rowscroll[i] = make_unique_clear<u16[]>(size);
+		m_rowscroll[i] = make_unique_clear<u16[]>(size);
 
-		save_pointer(NAME(m_pf_rowscroll[i]), size, i);
+		save_pointer(NAME(m_rowscroll[i]), size, i);
 	}
 	save_item(NAME(m_pri));
 }
@@ -112,24 +112,24 @@ u32 fghthist_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, c
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(m_palette->pen(0x300), cliprect); // Palette index not confirmed
 
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_tilegen[0]->update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_tilegen[1]->update(m_rowscroll[2].get(), m_rowscroll[3].get());
 
 	/* Draw screen */
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
 
 	if (m_pri & 1)
 	{
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 8);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 8);
 
 	// sprites are flipped relative to tilemaps
 	m_sprgen[0]->set_flip_screen(true);
@@ -293,8 +293,8 @@ void nslasher_state::mix_nslasher(screen_device &screen, bitmap_rgb32 &bitmap, c
 u32 nslasher_state::screen_update_nslasher(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	bool alphaTilemap = false;
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_tilegen[0]->update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_tilegen[1]->update(m_rowscroll[2].get(), m_rowscroll[3].get());
 
 	/* This is not a conclusive test for deciding if tilemap needs alpha blending */
 	if (m_deco_ace->get_aceram(0x17) != 0x0 && (m_pri & 3))
@@ -320,33 +320,33 @@ u32 nslasher_state::screen_update_nslasher(screen_device &screen, bitmap_rgb32 &
 	/* Draw playfields & sprites */
 	if (m_pri & 2)
 	{
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
 		if (m_pri & 1)
 		{
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 			if (alphaTilemap)
-				m_deco_tilegen[1]->tilemap_1_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_1_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
 			else
-				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 		}
 		else
 		{
-			m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 			if (alphaTilemap)
-				m_deco_tilegen[0]->tilemap_2_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
+				m_tilegen[0]->tilemap_2_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
 			else
-				m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 		}
 	}
 
 	mix_nslasher(screen, bitmap, cliprect, m_sprgen[0]->gfx(0), m_sprgen[1]->gfx(0), alphaTilemap);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -495,8 +495,8 @@ void tattass_state::mix_tattass(screen_device &screen, bitmap_rgb32 &bitmap, con
 u32 tattass_state::screen_update_tattass(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	bool alphaTilemap = false;
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0].get(), m_pf_rowscroll[1].get());
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2].get(), m_pf_rowscroll[3].get());
+	m_tilegen[0]->update(m_rowscroll[0].get(), m_rowscroll[1].get());
+	m_tilegen[1]->update(m_rowscroll[2].get(), m_rowscroll[3].get());
 
 	/* This is not a conclusive test for deciding if tilemap needs alpha blending */
 	if (m_deco_ace->get_aceram(0x17) != 0x0 && (m_pri & 3))
@@ -522,32 +522,32 @@ u32 tattass_state::screen_update_tattass(screen_device &screen, bitmap_rgb32 &bi
 	/* Draw playfields & sprites */
 	if (m_pri & 2)
 	{
-		m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 1);
 		if (m_pri & 1)
 		{
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
 			if (alphaTilemap)
-				m_deco_tilegen[1]->tilemap_1_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_1_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
 			else
-				m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 		}
 		else
 		{
-			m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 			if (alphaTilemap)
-				m_deco_tilegen[0]->tilemap_2_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
+				m_tilegen[0]->tilemap_2_draw(screen, m_tilemap_alpha_bitmap, cliprect, 0, 4);
 			else
-				m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+				m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 		}
 	}
 
 	mix_tattass(screen, bitmap, cliprect, m_sprgen[0]->gfx(0), m_sprgen[1]->gfx(0), alphaTilemap);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }

--- a/src/mame/dataeast/funkyjet.cpp
+++ b/src/mame/dataeast/funkyjet.cpp
@@ -116,13 +116,13 @@ public:
 	funkyjet_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_spriteram(*this, "spriteram")
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1)
+		, m_rowscroll(*this, "rowscroll_%u", 1)
 		, m_screen(*this, "screen")
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_deco146(*this, "ioprot")
 		, m_sprgen(*this, "spritegen")
-		, m_deco_tilegen(*this, "tilegen")
+		, m_tilegen(*this, "tilegen")
 	{ }
 
 	void funkyjet(machine_config &config);
@@ -132,7 +132,7 @@ public:
 private:
 	// memory pointers
 	required_shared_ptr<uint16_t> m_spriteram;
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 
 	// devices
 	required_device<screen_device> m_screen;
@@ -140,7 +140,7 @@ private:
 	required_device<h6280_device> m_audiocpu;
 	required_device<deco146_device> m_deco146;
 	required_device<decospr_device> m_sprgen;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
@@ -165,20 +165,20 @@ uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	//
 	// it is unclear where this offset comes from, but real hardware videos confirm it is needed
 
-	m_deco_tilegen->set_scrolldx(0, 0, 1, 1);
-	m_deco_tilegen->set_scrolldx(0, 1, 1, 1);
-	m_deco_tilegen->set_scrolldx(1, 0, 1, 1);
-	m_deco_tilegen->set_scrolldx(1, 1, 1, 1);
+	m_tilegen->set_scrolldx(0, 0, 1, 1);
+	m_tilegen->set_scrolldx(0, 1, 1, 1);
+	m_tilegen->set_scrolldx(1, 0, 1, 1);
+	m_tilegen->set_scrolldx(1, 1, 1, 1);
 
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(768, cliprect);
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	return 0;
 }
@@ -215,14 +215,14 @@ void funkyjet_state::maincpu_map(address_map &map)
 	map(0x120000, 0x1207ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0x140000, 0x143fff).ram();
 	map(0x160000, 0x1607ff).ram().share(m_spriteram);
-	map(0x180000, 0x183fff).rw(FUNC(funkyjet_state::ioprot_r), FUNC(funkyjet_state::ioprot_w)).share("prot16ram"); // Protection device, unlikely to be cs0 region
+	map(0x180000, 0x183fff).rw(FUNC(funkyjet_state::ioprot_r), FUNC(funkyjet_state::ioprot_w)); // Protection device, unlikely to be cs0 region
 	map(0x184000, 0x184001).nopw();
 	map(0x188000, 0x188001).nopw();
-	map(0x300000, 0x30000f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
-	map(0x320000, 0x321fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x322000, 0x323fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x340000, 0x340bff).ram().share(m_pf_rowscroll[0]);
-	map(0x342000, 0x342bff).ram().share(m_pf_rowscroll[1]);
+	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::control_w));
+	map(0x320000, 0x321fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x322000, 0x323fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x340000, 0x340bff).ram().share(m_rowscroll[0]);
+	map(0x342000, 0x342bff).ram().share(m_rowscroll[1]);
 }
 
 /******************************************************************************/
@@ -386,8 +386,8 @@ static const gfx_layout tile_layout =
 };
 
 static GFXDECODE_START( gfx_funkyjet )
-	GFXDECODE_ENTRY( "chars", 0, charlayout,  256, 32 )  // Characters 8x8
-	GFXDECODE_ENTRY( "chars", 0, tile_layout, 256, 32 )  // Tiles 16x16
+	GFXDECODE_ENTRY( "tiles", 0, charlayout,  256, 32 )  // Characters 8x8
+	GFXDECODE_ENTRY( "tiles", 0, tile_layout, 256, 32 )  // Tiles 16x16
 GFXDECODE_END
 
 static GFXDECODE_START( gfx_funkyjet_spr )
@@ -427,16 +427,16 @@ void funkyjet_state::funkyjet(machine_config &config)
 	GFXDECODE(config, "gfxdecode", "palette", gfx_funkyjet);
 	PALETTE(config, "palette").set_format(palette_device::xBGR_444, 1024);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, "palette", gfx_funkyjet_spr);
 
@@ -463,7 +463,7 @@ ROM_START( funkyjet )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "jk02.16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) )
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mat02", 0x000000, 0x80000, CRC(e4b94c7e) SHA1(7b6ddd0bd388c8d32277fce4b3abb102724bc7d1) ) // encrypted
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -484,7 +484,7 @@ ROM_START( funkyjeta )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "jk02.16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) )
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mat02", 0x000000, 0x80000, CRC(e4b94c7e) SHA1(7b6ddd0bd388c8d32277fce4b3abb102724bc7d1) ) // encrypted
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -504,7 +504,7 @@ ROM_START( funkyjeta2 )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) )
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mat02", 0x000000, 0x80000, CRC(e4b94c7e) SHA1(7b6ddd0bd388c8d32277fce4b3abb102724bc7d1) ) // encrypted
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -523,7 +523,7 @@ ROM_START( funkyjetj )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "jh02.16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) ) // same as jk02.16f from world set
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "mat02", 0x000000, 0x80000, CRC(e4b94c7e) SHA1(7b6ddd0bd388c8d32277fce4b3abb102724bc7d1) ) // encrypted
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -543,7 +543,7 @@ ROM_START( sotsugyo )
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "sb020.16f",    0x00000, 0x10000, CRC(baf5ec93) SHA1(82b22a0b565e51cd40733f21fa876dd7064eb604) )
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "02.2f", 0x000000, 0x80000, CRC(337b1451) SHA1(ab3a4526e683c23b7634ac3304fb073f6ce98e82) )
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -562,7 +562,7 @@ ROM_START( sotsugyok ) // only ROMs that match the parent are the audio CPU and 
 	ROM_REGION( 0x10000, "audiocpu", 0 )
 	ROM_LOAD( "27c512.16f",    0x00000, 0x10000, CRC(baf5ec93) SHA1(82b22a0b565e51cd40733f21fa876dd7064eb604) )
 
-	ROM_REGION( 0x080000, "chars", 0 )
+	ROM_REGION( 0x080000, "tiles", 0 )
 	ROM_LOAD( "27c4000.2f", 0x000000, 0x80000, CRC(8a76a083) SHA1(f5cccb3a7834225af0c6118af33362efeff66999) )
 
 	ROM_REGION( 0x100000, "sprites", 0 )
@@ -575,7 +575,7 @@ ROM_END
 
 void funkyjet_state::init_funkyjet()
 {
-	deco74_decrypt_gfx(machine(), "chars");
+	deco74_decrypt_gfx(machine(), "tiles");
 }
 
 } // Anonymous namespace

--- a/src/mame/dataeast/hvysmsh.cpp
+++ b/src/mame/dataeast/hvysmsh.cpp
@@ -38,7 +38,7 @@ public:
 		, m_tilegen(*this, "tilegen")
 		, m_sprgen(*this, "spritegen")
 		, m_palette(*this, "palette")
-		, m_rowscroll(*this, "pf%u_rowscroll", 1U, 0x800U, ENDIANNESS_LITTLE)
+		, m_rowscroll(*this, "rowscroll_%u", 1U, 0x800U, ENDIANNESS_LITTLE)
 		, m_spriteram(*this, "spriteram", 0x1000U, ENDIANNESS_LITTLE)
 		, m_io_eepromout(*this, "EEPROMOUT")
 	{ }
@@ -55,7 +55,7 @@ protected:
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void vblank_interrupt(int state);
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	void descramble_sound(const char *tag) ATTR_COLD;
@@ -109,7 +109,7 @@ uint32_t wcvol95_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 	screen.priority().fill(0);
 	bitmap.fill(0);
 
-	m_tilegen->pf_update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x800);
@@ -154,9 +154,9 @@ void wcvol95_state::spriteram_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 void wcvol95_state::tilegen_map(address_map &map)
 {
-	map(0x00000, 0x0001f).rw(m_tilegen, FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x10000, 0x11fff).rw(m_tilegen, FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x14000, 0x15fff).rw(m_tilegen, FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x00000, 0x0001f).rw(m_tilegen, FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x10000, 0x11fff).rw(m_tilegen, FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x14000, 0x15fff).rw(m_tilegen, FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
 	map(0x20000, 0x20fff).rw(FUNC(hvysmsh_state::rowscroll_r<0>), FUNC(hvysmsh_state::rowscroll_w<0>));
 	map(0x24000, 0x24fff).rw(FUNC(hvysmsh_state::rowscroll_r<1>), FUNC(hvysmsh_state::rowscroll_w<1>));
 }
@@ -320,9 +320,9 @@ void wcvol95_state::vblank_interrupt(int state)
 	m_maincpu->set_input_line(ARM_IRQ_LINE, state ? HOLD_LINE : CLEAR_LINE);
 }
 
-DECO16IC_BANK_CB_MEMBER(wcvol95_state::bank_callback)
+int wcvol95_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(wcvol95_state::pri_callback)
@@ -358,16 +358,16 @@ void hvysmsh_state::hvysmsh(machine_config &config)
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_888, 1024);
 
 	DECO16IC(config, m_tilegen);
-	m_tilegen->set_pf1_size(DECO_64x32);
-	m_tilegen->set_pf2_size(DECO_64x32);
-	m_tilegen->set_pf1_col_bank(0x00);
-	m_tilegen->set_pf2_col_bank(0x10);
-	m_tilegen->set_pf1_col_mask(0x0f);
-	m_tilegen->set_pf2_col_mask(0x0f);
-	m_tilegen->set_bank1_callback(FUNC(hvysmsh_state::bank_callback));
-	m_tilegen->set_bank2_callback(FUNC(hvysmsh_state::bank_callback));
-	m_tilegen->set_pf12_8x8_bank(0);
-	m_tilegen->set_pf12_16x16_bank(1);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(hvysmsh_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(hvysmsh_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
 	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_hvysmsh_spr);
@@ -403,16 +403,16 @@ void wcvol95_state::wcvol95(machine_config &config)
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 1024);
 
 	DECO16IC(config, m_tilegen);
-	m_tilegen->set_pf1_size(DECO_64x32);
-	m_tilegen->set_pf2_size(DECO_64x32);
-	m_tilegen->set_pf1_col_bank(0x00);
-	m_tilegen->set_pf2_col_bank(0x10);
-	m_tilegen->set_pf1_col_mask(0x0f);
-	m_tilegen->set_pf2_col_mask(0x0f);
-	m_tilegen->set_bank1_callback(FUNC(wcvol95_state::bank_callback));
-	m_tilegen->set_bank2_callback(FUNC(wcvol95_state::bank_callback));
-	m_tilegen->set_pf12_8x8_bank(0);
-	m_tilegen->set_pf12_16x16_bank(1);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(wcvol95_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(wcvol95_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
 	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_hvysmsh_spr);

--- a/src/mame/dataeast/mirage.cpp
+++ b/src/mame/dataeast/mirage.cpp
@@ -67,12 +67,12 @@ public:
 	miragemj_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_deco_tilegen(*this, "tilegen"),
+		m_tilegen(*this, "tilegen"),
 		m_eeprom(*this, "eeprom"),
 		m_oki_sfx(*this, "oki_sfx"),
 		m_oki_bgm(*this, "oki_bgm"),
 		m_spriteram(*this, "spriteram") ,
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U),
+		m_rowscroll(*this, "rowscroll_%u", 1U),
 		m_sprgen(*this, "spritegen"),
 		m_io_key(*this, "KEY%u", 0U)
 	{ }
@@ -89,23 +89,23 @@ private:
 	void key_matrix_w(uint16_t data);
 	uint16_t key_matrix_r();
 	void okim1_rombank_w(uint16_t data);
-	void okim0_rombank_w(uint16_t data);
+	void eeprom_okim0_rombank_w(uint16_t data);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	void main_map(address_map &map) ATTR_COLD;
 
 	/* devices */
 	required_device<m68000_device> m_maincpu;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<okim6295_device> m_oki_sfx;
 	required_device<okim6295_device> m_oki_bgm;
 	required_device<buffered_spriteram16_device> m_spriteram;
 
 	/* memory pointers */
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 	optional_device<decospr_device> m_sprgen;
 
 	required_ioport_array<5> m_io_key;
@@ -117,18 +117,18 @@ private:
 
 uint32_t miragemj_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
 
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(256, cliprect); /* not verified */
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram->buffer(), 0x400);
 	return 0;
 }
@@ -156,7 +156,7 @@ void miragemj_state::okim1_rombank_w(uint16_t data)
 	m_oki_sfx->set_rom_bank(data & 0x3);
 }
 
-void miragemj_state::okim0_rombank_w(uint16_t data)
+void miragemj_state::eeprom_okim0_rombank_w(uint16_t data)
 {
 	m_eeprom->clk_write(BIT(data, 5) ? ASSERT_LINE : CLEAR_LINE);
 	m_eeprom->di_write(BIT(data, 4));
@@ -170,20 +170,20 @@ void miragemj_state::main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 	/* tilemaps */
-	map(0x100000, 0x101fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w)); // 0x100000 - 0x101fff tested
-	map(0x102000, 0x103fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w)); // 0x102000 - 0x102fff tested
+	map(0x100000, 0x101fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>)); // 0x100000 - 0x101fff tested
+	map(0x102000, 0x103fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>)); // 0x102000 - 0x102fff tested
 	/* linescroll */
-	map(0x110000, 0x110bff).ram().share(m_pf_rowscroll[0]);
-	map(0x112000, 0x112bff).ram().share(m_pf_rowscroll[1]);
+	map(0x110000, 0x110bff).ram().share(m_rowscroll[0]);
+	map(0x112000, 0x112bff).ram().share(m_rowscroll[1]);
 	map(0x120000, 0x1207ff).ram().share("spriteram");
 	map(0x130000, 0x1307ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
 	map(0x140000, 0x14000f).rw(m_oki_sfx, FUNC(okim6295_device::read), FUNC(okim6295_device::write)).umask16(0x00ff);
 	map(0x150000, 0x15000f).rw(m_oki_bgm, FUNC(okim6295_device::read), FUNC(okim6295_device::write)).umask16(0x00ff);
 	map(0x160000, 0x160001).nopw();
-	map(0x168000, 0x16800f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
+	map(0x168000, 0x16800f).w(m_tilegen, FUNC(deco16ic_device::control_w));
 	map(0x16a000, 0x16a001).nopw();
 	map(0x16c000, 0x16c001).w(FUNC(miragemj_state::okim1_rombank_w));
-	map(0x16c002, 0x16c003).w(FUNC(miragemj_state::okim0_rombank_w));
+	map(0x16c002, 0x16c003).w(FUNC(miragemj_state::eeprom_okim0_rombank_w));
 	map(0x16c004, 0x16c005).w(FUNC(miragemj_state::key_matrix_w));
 	map(0x16c006, 0x16c007).r(FUNC(miragemj_state::key_matrix_r));
 	map(0x16e000, 0x16e001).nopw();
@@ -247,9 +247,9 @@ DECOSPR_PRIORITY_CB_MEMBER(miragemj_state::pri_callback)
 	return mask;
 }
 
-DECO16IC_BANK_CB_MEMBER(miragemj_state::bank_callback)
+int miragemj_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 void miragemj_state::machine_start()
@@ -285,18 +285,18 @@ void miragemj_state::mirage(machine_config &config)
 	GFXDECODE(config, "gfxdecode", "palette", gfx_mirage);
 	PALETTE(config, "palette").set_format(palette_device::xBGR_555, 1024);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(miragemj_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(miragemj_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(miragemj_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(miragemj_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, "palette", gfx_mirage_spr);
 	m_sprgen->set_pri_callback(FUNC(miragemj_state::pri_callback));
@@ -322,14 +322,12 @@ ROM_START( mirage )
 	ROM_LOAD( "mbl-01.11a", 0x200000, 0x200000, CRC(895be69a) SHA1(541d8f37fb4cf99312b80a0eb0d729fbbeab5f4f) )
 	ROM_LOAD( "mbl-02.12a", 0x000000, 0x200000, CRC(474f6104) SHA1(ff81b32b90192c3d5f27c436a9246aa6caaeeeee) )
 
-	ROM_REGION( 0x200000, "oki_bgm_data", 0 )
-	ROM_LOAD( "mbl-03.10a", 0x000000, 0x200000, CRC(4a599703) SHA1(b49e84faa2d6acca952740d30fc8d1a33ac47e79) )
-
+	// - banks 2,3 and 4,5 are swapped, PAL address shuffle
 	ROM_REGION( 0x200000, "oki_bgm", 0 )
-	ROM_COPY( "oki_bgm_data", 0x000000, 0x000000, 0x080000 )
-	ROM_COPY( "oki_bgm_data", 0x100000, 0x080000, 0x080000 ) // - banks 2,3 and 4,5 are swapped, PAL address shuffle
-	ROM_COPY( "oki_bgm_data", 0x080000, 0x100000, 0x080000 ) // /
-	ROM_COPY( "oki_bgm_data", 0x180000, 0x180000, 0x080000 )
+	ROM_LOAD( "mbl-03.10a", 0x000000, 0x080000, CRC(4a599703) SHA1(b49e84faa2d6acca952740d30fc8d1a33ac47e79) )
+	ROM_CONTINUE(           0x100000, 0x080000)
+	ROM_CONTINUE(           0x080000, 0x080000)
+	ROM_CONTINUE(           0x180000, 0x080000)
 
 	ROM_REGION( 0x100000, "oki_sfx", 0 )    /* M6295 samples */
 	ROM_LOAD( "mbl-04.12k", 0x000000, 0x100000, CRC(b533123d) SHA1(2cb2f11331d00c2d282113932ed2836805f4fc6e) )

--- a/src/mame/dataeast/pktgaldx.cpp
+++ b/src/mame/dataeast/pktgaldx.cpp
@@ -103,12 +103,12 @@ class pktgaldx_state : public base_state
 public:
 	pktgaldx_state(const machine_config &mconfig, device_type type, const char *tag) :
 		base_state(mconfig, type, tag),
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U),
+		m_rowscroll(*this, "rowscroll_%u", 1U),
 		m_spriteram(*this, "spriteram"),
 		m_decrypted_opcodes(*this, "decrypted_opcodes"),
 		m_deco104(*this, "ioprot104"),
 		m_sprgen(*this, "spritegen"),
-		m_deco_tilegen(*this, "tilegen")
+		m_tilegen(*this, "tilegen")
 	{ }
 
 	void pktgaldx(machine_config &config);
@@ -117,17 +117,17 @@ public:
 
 private:
 	// memory pointers
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 	required_shared_ptr<uint16_t> m_spriteram;
 	required_shared_ptr<uint16_t> m_decrypted_opcodes;
 
 	// devices
 	required_device<deco104_device> m_deco104;
 	required_device<decospr_device> m_sprgen;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 
 	uint16_t ioprot_r(offs_t offset);
 	void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
@@ -163,19 +163,19 @@ private:
 
 uint32_t pktgaldx_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	// sprites are flipped relative to tilemaps
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(!BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(0, cliprect); // not confirmed
 	screen.priority().fill(0);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -269,10 +269,10 @@ void pktgaldx_state::prg_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
 
-	map(0x100000, 0x100fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x102000, 0x102fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x110000, 0x1107ff).ram().share(m_pf_rowscroll[0]);
-	map(0x112000, 0x1127ff).ram().share(m_pf_rowscroll[1]);
+	map(0x100000, 0x100fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x102000, 0x102fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x110000, 0x1107ff).ram().share(m_rowscroll[0]);
+	map(0x112000, 0x1127ff).ram().share(m_rowscroll[1]);
 
 	map(0x120000, 0x1207ff).ram().share(m_spriteram);
 	map(0x130000, 0x130fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
@@ -282,10 +282,10 @@ void pktgaldx_state::prg_map(address_map &map)
 	map(0x150000, 0x15000f).w(m_oki2, FUNC(okim6295_device::write)).umask16(0x00ff);
 	map(0x150007, 0x150007).r(m_oki2, FUNC(okim6295_device::read));
 
-	map(0x161800, 0x16180f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
+	map(0x161800, 0x16180f).w(m_tilegen, FUNC(deco16ic_device::control_w));
 	map(0x164800, 0x164801).w(FUNC(pktgaldx_state::oki_bank_w));
 	map(0x166800, 0x166801).w(FUNC(pktgaldx_state::vblank_ack_w));
-	map(0x167800, 0x167fff).rw(FUNC(pktgaldx_state::ioprot_r), FUNC(pktgaldx_state::ioprot_w)).share("prot16ram");
+	map(0x167800, 0x167fff).rw(FUNC(pktgaldx_state::ioprot_r), FUNC(pktgaldx_state::ioprot_w));
 
 	map(0x170000, 0x17ffff).ram();
 }
@@ -479,13 +479,13 @@ static const gfx_layout bootleg_spritelayout =
 };
 
 static GFXDECODE_START( gfx_bootleg )
-	GFXDECODE_ENTRY( "tiles", 0, bootleg_spritelayout,     0, 64 )
+	GFXDECODE_ENTRY( "tiles", 0, bootleg_spritelayout, 0, 64 )
 GFXDECODE_END
 
 
-DECO16IC_BANK_CB_MEMBER(pktgaldx_state::bank_callback)
+int pktgaldx_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 
@@ -510,18 +510,18 @@ void pktgaldx_state::pktgaldx(machine_config &config)
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_pktgaldx);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(pktgaldx_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(pktgaldx_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(pktgaldx_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(pktgaldx_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_pktgaldx_spr);
 

--- a/src/mame/dataeast/rohga.cpp
+++ b/src/mame/dataeast/rohga.cpp
@@ -147,12 +147,12 @@ public:
 		m_audiocpu(*this, "audiocpu"),
 		m_palette(*this, "palette"),
 		m_ioprot(*this, "ioprot"),
-		m_deco_tilegen(*this, "tilegen%u", 1),
+		m_tilegen(*this, "tilegen%u", 1),
 		m_oki(*this, "oki%u", 1),
 		m_spriteram(*this, "spriteram%u", 1),
 		m_sprgen(*this, "spritegen%u", 1),
 		m_paletteram(*this, "paletteram"),
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1)
+		m_rowscroll(*this, "rowscroll_%u", 1)
 	{ }
 
 	void wizdfire(machine_config &config) ATTR_COLD;
@@ -176,13 +176,13 @@ private:
 	required_device<h6280_device> m_audiocpu;
 	required_device<palette_device> m_palette;
 	required_device<deco_146_base_device> m_ioprot;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device_array<okim6295_device, 2> m_oki;
 	optional_device_array<buffered_spriteram16_device, 2> m_spriteram;
 	optional_device_array<decospr_device, 2> m_sprgen;
 
 	required_shared_ptr<u16> m_paletteram;
-	optional_shared_ptr_array<u16, 4> m_pf_rowscroll;
+	optional_shared_ptr_array<u16, 4> m_rowscroll;
 
 	std::unique_ptr<u8[]> m_dirty_palette{};
 	u16 m_priority = 0;
@@ -201,7 +201,7 @@ private:
 	u32 screen_update_nitrobal(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void mixwizdfirelayer(bitmap_rgb32 &bitmap, const rectangle &cliprect, u16 pri, u16 primask);
 	void mixnitroballlayer(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(rohga_pri_callback);
 	DECOSPR_COLOUR_CB_MEMBER(rohga_col_callback);
 	DECOSPR_COLOUR_CB_MEMBER(schmeisr_col_callback);
@@ -279,15 +279,15 @@ void rohga_state::priority_w(u16 data)
 
 u32 rohga_state::screen_update_rohga(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	const u16 flip = m_deco_tilegen[0]->pf_control_r(0);
+	const u16 flip = m_tilegen[0]->control_r(0);
 
 	// sprites are flipped relative to tilemaps
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(!BIT(flip, 7));
 
 	// Update playfields
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	// Draw playfields
 	screen.priority().fill(0, cliprect);
@@ -299,30 +299,30 @@ u32 rohga_state::screen_update_rohga(screen_device &screen, bitmap_ind16 &bitmap
 		if (m_priority & 4)
 		{
 			// Draw as 1 8BPP layer
-			m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 3);
+			m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 3);
 		}
 		else
 		{
 			// Draw as 2 4BPP layers
-			m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-			m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+			m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+			m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
 		}
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 		break;
 	case 1:
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 		break;
 	case 2:
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0/*TILEMAP_DRAW_OPAQUE*/, 1);
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0/*TILEMAP_DRAW_OPAQUE*/, 1);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 		break;
 	}
 
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -377,7 +377,7 @@ void rohga_state::mixwizdfirelayer(bitmap_rgb32 &bitmap, const rectangle &clipre
 
 u32 rohga_state::screen_update_wizdfire(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	const u16 flip = m_deco_tilegen[0]->pf_control_r(0);
+	const u16 flip = m_tilegen[0]->control_r(0);
 
 	// sprites are flipped relative to tilemaps
 	flip_screen_set(BIT(flip, 7));
@@ -389,27 +389,27 @@ u32 rohga_state::screen_update_wizdfire(screen_device &screen, bitmap_rgb32 &bit
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
 
 	// Update playfields
-	m_deco_tilegen[0]->pf_update(nullptr, nullptr);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(nullptr, nullptr);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	// Draw playfields - Palette of 2nd playfield chip visible if playfields turned off
 	bitmap.fill(m_palette->pen(512), cliprect);
 
-	m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_sprgen[0]->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0600, 0x0600, 0x400, 0x1ff);
-	m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen[0]->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0400, 0x0600, 0x400, 0x1ff);
 
 	if ((m_priority & 0x1f) == 0x1f) // Wizdfire has bit 0x40 always set, Dark Seal 2 doesn't?!
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_ALPHA(0x80), 0);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_ALPHA(0x80), 0);
 	else
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	m_sprgen[0]->inefficient_copy_sprite_bitmap(bitmap, cliprect, 0x0000, 0x0400, 0x400, 0x1ff); // 0x000 and 0x200 of 0x600
 
 	mixwizdfirelayer(bitmap, cliprect, 0x000, 0x000);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -569,7 +569,7 @@ void rohga_state::mixnitroballlayer(screen_device &screen, bitmap_rgb32 &bitmap,
 
 u32 rohga_state::screen_update_nitrobal(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	const u16 flip = m_deco_tilegen[0]->pf_control_r(0);
+	const u16 flip = m_tilegen[0]->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(BIT(flip, 7));
@@ -580,31 +580,31 @@ u32 rohga_state::screen_update_nitrobal(screen_device &screen, bitmap_rgb32 &bit
 	m_sprgen[0]->draw_sprites(bitmap, cliprect, m_spriteram[0]->buffer(), 0x400);
 
 	// Update playfields
-	m_deco_tilegen[0]->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
-	m_deco_tilegen[1]->pf_update(m_pf_rowscroll[2], m_pf_rowscroll[3]);
+	m_tilegen[0]->update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen[1]->update(m_rowscroll[2], m_rowscroll[3]);
 
 	// Draw playfields - Palette of 2nd playfield chip visible if playfields turned off
 	bitmap.fill(m_palette->pen(512), cliprect);
 	screen.priority().fill(0);
 
 	// pf3 and pf4 are combined into a single 8bpp bitmap
-	m_deco_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->tilemap_12_combine_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 
 	switch (m_priority)
 	{
 		case 0:
 		default:
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0x008);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0x008);
 			break;
 		case 0x20:
-			m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0x040);
+			m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 0x040);
 			break;
 	}
 
 	// TODO verify priorities + mixing / alpha
 	mixnitroballlayer(screen, bitmap, cliprect);
 
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -648,10 +648,10 @@ void rohga_state::rohga_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();
 
-	map(0x200000, 0x20000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x240000, 0x24000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x200000, 0x20000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x240000, 0x24000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 
-	map(0x280000, 0x283fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)).share("prot16ram"); // Protection device
+	map(0x280000, 0x283fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
 
 	map(0x2c0000, 0x2c0001).portr("DSW3");
 
@@ -662,15 +662,15 @@ void rohga_state::rohga_map(address_map &map)
 	map(0x322000, 0x322001).w(FUNC(rohga_state::priority_w));
 	map(0x321100, 0x321101).r(FUNC(rohga_state::irq_ack_r)); // IRQ ack?  Value not used
 
-	map(0x3c0000, 0x3c1fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x3c2000, 0x3c2fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x3c4000, 0x3c4fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x3c6000, 0x3c6fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
+	map(0x3c0000, 0x3c1fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x3c2000, 0x3c2fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x3c4000, 0x3c4fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x3c6000, 0x3c6fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
 
-	map(0x3c8000, 0x3c9fff).ram().share(m_pf_rowscroll[0]);
-	map(0x3ca000, 0x3cafff).mirror(0x1000).ram().share(m_pf_rowscroll[1]);
-	map(0x3cc000, 0x3ccfff).mirror(0x1000).ram().share(m_pf_rowscroll[2]);
-	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_pf_rowscroll[3]);
+	map(0x3c8000, 0x3c9fff).ram().share(m_rowscroll[0]);
+	map(0x3ca000, 0x3cafff).mirror(0x1000).ram().share(m_rowscroll[1]);
+	map(0x3cc000, 0x3ccfff).mirror(0x1000).ram().share(m_rowscroll[2]);
+	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
 	map(0x3e0000, 0x3e1fff).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
@@ -682,17 +682,17 @@ void rohga_state::wizdfire_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();
 
-	map(0x200000, 0x200fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x202fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x208000, 0x208fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x20a000, 0x20afff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
+	map(0x200000, 0x200fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x202fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x208000, 0x208fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x20a000, 0x20afff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
 
 	map(0x20b000, 0x20b3ff).nopw(); // ? Always 0 written
-	map(0x20c000, 0x20c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x20e000, 0x20e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x20c000, 0x20c7ff).ram().share(m_rowscroll[2]);
+	map(0x20e000, 0x20e7ff).ram().share(m_rowscroll[3]);
 
-	map(0x300000, 0x30000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x310000, 0x31000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x300000, 0x30000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x310000, 0x31000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 
 	map(0x320000, 0x320001).w(FUNC(rohga_state::priority_w)); // Priority
 	map(0x320002, 0x320003).nopw(); // ?
@@ -707,7 +707,7 @@ void rohga_state::wizdfire_map(address_map &map)
 	map(0x390008, 0x390009).w(FUNC(rohga_state::palette_dma_w));
 
 	map(0xfdc000, 0xfe3fff).ram();
-	map(0xfe4000, 0xfe7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)).share("prot16ram"); // Protection device
+	map(0xfe4000, 0xfe7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
 	map(0xfe8000, 0xffffff).ram();
 }
 
@@ -716,18 +716,18 @@ void rohga_state::nitrobal_map(address_map &map)
 {
 	map(0x000000, 0x1fffff).rom();
 
-	map(0x200000, 0x200fff).mirror(0x1000).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x2027ff).mirror(0x800).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x208000, 0x2087ff).mirror(0x800).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x20a000, 0x20a7ff).mirror(0x800).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
+	map(0x200000, 0x200fff).mirror(0x1000).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x2027ff).mirror(0x800).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x208000, 0x2087ff).mirror(0x800).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x20a000, 0x20a7ff).mirror(0x800).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
 
-	map(0x204000, 0x2047ff).ram().share(m_pf_rowscroll[0]);
-	map(0x206000, 0x2067ff).ram().share(m_pf_rowscroll[1]);
-	map(0x20c000, 0x20c7ff).ram().share(m_pf_rowscroll[2]);
-	map(0x20e000, 0x20e7ff).ram().share(m_pf_rowscroll[3]);
+	map(0x204000, 0x2047ff).ram().share(m_rowscroll[0]);
+	map(0x206000, 0x2067ff).ram().share(m_rowscroll[1]);
+	map(0x20c000, 0x20c7ff).ram().share(m_rowscroll[2]);
+	map(0x20e000, 0x20e7ff).ram().share(m_rowscroll[3]);
 
-	map(0x300000, 0x30000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x310000, 0x31000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
+	map(0x300000, 0x30000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x310000, 0x31000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
 
 	map(0x320000, 0x320001).portr("DSW3").w(FUNC(rohga_state::priority_w)); // Priority
 	map(0x320002, 0x320003).nopw(); // ?
@@ -742,7 +742,7 @@ void rohga_state::nitrobal_map(address_map &map)
 	map(0x390008, 0x390009).w(FUNC(rohga_state::palette_dma_w));
 
 	map(0xfec000, 0xff3fff).ram();
-	map(0xff4000, 0xff7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)).share("prot16ram"); // Protection device
+	map(0xff4000, 0xff7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
 
 	map(0xff8000, 0xffffff).ram();
 }
@@ -751,9 +751,9 @@ void rohga_state::nitrobal_map(address_map &map)
 void rohga_state::hotb_base_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom();
-	map(0x200000, 0x20000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
-	map(0x240000, 0x24000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
-	map(0x280000, 0x283fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)).share("prot16ram"); // Protection device
+	map(0x200000, 0x20000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
+	map(0x240000, 0x24000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
+	map(0x280000, 0x283fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
 
 	map(0x2c0000, 0x2c0001).portr("DSW3");
 	map(0x300000, 0x300001).portr("DSW3").w(FUNC(rohga_state::rohga_buffer_spriteram16_w)); // write 1 for sprite DMA
@@ -764,14 +764,14 @@ void rohga_state::hotb_base_map(address_map &map)
 	map(0x322000, 0x322001).w(FUNC(rohga_state::priority_w));
 	map(0x321100, 0x321101).w(FUNC(rohga_state::irq_ack_w));  // IRQ ack?  Value not used
 
-	map(0x3c0000, 0x3c1fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x3c2000, 0x3c2fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x3c4000, 0x3c4fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x3c6000, 0x3c6fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x3c8000, 0x3c9fff).ram().share(m_pf_rowscroll[0]);
-	map(0x3ca000, 0x3cafff).mirror(0x1000).ram().share(m_pf_rowscroll[1]);
-	map(0x3cc000, 0x3ccfff).mirror(0x1000).ram().share(m_pf_rowscroll[2]);
-	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_pf_rowscroll[3]);
+	map(0x3c0000, 0x3c1fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x3c2000, 0x3c2fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x3c4000, 0x3c4fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x3c6000, 0x3c6fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x3c8000, 0x3c9fff).ram().share(m_rowscroll[0]);
+	map(0x3ca000, 0x3cafff).mirror(0x1000).ram().share(m_rowscroll[1]);
+	map(0x3cc000, 0x3ccfff).mirror(0x1000).ram().share(m_rowscroll[2]);
+	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
 	map(0x3e0000, 0x3e1fff).mirror(0x2000).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
@@ -1314,9 +1314,9 @@ void rohga_state::sound_bankswitch_w(u8 data)
 
 /**********************************************************************************/
 
-DECO16IC_BANK_CB_MEMBER(rohga_state::bank_callback)
+int rohga_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x3) << 12;
+	return (bank & 0x30) << 8;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(rohga_state::rohga_pri_callback)
@@ -1368,31 +1368,31 @@ void rohga_state::rohga_base(machine_config &config)
 
 	PALETTE(config, m_palette).set_entries(2048);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x64);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(rohga_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(rohga_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x64);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x10);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(rohga_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(rohga_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag("gfxdecode");
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x10);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(rohga_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(rohga_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(2);
-	m_deco_tilegen[1]->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x00);
+	m_tilegen[1]->set_col_bank<1>(0x10);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(rohga_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(rohga_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(0);
+	m_tilegen[1]->set_16x16_bank(2);
+	m_tilegen[1]->set_gfxdecode_tag("gfxdecode");
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_rohga);
 
@@ -1448,7 +1448,7 @@ void rohga_state::wizdfire(machine_config &config)
 
 	subdevice<screen_device>("screen")->set_screen_update(FUNC(rohga_state::screen_update_wizdfire));
 
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_wizdfire_spr1);
 	DECO_SPRITE(config, m_sprgen[1], m_palette, gfx_wizdfire_spr2);
@@ -1470,15 +1470,15 @@ void rohga_state::nitrobal(machine_config &config)
 
 	subdevice<screen_device>("screen")->set_screen_update(FUNC(rohga_state::screen_update_nitrobal));
 
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_32x32);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_32x32);
 
-	m_deco_tilegen[1]->set_pf1_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_32x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0);
-	m_deco_tilegen[1]->set_pf2_col_bank(0);
-	m_deco_tilegen[1]->set_pf1_col_mask(0);
-	m_deco_tilegen[1]->set_pf2_col_mask(0);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_32x32);
+	m_tilegen[1]->set_col_bank<0>(0);
+	m_tilegen[1]->set_col_bank<1>(0);
+	m_tilegen[1]->set_col_mask<0>(0);
+	m_tilegen[1]->set_col_mask<1>(0);
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_wizdfire_spr1);
 	m_sprgen[0]->set_alt_format(true);

--- a/src/mame/dataeast/simpl156.cpp
+++ b/src/mame/dataeast/simpl156.cpp
@@ -118,7 +118,7 @@ public:
 	simpl156_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_maincpu(*this, "maincpu"),
-		m_deco_tilegen(*this, "tilegen"),
+		m_tilegen(*this, "tilegen"),
 		m_eeprom(*this, "eeprom"),
 		m_okimusic(*this, "okimusic"),
 		m_sprgen(*this, "spritegen"),
@@ -146,7 +146,7 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 private:
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	DECOSPR_PRIORITY_CB_MEMBER(pri_callback);
 
 	void eeprom_w(u32 data);
@@ -175,7 +175,7 @@ private:
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<okim6295_device> m_okimusic;
 	required_device<decospr_device> m_sprgen;
@@ -302,9 +302,9 @@ void simpl156_state::common_map(address_map &map)
 	map(0x10000, 0x11fff).rw(FUNC(simpl156_state::spriteram_r), FUNC(simpl156_state::spriteram_w));
 	map(0x20000, 0x20fff).rw(m_palette, FUNC(palette_device::read16), FUNC(palette_device::write16)).umask32(0x0000ffff).share("palette");
 	map(0x30000, 0x30003).portr("IN1").w(FUNC(simpl156_state::eeprom_w));
-	map(0x40000, 0x4001f).rw(m_deco_tilegen, FUNC(deco16ic_device::pf_control_dword_r), FUNC(deco16ic_device::pf_control_dword_w));
-	map(0x50000, 0x51fff).mirror(0x2000).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_dword_r), FUNC(deco16ic_device::pf1_data_dword_w));
-	map(0x54000, 0x55fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_dword_r), FUNC(deco16ic_device::pf2_data_dword_w));
+	map(0x40000, 0x4001f).rw(m_tilegen, FUNC(deco16ic_device::control32_r), FUNC(deco16ic_device::control32_w));
+	map(0x50000, 0x51fff).mirror(0x2000).rw(m_tilegen, FUNC(deco16ic_device::vram32_r<0>), FUNC(deco16ic_device::vram32_w<0>));
+	map(0x54000, 0x55fff).rw(m_tilegen, FUNC(deco16ic_device::vram32_r<1>), FUNC(deco16ic_device::vram32_w<1>));
 	map(0x60000, 0x61fff).rw(FUNC(simpl156_state::rowscroll_r<0>), FUNC(simpl156_state::rowscroll_w<0>));
 	map(0x64000, 0x65fff).rw(FUNC(simpl156_state::rowscroll_r<1>), FUNC(simpl156_state::rowscroll_w<1>));
 	map(0x70000, 0x70003).readonly().nopw(); // ?
@@ -397,9 +397,9 @@ void simpl156_state::vblank_interrupt(int state)
 }
 
 
-DECO16IC_BANK_CB_MEMBER(simpl156_state::bank_callback)
+int simpl156_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 DECOSPR_PRIORITY_CB_MEMBER(simpl156_state::pri_callback)
@@ -425,12 +425,12 @@ u32 simpl156_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, c
 {
 	screen.priority().fill(0, cliprect);
 
-	m_deco_tilegen->pf_update(m_rowscroll[0], m_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(256, cliprect);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 
 	// sprites are flipped relative to tilemaps
 	m_sprgen->set_flip_screen(true);
@@ -464,18 +464,18 @@ void simpl156_state::chainrec(machine_config &config)
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_simpl156);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_bank1_callback(FUNC(simpl156_state::bank_callback));
-	m_deco_tilegen->set_bank2_callback(FUNC(simpl156_state::bank_callback));
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(simpl156_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(simpl156_state::bank_callback));
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, m_palette, gfx_simpl156_spr);
 	m_sprgen->set_pri_callback(FUNC(simpl156_state::pri_callback));

--- a/src/mame/dataeast/sshangha.cpp
+++ b/src/mame/dataeast/sshangha.cpp
@@ -121,8 +121,7 @@ public:
 		m_deco146(*this, "ioprot"),
 		m_spriteram(*this, "spriteram%u", 1U),
 		m_sound_shared_ram(*this, "sound_shared"),
-		m_pf_rowscroll(*this, "pf%u_rowscroll", 1U),
-		m_prot_data(*this, "prot_data"),
+		m_rowscroll(*this, "rowscroll_%u", 1U),
 		m_inputs(*this, "INPUTS"),
 		m_system(*this, "SYSTEM"),
 		m_dsw(*this, "DSW")
@@ -146,8 +145,7 @@ private:
 
 	required_shared_ptr_array<uint16_t, 2> m_spriteram;
 	required_shared_ptr<uint16_t> m_sound_shared_ram;
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
-	optional_shared_ptr<uint16_t> m_prot_data;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 
 	required_ioport m_inputs;
 	required_ioport m_system;
@@ -155,13 +153,11 @@ private:
 
 	uint16_t m_video_control = 0;
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 	uint16_t mix_callback(uint16_t p, uint16_t p2);
 
-	uint16_t sshangha_protection_region_8_146_r(offs_t offset);
-	void sshangha_protection_region_8_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t sshangha_protection_region_d_146_r(offs_t offset);
-	void sshangha_protection_region_d_146_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	template <offs_t Base> uint16_t ioprot_r(offs_t offset);
+	template <offs_t Base> void ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t deco_71_r();
 	uint16_t sshanghab_protection16_r(offs_t offset);
 
@@ -172,8 +168,8 @@ private:
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	void sshangha_main_map(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
+	void sshangha_main_map(address_map &map) ATTR_COLD;
 	void sshanghab_main_map(address_map &map) ATTR_COLD;
 };
 
@@ -191,7 +187,7 @@ void sshangha_state::video_w(uint16_t data)
 {
 	// 0x4: Special video mode, other bits unknown
 	m_video_control = data;
-	LOGVIDEOREGS("video_w: %04x", data);
+	LOGVIDEOREGS("%s: video_w: %04x", machine().describe_context(), data);
 }
 
 /******************************************************************************/
@@ -211,7 +207,7 @@ uint32_t sshangha_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 	const bool combine_tilemaps = (m_video_control & 4) ? false : true;
 
 	// sprites are flipped relative to tilemaps
-	uint16_t flip = m_tilegen->pf_control_r(0);
+	uint16_t flip = m_tilegen->control_r(0);
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen[0]->set_flip_screen(!BIT(flip, 7));
 	m_sprgen[1]->set_flip_screen(!BIT(flip, 7));
@@ -223,7 +219,7 @@ uint32_t sshangha_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 	// draw / mix
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	m_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	// TODO: fully verify draw order / priorities
 
@@ -249,9 +245,6 @@ uint32_t sshangha_state::screen_update(screen_device &screen, bitmap_rgb32 &bitm
 
 /******************************************************************************/
 
-
-
-
 uint16_t sshangha_state::sshanghab_protection16_r(offs_t offset) // bootleg inputs
 {
 	switch (offset)
@@ -264,7 +257,7 @@ uint16_t sshangha_state::sshanghab_protection16_r(offs_t offset) // bootleg inpu
 			return m_dsw->read();
 	}
 
-	return m_prot_data[offset]; // TODO: m_prot_data share isn't mapped in the bootleg, so this is useless?
+	return 0; // TODO: this is useless?
 }
 
 // Probably returns 0xffff when sprite DMA is complete, the game waits on it
@@ -276,35 +269,20 @@ uint16_t sshangha_state::deco_71_r()
 
 /******************************************************************************/
 
-uint16_t sshangha_state::sshangha_protection_region_d_146_r(offs_t offset)
+template <offs_t Base>
+uint16_t sshangha_state::ioprot_r(offs_t offset)
 {
-	int const real_address = 0x3f4000 + (offset * 2);
+	int const real_address = Base + (offset * 2);
 	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	uint16_t const data = m_deco146->read_data(deco146_addr, cs);
 	return data;
 }
 
-void sshangha_state::sshangha_protection_region_d_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+template <offs_t Base>
+void sshangha_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	int const real_address = 0x3f4000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	m_deco146->write_data(deco146_addr, data, mem_mask, cs);
-}
-
-uint16_t sshangha_state::sshangha_protection_region_8_146_r(offs_t offset)
-{
-	int const real_address = 0x3e0000 + (offset * 2);
-	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
-	uint8_t cs = 0;
-	uint16_t const data = m_deco146->read_data(deco146_addr, cs);
-	return data;
-}
-
-void sshangha_state::sshangha_protection_region_8_146_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	int const real_address = 0x3e0000 + (offset *2);
+	int const real_address = Base + (offset * 2);
 	int const deco146_addr = bitswap<32>(real_address, /* NC */31,30,29,28,27,26,25,24,23,22,21,20,19,18, 13,12,11,/**/      17,16,15,14,    10,9,8, 7,6,5,4, 3,2,1,0) & 0x7fff;
 	uint8_t cs = 0;
 	m_deco146->write_data(deco146_addr, data, mem_mask, cs);
@@ -316,12 +294,12 @@ void sshangha_state::sshangha_main_map(address_map &map)
 	map(0x000000, 0x03ffff).rom();
 	map(0x100000, 0x10000f).ram().share(m_sound_shared_ram);
 
-	map(0x200000, 0x201fff).rw(m_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x203fff).rw(m_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x204000, 0x2047ff).ram().share(m_pf_rowscroll[0]);
-	map(0x206000, 0x2067ff).ram().share(m_pf_rowscroll[1]);
+	map(0x200000, 0x201fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x203fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x204000, 0x2047ff).ram().share(m_rowscroll[0]);
+	map(0x206000, 0x2067ff).ram().share(m_rowscroll[1]);
 	map(0x206800, 0x207fff).ram();
-	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::pf_control_w));
+	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::control_w));
 	map(0x320000, 0x320001).w(FUNC(sshangha_state::video_w));
 	map(0x320002, 0x320005).nopw();
 	map(0x320006, 0x320007).nopr(); //irq ack
@@ -335,9 +313,9 @@ void sshangha_state::sshangha_main_map(address_map &map)
 
 	map(0x380000, 0x380fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x381000, 0x383fff).ram(); // unused palette area
-	map(0x3e0000, 0x3e3fff).rw(FUNC(sshangha_state::sshangha_protection_region_8_146_r), FUNC(sshangha_state::sshangha_protection_region_8_146_w));
+	map(0x3e0000, 0x3e3fff).rw(FUNC(sshangha_state::ioprot_r<0x3e0000>), FUNC(sshangha_state::ioprot_w<0x3e0000>));
 	map(0x3ec000, 0x3f3fff).ram();
-	map(0x3f4000, 0x3f7fff).rw(FUNC(sshangha_state::sshangha_protection_region_d_146_r), FUNC(sshangha_state::sshangha_protection_region_d_146_w)).share(m_prot_data);
+	map(0x3f4000, 0x3f7fff).rw(FUNC(sshangha_state::ioprot_r<0x3f4000>), FUNC(sshangha_state::ioprot_w<0x3f4000>));
 }
 
 void sshangha_state::sshanghab_main_map(address_map &map)
@@ -346,12 +324,12 @@ void sshangha_state::sshanghab_main_map(address_map &map)
 	map(0x084000, 0x0847ff).r(FUNC(sshangha_state::sshanghab_protection16_r));
 	map(0x101000, 0x10100f).ram().share(m_sound_shared_ram); // the bootleg writes here
 
-	map(0x200000, 0x201fff).rw(m_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x203fff).rw(m_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x204000, 0x2047ff).ram().share(m_pf_rowscroll[0]);
-	map(0x206000, 0x2067ff).ram().share(m_pf_rowscroll[1]);
+	map(0x200000, 0x201fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x203fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x204000, 0x2047ff).ram().share(m_rowscroll[0]);
+	map(0x206000, 0x2067ff).ram().share(m_rowscroll[1]);
 	map(0x206800, 0x207fff).ram();
-	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::pf_control_w));
+	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::control_w));
 	map(0x320000, 0x320001).w(FUNC(sshangha_state::video_w));
 	map(0x320002, 0x320005).nopw();
 	map(0x320006, 0x320007).nopr(); //irq ack
@@ -519,9 +497,9 @@ GFXDECODE_END
 
 /******************************************************************************/
 
-DECO16IC_BANK_CB_MEMBER(sshangha_state::bank_callback)
+int sshangha_state::bank_callback(int bank)
 {
-	return (bank >> 4) * 0x1000;
+	return (bank & ~0xf) << 8;
 }
 
 // similar as tattass (dataeast/deco32.cpp) but base color is pf2 color bank
@@ -556,17 +534,17 @@ void sshangha_state::sshangha(machine_config &config)
 	DECO16IC(config, m_tilegen);
 	// requires pf1 to be 64x64 for the ending screen to be displayed properly
 	// TODO: confirm arrangement, game barely uses scrolling otherwise
-	m_tilegen->set_pf1_size(DECO_64x64);
-	m_tilegen->set_pf2_size(DECO_64x32);
-	m_tilegen->set_pf1_col_bank(0x10);
-	m_tilegen->set_pf2_col_bank(0x30);
-	m_tilegen->set_pf1_col_mask(0x0f);
-	m_tilegen->set_pf2_col_mask(0x0f);
-	m_tilegen->set_bank1_callback(FUNC(sshangha_state::bank_callback));
-	m_tilegen->set_bank2_callback(FUNC(sshangha_state::bank_callback));
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x64);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x10);
+	m_tilegen->set_col_bank<1>(0x30);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_bank_callback<0>(FUNC(sshangha_state::bank_callback));
+	m_tilegen->set_bank_callback<1>(FUNC(sshangha_state::bank_callback));
 	m_tilegen->set_mix_callback(FUNC(sshangha_state::mix_callback));
-	m_tilegen->set_pf12_8x8_bank(0);
-	m_tilegen->set_pf12_16x16_bank(1);
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
 	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen[0], m_palette, gfx_sshangha_spr1);

--- a/src/mame/dataeast/supbtime.cpp
+++ b/src/mame/dataeast/supbtime.cpp
@@ -87,10 +87,10 @@ public:
 	supbtime_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_spriteram(*this, "spriteram")
-		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1U)
+		, m_rowscroll(*this, "rowscroll_%u", 1U)
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_deco_tilegen(*this, "tilegen")
+		, m_tilegen(*this, "tilegen")
 		, m_sprgen(*this, "spritegen")
 	{ }
 
@@ -102,10 +102,10 @@ public:
 
 private:
 	required_shared_ptr<uint16_t> m_spriteram;
-	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
+	required_shared_ptr_array<uint16_t, 2> m_rowscroll;
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
-	required_device<deco16ic_device> m_deco_tilegen;
+	required_device<deco16ic_device> m_tilegen;
 	required_device<decospr_device> m_sprgen;
 
 	void vblank_w(int state);
@@ -135,21 +135,21 @@ private:
 
 uint32_t supbtime_state::screen_update_common(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, bool use_offsets)
 {
-	uint16_t const flip = m_deco_tilegen->pf_control_r(0);
+	uint16_t const flip = m_tilegen->control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
 	m_sprgen->set_flip_screen(BIT(flip, 7));
-	m_deco_tilegen->pf_update(m_pf_rowscroll[0], m_pf_rowscroll[1]);
+	m_tilegen->update(m_rowscroll[0], m_rowscroll[1]);
 
 	bitmap.fill(768, cliprect);
 
 	if (use_offsets)
 	{
 		// chinatwn and tumblep are verified as needing a 1 pixel offset on the tilemaps to match original hardware (supbtime appears to not want them)
-		m_deco_tilegen->set_scrolldx(0, 0, 1, -1);
-		m_deco_tilegen->set_scrolldx(0, 1, 1, -1);
-		m_deco_tilegen->set_scrolldx(1, 0, 1, -1);
-		m_deco_tilegen->set_scrolldx(1, 1, 1, -1);
+		m_tilegen->set_scrolldx(0, 0, 1, -1);
+		m_tilegen->set_scrolldx(0, 1, 1, -1);
+		m_tilegen->set_scrolldx(1, 0, 1, -1);
+		m_tilegen->set_scrolldx(1, 1, 1, -1);
 	}
 
 	return 0;
@@ -160,9 +160,9 @@ uint32_t supbtime_state::screen_update_supbtime(screen_device &screen, bitmap_in
 {
 	screen_update_common(screen, bitmap, cliprect, false);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -171,9 +171,9 @@ uint32_t supbtime_state::screen_update_chinatwn(screen_device &screen, bitmap_in
 {
 	screen_update_common(screen, bitmap, cliprect, true);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -182,8 +182,8 @@ uint32_t supbtime_state::screen_update_tumblep(screen_device &screen, bitmap_ind
 {
 	screen_update_common(screen, bitmap, cliprect, true);
 
-	m_deco_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_deco_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 
 	return 0;
@@ -208,11 +208,11 @@ void supbtime_state::supbtime_map(address_map &map)
 	map(0x18000a, 0x18000b).r(FUNC(supbtime_state::vblank_ack_r));
 	map(0x18000a, 0x18000d).nopw(); // ?
 	map(0x1a0001, 0x1a0001).w("soundlatch", FUNC(generic_latch_8_device::write));
-	map(0x300000, 0x30000f).rw(m_deco_tilegen, FUNC(deco16ic_device::pf_control_r), FUNC(deco16ic_device::pf_control_w));
-	map(0x320000, 0x321fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x322000, 0x323fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x340000, 0x3407ff).ram().share(m_pf_rowscroll[0]);
-	map(0x342000, 0x3427ff).ram().share(m_pf_rowscroll[1]);
+	map(0x300000, 0x30000f).rw(m_tilegen, FUNC(deco16ic_device::control_r), FUNC(deco16ic_device::control_w));
+	map(0x320000, 0x321fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x322000, 0x323fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x340000, 0x3407ff).ram().share(m_rowscroll[0]);
+	map(0x342000, 0x3427ff).ram().share(m_rowscroll[1]);
 }
 
 void supbtime_state::chinatwn_map(address_map &map)
@@ -227,11 +227,11 @@ void supbtime_state::chinatwn_map(address_map &map)
 	map(0x18000a, 0x18000b).r(FUNC(supbtime_state::vblank_ack_r));
 	map(0x18000a, 0x18000d).nopw(); // ?
 	map(0x1a0000, 0x1a3fff).ram();
-	map(0x300000, 0x30000f).rw(m_deco_tilegen, FUNC(deco16ic_device::pf_control_r), FUNC(deco16ic_device::pf_control_w));
-	map(0x320000, 0x321fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x322000, 0x323fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x340000, 0x3407ff).ram().share(m_pf_rowscroll[0]); // unused
-	map(0x342000, 0x3427ff).ram().share(m_pf_rowscroll[1]); // unused
+	map(0x300000, 0x30000f).rw(m_tilegen, FUNC(deco16ic_device::control_r), FUNC(deco16ic_device::control_w));
+	map(0x320000, 0x321fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x322000, 0x323fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x340000, 0x3407ff).ram().share(m_rowscroll[0]); // unused
+	map(0x342000, 0x3427ff).ram().share(m_rowscroll[1]); // unused
 }
 
 void supbtime_state::tumblep_map(address_map &map)
@@ -249,11 +249,11 @@ void supbtime_state::tumblep_map(address_map &map)
 	map(0x18000a, 0x18000b).r(FUNC(supbtime_state::vblank_ack_r));
 	map(0x18000a, 0x18000d).nopw(); // ?
 	map(0x1a0000, 0x1a07ff).ram().share(m_spriteram);
-	map(0x300000, 0x30000f).w(m_deco_tilegen, FUNC(deco16ic_device::pf_control_w));
-	map(0x320000, 0x320fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x322000, 0x322fff).rw(m_deco_tilegen, FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x340000, 0x3407ff).writeonly().share(m_pf_rowscroll[0]); // unused
-	map(0x342000, 0x3427ff).writeonly().share(m_pf_rowscroll[1]); // unused
+	map(0x300000, 0x30000f).w(m_tilegen, FUNC(deco16ic_device::control_w));
+	map(0x320000, 0x320fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x322000, 0x322fff).rw(m_tilegen, FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x340000, 0x3407ff).writeonly().share(m_rowscroll[0]); // unused
+	map(0x342000, 0x3427ff).writeonly().share(m_rowscroll[1]); // unused
 }
 
 // Physical memory map (21 bits)
@@ -473,16 +473,16 @@ void supbtime_state::supbtime(machine_config &config)
 	GFXDECODE(config, "gfxdecode", "palette", gfx_supbtime);
 	PALETTE(config, "palette").set_format(palette_device::xBGR_444, 1024);
 
-	DECO16IC(config, m_deco_tilegen);
-	m_deco_tilegen->set_pf1_size(DECO_64x32);
-	m_deco_tilegen->set_pf2_size(DECO_64x32);
-	m_deco_tilegen->set_pf1_col_bank(0x00);
-	m_deco_tilegen->set_pf2_col_bank(0x10);
-	m_deco_tilegen->set_pf1_col_mask(0x0f);
-	m_deco_tilegen->set_pf2_col_mask(0x0f);
-	m_deco_tilegen->set_pf12_8x8_bank(0);
-	m_deco_tilegen->set_pf12_16x16_bank(1);
-	m_deco_tilegen->set_gfxdecode_tag("gfxdecode");
+	DECO16IC(config, m_tilegen);
+	m_tilegen->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen->set_col_bank<0>(0x00);
+	m_tilegen->set_col_bank<1>(0x10);
+	m_tilegen->set_col_mask<0>(0x0f);
+	m_tilegen->set_col_mask<1>(0x0f);
+	m_tilegen->set_8x8_bank(0);
+	m_tilegen->set_16x16_bank(1);
+	m_tilegen->set_gfxdecode_tag("gfxdecode");
 
 	DECO_SPRITE(config, m_sprgen, "palette", gfx_supbtime_spr);
 

--- a/src/mame/dataeast/vaportra.cpp
+++ b/src/mame/dataeast/vaportra.cpp
@@ -43,11 +43,11 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_deco_tilegen(*this, "tilegen%u", 1U)
+		, m_tilegen(*this, "tilegen%u", 1U)
 		, m_spritegen(*this, "spritegen")
 		, m_spriteram(*this, "spriteram")
 		, m_gfxdecode(*this, "gfxdecode")
-		, m_palette(*this, "colors")
+		, m_palette(*this, "palette")
 		, m_soundlatch(*this, "soundlatch")
 		, m_paletteram(*this, "palette")
 		, m_paletteram_ext(*this, "palette_ext")
@@ -65,7 +65,7 @@ private:
 	// devices
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
-	required_device_array<deco16ic_device, 2> m_deco_tilegen;
+	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device<deco_mxc06_device> m_spritegen;
 	required_device<buffered_spriteram16_device> m_spriteram;
 	required_device<gfxdecode_device> m_gfxdecode;
@@ -88,7 +88,7 @@ private:
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void update_palette( int offset );
 
-	DECO16IC_BANK_CB_MEMBER(bank_callback);
+	int bank_callback(int bank);
 
 	void main_map(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
@@ -111,15 +111,13 @@ void vaportra_state::priority_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 /******************************************************************************/
 
-void vaportra_state::update_palette( int offset )
+void vaportra_state::update_palette(int offset)
 {
-	uint8_t r, g, b;
-
 	// TODO : Values aren't written in game when higher than 0xf0,
 	// It's related to hardware colour resistors?
-	r = (m_paletteram[offset] >> 0) & 0xff;
-	g = (m_paletteram[offset] >> 8) & 0xff;
-	b = (m_paletteram_ext[offset] >> 0) & 0xff;
+	uint8_t const r = (m_paletteram[offset] >> 0) & 0xff;
+	uint8_t const g = (m_paletteram[offset] >> 8) & 0xff;
+	uint8_t const b = (m_paletteram_ext[offset] >> 0) & 0xff;
 
 	m_palette->set_pen_color(offset, rgb_t(r,g,b));
 }
@@ -149,44 +147,44 @@ void vaportra_state::colpri_cb(u32 &colour, u32 &pri_mask)
 
 uint32_t vaportra_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	uint16_t const flip = m_deco_tilegen[0]->pf_control_r(0);
+	uint16_t const flip = m_tilegen[0]->control_r(0);
 	int const pri = m_priority[0] & 0x03;
 
 	screen.priority().fill(0, cliprect);
 	flip_screen_set(!BIT(flip, 7));
-	m_deco_tilegen[0]->pf_update(nullptr, nullptr);
-	m_deco_tilegen[1]->pf_update(nullptr, nullptr);
+	m_tilegen[0]->update(nullptr, nullptr);
+	m_tilegen[1]->update(nullptr, nullptr);
 
 	m_spritegen->set_flip_screen(!BIT(flip, 7));
 
 	// Draw playfields
 	if (pri == 0)
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else if (pri == 1)
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else if (pri == 2)
 	{
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_deco_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_deco_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
-		m_deco_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->tilemap_1_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[0]->tilemap_2_draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[1]->tilemap_2_draw(screen, bitmap, cliprect, 0, 4);
 	}
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram->buffer(), 0x800 / 2);
-	m_deco_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->tilemap_1_draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -215,12 +213,12 @@ void vaportra_state::main_map(address_map &map)
 	map(0x100004, 0x100005).portr("DSW");
 	map(0x100000, 0x100003).w(FUNC(vaportra_state::priority_w));
 	map(0x100007, 0x100007).w(m_soundlatch, FUNC(generic_latch_8_device::write));
-	map(0x200000, 0x201fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x202000, 0x203fff).rw(m_deco_tilegen[1], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x240000, 0x24000f).w(m_deco_tilegen[1], FUNC(deco16ic_device::pf_control_w));
-	map(0x280000, 0x281fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf1_data_r), FUNC(deco16ic_device::pf1_data_w));
-	map(0x282000, 0x283fff).rw(m_deco_tilegen[0], FUNC(deco16ic_device::pf2_data_r), FUNC(deco16ic_device::pf2_data_w));
-	map(0x2c0000, 0x2c000f).w(m_deco_tilegen[0], FUNC(deco16ic_device::pf_control_w));
+	map(0x200000, 0x201fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x202000, 0x203fff).rw(m_tilegen[1], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x240000, 0x24000f).w(m_tilegen[1], FUNC(deco16ic_device::control_w));
+	map(0x280000, 0x281fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<0>), FUNC(deco16ic_device::vram_w<0>));
+	map(0x282000, 0x283fff).rw(m_tilegen[0], FUNC(deco16ic_device::vram_r<1>), FUNC(deco16ic_device::vram_w<1>));
+	map(0x2c0000, 0x2c000f).w(m_tilegen[0], FUNC(deco16ic_device::control_w));
 	map(0x300000, 0x3009ff).ram().w(FUNC(vaportra_state::palette_w)).share(m_paletteram);
 	map(0x304000, 0x3049ff).ram().w(FUNC(vaportra_state::palette_ext_w)).share(m_paletteram_ext);
 	map(0x308001, 0x308001).rw(FUNC(vaportra_state::irq6_ack_r), FUNC(vaportra_state::irq6_ack_w));
@@ -358,9 +356,9 @@ GFXDECODE_END
 
 /******************************************************************************/
 
-DECO16IC_BANK_CB_MEMBER(vaportra_state::bank_callback)
+int vaportra_state::bank_callback(int bank)
 {
-	return ((bank >> 4) & 0x7) * 0x1000;
+	return (bank & 0x70) << 8;
 }
 
 void vaportra_state::machine_start()
@@ -400,31 +398,31 @@ void vaportra_state::vaportra(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_vaportra);
 	PALETTE(config, m_palette).set_entries(1280);
 
-	DECO16IC(config, m_deco_tilegen[0]);
-	m_deco_tilegen[0]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[0]->set_pf1_col_bank(0x00);
-	m_deco_tilegen[0]->set_pf2_col_bank(0x20);
-	m_deco_tilegen[0]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[0]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[0]->set_bank1_callback(FUNC(vaportra_state::bank_callback));
-	m_deco_tilegen[0]->set_bank2_callback(FUNC(vaportra_state::bank_callback));
-	m_deco_tilegen[0]->set_pf12_8x8_bank(0);
-	m_deco_tilegen[0]->set_pf12_16x16_bank(1);
-	m_deco_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[0]);
+	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[0]->set_col_bank<0>(0x00);
+	m_tilegen[0]->set_col_bank<1>(0x20);
+	m_tilegen[0]->set_col_mask<0>(0x0f);
+	m_tilegen[0]->set_col_mask<1>(0x0f);
+	m_tilegen[0]->set_bank_callback<0>(FUNC(vaportra_state::bank_callback));
+	m_tilegen[0]->set_bank_callback<1>(FUNC(vaportra_state::bank_callback));
+	m_tilegen[0]->set_8x8_bank(0);
+	m_tilegen[0]->set_16x16_bank(1);
+	m_tilegen[0]->set_gfxdecode_tag(m_gfxdecode);
 
-	DECO16IC(config, m_deco_tilegen[1]);
-	m_deco_tilegen[1]->set_pf1_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf2_size(DECO_64x32);
-	m_deco_tilegen[1]->set_pf1_col_bank(0x30);
-	m_deco_tilegen[1]->set_pf2_col_bank(0x40);
-	m_deco_tilegen[1]->set_pf1_col_mask(0x0f);
-	m_deco_tilegen[1]->set_pf2_col_mask(0x0f);
-	m_deco_tilegen[1]->set_bank1_callback(FUNC(vaportra_state::bank_callback));
-	m_deco_tilegen[1]->set_bank2_callback(FUNC(vaportra_state::bank_callback));
-	m_deco_tilegen[1]->set_pf12_8x8_bank(2);
-	m_deco_tilegen[1]->set_pf12_16x16_bank(3);
-	m_deco_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
+	DECO16IC(config, m_tilegen[1]);
+	m_tilegen[1]->set_size<0>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_size<1>(deco16ic_device::DECO_64x32);
+	m_tilegen[1]->set_col_bank<0>(0x30);
+	m_tilegen[1]->set_col_bank<1>(0x40);
+	m_tilegen[1]->set_col_mask<0>(0x0f);
+	m_tilegen[1]->set_col_mask<1>(0x0f);
+	m_tilegen[1]->set_bank_callback<0>(FUNC(vaportra_state::bank_callback));
+	m_tilegen[1]->set_bank_callback<1>(FUNC(vaportra_state::bank_callback));
+	m_tilegen[1]->set_8x8_bank(2);
+	m_tilegen[1]->set_16x16_bank(3);
+	m_tilegen[1]->set_gfxdecode_tag(m_gfxdecode);
 
 	DECO_MXC06(config, m_spritegen, m_palette, gfx_vaportra_spr);
 	m_spritegen->set_colpri_callback(FUNC(vaportra_state::colpri_cb));


### PR DESCRIPTION
- Reduce duplicates
- Fix naming based on usage
- Remove unnecessary preprocessor macro
- Reduce unnecessary prefix in namings
- Minor optimization in bank callback
- Fix side effect check for debugger
- Fix spacings
- Make some variables constant

- dataeast/backfire.cpp:
  - Fix speaker configurations (Each screen paired with mono speaker)

- dataeast/dreambal.cpp:
  - Fix notes (Tilemap generator is 141)

- dataeast/mirage.cpp:
  - Reduce unnecessary memory region

- dataeast/sshangha.cpp:
  - Fix logging