### PR TITLE
dataeast/decbac06.cpp: Updates

### DIFF
--- a/src/mame/dataeast/actfancr.cpp
+++ b/src/mame/dataeast/actfancr.cpp
@@ -112,9 +112,9 @@ uint32_t actfancr_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_tilegen[1]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram16.target(), 0x800/2);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, 0, 0);
 
 	return 0;
 }
@@ -154,12 +154,12 @@ void actfancr_state::buffer_spriteram_w(uint8_t data)
 void actfancr_state::prg_map(address_map &map)
 {
 	map(0x000000, 0x02ffff).rom();
-	map(0x060000, 0x060007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x060010, 0x06001f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
-	map(0x062000, 0x063fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
-	map(0x070000, 0x070007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x070010, 0x07001f).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
-	map(0x072000, 0x0727ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
+	map(0x060000, 0x060007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x060010, 0x06001f).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg8_w<true>));
+	map(0x062000, 0x063fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));
+	map(0x070000, 0x070007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x070010, 0x07001f).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg8_w<true>));
+	map(0x072000, 0x0727ff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));
 	map(0x100000, 0x1007ff).ram().share(m_spriteram);
 	map(0x110000, 0x110001).w(FUNC(actfancr_state::buffer_spriteram_w));
 	map(0x120000, 0x1205ff).ram().w("palette", FUNC(palette_device::write8)).share("palette");
@@ -175,14 +175,14 @@ void actfancr_state::prg_map(address_map &map)
 void triothep_state::prg_map(address_map &map)
 {
 	map(0x000000, 0x03ffff).rom();
-	map(0x040000, 0x040007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x040010, 0x04001f).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
-	map(0x044000, 0x045fff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
-	map(0x046400, 0x0467ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_rowscroll_8bit_swap_r), FUNC(deco_bac06_device::pf_rowscroll_8bit_swap_w));
-	map(0x060000, 0x060007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x060010, 0x06001f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
-	map(0x064000, 0x0647ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
-	map(0x066400, 0x0667ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_8bit_swap_r), FUNC(deco_bac06_device::pf_rowscroll_8bit_swap_w));
+	map(0x040000, 0x040007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x040010, 0x04001f).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg8_w<true>));
+	map(0x044000, 0x045fff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));
+	map(0x046400, 0x0467ff).rw(m_tilegen[1], FUNC(deco_bac06_device::rowscroll8_r<true>), FUNC(deco_bac06_device::rowscroll8_w<true>));
+	map(0x060000, 0x060007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x060010, 0x06001f).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg8_w<true>));
+	map(0x064000, 0x0647ff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));
+	map(0x066400, 0x0667ff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll8_r<true>), FUNC(deco_bac06_device::rowscroll8_w<true>));
 	map(0x100000, 0x100000).w("soundlatch", FUNC(generic_latch_8_device::write));
 	map(0x110000, 0x110001).w(FUNC(triothep_state::buffer_spriteram_w));
 	map(0x120000, 0x1207ff).ram().share("spriteram");

--- a/src/mame/dataeast/actfancr.cpp
+++ b/src/mame/dataeast/actfancr.cpp
@@ -107,7 +107,7 @@ private:
 uint32_t actfancr_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// Draw playfield
-	bool flip = m_tilegen[1]->get_flip_state();
+	const bool flip = m_tilegen[1]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
 	m_tilegen[1]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);

--- a/src/mame/dataeast/dec0.cpp
+++ b/src/mame/dataeast/dec0.cpp
@@ -474,24 +474,24 @@ void automat_state::automat_control_w(offs_t offset, u16 data, u16 mem_mask)
 void dec0_state::dec0_map(address_map &map)
 {
 	map(0x000000, 0x05ffff).rom();
-	map(0x240000, 0x240007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_0_w));                          /* text layer */
-	map(0x240010, 0x240017).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x242000, 0x24207f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x242400, 0x2427ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+	map(0x240000, 0x240007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg_w));                          /* text layer */
+	map(0x240010, 0x240017).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x242000, 0x24207f).rw(m_tilegen[0], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x242400, 0x2427ff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 	map(0x242800, 0x243fff).ram();                                                     /* Robocop only */
-	map(0x244000, 0x245fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x244000, 0x245fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
-	map(0x246000, 0x246007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_0_w));                                  /* first tile layer */
-	map(0x246010, 0x246017).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x248000, 0x24807f).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x248400, 0x2487ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
-	map(0x24a000, 0x24a7ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x246000, 0x246007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg_w));                                  /* first tile layer */
+	map(0x246010, 0x246017).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x248000, 0x24807f).rw(m_tilegen[1], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x248400, 0x2487ff).rw(m_tilegen[1], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
+	map(0x24a000, 0x24a7ff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
-	map(0x24c000, 0x24c007).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_0_w));                              /* second tile layer */
-	map(0x24c010, 0x24c017).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x24c800, 0x24c87f).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x24cc00, 0x24cfff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
-	map(0x24d000, 0x24d7ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x24c000, 0x24c007).w(m_tilegen[2], FUNC(deco_bac06_device::ctrlreg_w));                              /* second tile layer */
+	map(0x24c010, 0x24c017).w(m_tilegen[2], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x24c800, 0x24c87f).rw(m_tilegen[2], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x24cc00, 0x24cfff).rw(m_tilegen[2], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
+	map(0x24d000, 0x24d7ff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
 	map(0x300000, 0x300001).portr("AN0");
 	map(0x300008, 0x300009).portr("AN1");
@@ -553,9 +553,9 @@ void hippodrm_state::sub_map(address_map &map)
 {
 	map(0x000000, 0x00ffff).rom();
 	map(0x180000, 0x18001f).ram().share(m_sharedram);
-	map(0x1a0000, 0x1a0007).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control0_8bit_packed_w));
-	map(0x1a0010, 0x1a001f).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
-	map(0x1a1000, 0x1a17ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));
+	map(0x1a0000, 0x1a0007).w(m_tilegen[2], FUNC(deco_bac06_device::ctrlreg8_packed_w<true>));
+	map(0x1a0010, 0x1a001f).w(m_tilegen[2], FUNC(deco_bac06_device::scrollreg8_w<true>));
+	map(0x1a1000, 0x1a17ff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));
 	map(0x1d0000, 0x1d00ff).rw(FUNC(hippodrm_state::prot_r), FUNC(hippodrm_state::prot_w));
 	map(0x1f0000, 0x1f1fff).ram(); /* Local RAM */
 }
@@ -663,33 +663,33 @@ void slyspy_state::main_map(address_map &map)
 	map(0x24a000, 0x24a001).w(FUNC(slyspy_state::prot_state_w));
 	map(0x240000, 0x24ffff).view(m_pfview);
 	// Default state (called by Traps 1, 3, 4, 7, C)
-	m_pfview[0](0x240000, 0x240007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_0_w));
-	m_pfview[0](0x240010, 0x240017).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_1_w));
-	m_pfview[0](0x242000, 0x24207f).w(m_tilegen[1], FUNC(deco_bac06_device::pf_colscroll_w));
-	m_pfview[0](0x242400, 0x2427ff).w(m_tilegen[1], FUNC(deco_bac06_device::pf_rowscroll_w));
-	m_pfview[0](0x246000, 0x247fff).w(m_tilegen[1], FUNC(deco_bac06_device::pf_data_w));
-	m_pfview[0](0x248000, 0x248007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_0_w));
-	m_pfview[0](0x248010, 0x248017).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_1_w));
-	m_pfview[0](0x24c000, 0x24c07f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_colscroll_w));
-	m_pfview[0](0x24c400, 0x24c7ff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_w));
-	m_pfview[0](0x24e000, 0x24ffff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_data_w));
+	m_pfview[0](0x240000, 0x240007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg_w));
+	m_pfview[0](0x240010, 0x240017).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg_w));
+	m_pfview[0](0x242000, 0x24207f).w(m_tilegen[1], FUNC(deco_bac06_device::colscroll_w));
+	m_pfview[0](0x242400, 0x2427ff).w(m_tilegen[1], FUNC(deco_bac06_device::rowscroll_w));
+	m_pfview[0](0x246000, 0x247fff).w(m_tilegen[1], FUNC(deco_bac06_device::vram_w));
+	m_pfview[0](0x248000, 0x248007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg_w));
+	m_pfview[0](0x248010, 0x248017).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg_w));
+	m_pfview[0](0x24c000, 0x24c07f).w(m_tilegen[0], FUNC(deco_bac06_device::colscroll_w));
+	m_pfview[0](0x24c400, 0x24c7ff).w(m_tilegen[0], FUNC(deco_bac06_device::rowscroll_w));
+	m_pfview[0](0x24e000, 0x24ffff).w(m_tilegen[0], FUNC(deco_bac06_device::vram_w));
 	// State 1 (Called by Trap 9)
-	m_pfview[1](0x248000, 0x249fff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_data_w));
-	m_pfview[1](0x24c000, 0x24dfff).w(m_tilegen[1], FUNC(deco_bac06_device::pf_data_w));
+	m_pfview[1](0x248000, 0x249fff).w(m_tilegen[0], FUNC(deco_bac06_device::vram_w));
+	m_pfview[1](0x24c000, 0x24dfff).w(m_tilegen[1], FUNC(deco_bac06_device::vram_w));
 	// State 2 (Called by Trap A)
-	m_pfview[2](0x240000, 0x241fff).w(m_tilegen[1], FUNC(deco_bac06_device::pf_data_w));
-	m_pfview[2](0x242000, 0x243fff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_data_w));
-	m_pfview[2](0x24e000, 0x24ffff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_data_w));
+	m_pfview[2](0x240000, 0x241fff).w(m_tilegen[1], FUNC(deco_bac06_device::vram_w));
+	m_pfview[2](0x242000, 0x243fff).w(m_tilegen[0], FUNC(deco_bac06_device::vram_w));
+	m_pfview[2](0x24e000, 0x24ffff).w(m_tilegen[0], FUNC(deco_bac06_device::vram_w));
 	// State 3 (Called by Trap B)
-	m_pfview[3](0x240000, 0x241fff).w(m_tilegen[0], FUNC(deco_bac06_device::pf_data_w));
-	m_pfview[3](0x248000, 0x249fff).w(m_tilegen[1], FUNC(deco_bac06_device::pf_data_w));
+	m_pfview[3](0x240000, 0x241fff).w(m_tilegen[0], FUNC(deco_bac06_device::vram_w));
+	m_pfview[3](0x248000, 0x249fff).w(m_tilegen[1], FUNC(deco_bac06_device::vram_w));
 
 	/* Pf3 is unaffected by protection */
-	map(0x300000, 0x300007).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_0_w));
-	map(0x300010, 0x300017).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x300800, 0x30087f).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x300c00, 0x300fff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
-	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x300000, 0x300007).w(m_tilegen[2], FUNC(deco_bac06_device::ctrlreg_w));
+	map(0x300010, 0x300017).w(m_tilegen[2], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x300800, 0x30087f).rw(m_tilegen[2], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x300c00, 0x300fff).rw(m_tilegen[2], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
+	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
 	map(0x304000, 0x307fff).ram().share(m_ram); /* Sly Spy main ram */
 	map(0x308000, 0x3087ff).ram().share("spriteram");   /* Sprites */
@@ -712,24 +712,24 @@ void dec0_state::midres_map(address_map &map)
 	map(0x180008, 0x18000f).nopw(); /* ?? watchdog ?? */
 	map(0x1a0001, 0x1a0001).w(m_soundlatch, FUNC(generic_latch_8_device::write));
 
-	map(0x200000, 0x200007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_0_w));
-	map(0x200010, 0x200017).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x220000, 0x2207ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-	map(0x220800, 0x220fff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w)); /* mirror address used in end sequence */
-	map(0x240000, 0x24007f).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x240400, 0x2407ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+	map(0x200000, 0x200007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg_w));
+	map(0x200010, 0x200017).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x220000, 0x2207ff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
+	map(0x220800, 0x220fff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w)); /* mirror address used in end sequence */
+	map(0x240000, 0x24007f).rw(m_tilegen[1], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x240400, 0x2407ff).rw(m_tilegen[1], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 
-	map(0x280000, 0x280007).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_0_w));
-	map(0x280010, 0x280017).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x2a0000, 0x2a07ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-	map(0x2c0000, 0x2c007f).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x2c0400, 0x2c07ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+	map(0x280000, 0x280007).w(m_tilegen[2], FUNC(deco_bac06_device::ctrlreg_w));
+	map(0x280010, 0x280017).w(m_tilegen[2], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x2a0000, 0x2a07ff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
+	map(0x2c0000, 0x2c007f).rw(m_tilegen[2], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x2c0400, 0x2c07ff).rw(m_tilegen[2], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 
-	map(0x300000, 0x300007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_0_w));
-	map(0x300010, 0x300017).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x320000, 0x321fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-	map(0x340000, 0x34007f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-	map(0x340400, 0x3407ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+	map(0x300000, 0x300007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg_w));
+	map(0x300010, 0x300017).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x320000, 0x321fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
+	map(0x340000, 0x34007f).rw(m_tilegen[0], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+	map(0x340400, 0x3407ff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 }
 
 void dec0_state::midresb_map(address_map &map)
@@ -862,19 +862,19 @@ void automat_state::automat_map(address_map &map)
 	map(0x242000, 0x24207f).ram();
 	map(0x242400, 0x2427ff).ram();
 	map(0x242800, 0x243fff).ram();
-	map(0x244000, 0x245fff).ram().rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x244000, 0x245fff).ram().rw(m_tilegen[0], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
 	map(0x246000, 0x246007).ram();         /* first tile layer */
 	map(0x246010, 0x246017).ram();
 	map(0x248000, 0x24807f).ram();
 	map(0x248400, 0x2487ff).ram();
-	map(0x24a000, 0x24a7ff).ram().rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x24a000, 0x24a7ff).ram().rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
 	map(0x24c000, 0x24c007).ram();         /* second tile layer */
 	map(0x24c010, 0x24c017).ram();
 	map(0x24c800, 0x24c87f).ram();
 	map(0x24cc00, 0x24cfff).ram();
-	map(0x24d000, 0x24d7ff).ram().rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x24d000, 0x24d7ff).ram().rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 
 	map(0x300000, 0x300001).portr("AN0");
 	map(0x300008, 0x300009).portr("AN1");
@@ -896,17 +896,17 @@ void automat_state::automat_map(address_map &map)
 void automat_state::secretab_map(address_map &map)
 {
 	map(0x000000, 0x05ffff).rom();
-//  map(0x240000, 0x240007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_0_w));
-//  map(0x240010, 0x240017).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x246000, 0x247fff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-//  map(0x240000, 0x24007f).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-//  map(0x240400, 0x2407ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+//  map(0x240000, 0x240007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg_w));
+//  map(0x240010, 0x240017).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x246000, 0x247fff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
+//  map(0x240000, 0x24007f).rw(m_tilegen[1], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+//  map(0x240400, 0x2407ff).rw(m_tilegen[1], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 
-//  map(0x200000, 0x300007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_0_w));
-//  map(0x300010, 0x300017).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x24e000, 0x24ffff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
-//  map(0x340000, 0x34007f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
-//  map(0x340400, 0x3407ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
+//  map(0x200000, 0x300007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg_w));
+//  map(0x300010, 0x300017).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x24e000, 0x24ffff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
+//  map(0x340000, 0x34007f).rw(m_tilegen[0], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
+//  map(0x340400, 0x3407ff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
 
 	map(0x314008, 0x31400f).r(FUNC(automat_state::slyspy_controls_r));
 	map(0x314001, 0x314001).w(m_soundlatch, FUNC(generic_latch_8_device::write));
@@ -915,7 +915,7 @@ void automat_state::secretab_map(address_map &map)
 	map(0x300010, 0x300017).ram();
 	map(0x300800, 0x30087f).ram();
 	map(0x300c00, 0x300fff).ram();
-	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x301000, 0x3017ff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 	map(0x301800, 0x307fff).ram().share(m_ram); /* Sly Spy main ram */
 	map(0x310000, 0x3107ff).rw(FUNC(automat_state::automat_palette_r), FUNC(automat_state::automat_palette_w)).share("palette");
 	map(0xb08000, 0xb08fff).ram().share("spriteram"); /* Sprites */

--- a/src/mame/dataeast/dec0_v.cpp
+++ b/src/mame/dataeast/dec0_v.cpp
@@ -31,9 +31,9 @@ u32 dec0_8751_state::screen_update_hbarrel(screen_device &screen, bitmap_ind16 &
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
+	m_tilegen[2]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 4);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 	return 0;
 }
@@ -65,15 +65,15 @@ u32 dec0_8751_state::screen_update_bandit(screen_device &screen, bitmap_ind16 &b
 
 	if (m_pri == 7)
 	{
-		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
-		m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[2]->draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 4);
 	}
 	else
 	{
-		m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
-		m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 4);
+		m_tilegen[2]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+		m_tilegen[1]->draw(screen, bitmap, cliprect, 0, 2);
+		m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 4);
 	}
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
@@ -98,18 +98,18 @@ u32 drgninjab_state::screen_update_baddudes(screen_device &screen, bitmap_ind16 
 	/* WARNING: inverted wrt Midnight Resistance */
 	const u8 fg = BIT(m_pri, 0) ? 1 : 2;
 	const u8 bg = BIT(m_pri, 0) ? 2 : 1;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[bg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[fg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
 	if (BIT(m_pri, 1))
-		m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
+		m_tilegen[bg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
 	if (BIT(m_pri, 2))
-		m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
+		m_tilegen[fg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles /* Foreground pens only */
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -154,10 +154,10 @@ u32 dec0_state::screen_update_robocop(screen_device &screen, bitmap_ind16 &bitma
 
 	const u8 fg = BIT(m_pri, 0) ? 2 : 1;
 	const u8 bg = BIT(m_pri, 0) ? 1 : 2;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[bg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[fg]->draw(screen, bitmap, cliprect, 0, 2);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -168,30 +168,30 @@ u32 automat_state::screen_update_automat(screen_device &screen, bitmap_ind16 &bi
 	// layer enables seem different... where are they?
 
 	// the bootleg doesn't write these registers, I think they're hardcoded?, so fake them for compatibility with our implementation..
-	m_tilegen[0]->pf_control_0_w(0,0x0003, 0x00ff); // 8x8
-	m_tilegen[0]->pf_control_0_w(1,0x0003, 0x00ff);
-	m_tilegen[0]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[0]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[0]->ctrlreg_w(0,0x0003, 0x00ff); // 8x8
+	m_tilegen[0]->ctrlreg_w(1,0x0003, 0x00ff);
+	m_tilegen[0]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[0]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
-	m_tilegen[1]->pf_control_0_w(0,0x0082, 0x00ff); // 16x16
-	m_tilegen[1]->pf_control_0_w(1,0x0000, 0x00ff);
-	m_tilegen[1]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[1]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[1]->ctrlreg_w(0,0x0082, 0x00ff); // 16x16
+	m_tilegen[1]->ctrlreg_w(1,0x0000, 0x00ff);
+	m_tilegen[1]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[1]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
-	m_tilegen[2]->pf_control_0_w(0,0x0082, 0x00ff); // 16x16
-	m_tilegen[2]->pf_control_0_w(1,0x0003, 0x00ff);
-	m_tilegen[2]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[2]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[2]->ctrlreg_w(0,0x0082, 0x00ff); // 16x16
+	m_tilegen[2]->ctrlreg_w(1,0x0003, 0x00ff);
+	m_tilegen[2]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[2]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
 	// scroll registers got written elsewhere, copy them across
-	m_tilegen[0]->pf_control_1_w(0,0x0000, 0xffff); // no scroll?
-	m_tilegen[0]->pf_control_1_w(1,0x0000, 0xffff); // no scroll?
+	m_tilegen[0]->scrollreg_w(0,0x0000, 0xffff); // no scroll?
+	m_tilegen[0]->scrollreg_w(1,0x0000, 0xffff); // no scroll?
 
-	m_tilegen[1]->pf_control_1_w(0,m_automat_scroll_regs[3] - 0x010a, 0xffff);
-	m_tilegen[1]->pf_control_1_w(1,m_automat_scroll_regs[2], 0xffff);
+	m_tilegen[1]->scrollreg_w(0,m_automat_scroll_regs[3] - 0x010a, 0xffff);
+	m_tilegen[1]->scrollreg_w(1,m_automat_scroll_regs[2], 0xffff);
 
-	m_tilegen[2]->pf_control_1_w(0,m_automat_scroll_regs[1] - 0x0108, 0xffff);
-	m_tilegen[2]->pf_control_1_w(1,m_automat_scroll_regs[0], 0xffff);
+	m_tilegen[2]->scrollreg_w(0,m_automat_scroll_regs[1] - 0x0108, 0xffff);
+	m_tilegen[2]->scrollreg_w(1,m_automat_scroll_regs[0], 0xffff);
 
 
 	const bool flip = m_tilegen[0]->get_flip_state();
@@ -202,10 +202,10 @@ u32 automat_state::screen_update_automat(screen_device &screen, bitmap_ind16 &bi
 
 	const u8 fg = BIT(m_pri, 0) ? 2 : 1;
 	const u8 bg = BIT(m_pri, 0) ? 1 : 2;
-	m_tilegen[bg]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[fg]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 2);
+	m_tilegen[bg]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[fg]->draw(screen, bitmap, cliprect, 0, 2);
 	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -222,9 +222,9 @@ u32 dec0_8751_state::screen_update_birdtry(screen_device &screen, bitmap_ind16 &
 	/* This game doesn't have the extra playfield chip on the game board, but
 	the palette does show through. */
 	bitmap.fill(m_palette->pen(768), cliprect);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, 0, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 
@@ -239,16 +239,16 @@ u32 slyspy_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[2]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2);
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
 	if (BIT(m_pri, 7))
-		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
+		m_tilegen[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0,0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0,0);
 	return 0;
 }
 
@@ -257,30 +257,30 @@ u32 automat_state::screen_update_secretab(screen_device &screen, bitmap_ind16 &b
 	// layer enables seem different... where are they?
 
 	// the bootleg doesn't write these registers, I think they're hardcoded?, so fake them for compatibility with our implementation..
-	m_tilegen[0]->pf_control_0_w(0,0x0003, 0x00ff); // 8x8
-	m_tilegen[0]->pf_control_0_w(1,0x0003, 0x00ff);
-	m_tilegen[0]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[0]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[0]->ctrlreg_w(0,0x0003, 0x00ff); // 8x8
+	m_tilegen[0]->ctrlreg_w(1,0x0003, 0x00ff);
+	m_tilegen[0]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[0]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
-	m_tilegen[1]->pf_control_0_w(0,0x0082, 0x00ff); // 16x16
-	m_tilegen[1]->pf_control_0_w(1,0x0000, 0x00ff);
-	m_tilegen[1]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[1]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[1]->ctrlreg_w(0,0x0082, 0x00ff); // 16x16
+	m_tilegen[1]->ctrlreg_w(1,0x0000, 0x00ff);
+	m_tilegen[1]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[1]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
-	m_tilegen[2]->pf_control_0_w(0,0x0082, 0x00ff); // 16x16
-	m_tilegen[2]->pf_control_0_w(1,0x0003, 0x00ff);
-	m_tilegen[2]->pf_control_0_w(2,0x0000, 0x00ff);
-	m_tilegen[2]->pf_control_0_w(3,0x0001, 0x00ff); // dimensions
+	m_tilegen[2]->ctrlreg_w(0,0x0082, 0x00ff); // 16x16
+	m_tilegen[2]->ctrlreg_w(1,0x0003, 0x00ff);
+	m_tilegen[2]->ctrlreg_w(2,0x0000, 0x00ff);
+	m_tilegen[2]->ctrlreg_w(3,0x0001, 0x00ff); // dimensions
 
 	// scroll registers got written elsewhere, copy them across
-	m_tilegen[0]->pf_control_1_w(0,0x0000, 0xffff); // no scroll?
-	m_tilegen[0]->pf_control_1_w(1,0x0000, 0xffff); // no scroll?
+	m_tilegen[0]->scrollreg_w(0,0x0000, 0xffff); // no scroll?
+	m_tilegen[0]->scrollreg_w(1,0x0000, 0xffff); // no scroll?
 
-	m_tilegen[1]->pf_control_1_w(0,m_automat_scroll_regs[3] - 0x010a, 0xffff);
-	m_tilegen[1]->pf_control_1_w(1,m_automat_scroll_regs[2], 0xffff);
+	m_tilegen[1]->scrollreg_w(0,m_automat_scroll_regs[3] - 0x010a, 0xffff);
+	m_tilegen[1]->scrollreg_w(1,m_automat_scroll_regs[2], 0xffff);
 
-	m_tilegen[2]->pf_control_1_w(0,m_automat_scroll_regs[1] - 0x0108, 0xffff);
-	m_tilegen[2]->pf_control_1_w(1,m_automat_scroll_regs[0], 0xffff);
+	m_tilegen[2]->scrollreg_w(0,m_automat_scroll_regs[1] - 0x0108, 0xffff);
+	m_tilegen[2]->scrollreg_w(1,m_automat_scroll_regs[0], 0xffff);
 
 	const bool flip = m_tilegen[0]->get_flip_state();
 	m_tilegen[0]->set_flip_screen(flip);
@@ -288,16 +288,16 @@ u32 automat_state::screen_update_secretab(screen_device &screen, bitmap_ind16 &b
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[2]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | TILEMAP_DRAW_LAYER1, 0);
 
 	m_spritegen->draw_sprites_bootleg(screen, bitmap, cliprect, m_buffered_spriteram, 0x800/2); // TODO : RAM size
 
 	/* Redraw top 8 pens of top 8 palettes over sprites */
 	if (BIT(m_pri, 7))
-		m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
+		m_tilegen[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0, 0); // upper 8 pens of upper 8 priority marked tiles
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0,0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0,0);
 	return 0;
 }
 

--- a/src/mame/dataeast/dec8.cpp
+++ b/src/mame/dataeast/dec8.cpp
@@ -70,7 +70,6 @@ TODO:
 #include "cpu/m6502/r65c02.h"
 #include "cpu/m6809/hd6309.h"
 #include "cpu/m6809/m6809.h"
-#include "sound/msm5205.h"
 #include "sound/ymopn.h"
 #include "sound/ymopl.h"
 
@@ -249,7 +248,8 @@ void csilver_state::adpcm_int(int state)
 
 u8 csilver_state::adpcm_reset_r()
 {
-	m_msm->reset_w(0);
+	if (!machine().side_effects_disabled())
+		m_msm->reset_w(0);
 	return 0;
 }
 
@@ -367,7 +367,7 @@ void lastmisn_state::shackled_map(address_map &map)
 	map(0x2000, 0x27ff).ram().w(FUNC(lastmisn_state::videoram_w));
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share("bg_ram");
+	map(0x3800, 0x3fff).rw(FUNC(lastmisn_state::bg_ram_r), FUNC(lastmisn_state::bg_ram_w)).share(m_bg_ram);
 	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
@@ -403,9 +403,9 @@ void ghostb_state::ghostb_map(address_map &map)
 	map(0x0000, 0x0fff).ram();
 	map(0x1000, 0x17ff).ram();
 	map(0x1800, 0x1fff).ram().w(FUNC(ghostb_state::videoram_w)).share(m_videoram);
-	map(0x2000, 0x27ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x2000, 0x27ff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram8_r<false>), FUNC(deco_bac06_device::vram8_w<false>));
 	map(0x2800, 0x2bff).ram(); // colscroll? mirror?
-	map(0x2c00, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_8bit_r), FUNC(deco_bac06_device::pf_rowscroll_8bit_w));
+	map(0x2c00, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll8_r<false>), FUNC(deco_bac06_device::rowscroll8_w<false>));
 	map(0x3000, 0x37ff).ram().share("spriteram");
 	map(0x3800, 0x3800).portr("IN0");
 	map(0x3800, 0x3800).w(FUNC(ghostb_state::sound_w));
@@ -413,8 +413,8 @@ void ghostb_state::ghostb_map(address_map &map)
 	map(0x3802, 0x3802).portr("IN2");
 	map(0x3803, 0x3803).portr("DSW0");
 	map(0x3820, 0x3820).portr("DSW1");
-	map(0x3820, 0x3827).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3830, 0x383f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_r), FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3820, 0x3827).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x3830, 0x383f).rw(m_tilegen[0], FUNC(deco_bac06_device::scrollreg8_r<false>), FUNC(deco_bac06_device::scrollreg8_w<false>));
 	map(0x3840, 0x3840).r(FUNC(ghostb_state::i8751_hi_r));
 	map(0x3840, 0x3840).w(FUNC(ghostb_state::ghostb_bank_w));
 	map(0x3860, 0x3860).r(FUNC(ghostb_state::i8751_lo_r));
@@ -428,7 +428,7 @@ void gondo_state::gondo_map(address_map &map)
 {
 	map(0x0000, 0x17ff).ram();
 	map(0x1800, 0x1fff).ram().w(FUNC(gondo_state::videoram_w)).share(m_videoram);
-	map(0x2000, 0x27ff).rw(FUNC(gondo_state::bg_ram_r), FUNC(gondo_state::bg_ram_w)).share("bg_ram");
+	map(0x2000, 0x27ff).rw(FUNC(gondo_state::bg_ram_r), FUNC(gondo_state::bg_ram_w)).share(m_bg_ram);
 	map(0x2800, 0x2bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x2c00, 0x2fff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
 	map(0x3000, 0x37ff).ram().share("spriteram");
@@ -453,7 +453,7 @@ void ghostb_state::garyoret_map(address_map &map)
 {
 	map(0x0000, 0x17ff).ram();
 	map(0x1800, 0x1fff).ram().w(FUNC(ghostb_state::videoram_w)).share(m_videoram);
-	map(0x2000, 0x27ff).rw(FUNC(ghostb_state::bg_ram_r), FUNC(ghostb_state::bg_ram_w)).share("bg_ram");
+	map(0x2000, 0x27ff).rw(FUNC(ghostb_state::bg_ram_r), FUNC(ghostb_state::bg_ram_w)).share(m_bg_ram);
 	map(0x2800, 0x2bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x2c00, 0x2fff).ram().w(m_palette, FUNC(deco_rmc3_device::write8_ext)).share("palette_ext");
 	map(0x3000, 0x37ff).ram().share("spriteram");
@@ -495,7 +495,7 @@ void csilver_state::main_map(address_map &map)
 	map(0x2000, 0x27ff).ram().w(FUNC(csilver_state::videoram_w));
 	map(0x2800, 0x2fff).ram().share("spriteram");
 	map(0x3000, 0x37ff).ram().share("share2");
-	map(0x3800, 0x3fff).rw(FUNC(csilver_state::bg_ram_r), FUNC(csilver_state::bg_ram_w)).share("bg_ram");
+	map(0x3800, 0x3fff).rw(FUNC(csilver_state::bg_ram_r), FUNC(csilver_state::bg_ram_w)).share(m_bg_ram);
 	map(0x4000, 0x7fff).bankr(m_mainbank);
 	map(0x8000, 0xffff).rom();
 }
@@ -525,7 +525,7 @@ void oscar_state::oscar_map(address_map &map)
 	map(0x0f00, 0x0fff).ram();
 	map(0x1000, 0x1fff).ram().share("share2");
 	map(0x2000, 0x27ff).ram().w(FUNC(oscar_state::videoram_w)).share(m_videoram);
-	map(0x2800, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x2800, 0x2fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram8_r<false>), FUNC(deco_bac06_device::vram8_w<false>));
 	map(0x3000, 0x37ff).ram().share("spriteram");
 	map(0x3800, 0x3bff).ram().w(m_palette, FUNC(deco_rmc3_device::write8)).share("palette");
 	map(0x3c00, 0x3c00).portr("IN0");
@@ -533,8 +533,8 @@ void oscar_state::oscar_map(address_map &map)
 	map(0x3c02, 0x3c02).portr("IN2");
 	map(0x3c03, 0x3c03).portr("DSW0");
 	map(0x3c04, 0x3c04).portr("DSW1");
-	map(0x3c00, 0x3c07).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3c10, 0x3c1f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3c00, 0x3c07).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x3c10, 0x3c1f).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg8_w<false>));
 	map(0x3c80, 0x3c80).w(FUNC(oscar_state::buffer_spriteram16_w)); // DMA
 	map(0x3d00, 0x3d00).w(FUNC(oscar_state::bank_w)); // BNKS
 	map(0x3d80, 0x3d80).w(m_soundlatch, FUNC(generic_latch_8_device::write)); // SOUN
@@ -565,7 +565,7 @@ void srdarwin_state::main_map(address_map &map)
 	map(0x0600, 0x07ff).ram().share("spriteram");
 	map(0x0800, 0x0fff).ram().w(FUNC(srdarwin_state::srdarwin_videoram_w)).share(m_videoram);
 	map(0x1000, 0x13ff).ram();
-	map(0x1400, 0x17ff).rw(FUNC(srdarwin_state::bg_ram_r), FUNC(srdarwin_state::bg_ram_w)).share("bg_ram");
+	map(0x1400, 0x17ff).rw(FUNC(srdarwin_state::bg_ram_r), FUNC(srdarwin_state::bg_ram_w)).share(m_bg_ram);
 	map(0x1800, 0x1800).w(FUNC(srdarwin_state::i8751_hi_w));
 	map(0x1801, 0x1801).w(FUNC(srdarwin_state::i8751_lo_w));
 	map(0x1803, 0x1803).nopw();
@@ -595,8 +595,8 @@ void srdarwin_state::srdarwinb_map(address_map &map)
 void oscar_state::cobra_map(address_map &map)
 {
 	map(0x0000, 0x07ff).ram();
-	map(0x0800, 0x0fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
-	map(0x1000, 0x17ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x0800, 0x0fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram8_r<false>), FUNC(deco_bac06_device::vram8_w<false>));
+	map(0x1000, 0x17ff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram8_r<false>), FUNC(deco_bac06_device::vram8_w<false>));
 	map(0x1800, 0x1fff).ram();
 	map(0x2000, 0x27ff).ram().w(FUNC(oscar_state::videoram_w)).share(m_videoram);
 	map(0x2800, 0x2fff).ram().share("spriteram");
@@ -606,11 +606,11 @@ void oscar_state::cobra_map(address_map &map)
 	map(0x3801, 0x3801).portr("IN1");
 	map(0x3802, 0x3802).portr("DSW0");
 	map(0x3803, 0x3803).portr("DSW1");
-	map(0x3800, 0x3807).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3810, 0x381f).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3800, 0x3807).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x3810, 0x381f).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg8_w<false>));
 	map(0x3a00, 0x3a00).portr("IN2");
-	map(0x3a00, 0x3a07).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x3a10, 0x3a1f).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x3a00, 0x3a07).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x3a10, 0x3a1f).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg8_w<false>));
 	map(0x3c00, 0x3c00).w(FUNC(oscar_state::bank_w));
 	map(0x3c02, 0x3c02).w(FUNC(oscar_state::buffer_spriteram16_w));
 	map(0x3e00, 0x3e00).w(m_soundlatch, FUNC(generic_latch_8_device::write));

--- a/src/mame/dataeast/dec8_v.cpp
+++ b/src/mame/dataeast/dec8_v.cpp
@@ -225,8 +225,8 @@ u32 oscar_state::screen_update_cobracom(screen_device &screen, bitmap_ind16 &bit
 	m_spritegen_mxc->set_flip_screen(flip);
 	m_fix_tilemap->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
-	m_tilegen[1]->deco_bac06_pf_draw(screen,bitmap,cliprect,0, 2);
+	m_tilegen[0]->draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 1);
+	m_tilegen[1]->draw(screen,bitmap,cliprect,0, 2);
 	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x800/2);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -259,7 +259,7 @@ VIDEO_START_MEMBER(oscar_state,cobracom)
 
 u32 ghostb_state::screen_update_ghostb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[0]->draw(screen,bitmap,cliprect,TILEMAP_DRAW_OPAQUE, 0);
 	m_spritegen_krn->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x400);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -300,9 +300,9 @@ u32 oscar_state::screen_update_oscar(screen_device &screen, bitmap_ind16 &bitmap
 	m_spritegen_mxc->set_flip_screen(flip);
 	m_fix_tilemap->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER1, 0);
+	m_tilegen[0]->draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER1, 0);
 	m_spritegen_mxc->draw_sprites(screen, bitmap, cliprect, m_buffered_spriteram16.get(), 0x800/2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0);
+	m_tilegen[0]->draw(screen,bitmap,cliprect,TILEMAP_DRAW_LAYER0, 0);
 	m_fix_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }

--- a/src/mame/dataeast/decbac06.cpp
+++ b/src/mame/dataeast/decbac06.cpp
@@ -23,7 +23,7 @@
 configuration is 2 chips of 16*16 tiles, 1 of 8*8.
 
  Playfield control registers:
-   bank 0:
+   ctrlreg:
    0:
         bit 0 (0x1) set = 8*8 tiles, else 16*16 tiles
         Bit 1 (0x2) set = row major tile layout, else column major*
@@ -35,7 +35,7 @@ configuration is 2 chips of 16*16 tiles, 1 of 8*8.
    4: unknown (always 00) [Used to access 2nd bank of tiles in Stadium Hero)
    6: playfield shape: 00 = 4x1, 01 = 2x2, 02 = 1x4 (low 4 bits only)
 
-   bank 1:
+   scrollreg:
    0: horizontal scroll
    2: vertical scroll
    4: colscroll shifter (low 4 bits, top 4 bits do nothing)
@@ -77,24 +77,27 @@ DEFINE_DEVICE_TYPE(DECO_BAC06, deco_bac06_device, "deco_bac06", "DECO BAC06 Tile
 
 deco_bac06_device::deco_bac06_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, DECO_BAC06, tag, owner, clock)
-	, m_pf_data(nullptr)
-	, m_pf_rowscroll(nullptr)
-	, m_pf_colscroll(nullptr)
+	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
+	// 0x2000 is the maximum needed, some games / chip setups map less and mirror - stadium hero banks this to 0x4000?!
+	, m_vram(*this, "vram", 0x4000U, ENDIANNESS_BIG) 
+	, m_rowscroll(*this, "rowscroll", 0x2000U, ENDIANNESS_BIG)
+	, m_colscroll(*this, "colscroll", 0x2000U, ENDIANNESS_BIG)
+	, m_tile_cb(*this)
 	, m_tile_region_8(0)
 	, m_tile_region_16(0)
-	, m_supports_8x8(true)
-	, m_supports_16x16(true)
-	, m_supports_rc_scroll(true)
-	, m_rambank(0)
 	, m_gfxregion8x8(0)
 	, m_gfxregion16x16(0)
 	, m_wide(0)
-	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
-	, m_tile_cb(*this)
-	, m_thedeep_kludge(0)
+	, m_supports_8x8(true)
+	, m_supports_16x16(true)
+	, m_supports_rc_scroll(true)
+	, m_thedeep_kludge(false)
+	, m_has_bank(false)
+	, m_ctrlreg{0}
+	, m_scrollreg{0}
+	, m_rambank(0)
+	, m_flip_screen(false)
 {
-	std::fill(std::begin(m_pf_control_0), std::end(m_pf_control_0), 0);
-	std::fill(std::begin(m_pf_control_1), std::end(m_pf_control_1), 0);
 }
 
 void deco_bac06_device::device_start()
@@ -104,20 +107,13 @@ void deco_bac06_device::device_start()
 
 	m_tile_cb.resolve();
 
-	m_pf_data = make_unique_clear<u16[]>(0x4000 / 2); // 0x2000 is the maximum needed, some games / chip setups map less and mirror - stadium hero banks this to 0x4000?!
-	m_pf_rowscroll = make_unique_clear<u16[]>(0x2000 / 2);
-	m_pf_colscroll = make_unique_clear<u16[]>(0x2000 / 2);
-
 	create_tilemaps(m_gfxregion8x8, m_gfxregion16x16);
 
 	m_rambank = 0;
 	m_flip_screen = false;
 
-	save_pointer(NAME(m_pf_data), 0x4000 / 2);
-	save_pointer(NAME(m_pf_rowscroll), 0x2000 / 2);
-	save_pointer(NAME(m_pf_colscroll), 0x2000 / 2);
-	save_item(NAME(m_pf_control_0));
-	save_item(NAME(m_pf_control_1));
+	save_item(NAME(m_ctrlreg));
+	save_item(NAME(m_scrollreg));
 	save_item(NAME(m_rambank));
 	save_item(NAME(m_flip_screen));
 }
@@ -133,17 +129,17 @@ void deco_bac06_device::set_flip_screen(bool flip)
 		m_flip_screen = flip;
 		for (int i = 0; i < 3; i++)
 		{
-			m_pf8x8_tilemap[i]->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
-			m_pf16x16_tilemap[i]->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
+			m_tilemap_8x8[i]->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
+			m_tilemap_16x16[i]->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 		}
 	}
 }
 
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape0_scan)
 {
-	if ((m_pf_control_0[0] & 2) == 0)
+	if ((m_ctrlreg[0] & 2) == 0)
 	{
-		int col_mask = num_cols - 1;
+		const int col_mask = num_cols - 1;
 		return (row & 0xf) + ((col_mask - (col & col_mask)) << 4);
 	}
 	return (col & 0xf) + ((row & 0xf) << 4) + ((col & 0x1f0) << 4);
@@ -152,69 +148,69 @@ TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape0_scan)
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape1_scan)
 {
 	// TODO: bandit ending wants this arrangement for truck layer at [2]
-//  if ((m_pf_control_0[0] & 2) == 0)
+//  if ((m_ctrlreg[0] & 2) == 0)
 //  {
 //      int col_mask = num_cols - 1;
 //      return (row & 0xf) + ((col_mask - (col & col_mask)) << 4) + ((row & 0xf0) << 5);
 //  }
 
-	//if (m_pf_control_0[0] & 2) // Needs testing on real hardware, not used by any game
+	//if (m_ctrlreg[0] & 2) // Needs testing on real hardware, not used by any game
 	//  return (row & 0xf) + ((col & 0x1f) << 4) + ((col & 0xf0) << 5);
 	return (col & 0xf) + ((row & 0x1f) << 4) + ((col & 0xf0) << 5);
 }
 
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape2_scan)
 {
-	//if (m_pf_control_0[0] & 2)  // Needs testing on real hardware, not used by any game
+	//if (m_ctrlreg[0] & 2)  // Needs testing on real hardware, not used by any game
 	//  return (col & 0xf) + ((row & 0x3f) << 4) + ((row & 0x70) << 6);
 	return (col & 0xf) + ((row & 0x3f) << 4) + ((col & 0x70) << 6);
 }
 
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape0_8x8_scan)
 {
-	//if (m_pf_control_0[0] & 2)   // Needs testing on real hardware, not used by any game
+	//if (m_ctrlreg[0] & 2)   // Needs testing on real hardware, not used by any game
 	//  return (col & 0x1f) + ((row & 0x1f) << 5) + ((row & 0x60) << 5);
 	return (col & 0x1f) + ((row & 0x1f) << 5) + ((col & 0x60) << 5);
 }
 
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape1_8x8_scan)
 {
-	//if (m_pf_control_0[0] & 2)   // Needs testing on real hardware, not used by any game
+	//if (m_ctrlreg[0] & 2)   // Needs testing on real hardware, not used by any game
 	//  return (row & 0x1f) + ((col & 0x1f) << 5) + ((col & 0x20) << 5) + ((row & 0x20) << 6);
 	return (col & 0x1f) + ((row & 0x1f) << 5) + ((row & 0x20) << 5) + ((col & 0x20) << 6);
 }
 
 TILEMAP_MAPPER_MEMBER(deco_bac06_device::tile_shape2_8x8_scan)
 {
-	//if (m_pf_control_0[0] & 2)   // Needs testing on real hardware, not used by any game
+	//if (m_ctrlreg[0] & 2)   // Needs testing on real hardware, not used by any game
 	//  return (row & 0x1f) + ((col & 0x7f) << 5);
 	return (col & 0x1f) + ((row & 0x7f) << 5);
 }
 
-TILE_GET_INFO_MEMBER(deco_bac06_device::get_pf8x8_tile_info)
+TILE_GET_INFO_MEMBER(deco_bac06_device::get_tile_info_8x8)
 {
 	if (m_rambank & 1) tile_index += 0x1000;
-	u32 tile = m_pf_data[tile_index];
+	u32 tile = m_vram[tile_index];
 	u32 colour = (tile >> 12);
-	u32 flags = (m_pf_control_0[0] & 2) ? 0 : TILE_FLIPX;
+	u32 flags = (m_ctrlreg[0] & 2) ? 0 : TILE_FLIPX;
 	tile &= 0xfff;
 	if (!m_tile_cb.isnull())
 		m_tile_cb(tileinfo, tile, colour, flags);
 
-	tileinfo.set(m_tile_region_8,tile,colour,flags);
+	tileinfo.set(m_tile_region_8, tile, colour, flags);
 }
 
-TILE_GET_INFO_MEMBER(deco_bac06_device::get_pf16x16_tile_info)
+TILE_GET_INFO_MEMBER(deco_bac06_device::get_tile_info_16x16)
 {
 	if (m_rambank & 1) tile_index += 0x1000;
-	u32 tile = m_pf_data[tile_index];
+	u32 tile = m_vram[tile_index];
 	u32 colour = (tile >> 12);
-	u32 flags = (BIT(m_pf_control_0[0], 1) ^ m_thedeep_kludge) ? 0 : TILE_FLIPX;
+	u32 flags = (BIT(m_ctrlreg[0], 1) ^ m_thedeep_kludge) ? 0 : TILE_FLIPX;
 	tile &= 0xfff;
 	if (!m_tile_cb.isnull())
 		m_tile_cb(tileinfo, tile, colour, flags);
 
-	tileinfo.set(m_tile_region_16,tile,colour,flags);
+	tileinfo.set(m_tile_region_16, tile, colour, flags);
 }
 
 void deco_bac06_device::create_tilemaps(int region8x8, int region16x16)
@@ -225,29 +221,29 @@ void deco_bac06_device::create_tilemaps(int region8x8, int region16x16)
 	if (m_wide > 2)
 		m_wide = 2;
 
-	m_pf8x8_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf8x8_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape0_8x8_scan)), 8, 8, 128,  32);
-	m_pf8x8_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf8x8_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape1_8x8_scan)), 8, 8,  64,  64);
-	m_pf8x8_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf8x8_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape2_8x8_scan)), 8, 8,  32, 128);
+	m_tilemap_8x8[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_8x8)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape0_8x8_scan)), 8, 8, 128,  32);
+	m_tilemap_8x8[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_8x8)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape1_8x8_scan)), 8, 8,  64,  64);
+	m_tilemap_8x8[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_8x8)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape2_8x8_scan)), 8, 8,  32, 128);
 
-	m_pf8x8_tilemap[0]->set_transparent_pen(0);
-	m_pf8x8_tilemap[1]->set_transparent_pen(0);
-	m_pf8x8_tilemap[2]->set_transparent_pen(0);
+	m_tilemap_8x8[0]->set_transparent_pen(0);
+	m_tilemap_8x8[1]->set_transparent_pen(0);
+	m_tilemap_8x8[2]->set_transparent_pen(0);
 
-	m_pf16x16_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf16x16_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape0_scan)), 16, 16, 64 << m_wide, 16);
-	m_pf16x16_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf16x16_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape1_scan)), 16, 16, 32 << m_wide, 32);
-	m_pf16x16_tilemap[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_pf16x16_tile_info)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape2_scan)), 16, 16, 16 << m_wide, 64);
+	m_tilemap_16x16[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_16x16)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape0_scan)), 16, 16, 64 << m_wide, 16);
+	m_tilemap_16x16[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_16x16)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape1_scan)), 16, 16, 32 << m_wide, 32);
+	m_tilemap_16x16[2] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(deco_bac06_device::get_tile_info_16x16)), tilemap_mapper_delegate(*this, FUNC(deco_bac06_device::tile_shape2_scan)), 16, 16, 16 << m_wide, 64);
 
-	m_pf16x16_tilemap[0]->set_transparent_pen(0);
-	m_pf16x16_tilemap[1]->set_transparent_pen(0);
-	m_pf16x16_tilemap[2]->set_transparent_pen(0);
+	m_tilemap_16x16[0]->set_transparent_pen(0);
+	m_tilemap_16x16[1]->set_transparent_pen(0);
+	m_tilemap_16x16[2]->set_transparent_pen(0);
 }
 
 void deco_bac06_device::set_transmask(int group, u32 fgmask, u32 bgmask)
 {
-	for (auto & elem : m_pf8x8_tilemap)
+	for (auto & elem : m_tilemap_8x8)
 		elem->set_transmask(group, fgmask, bgmask);
 
-	for (auto & elem : m_pf16x16_tilemap)
+	for (auto & elem : m_tilemap_16x16)
 		elem->set_transmask(group, fgmask, bgmask);
 }
 
@@ -265,7 +261,6 @@ void deco_bac06_device::custom_tilemap_draw(bitmap_ind16 &bitmap,
 {
 	const bitmap_ind16 &src_bitmap = tilemap_ptr->pixmap();
 	const bitmap_ind8 &flags_bitmap = tilemap_ptr->flagsmap();
-	int column_offset = 0, src_x = 0, src_y = 0;
 	u32 scrollx = 0;
 	u32 scrolly = 0;
 
@@ -278,15 +273,15 @@ void deco_bac06_device::custom_tilemap_draw(bitmap_ind16 &bitmap,
 		scrolly = control1[1];
 	}
 
-	int row_scroll_enabled = 0;
-	int col_scroll_enabled = 0;
+	bool row_scroll_enabled = false;
+	bool col_scroll_enabled = false;
 
 	if (m_supports_rc_scroll)
 	{
 		if (control0)
 		{
-			row_scroll_enabled = (rowscroll_ptr && (control0[0] & 0x4));
-			col_scroll_enabled = (colscroll_ptr && (control0[0] & 0x8));
+			row_scroll_enabled = (rowscroll_ptr && BIT(control0[0], 2));
+			col_scroll_enabled = (colscroll_ptr && BIT(control0[0], 3));
 		}
 	}
 
@@ -315,6 +310,7 @@ void deco_bac06_device::custom_tilemap_draw(bitmap_ind16 &bitmap,
 	doesn't affect any games.
 	*/
 
+	int src_y = 0;
 	if (m_flip_screen)
 		src_y = (src_bitmap.height() - 256) - scrolly;
 	else
@@ -325,17 +321,19 @@ void deco_bac06_device::custom_tilemap_draw(bitmap_ind16 &bitmap,
 	{
 		u16 *dstpix = &bitmap.pix(y);
 		u8 *dstpri = &primap.pix(y);
+		int src_x = 0;
 		if (row_scroll_enabled)
-			src_x=scrollx + rowscroll_ptr[(src_y >> (control1[3] & 0xf)) & (0x1ff >> (control1[3] & 0xf))];
+			src_x = scrollx + rowscroll_ptr[(src_y >> (control1[3] & 0xf)) & (0x1ff >> (control1[3] & 0xf))];
 		else
-			src_x=scrollx;
+			src_x = scrollx;
 
 		if (m_flip_screen)
-			src_x=(src_bitmap.width() - 256) - src_x;
+			src_x = (src_bitmap.width() - 256) - src_x;
 
 		src_x += cliprect.left();
 		for (int x = cliprect.left(); x <= cliprect.right(); x++)
 		{
+			int column_offset = 0;
 			if (col_scroll_enabled)
 				column_offset=colscroll_ptr[((src_x >> 3) >> (control1[2] & 0xf)) & (0x3f >> (control1[2] & 0xf))];
 
@@ -361,90 +359,90 @@ void deco_bac06_device::custom_tilemap_draw(bitmap_ind16 &bitmap,
 	}
 }
 
-void deco_bac06_device::deco_bac06_pf_draw(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, u8 pri, u8 primask)
+void deco_bac06_device::draw(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, u8 pri, u8 primask)
 {
 	tilemap_t* tm = nullptr;
 
-	int tm_dimensions = m_pf_control_0[3] & 0x3;
+	int tm_dimensions = m_ctrlreg[3] & 0x3;
 	if (tm_dimensions == 3) tm_dimensions = 1; // 3 is invalid / the same as 1?
 
-	if (m_pf_control_0[0] & 0x1) // is 8x8 tiles mode selected?
+	if (BIT(m_ctrlreg[0], 0)) // is 8x8 tiles mode selected?
 	{
 		if (m_supports_8x8)
 		{
-			tm = m_pf8x8_tilemap[tm_dimensions];
+			tm = m_tilemap_8x8[tm_dimensions];
 		}
 		else if (m_supports_16x16)
 		{
-			tm = m_pf16x16_tilemap[tm_dimensions];
+			tm = m_tilemap_16x16[tm_dimensions];
 		}
 	}
 	else // 16x16 tiles mode is selected
 	{
 		if (m_supports_16x16)
 		{
-			tm = m_pf16x16_tilemap[tm_dimensions];
+			tm = m_tilemap_16x16[tm_dimensions];
 		}
 		else if (m_supports_8x8)
 		{
-			tm = m_pf8x8_tilemap[tm_dimensions];
+			tm = m_tilemap_8x8[tm_dimensions];
 		}
 	}
 
 	if (tm)
-		custom_tilemap_draw(bitmap,screen.priority(),cliprect,tm,m_pf_rowscroll.get(),m_pf_colscroll.get(),m_pf_control_0,m_pf_control_1,flags, pri, primask);
+		custom_tilemap_draw(bitmap,screen.priority(),cliprect,tm,m_rowscroll.target(),m_colscroll.target(),m_ctrlreg,m_scrollreg,flags, pri, primask);
 }
 
 // used for pocket gal bootleg, which doesn't set registers properly and simply expects a fixed size tilemap.
-void deco_bac06_device::deco_bac06_pf_draw_bootleg(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, int mode, int type, u8 pri, u8 primask)
+void deco_bac06_device::draw_bootleg(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, int mode, int type, u8 pri, u8 primask)
 {
 	tilemap_t* tm = nullptr;
 	if (!mode)
 	{
-		tm = m_pf8x8_tilemap[type];
+		tm = m_tilemap_8x8[type];
 	}
 	else
 	{
-		tm = m_pf16x16_tilemap[type];
+		tm = m_tilemap_16x16[type];
 	}
 
-	custom_tilemap_draw(bitmap,screen.priority(),cliprect,tm,m_pf_rowscroll.get(),m_pf_colscroll.get(),nullptr,nullptr,flags, pri, primask);
+	custom_tilemap_draw(bitmap,screen.priority(),cliprect,tm,m_rowscroll.target(),m_colscroll.target(),nullptr,nullptr,flags, pri, primask);
 }
 
 
 
-void deco_bac06_device::pf_control_0_w(offs_t offset, u16 data, u16 mem_mask)
+void deco_bac06_device::ctrlreg_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	int old_register0 = m_pf_control_0[0];
+	const u16 old_register0 = m_ctrlreg[0];
 
 	offset &= 3;
 
-	COMBINE_DATA(&m_pf_control_0[offset]);
+	COMBINE_DATA(&m_ctrlreg[offset]);
 
 	bool dirty_all = false;
 	if (offset == 0)
 	{
-		if ((old_register0 & 2) != (m_pf_control_0[offset] & 2))
+		if ((old_register0 & 2) != (m_ctrlreg[offset] & 2))
 		{
 			// The tilemap has changed from row major to column major or vice versa.
 			// Must force an update of the mapping.
 			for (int i = 0; i < 3; i++)
 			{
-				m_pf8x8_tilemap[i]->mark_mapping_dirty();
-				m_pf16x16_tilemap[i]->mark_mapping_dirty();
+				m_tilemap_8x8[i]->mark_mapping_dirty();
+				m_tilemap_16x16[i]->mark_mapping_dirty();
 			}
 			dirty_all = true;
 		}
 	}
 	if (offset == 2)
 	{
-		int newbank = m_pf_control_0[offset] & 1;
+		const u32 newbank = m_ctrlreg[offset] & 1;
 		if ((newbank & 1) != (m_rambank & 1))
 		{
 			// I don't know WHY Stadium Hero uses this as a bank but the RAM test expects it..
 			// I'm curious as to if anything else sets it tho
-			if (strcmp(machine().system().name,"stadhero"))
-				logerror("tilemap ram bank change to %02x\n", newbank & 1);
+			if (!m_has_bank)
+				logerror("%s: tilemap ram bank change to %02x\n", machine().describe_context(), newbank & 1);
 
 			dirty_all = true;
 			m_rambank = newbank & 1;
@@ -455,190 +453,60 @@ void deco_bac06_device::pf_control_0_w(offs_t offset, u16 data, u16 mem_mask)
 	{
 		for (int i = 0; i < 3; i++)
 		{
-			m_pf8x8_tilemap[i]->mark_all_dirty();
-			m_pf16x16_tilemap[i]->mark_all_dirty();
+			m_tilemap_8x8[i]->mark_all_dirty();
+			m_tilemap_16x16[i]->mark_all_dirty();
 		}
 	}
 }
 
-u16 deco_bac06_device::pf_control_1_r(offs_t offset)
+u16 deco_bac06_device::scrollreg_r(offs_t offset)
 {
 	offset &= 7;
-	return m_pf_control_1[offset];
+	return m_scrollreg[offset];
 }
 
-void deco_bac06_device::pf_control_1_w(offs_t offset, u16 data, u16 mem_mask)
+void deco_bac06_device::scrollreg_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	offset &= 7;
-	COMBINE_DATA(&m_pf_control_1[offset]);
+	COMBINE_DATA(&m_scrollreg[offset]);
 }
 
-void deco_bac06_device::pf_data_w(offs_t offset, u16 data, u16 mem_mask)
+void deco_bac06_device::vram_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	if (m_rambank & 1) offset += 0x1000;
 
-	COMBINE_DATA(&m_pf_data[offset]);
+	COMBINE_DATA(&m_vram[offset]);
 
 	for (int i = 0; i < 3; i++)
 	{
-		m_pf8x8_tilemap[i]->mark_tile_dirty(offset);
-		m_pf16x16_tilemap[i]->mark_tile_dirty(offset);
+		m_tilemap_8x8[i]->mark_tile_dirty(offset);
+		m_tilemap_16x16[i]->mark_tile_dirty(offset);
 	}
 }
 
-u16 deco_bac06_device::pf_data_r(offs_t offset)
+u16 deco_bac06_device::vram_r(offs_t offset)
 {
 	if (m_rambank & 1) offset += 0x1000;
 
-	return m_pf_data[offset];
+	return m_vram[offset];
 }
 
-void deco_bac06_device::pf_data_8bit_w(offs_t offset, u8 data)
+void deco_bac06_device::rowscroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	if (offset & 1)
-		pf_data_w(offset / 2, data, 0x00ff);
-	else
-		pf_data_w(offset / 2, data << 8, 0xff00);
+	COMBINE_DATA(&m_rowscroll[offset]);
 }
 
-u8 deco_bac06_device::pf_data_8bit_r(offs_t offset)
+void deco_bac06_device::colscroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	if (offset & 1) /* MSB */
-		return pf_data_r(offset / 2);
-	else
-		return pf_data_r(offset / 2)>>8;
+	COMBINE_DATA(&m_colscroll[offset]);
 }
 
-void deco_bac06_device::pf_rowscroll_w(offs_t offset, u16 data, u16 mem_mask)
+u16 deco_bac06_device::rowscroll_r(offs_t offset)
 {
-	COMBINE_DATA(&m_pf_rowscroll[offset]);
+	return m_rowscroll[offset];
 }
 
-void deco_bac06_device::pf_colscroll_w(offs_t offset, u16 data, u16 mem_mask)
+u16 deco_bac06_device::colscroll_r(offs_t offset)
 {
-	COMBINE_DATA(&m_pf_colscroll[offset]);
-}
-
-u16 deco_bac06_device::pf_rowscroll_r(offs_t offset)
-{
-	return m_pf_rowscroll[offset];
-}
-
-u16 deco_bac06_device::pf_colscroll_r(offs_t offset)
-{
-	return m_pf_colscroll[offset];
-}
-
-/* used by dec8.cpp */
-void deco_bac06_device::pf_control0_8bit_w(offs_t offset, u8 data)
-{
-	if (offset & 1)
-		pf_control_0_w(offset / 2, data, 0x00ff); // oscar (mirrors?)
-	else
-		pf_control_0_w(offset / 2, data, 0x00ff);
-}
-
-/* used by dec8.cpp */
-u8 deco_bac06_device::pf_control1_8bit_r(offs_t offset)
-{
-	if (offset & 1)
-		return pf_control_1_r(offset / 2);
-	else
-		return pf_control_1_r(offset / 2)>>8;
-}
-
-/* used by dec8.cpp */
-void deco_bac06_device::pf_control1_8bit_w(offs_t offset, u8 data)
-{
-	if (offset<4) // these registers are 16-bit?
-	{
-		if (offset & 1)
-			pf_control_1_w(offset / 2, data, 0x00ff);
-		else
-			pf_control_1_w(offset / 2, data << 8, 0xff00);
-	}
-	else // these registers are 8-bit and mirror? (triothep vs actfancr)
-	{
-		if (offset & 1)
-			pf_control_1_w(offset / 2, data, 0x00ff);
-		else
-			pf_control_1_w(offset / 2, data, 0x00ff);
-	}
-}
-
-u8 deco_bac06_device::pf_rowscroll_8bit_r(offs_t offset)
-{
-	if (offset & 1)
-		return pf_rowscroll_r(offset / 2);
-	else
-		return pf_rowscroll_r(offset / 2)>>8;
-}
-
-
-void deco_bac06_device::pf_rowscroll_8bit_w(offs_t offset, u8 data)
-{
-	if (offset & 1)
-		pf_rowscroll_w(offset / 2, data, 0x00ff);
-	else
-		pf_rowscroll_w(offset / 2, data << 8, 0xff00);
-}
-
-u8 deco_bac06_device::pf_rowscroll_8bit_swap_r(offs_t offset)
-{
-	if (offset & 1)
-		return pf_rowscroll_r(offset / 2)>>8;
-	else
-		return pf_rowscroll_r(offset / 2);
-}
-
-void deco_bac06_device::pf_rowscroll_8bit_swap_w(offs_t offset, u8 data)
-{
-	if (offset & 1)
-		pf_rowscroll_w(offset / 2, data << 8, 0xff00);
-	else
-		pf_rowscroll_w(offset / 2, data, 0x00ff);
-}
-
-// used by thedeep
-u8 deco_bac06_device::pf_colscroll_8bit_swap_r(offs_t offset)
-{
-	if (offset & 1)
-		return pf_colscroll_r(offset / 2)>>8;
-	else
-		return pf_colscroll_r(offset / 2);
-}
-
-void deco_bac06_device::pf_colscroll_8bit_swap_w(offs_t offset, u8 data)
-{
-	if (offset & 1)
-		pf_colscroll_w(offset / 2, data << 8, 0xff00);
-	else
-		pf_colscroll_w(offset / 2, data, 0x00ff);
-}
-
-/* used by hippodrm */
-void deco_bac06_device::pf_control0_8bit_packed_w(offs_t offset, u8 data)
-{
-	if (offset & 1)
-		pf_control_0_w(offset / 2, data << 8, 0xff00);
-	else
-		pf_control_0_w(offset / 2, data, 0x00ff);
-}
-
-/* used by hippodrm */
-void deco_bac06_device::pf_control1_8bit_swap_w(offs_t offset, u8 data)
-{
-	pf_control1_8bit_w(offset ^ 1, data);
-}
-
-/* used by hippodrm */
-u8 deco_bac06_device::pf_data_8bit_swap_r(offs_t offset)
-{
-	return pf_data_8bit_r(offset ^ 1);
-}
-
-/* used by hippodrm */
-void deco_bac06_device::pf_data_8bit_swap_w(offs_t offset, u8 data)
-{
-	pf_data_8bit_w(offset ^ 1, data);
+	return m_colscroll[offset];
 }

--- a/src/mame/dataeast/decbac06.h
+++ b/src/mame/dataeast/decbac06.h
@@ -12,14 +12,14 @@
 #include <utility>
 
 
-typedef device_delegate<void (tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags)> decbac06_tile_cb_delegate;
-
 class deco_bac06_device : public device_t
 {
 public:
 	deco_bac06_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
 	// configuration
+	typedef device_delegate<void (tile_data &tileinfo, u32 &tile, u32 &colour, u32 &flags)> decbac06_tile_cb_delegate;
+
 	template <typename T> void set_gfxdecode_tag(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
 	void set_gfx_region_wide(int region8x8, int region16x16, int wide)
 	{
@@ -27,99 +27,113 @@ public:
 		m_gfxregion16x16 = region16x16;
 		m_wide = wide;
 	}
-	void set_thedeep_kludge() { m_thedeep_kludge = 1; } // thedeep requires TILE_FLIPX always set, for reasons to be investigated
+	void set_thedeep_kludge() { m_thedeep_kludge = true; } // thedeep requires TILE_FLIPX always set, for reasons to be investigated
 	void disable_8x8() { m_supports_8x8 = false; }
 	void disable_16x16() { m_supports_16x16 = false; }
 	void disable_rc_scroll() { m_supports_rc_scroll = false; }
+	void set_has_bank(bool has_bank) { m_has_bank = has_bank; }
 	template <typename... T> void set_tile_callback(T &&... args) { m_tile_cb.set(std::forward<T>(args)...); }
 
 	void set_transmask(int group, u32 fgmask, u32 bgmask);
 
-	void deco_bac06_pf_draw(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, u8 pri = 0, u8 primask = 0xff);
-	void deco_bac06_pf_draw_bootleg(screen_device &screen,bitmap_ind16 &bitmap,const rectangle &cliprect,u32 flags, int mode, int type, u8 pri = 0, u8 primask = 0xff);
+	void draw(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u32 flags, u8 pri = 0, u8 primask = 0xff);
+	void draw_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u32 flags, int mode, int type, u8 pri = 0, u8 primask = 0xff);
 
-	/* I wonder if pf_control_0 is really registers, or a selection of pins.
+	/* I wonder if ctrlreg is really registers, or a selection of pins.
 
 	  For games with multiple chips typically the flip bit only gets set on one of the chips, but
 	  is expected to apply to both (and often the sprites as well?)
 
 	  Furthermore we have the m_rambank thing used by Stadium Hero which appears to be used to
-	  control the upper address line on some external RAM even if it gets written to the control_0
+	  control the upper address line on some external RAM even if it gets written to the ctrlreg
 	  area
 
 	  For now we have this get_flip_state function so that drivers can query the bit and set other
 	  flip flags accordingly
 	*/
-	u8 get_flip_state(void) { return m_pf_control_0[0] & 0x80; }
+	u8 get_flip_state() { return BIT(m_ctrlreg[0], 7); }
 
 	void set_flip_screen(bool flip);
 
 	/* 16-bit accessors */
+	void ctrlreg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 scrollreg_r(offs_t offset);
+	void scrollreg_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
-	void pf_control_0_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 pf_control_1_r(offs_t offset);
-	void pf_control_1_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-
-	void pf_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 pf_data_r(offs_t offset);
-	void pf_rowscroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 pf_rowscroll_r(offs_t offset);
-	void pf_colscroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	u16 pf_colscroll_r(offs_t offset);
+	void vram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 vram_r(offs_t offset);
+	void rowscroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 rowscroll_r(offs_t offset);
+	void colscroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 colscroll_r(offs_t offset);
 
 	/* 8-bit accessors */
+	template <bool IsLittleEndian> u8 vram8_r(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		return (vram_r(offset >> 1) >> shift) & 0xff;
+	}
 
-	/* for dec8.cpp, pcktgal.cpp (Big endian CPU (6809, etc) based games) */
-	u8 pf_data_8bit_r(offs_t offset);
-	void pf_data_8bit_w(offs_t offset, u8 data);
+	template <bool IsLittleEndian> void vram8_w(offs_t offset, u8 data)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		vram_w(offset >> 1, u16(data) << shift, 0xff << shift);
+	}
 
-	void pf_control0_8bit_w(offs_t offset, u8 data);
-	u8 pf_control1_8bit_r(offs_t offset);
-	void pf_control1_8bit_w(offs_t offset, u8 data);
+	void ctrlreg8_w(offs_t offset, u8 data)
+	{
+		ctrlreg_w(offset >> 1, data, 0x00ff); // oscar (mirrors?)
+	}
 
-	u8 pf_rowscroll_8bit_r(offs_t offset);
-	void pf_rowscroll_8bit_w(offs_t offset, u8 data);
+	template <bool IsLittleEndian> void ctrlreg8_packed_w(offs_t offset, u8 data)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		ctrlreg_w(offset >> 1, u16(data) << shift, 0xff << shift);
+	}
 
-	/* for hippodrm (dec0.cpp) and actfancr / triothep (Little endian CPU (HuC6280, etc) based games)*/
-	void pf_control0_8bit_packed_w(offs_t offset, u8 data);
-	void pf_control1_8bit_swap_w(offs_t offset, u8 data);
-	u8 pf_data_8bit_swap_r(offs_t offset);
-	void pf_data_8bit_swap_w(offs_t offset, u8 data);
-	u8 pf_rowscroll_8bit_swap_r(offs_t offset);
-	void pf_rowscroll_8bit_swap_w(offs_t offset, u8 data);
-	u8 pf_colscroll_8bit_swap_r(offs_t offset);
-	void pf_colscroll_8bit_swap_w(offs_t offset, u8 data);
+	template <bool IsLittleEndian> u8 scrollreg8_r(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		return (scrollreg_r(offset >> 1) >> shift) & 0xff;
+	}
 
-// TODO: privatize values
-	std::unique_ptr<u16[]> m_pf_data;
-	std::unique_ptr<u16[]> m_pf_rowscroll;
-	std::unique_ptr<u16[]> m_pf_colscroll;
+	template <bool IsLittleEndian> void scrollreg8_w(offs_t offset, u8 data)
+	{
+		const u8 shift = (offset < 4) ?  // these registers are 16-bit?
+						BIT(IsLittleEndian ? offset : ~offset, 0) << 3 :
+						0; // these registers are 8-bit and mirror? (triothep vs actfancr)
+		scrollreg_w(offset >> 1, u16(data) << shift, 0xff << shift);
+	}
 
-	tilemap_t* m_pf8x8_tilemap[3]{};
-	tilemap_t* m_pf16x16_tilemap[3]{};
-	int    m_tile_region_8;
-	int    m_tile_region_16;
+	template <bool IsLittleEndian> u8 rowscroll8_r(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		return (rowscroll_r(offset >> 1) >> shift) & 0xff;
+	}
 
-	// some bootlegs (eg midresb / midresbj) don't appear to actually support the alt modes, they set them and end up with broken gfx on later levels.
-	bool    m_supports_8x8;
-	bool    m_supports_16x16;
-	bool    m_supports_rc_scroll;
+	template <bool IsLittleEndian> void rowscroll8_w(offs_t offset, u8 data)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		rowscroll_w(offset >> 1, u16(data) << shift, 0xff << shift);
+	}
 
-	void create_tilemaps(int region8x8,int region16x16);
-	u16 m_pf_control_0[8];
-	u16 m_pf_control_1[8];
+	template <bool IsLittleEndian> u8 colscroll8_r(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		return (colscroll_r(offset >> 1) >> shift) & 0xff;
+	}
 
-	int m_rambank; // external connection?
-	bool m_flip_screen = false;
+	template <bool IsLittleEndian> void colscroll8_w(offs_t offset, u8 data)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 3;
+		colscroll_w(offset >> 1, u16(data) << shift, 0xff << shift);
+	}
 
 protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
-	u8 m_gfxregion8x8;
-	u8 m_gfxregion16x16;
-	int m_wide;
-
+private:
 	void custom_tilemap_draw(bitmap_ind16 &bitmap,
 							bitmap_ind8 &primap,
 							const rectangle &cliprect,
@@ -131,19 +145,49 @@ protected:
 							u32 flags,
 							u8 pri = 0, u8 pmask = 0xff);
 
-private:
+	void create_tilemaps(int region8x8, int region16x16);
+
 	TILEMAP_MAPPER_MEMBER(tile_shape0_scan);
 	TILEMAP_MAPPER_MEMBER(tile_shape1_scan);
 	TILEMAP_MAPPER_MEMBER(tile_shape2_scan);
 	TILEMAP_MAPPER_MEMBER(tile_shape0_8x8_scan);
 	TILEMAP_MAPPER_MEMBER(tile_shape1_8x8_scan);
 	TILEMAP_MAPPER_MEMBER(tile_shape2_8x8_scan);
-	TILE_GET_INFO_MEMBER(get_pf8x8_tile_info);
-	TILE_GET_INFO_MEMBER(get_pf16x16_tile_info);
+	TILE_GET_INFO_MEMBER(get_tile_info_8x8);
+	TILE_GET_INFO_MEMBER(get_tile_info_16x16);
+
 	required_device<gfxdecode_device> m_gfxdecode;
 
+	memory_share_creator<u16> m_vram;
+	memory_share_creator<u16> m_rowscroll;
+	memory_share_creator<u16> m_colscroll;
+
 	decbac06_tile_cb_delegate m_tile_cb;
+
+	tilemap_t* m_tilemap_8x8[3]{};
+	tilemap_t* m_tilemap_16x16[3]{};
+	int m_tile_region_8;
+	int m_tile_region_16;
+
+	u8 m_gfxregion8x8;
+	u8 m_gfxregion16x16;
+	int m_wide;
+
+	// some bootlegs (eg midresb / midresbj) don't appear to actually support the alt modes, they set them and end up with broken gfx on later levels.
+	bool m_supports_8x8;
+	bool m_supports_16x16;
+	bool m_supports_rc_scroll;
+
 	bool m_thedeep_kludge;
+
+	bool m_has_bank;
+
+	u16 m_ctrlreg[8];
+	u16 m_scrollreg[8];
+
+	u32 m_rambank; // external connection?
+	bool m_flip_screen;
+
 };
 
 DECLARE_DEVICE_TYPE(DECO_BAC06, deco_bac06_device)

--- a/src/mame/dataeast/madmotor.cpp
+++ b/src/mame/dataeast/madmotor.cpp
@@ -74,20 +74,20 @@ private:
 void madmotor_state::main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom();
-	map(0x180000, 0x180007).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_0_w));                          // text layer
-	map(0x180010, 0x180017).w(m_tilegen[0], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x184000, 0x18407f).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_colscroll_r), FUNC(deco_bac06_device::pf_colscroll_w));
+	map(0x180000, 0x180007).w(m_tilegen[0], FUNC(deco_bac06_device::ctrlreg_w));                          // text layer
+	map(0x180010, 0x180017).w(m_tilegen[0], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x184000, 0x18407f).rw(m_tilegen[0], FUNC(deco_bac06_device::colscroll_r), FUNC(deco_bac06_device::colscroll_w));
 	map(0x184080, 0x1843ff).ram();
-	map(0x184400, 0x1847ff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_rowscroll_r), FUNC(deco_bac06_device::pf_rowscroll_w));
-	map(0x188000, 0x189fff).rw(m_tilegen[0], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x184400, 0x1847ff).rw(m_tilegen[0], FUNC(deco_bac06_device::rowscroll_r), FUNC(deco_bac06_device::rowscroll_w));
+	map(0x188000, 0x189fff).rw(m_tilegen[0], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 	map(0x18c000, 0x18c001).noprw();
-	map(0x190000, 0x190007).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_0_w));                          // text layer
-	map(0x190010, 0x190017).w(m_tilegen[1], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x198000, 0x1987ff).rw(m_tilegen[1], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x190000, 0x190007).w(m_tilegen[1], FUNC(deco_bac06_device::ctrlreg_w));                          // text layer
+	map(0x190010, 0x190017).w(m_tilegen[1], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x198000, 0x1987ff).rw(m_tilegen[1], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 	map(0x19c000, 0x19c001).nopr();
-	map(0x1a0000, 0x1a0007).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_0_w));                          // text layer
-	map(0x1a0010, 0x1a0017).w(m_tilegen[2], FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x1a4000, 0x1a4fff).rw(m_tilegen[2], FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x1a0000, 0x1a0007).w(m_tilegen[2], FUNC(deco_bac06_device::ctrlreg_w));                          // text layer
+	map(0x1a0010, 0x1a0017).w(m_tilegen[2], FUNC(deco_bac06_device::scrollreg_w));
+	map(0x1a4000, 0x1a4fff).rw(m_tilegen[2], FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 	map(0x3e0000, 0x3e3fff).ram();
 	map(0x3e8000, 0x3e87ff).ram().share(m_spriteram);
 	map(0x3f0000, 0x3f07ff).ram().w("palette", FUNC(palette_device::write16)).share("palette");
@@ -235,10 +235,10 @@ uint32_t madmotor_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_tilegen[2]->set_flip_screen(flip);
 	m_spritegen->set_flip_screen(flip);
 
-	m_tilegen[2]->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
-	m_tilegen[1]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[2]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen[1]->draw(screen, bitmap, cliprect, 0, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram, 0x800 / 2);
-	m_tilegen[0]->deco_bac06_pf_draw(screen, bitmap, cliprect, 0, 0);
+	m_tilegen[0]->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
 }
 

--- a/src/mame/dataeast/pcktgal.cpp
+++ b/src/mame/dataeast/pcktgal.cpp
@@ -151,7 +151,7 @@ uint32_t pcktgal_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 {
 	bool flip = m_tilegen->get_flip_state();
 	m_tilegen->set_flip_screen(flip);
-	m_tilegen->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	draw_sprites(bitmap, cliprect, flip);
 	return 0;
 }
@@ -161,7 +161,7 @@ uint32_t pcktgal_state::screen_update_bootleg(screen_device &screen, bitmap_ind1
 	bool flip = m_tilegen->get_flip_state();
 	m_tilegen->set_flip_screen(flip);
 	// the bootleg doesn't properly set the tilemap registers, because it's on non-original hardware, which probably doesn't have the flexible tilemaps.
-	m_tilegen->deco_bac06_pf_draw_bootleg(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0, 2, 0);
+	m_tilegen->draw_bootleg(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0, 2, 0);
 	draw_sprites(bitmap, cliprect, flip);
 	return 0;
 }
@@ -216,11 +216,11 @@ uint8_t pcktgal_state::sound_unk_r()
 void pcktgal_state::main_map(address_map &map)
 {
 	map(0x0000, 0x07ff).ram();
-	map(0x0800, 0x0fff).rw(m_tilegen, FUNC(deco_bac06_device::pf_data_8bit_r), FUNC(deco_bac06_device::pf_data_8bit_w));
+	map(0x0800, 0x0fff).rw(m_tilegen, FUNC(deco_bac06_device::vram8_r<false>), FUNC(deco_bac06_device::vram8_w<false>));
 	map(0x1000, 0x11ff).ram().share(m_spriteram);
 	map(0x1800, 0x1800).portr("P1");
-	map(0x1800, 0x1807).w(m_tilegen, FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0x1810, 0x181f).rw(m_tilegen, FUNC(deco_bac06_device::pf_control1_8bit_r), FUNC(deco_bac06_device::pf_control1_8bit_w));
+	map(0x1800, 0x1807).w(m_tilegen, FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0x1810, 0x181f).rw(m_tilegen, FUNC(deco_bac06_device::scrollreg8_r<false>), FUNC(deco_bac06_device::scrollreg8_w<false>));
 	map(0x1a00, 0x1a00).portr("P2").w(FUNC(pcktgal_state::sound_w));
 	map(0x1c00, 0x1c00).portr("DSW").w(FUNC(pcktgal_state::bank_w));
 	map(0x4000, 0x5fff).bankr(m_mainbank[0]);

--- a/src/mame/dataeast/stadhero.cpp
+++ b/src/mame/dataeast/stadhero.cpp
@@ -169,7 +169,7 @@ uint32_t stadhero_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_spritegen->set_flip_screen(flip);
 	m_pf1_tilemap->set_flip(flip ? (TILEMAP_FLIPY | TILEMAP_FLIPX) : 0);
 
-	m_tilegen->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, m_spriteram, 0x800 / 2);
 	m_pf1_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -227,9 +227,9 @@ void stadhero_state::main_map(address_map &map)
 {
 	map(0x000000, 0x01ffff).rom();
 	map(0x200000, 0x2007ff).ram().w(FUNC(stadhero_state::pf1_data_w)).share(m_pf1_data);
-	map(0x240000, 0x240007).w(m_tilegen, FUNC(deco_bac06_device::pf_control_0_w)); // text layer
-	map(0x240010, 0x240017).w(m_tilegen, FUNC(deco_bac06_device::pf_control_1_w));
-	map(0x260000, 0x261fff).rw(m_tilegen, FUNC(deco_bac06_device::pf_data_r), FUNC(deco_bac06_device::pf_data_w));
+	map(0x240000, 0x240007).w(m_tilegen, FUNC(deco_bac06_device::ctrlreg_w)); // text layer
+	map(0x240010, 0x240017).w(m_tilegen, FUNC(deco_bac06_device::scrollreg_w));
+	map(0x260000, 0x261fff).rw(m_tilegen, FUNC(deco_bac06_device::vram_r), FUNC(deco_bac06_device::vram_w));
 	map(0x30c000, 0x30c001).portr("INPUTS");
 	map(0x30c002, 0x30c002).lr8(NAME([this] () { return uint8_t(m_coin->read()); }));
 	map(0x30c003, 0x30c003).r(FUNC(stadhero_state::mystery_r));
@@ -389,6 +389,7 @@ void stadhero_state::stadhero(machine_config &config)
 	DECO_BAC06(config, m_tilegen);
 	m_tilegen->set_gfx_region_wide(1, 1, 2);
 	m_tilegen->set_gfxdecode_tag(m_gfxdecode);
+	m_tilegen->set_has_bank(true);
 
 	DECO_MXC06(config, m_spritegen, "palette", gfx_stadhero_spr);
 

--- a/src/mame/dataeast/thedeep.cpp
+++ b/src/mame/dataeast/thedeep.cpp
@@ -207,7 +207,7 @@ uint32_t thedeep_state::screen_update(screen_device &screen, bitmap_ind16 &bitma
 {
 	bitmap.fill(m_palette->black_pen(), cliprect);
 
-	m_tilegen->deco_bac06_pf_draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
+	m_tilegen->draw(screen, bitmap, cliprect, TILEMAP_DRAW_OPAQUE, 0);
 	m_spritegen->draw_sprites(screen, bitmap, cliprect, reinterpret_cast<uint16_t *>(m_spriteram.target()), 0x400 / 2);
 	m_text_tilemap->draw(screen, bitmap, cliprect, 0, 0);
 	return 0;
@@ -283,12 +283,12 @@ void thedeep_state::main_map(address_map &map)
 	map(0xe00b, 0xe00b).portr("e00b");           // DSW2
 	map(0xe00c, 0xe00c).w("soundlatch", FUNC(generic_latch_8_device::write));  // To sound CPU
 	map(0xe100, 0xe100).w(FUNC(thedeep_state::e100_w));   // ?
-	map(0xe200, 0xe207).w(m_tilegen, FUNC(deco_bac06_device::pf_control0_8bit_w));
-	map(0xe210, 0xe217).w(m_tilegen, FUNC(deco_bac06_device::pf_control1_8bit_swap_w));
+	map(0xe200, 0xe207).w(m_tilegen, FUNC(deco_bac06_device::ctrlreg8_w));
+	map(0xe210, 0xe217).w(m_tilegen, FUNC(deco_bac06_device::scrollreg8_w<true>));
 	map(0xe400, 0xe7ff).ram().share(m_spriteram);   // Sprites
 	map(0xe800, 0xefff).ram().w(FUNC(thedeep_state::textram_w)).share(m_textram);  // Text layer
-	map(0xf000, 0xf7ff).rw(m_tilegen, FUNC(deco_bac06_device::pf_data_8bit_swap_r), FUNC(deco_bac06_device::pf_data_8bit_swap_w));  // Background layer
-	map(0xf800, 0xf83f).rw(m_tilegen, FUNC(deco_bac06_device::pf_colscroll_8bit_swap_r), FUNC(deco_bac06_device::pf_colscroll_8bit_swap_w));
+	map(0xf000, 0xf7ff).rw(m_tilegen, FUNC(deco_bac06_device::vram8_r<true>), FUNC(deco_bac06_device::vram8_w<true>));  // Background layer
+	map(0xf800, 0xf83f).rw(m_tilegen, FUNC(deco_bac06_device::colscroll8_r<true>), FUNC(deco_bac06_device::colscroll8_w<true>));
 	map(0xf840, 0xffff).ram();
 }
 


### PR DESCRIPTION
- Fix naming based on usage and purpose
- Reduce hardcoded string check
- Reduce duplicates
- Fix typename values
- Make some variables constant
- Make RAMs into memory_share

dataeast/dec8.cpp:
- Fix side effect check for debugger reads
- Reduce literal tag usage