### PR TITLE
compis.xml - Add key dump for RitEtt

### DIFF
--- a/hash/compis.xml
+++ b/hash/compis.xml
@@ -756,18 +756,26 @@ Doesn't start
 		</part>
 	</software>
 
-	<software name="ritett">
+	<software name="ritett" supported="no">
 		<description>RitEtt (enanvändare)</description>
 		<year>1986</year>
 		<publisher>Esselte Studium</publisher>
 		<notes><![CDATA[
-Requires hardware key 7, which isn't dumped
+Throws "Kan inte ladda"
+hardware key isn't hooked up yet
 ]]></notes>
 		<info name="serial" value="24-34250" />
 		<info name="release" value="19860404" />
 		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="2217597">
-				<rom name="RitEtt.mfm" size="2217597" crc="e7cf88d0" sha1="225396bc29cb2ba158949a9286fcee9201617265"/>
+			<dataarea name="flop" size="5108622">
+				<rom name="ritett.mfi" size="5108622" crc="20c3dc41" sha1="e2b0586d5b472959f65f0d07ad747bbcf481a497"/>
+			</dataarea>
+		</part>
+		<!-- Programvarunyckel 7 -->
+		<part name="key" interface="compis_key">
+			<dataarea name="rom" size="2">
+				<rom value="0xe3" offset="0" size="1" loadflag="fill" />
+				<rom value="0x0f" offset="1" size="1" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/telenova/compis.cpp
+++ b/src/mame/telenova/compis.cpp
@@ -18,6 +18,8 @@
         - Intel 82720 GDC Graphic display processor (NEC uPD 7220)
         - Intel 8272 FDC Floppy disk controller (Intel iSBX-218A)
         - Western Digital WD1002-05 Winchester controller
+        - J5 Styr- och mätkontakt (DIN-6); also hosts Esselte programvarunyckel
+          software keys (unemulated; see PPI section)
 
     Memory map:
 
@@ -42,6 +44,7 @@
         - 8087
         - programmable keyboard
     - hard disk
+    - programvarunyckel / hardware key on J5 (see PPI section)
 
 */
 
@@ -602,6 +605,40 @@ void compis_state::tmr5_w(int state)
 //-------------------------------------------------
 //  I8255A interface
 //-------------------------------------------------
+
+/*
+    J5 - Styr- och mätkontakt / programvarunyckel
+
+    J5 is a 6-pin DIN (IEC 60130-9 / DIN 45322 6/240°) control and measurement
+    port. Many titles also require a "programvarunyckel" (software key)
+    plugged into J5: an epoxy dongle with a product ID stamped on the shell
+    (roughly 50 variants). That key might be shared between titles; softlist 
+	notes such as "hardware key 7" refer to it.
+
+    Host wiring (pin numbers on the plug; socket face view is mirrored L/R):
+
+        DIN  8255   key role
+        1    PC0    CLOCK
+        2    PC1    PARALLEL/SERIAL CONTROL (PL)
+        3    GND    VSS
+        4    PB0    unused?
+        5    PB1    serial data in (Q8)
+        6    +5V    VDD (+ hardwired-high PI straps)
+
+    Internals (probed key number 7): two SCL4021BE (CD4021) 8-bit PISO
+    shift registers.
+
+        PC0 ──► CLOCK ──────┬──► chip1 CP
+                            └──► chip2 CP
+        PC1 ──► PL ─────────┬──► chip1 PL
+                            └──► chip2 PL
+        chip2 Q8 ──► chip1 SERIAL IN
+        chip1 Q8 ──► DIN5 (PB1)
+        chip2 SERIAL IN floating
+
+    Protocol: PL high loads the hardwired PI straps; PL low + rising CLOCK
+    shifts; host samples PB1. After parallel load, PI-8 exits on Q8 first.
+*/
 
 void compis_state::write_centronics_busy(int state)
 {


### PR DESCRIPTION
Add the key dongle for the RitEtt software. I opened up one of the epoxy blob dongles and read the key. I'm not 100% sure the dump is correct as I'm not good with electronics. I've documented what I could gander from the one opened though. The dongles are not emulated or hooked up yet.

I had trouble to start RitEtt, so redumped it to MFI. Dump seems good, but it still doesn't start. Doesn't even throw "bad key" like the others.