### PR TITLE
luaengine.cpp: Added a read-only property listing a device's outputs

### DIFF
--- a/docs/source/luascript/ref-devices.rst
+++ b/docs/source/luascript/ref-devices.rst
@@ -198,6 +198,15 @@ device.spaces[] (read-only)
     indexed by name.  Only valid for devices that implement the memory
     interface.  Note that the names are specific to the device type and have no
     special significance.
+device.outputs[] (read-only)
+    A table of the outputs the device has created, ordered by name.  Each
+    element is a table with a ``name`` field holding the output’s name relative
+    to the device, and a ``qualified_name`` field holding the name qualified by
+    the device’s tag (the form used by the ``-output`` host output modules).  An
+    :ref:`output proxy <luascript-ref-outputproxy>` may be obtained by passing
+    the ``name`` field to the device’s ``output`` method.  Note that outputs are
+    created while devices are being started, so the set of outputs is only
+    complete once the machine has finished starting.
 
 
 .. _luascript-ref-dipalette:

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1639,6 +1639,32 @@ void lua_engine::initialize()
 						table[rom.name()] = rom;
 				return table;
 			});
+	device_type["outputs"] = sol::property(
+			[this] (device_t &dev)
+			{
+				// outputs are created while devices are starting, the set is fixed after that
+				std::vector<osd::output_item const *> items;
+				dev.machine().output().notify_all(
+						[&dev, &items] (osd::output_item const &item)
+						{
+							if (item.device_tag() == dev.tag())
+								items.emplace_back(&item);
+						});
+				std::sort(
+						items.begin(),
+						items.end(),
+						[] (osd::output_item const *l, osd::output_item const *r) { return l->name() < r->name(); });
+				sol::table table = sol().create_table();
+				int index = 0;
+				for (osd::output_item const *item : items)
+				{
+					sol::table entry = sol().create_table();
+					entry["name"] = std::string(item->name());
+					entry["qualified_name"] = item->qualified_name();
+					table[++index] = entry;
+				}
+				return table;
+			});
 
 	auto dipalette_type = sol().registry().new_usertype<device_palette_interface>("dipalette", sol::no_constructor);
 	dipalette_type.set_function("pen", &device_palette_interface::pen);


### PR DESCRIPTION
Adds a read-only Lua property, `device.outputs`, listing the outputs a device has created. Each element is a table with `name` and `qualified_name`. It creates nothing, and doesn't change when or how outputs come into existence.

A script/plugin can already read an output by name with `device:output(name)`, but has no way to find out which names exist, leading to names being hardcoded or requiring a new scraped list with each MAME release. However, this information is already available: `output_manager::notify_all` is public, and `win32_output.cpp` uses it to enumerate a machine's outputs when a client registers. This exposes the same information to Lua.

The property sits beside `device:output(name)` so discovery and access use the same per-device model, and follows the collection properties already on that usertype (`spaces`, `items`, `roms`). No new usertype is introduced.

Tested on Windows against opwolf, crszone, rchase and zombraid.

Documentation for this change has been included in `ref-devices.rst`.

Happy to rename `outputs` if this looks awkward beside `device_sound_interface`'s `sound.outputs`.