### PR TITLE
sega/model1: Skip degenerate moire direct polygons

### DIFF
--- a/src/mame/sega/model1_v.cpp
+++ b/src/mame/sega/model1_v.cpp
@@ -1246,6 +1246,13 @@ int model1_state::push_direct(int list_offset) {
 			// backdrop/scene.
 			if ((m_tgp_ram[tex_adr - 0x40000] & 0x3ff) == 0)
 				cquad.col = MOIRE | (m_palette->pen(0) & 0xffffff);
+
+			// wingwar's display list carries a constant degenerate moiré record
+			// (all four vertices on one point) that the flat-quad filler would
+			// paint as a stray dot at the viewport centre; not seen on hardware.
+			if (cquad.p[0]->s.x == cquad.p[1]->s.x && cquad.p[1]->s.x == cquad.p[2]->s.x && cquad.p[2]->s.x == cquad.p[3]->s.x &&
+				cquad.p[0]->s.y == cquad.p[1]->s.y && cquad.p[1]->s.y == cquad.p[2]->s.y && cquad.p[2]->s.y == cquad.p[3]->s.y)
+				goto next;
 		}
 
 		// Direct polys are screen-space - project_point_direct only offsets x/y by


### PR DESCRIPTION
Fixes the stray blue pixel at the centre of the screen in Wing War, detected in #15715 and visible since the moiré stipple phase inversion in #15597.

wingwar's display list carries a constant moiré direct-poly record with all four vertices on one point; the flat-quad case of the scanline filler painted it as a single dot. Real hardware shows no dot there, and no game has been found to use these records as intentional point primitives, so drop them.