### PR TITLE
dataeast/deco146.cpp: Updates

### DIFF
--- a/src/mame/dataeast/captaven.cpp
+++ b/src/mame/dataeast/captaven.cpp
@@ -143,7 +143,7 @@ u8 captaven_state::captaven_soundcpu_status_r()
 	// 7-------  sound cpu status (0 = busy)
 	// -6543210  unknown
 
-	return 0xff;
+	return 0x7f | (m_ioprot->soundlatch_pending_r() ? 0 : 0x80);
 }
 
 void captaven_state::sound_bankswitch_w(u8 data)

--- a/src/mame/dataeast/dblewing.cpp
+++ b/src/mame/dataeast/dblewing.cpp
@@ -98,8 +98,7 @@ public:
 		m_audiocpu(*this, "audiocpu"),
 		m_deco_tilegen(*this, "tilegen"),
 		m_deco104(*this, "ioprot"),
-		m_sprgen(*this, "spritegen"),
-		m_soundlatch_pending(false)
+		m_sprgen(*this, "spritegen")
 	{ }
 
 	void dblewing(machine_config &config);
@@ -120,7 +119,6 @@ private:
 	required_device<decospr_device> m_sprgen;
 
 	uint8_t irq_latch_r();
-	void soundlatch_irq_w(int state);
 	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	DECO16IC_BANK_CB_MEMBER(bank_callback);
@@ -133,7 +131,6 @@ private:
 	void decrypted_opcodes_map(address_map &map) ATTR_COLD;
 	void sound_io(address_map &map) ATTR_COLD;
 	void sound_map(address_map &map) ATTR_COLD;
-	bool m_soundlatch_pending;
 };
 
 
@@ -171,11 +168,6 @@ void dblewing_state::ioprot_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	m_deco104->write_data( deco146_addr, data, mem_mask, cs );
 }
 
-void dblewing_state::soundlatch_irq_w(int state)
-{
-	m_soundlatch_pending = bool(state);
-}
-
 void dblewing_state::dblewing_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
@@ -204,7 +196,7 @@ void dblewing_state::decrypted_opcodes_map(address_map &map)
 uint8_t dblewing_state::irq_latch_r()
 {
 	// bit 0: irq type (0 = latch, 1 = ym)
-	return m_soundlatch_pending ? 0 : 1;
+	return m_deco104->soundlatch_pending_r() ? 0 : 1;
 }
 
 void dblewing_state::sound_map(address_map &map)
@@ -391,8 +383,7 @@ void dblewing_state::dblewing(machine_config &config)
 	m_deco104->port_c_cb().set_ioport("DSW");
 	m_deco104->set_interface_scramble_interleave();
 	m_deco104->set_use_magic_read_address_xor(true);
-	m_deco104->soundlatch_irq_cb().set(FUNC(dblewing_state::soundlatch_irq_w));
-	m_deco104->soundlatch_irq_cb().append("soundirq", FUNC(input_merger_device::in_w<0>));
+	m_deco104->soundlatch_irq_cb().set("soundirq", FUNC(input_merger_device::in_w<0>));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -488,8 +479,6 @@ void dblewing_state::init_dblewing()
 {
 	deco56_decrypt_gfx(machine(), "tiles");
 	deco102_decrypt_cpu((uint16_t *)memregion("maincpu")->base(), m_decrypted_opcodes, 0x80000, 0x399d, 0x25, 0x3d);
-
-	save_item(NAME(m_soundlatch_pending));
 }
 
 } // anonymous namespace

--- a/src/mame/dataeast/deco146.cpp
+++ b/src/mame/dataeast/deco146.cpp
@@ -1150,11 +1150,11 @@ void deco_146_base_device::write_data(u16 address, u16 data, u16 mem_mask, u8 &c
 	address = bitswap<16>(address >> 1, 15,14,13,12,11,10, m_external_addrswap[9],m_external_addrswap[8] ,m_external_addrswap[7],m_external_addrswap[6],m_external_addrswap[5],m_external_addrswap[4],m_external_addrswap[3],m_external_addrswap[2],m_external_addrswap[1],m_external_addrswap[0]) << 1;
 
 	csflags = 0;
-	int upper_addr_bits = (address & 0x7800) >> 11;
+	int const upper_addr_bits = (address & 0x7800) >> 11;
 
 	if (upper_addr_bits == 0x8) // configuration registers are hardcoded to this area
 	{
-		int real_address = address & 0xf;
+		int const real_address = address & 0xf;
 		LOGPROT("%s: write to config regs %04x %04x %04x\n", machine().describe_context(), real_address, data, mem_mask);
 
 		if ((real_address >= 0x2) && (real_address <= 0x0c))
@@ -1172,11 +1172,11 @@ void deco_146_base_device::write_data(u16 address, u16 data, u16 mem_mask, u8 &c
 
 	for (int i = 0; i < 6; i++)
 	{
-		int cs = m_region_selects[i];
+		int const cs = m_region_selects[i];
 
 		if (cs == upper_addr_bits)
 		{
-			int real_address = address & 0x7ff;
+			int const real_address = address & 0x7ff;
 			csflags |= (1 << i);
 
 			if (i == 0) // the first cs is our internal protection area
@@ -1218,7 +1218,7 @@ u16 deco_146_base_device::read_protport(u16 address)
 		address ^= m_magic_read_address_xor;
 
 	int location = 0;
-	u16 realret = read_data_getloc(address, location);
+	u16 const realret = read_data_getloc(address, location);
 
 	if ((location == m_bankswitch_swap_read_address) && !machine().side_effects_disabled()) // this has a special meaning
 	{
@@ -1233,6 +1233,7 @@ u16 deco_146_base_device::read_protport(u16 address)
 TIMER_CALLBACK_MEMBER(deco_146_base_device::write_soundlatch)
 {
 	m_soundlatch = param;
+	m_soundlatch_pending = true;
 	m_soundlatch_irq_cb(ASSERT_LINE);
 }
 
@@ -1269,11 +1270,11 @@ u16 deco_146_base_device::read_data(u16 address, u8 &csflags)
 
 	u16 retdata = 0;
 	csflags = 0;
-	int upper_addr_bits = (address & 0x7800) >> 11;
+	int const upper_addr_bits = (address & 0x7800) >> 11;
 
 	if (upper_addr_bits == 0x8) // configuration registers are hardcoded to this area
 	{
-		int real_address = address & 0xf;
+		int const real_address = address & 0xf;
 		if (!machine().side_effects_disabled())
 			LOGUNK("%s: read config regs? %04x\n", machine().describe_context(), real_address);
 
@@ -1283,11 +1284,11 @@ u16 deco_146_base_device::read_data(u16 address, u8 &csflags)
 	// what gets priority?
 	for (int i = 0; i < 6; i++)
 	{
-		int cs = m_region_selects[i];
+		int const cs = m_region_selects[i];
 
 		if (cs == upper_addr_bits)
 		{
-			int real_address = address & 0x7ff;
+			int const real_address = address & 0x7ff;
 			csflags |= (1 << i);
 
 			if (i == 0) // the first cs is our internal protection area
@@ -1312,7 +1313,11 @@ u16 deco_146_base_device::read_data(u16 address, u8 &csflags)
 
 u8 deco_146_base_device::soundlatch_r()
 {
-	m_soundlatch_irq_cb(CLEAR_LINE);
+	if (!machine().side_effects_disabled())
+	{
+		m_soundlatch_pending = false;
+		m_soundlatch_irq_cb(CLEAR_LINE);
+	}
 	return m_soundlatch;
 }
 
@@ -1345,6 +1350,7 @@ deco_146_base_device::deco_146_base_device(const machine_config &mconfig,
 	m_latchflag(0),
 	m_region_selects{0},
 	m_soundlatch(0),
+	m_soundlatch_pending(false),
 	m_soundlatch_irq_cb(*this),
 	m_port_a_r(*this, 0xffff),
 	m_port_b_r(*this, 0xffff),
@@ -1383,6 +1389,7 @@ void deco_146_base_device::device_start()
 	save_item(NAME(m_region_selects));
 
 	save_item(NAME(m_soundlatch));
+	save_item(NAME(m_soundlatch_pending));
 }
 
 void deco_146_base_device::device_reset()
@@ -1401,6 +1408,7 @@ void deco_146_base_device::device_reset()
 	m_latchflag = 0;
 
 	m_soundlatch = 0x00;
+	m_soundlatch_pending = false;
 	m_soundlatch_irq_cb(CLEAR_LINE);
 
 	m_xor = 0;

--- a/src/mame/dataeast/deco146.h
+++ b/src/mame/dataeast/deco146.h
@@ -75,7 +75,7 @@ public:
 	auto soundlatch_irq_cb() { return m_soundlatch_irq_cb.bind(); }
 
 	u8 soundlatch_r();
-	bool soundlatch_pending_r() { return m_soundlatch_pending; }
+	int soundlatch_pending_r() { return m_soundlatch_pending ? 1 : 0; }
 
 protected:
 	deco_146_base_device(const machine_config &mconfig,

--- a/src/mame/dataeast/deco146.h
+++ b/src/mame/dataeast/deco146.h
@@ -75,6 +75,7 @@ public:
 	auto soundlatch_irq_cb() { return m_soundlatch_irq_cb.bind(); }
 
 	u8 soundlatch_r();
+	bool soundlatch_pending_r() { return m_soundlatch_pending; }
 
 protected:
 	deco_146_base_device(const machine_config &mconfig,
@@ -128,6 +129,7 @@ private:
 	u8 m_region_selects[6];
 
 	u8 m_soundlatch;
+	bool m_soundlatch_pending;
 
 	// callbacks
 	devcb_write_line m_soundlatch_irq_cb;


### PR DESCRIPTION
- Make some variables constant
- Fix side effect check for debugger read

dataeast/captaven.cpp, dataeast/dblewing.cpp:
- Use soundlatch pending flag from ioprot device (dataeast/deco104.cpp, dataeast/deco146.cpp)