### PR TITLE
dataeast/deco_bufpal.cpp: Make buffered palette hardware as device

### DIFF
--- a/src/mame/dataeast/deco_bufpal.cpp
+++ b/src/mame/dataeast/deco_bufpal.cpp
@@ -83,13 +83,13 @@ void deco_buffered_palette_device::dma_w(u8 data)
 void deco_buffered_palette_device::write8(offs_t offset, u8 data)
 {
 	m_paletteram.write8(offset, data);
-	set_dirty_area(offset >> 2);
+	set_dirty_area(offset >> ((m_paletteram_ext.base() != nullptr) ? 1 : 2));
 }
 
 void deco_buffered_palette_device::write16(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_paletteram.write16(offset, data, mem_mask);
-	set_dirty_area(offset >> 1);
+	set_dirty_area(offset >> ((m_paletteram_ext.base() != nullptr) ? 0 : 1));
 }
 
 void deco_buffered_palette_device::write32(offs_t offset, u32 data, u32 mem_mask)
@@ -122,14 +122,14 @@ u32 deco_buffered_palette_device::read32(offs_t offset)
 void deco_buffered_palette_device::write8_ext(offs_t offset, u8 data)
 {
 	m_paletteram_ext.write8(offset, data);
-	set_dirty_area(offset >> 2);
+	set_dirty_area(offset >> 1);
 }
 
 
 void deco_buffered_palette_device::write16_ext(offs_t offset, u16 data, u16 mem_mask)
 {
 	m_paletteram_ext.write16(offset, data, mem_mask);
-	set_dirty_area(offset >> 1);
+	set_dirty_area(offset);
 }
 
 

--- a/src/mame/dataeast/deco_bufpal.cpp
+++ b/src/mame/dataeast/deco_bufpal.cpp
@@ -24,14 +24,15 @@
 DEFINE_DEVICE_TYPE(DECO_BUFFERED_PALETTE, deco_buffered_palette_device, "deco_bufpal", "DECO Buffered Palette Hardware")
 
 deco_buffered_palette_device::deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: deco_buffered_palette_device(mconfig, tag, owner, clock, 0)
+	: deco_buffered_palette_device(mconfig, tag, owner, clock, 0, ENDIANNESS_LITTLE)
 {
 }
 
-deco_buffered_palette_device::deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries)
+deco_buffered_palette_device::deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries, endianness_t endianness)
 	: device_t(mconfig, DECO_BUFFERED_PALETTE, tag, owner, clock)
 	, device_palette_interface(mconfig, *this)
 	, m_entries(entries)
+	, m_paletteram(*this, "paletteram", entries << 2, endianness)
 	, m_dirty_start(entries)
 	, m_dirty_end(-1)
 {
@@ -68,7 +69,7 @@ void deco_buffered_palette_device::dma_w(u8 data)
 	{
 		if (m_dirty[i])
 		{
-			set_pen_color(i, xbgr_888_decoder(read_entry(i)));
+			set_pen_color(i, xbgr_888_decoder(m_paletteram[i]));
 			m_dirty[i] = false;
 		}
 	}
@@ -77,59 +78,18 @@ void deco_buffered_palette_device::dma_w(u8 data)
 }
 
 //-------------------------------------------------
-//  write* - write a byte to the base paletteram
+//  write* - write a word to the base paletteram
 //-------------------------------------------------
-
-void deco_buffered_palette_device::write8(offs_t offset, u8 data)
-{
-	m_paletteram.write8(offset, data);
-	set_dirty_area(offset >> ((m_paletteram_ext.base() != nullptr) ? 1 : 2));
-}
-
-void deco_buffered_palette_device::write16(offs_t offset, u16 data, u16 mem_mask)
-{
-	m_paletteram.write16(offset, data, mem_mask);
-	set_dirty_area(offset >> ((m_paletteram_ext.base() != nullptr) ? 0 : 1));
-}
 
 void deco_buffered_palette_device::write32(offs_t offset, u32 data, u32 mem_mask)
 {
-	m_paletteram.write32(offset, data, mem_mask);
+	COMBINE_DATA(&m_paletteram[offset]);
 	set_dirty_area(offset);
-}
-
-u8 deco_buffered_palette_device::read8(offs_t offset)
-{
-	return m_paletteram.read8(offset);
-}
-
-u16 deco_buffered_palette_device::read16(offs_t offset)
-{
-	return m_paletteram.read16(offset);
 }
 
 u32 deco_buffered_palette_device::read32(offs_t offset)
 {
-	return m_paletteram.read32(offset);
-}
-
-
-//-------------------------------------------------
-//  write*_ext - write a byte to the extended
-//  paletteram
-//-------------------------------------------------
-
-void deco_buffered_palette_device::write8_ext(offs_t offset, u8 data)
-{
-	m_paletteram_ext.write8(offset, data);
-	set_dirty_area(offset >> 1);
-}
-
-
-void deco_buffered_palette_device::write16_ext(offs_t offset, u16 data, u16 mem_mask)
-{
-	m_paletteram_ext.write16(offset, data, mem_mask);
-	set_dirty_area(offset);
+	return m_paletteram[offset];
 }
 
 
@@ -145,24 +105,6 @@ void deco_buffered_palette_device::device_start()
 {
 	assert(m_entries > 0);
 
-	// find the memory, if present
-	const memory_share *share = memshare(tag());
-	if (share != nullptr)
-	{
-		// find the extended (split) memory, if present
-		std::string tag_ext = std::string(tag()).append("_ext");
-		const memory_share *share_ext = memshare(tag_ext.c_str());
-
-		// determine bytes per entry and configure
-		const int bytes_per_entry = 4;
-		if (share_ext == nullptr)
-			m_paletteram.set(*share, bytes_per_entry);
-		else
-		{
-			m_paletteram.set(*share, bytes_per_entry / 2);
-			m_paletteram_ext.set(*share_ext, bytes_per_entry / 2);
-		}
-	}
 	const u32 entries = m_entries;
 	m_dirty = make_unique_clear<bool[]>(entries);
 

--- a/src/mame/dataeast/deco_bufpal.cpp
+++ b/src/mame/dataeast/deco_bufpal.cpp
@@ -1,0 +1,179 @@
+// license:BSD-3-Clause
+// copyright-holders:Bryan McPhail
+/***************************************************************************
+
+    deco_bufpal.cpp
+
+    Data East buffered palette hardware.
+
+    Used by:
+    - dataeast/rohga.cpp
+    - dataeast/dragngun.cpp
+    - dataeast/fghthist.cpp (fghthist*)
+
+***************************************************************************/
+
+#include "emu.h"
+#include "deco_bufpal.h"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(DECO_BUFFERED_PALETTE, deco_buffered_palette_device, "deco_bufpal", "DECO Buffered Palette Hardware")
+
+deco_buffered_palette_device::deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: deco_buffered_palette_device(mconfig, tag, owner, clock, 0)
+{
+}
+
+deco_buffered_palette_device::deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries)
+	: device_t(mconfig, DECO_BUFFERED_PALETTE, tag, owner, clock)
+	, device_palette_interface(mconfig, *this)
+	, m_entries(entries)
+	, m_dirty_start(entries)
+	, m_dirty_end(-1)
+{
+}
+
+
+//**************************************************************************
+//  GENERIC WRITE HANDLERS
+//**************************************************************************
+
+//-------------------------------------------------
+//  set_dirty_area - set dirty area boundary
+//-------------------------------------------------
+
+void deco_buffered_palette_device::set_dirty_area(s32 offset)
+{
+	m_dirty[offset] = true;
+	if (m_dirty_start > offset)
+		m_dirty_start = offset;
+	if (m_dirty_end < offset)
+		m_dirty_end = offset;
+}
+
+//-------------------------------------------------
+//  dma_w - DMA request to buffer
+//-------------------------------------------------
+
+void deco_buffered_palette_device::dma_w(u8 data)
+{
+	if (m_dirty_start > m_dirty_end)
+		return;
+
+	for (u32 i = m_dirty_start; i <= m_dirty_end; i++)
+	{
+		if (m_dirty[i])
+		{
+			set_pen_color(i, xbgr_888_decoder(read_entry(i)));
+			m_dirty[i] = false;
+		}
+	}
+	m_dirty_start = m_entries;
+	m_dirty_end = -1;
+}
+
+//-------------------------------------------------
+//  write* - write a byte to the base paletteram
+//-------------------------------------------------
+
+void deco_buffered_palette_device::write8(offs_t offset, u8 data)
+{
+	m_paletteram.write8(offset, data);
+	set_dirty_area(offset >> 2);
+}
+
+void deco_buffered_palette_device::write16(offs_t offset, u16 data, u16 mem_mask)
+{
+	m_paletteram.write16(offset, data, mem_mask);
+	set_dirty_area(offset >> 1);
+}
+
+void deco_buffered_palette_device::write32(offs_t offset, u32 data, u32 mem_mask)
+{
+	m_paletteram.write32(offset, data, mem_mask);
+	set_dirty_area(offset);
+}
+
+u8 deco_buffered_palette_device::read8(offs_t offset)
+{
+	return m_paletteram.read8(offset);
+}
+
+u16 deco_buffered_palette_device::read16(offs_t offset)
+{
+	return m_paletteram.read16(offset);
+}
+
+u32 deco_buffered_palette_device::read32(offs_t offset)
+{
+	return m_paletteram.read32(offset);
+}
+
+
+//-------------------------------------------------
+//  write*_ext - write a byte to the extended
+//  paletteram
+//-------------------------------------------------
+
+void deco_buffered_palette_device::write8_ext(offs_t offset, u8 data)
+{
+	m_paletteram_ext.write8(offset, data);
+	set_dirty_area(offset >> 2);
+}
+
+
+void deco_buffered_palette_device::write16_ext(offs_t offset, u16 data, u16 mem_mask)
+{
+	m_paletteram_ext.write16(offset, data, mem_mask);
+	set_dirty_area(offset >> 1);
+}
+
+
+//**************************************************************************
+//  DEVICE MANAGEMENT
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_start - start up the device
+//-------------------------------------------------
+
+void deco_buffered_palette_device::device_start()
+{
+	assert(m_entries > 0);
+
+	// find the memory, if present
+	const memory_share *share = memshare(tag());
+	if (share != nullptr)
+	{
+		// find the extended (split) memory, if present
+		std::string tag_ext = std::string(tag()).append("_ext");
+		const memory_share *share_ext = memshare(tag_ext.c_str());
+
+		// determine bytes per entry and configure
+		const int bytes_per_entry = 4;
+		if (share_ext == nullptr)
+			m_paletteram.set(*share, bytes_per_entry);
+		else
+		{
+			m_paletteram.set(*share, bytes_per_entry / 2);
+			m_paletteram_ext.set(*share_ext, bytes_per_entry / 2);
+		}
+	}
+	const u32 entries = m_entries;
+	m_dirty = make_unique_clear<bool[]>(entries);
+
+	save_pointer(NAME(m_dirty), entries);
+	save_item(NAME(m_dirty_start));
+	save_item(NAME(m_dirty_end));
+}
+
+
+rgb_t deco_buffered_palette_device::xbgr_888_decoder(u32 raw)
+{
+	// exact resistor unknown
+	return rgb_t(raw & 0xff, (raw >> 8) & 0xff, (raw >> 16) & 0xff);
+}

--- a/src/mame/dataeast/deco_bufpal.h
+++ b/src/mame/dataeast/deco_bufpal.h
@@ -1,0 +1,94 @@
+// license:BSD-3-Clause
+// copyright-holders:Bryan McPhail
+/***************************************************************************
+
+    deco_bufpal.h
+
+    Data East buffered palette hardware.
+
+******************************************************************************/
+
+#ifndef MAME_DATAEAST_DECO_BUFPAL_H
+#define MAME_DATAEAST_DECO_BUFPAL_H
+
+#pragma once
+
+#include "memarray.h"
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// device type definition
+DECLARE_DEVICE_TYPE(DECO_BUFFERED_PALETTE, deco_buffered_palette_device)
+
+class deco_buffered_palette_device : public device_t, public device_palette_interface
+{
+public:
+	// construction/destruction
+	deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries);
+	deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	// configuration
+//  void set_membits(int membits);
+//  void set_endianness(endianness_t endianness);
+	void set_entries(u32 entries) { m_entries = entries; }
+
+	// palette RAM accessors
+	memory_array &basemem() { return m_paletteram; }
+	memory_array &extmem() { return m_paletteram_ext; }
+
+	// raw entry reading
+	u32 read_entry(pen_t pen) const
+	{
+		u32 data = m_paletteram.read(pen);
+		if (m_paletteram_ext.base() != nullptr)
+			data |= m_paletteram_ext.read(pen) << (8 * m_paletteram.bytes_per_entry());
+		return data;
+	}
+
+	// generic read/write handlers
+	u8 read8(offs_t offset);
+	void write8(offs_t offset, u8 data);
+	void write8_ext(offs_t offset, u8 data);
+	u16 read16(offs_t offset);
+	void write16(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void write16_ext(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u32 read32(offs_t offset);
+	void write32(offs_t offset, u32 data, u32 mem_mask = ~0);
+
+	void dma_w(u8 data);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+
+	// device_palette_interface overrides
+	virtual u32 palette_entries() const noexcept override { return m_entries; }
+
+private:
+	void set_dirty_area(s32 offset);
+	rgb_t xbgr_888_decoder(u32 raw);
+
+	// configuration state
+	u32                     m_entries;              // number of entries in the palette
+//  u32                     m_indirect_entries;     // number of indirect colors in the palette
+//  bool                    m_enable_shadows;       // are shadows enabled?
+//  bool                    m_enable_highlights;    // are highlights enabled?
+//  int                     m_membits;              // width of palette RAM, if different from native
+//  bool                    m_membits_supplied;     // true if membits forced in static config
+//  endianness_t            m_endianness;           // endianness of palette RAM, if different from native
+//  bool                    m_endianness_supplied;  // true if endianness forced in static config
+
+	// palette RAM
+	memory_array            m_paletteram;           // base memory
+	memory_array            m_paletteram_ext;       // extended memory
+
+	// dirty flag
+	std::unique_ptr<bool[]> m_dirty;
+	s32                     m_dirty_start;
+	s32                     m_dirty_end;
+};
+
+#endif  // MAME_DATAEAST_DECO_BUFPAL_H

--- a/src/mame/dataeast/deco_bufpal.h
+++ b/src/mame/dataeast/deco_bufpal.h
@@ -13,8 +13,6 @@
 
 #pragma once
 
-#include "memarray.h"
-
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -27,36 +25,37 @@ class deco_buffered_palette_device : public device_t, public device_palette_inte
 {
 public:
 	// construction/destruction
-	deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries);
+	deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, u32 entries, endianness_t endianness);
 	deco_buffered_palette_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	// configuration
-//  void set_membits(int membits);
-//  void set_endianness(endianness_t endianness);
 	void set_entries(u32 entries) { m_entries = entries; }
 
-	// palette RAM accessors
-	memory_array &basemem() { return m_paletteram; }
-	memory_array &extmem() { return m_paletteram_ext; }
-
-	// raw entry reading
-	u32 read_entry(pen_t pen) const
-	{
-		u32 data = m_paletteram.read(pen);
-		if (m_paletteram_ext.base() != nullptr)
-			data |= m_paletteram_ext.read(pen) << (8 * m_paletteram.bytes_per_entry());
-		return data;
-	}
-
 	// generic read/write handlers
-	u8 read8(offs_t offset);
-	void write8(offs_t offset, u8 data);
-	void write8_ext(offs_t offset, u8 data);
-	u16 read16(offs_t offset);
-	void write16(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void write16_ext(offs_t offset, u16 data, u16 mem_mask = ~0);
 	u32 read32(offs_t offset);
 	void write32(offs_t offset, u32 data, u32 mem_mask = ~0);
+
+	template <bool IsLittleEndian> u16 read16(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 4;
+		return (read32(offset >> 1) >> shift) & 0xffff;
+	}
+	template <bool IsLittleEndian> void write16(offs_t offset, u16 data, u16 mem_mask = ~0)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0) << 4;
+		write32(offset >> 1, u32(data) << shift, u32(mem_mask) << shift);
+	}
+
+	template <bool IsLittleEndian> u8 read8(offs_t offset)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0, 2) << 3;
+		return (read32(offset >> 2) >> shift) & 0xff;
+	}
+	template <bool IsLittleEndian> void write8(offs_t offset, u8 data)
+	{
+		const u8 shift = BIT(IsLittleEndian ? offset : ~offset, 0, 2) << 3;
+		write32(offset >> 2, u32(data) << shift, u32(0xff) << shift);
+	}
 
 	void dma_w(u8 data);
 
@@ -72,23 +71,15 @@ private:
 	rgb_t xbgr_888_decoder(u32 raw);
 
 	// configuration state
-	u32                     m_entries;              // number of entries in the palette
-//  u32                     m_indirect_entries;     // number of indirect colors in the palette
-//  bool                    m_enable_shadows;       // are shadows enabled?
-//  bool                    m_enable_highlights;    // are highlights enabled?
-//  int                     m_membits;              // width of palette RAM, if different from native
-//  bool                    m_membits_supplied;     // true if membits forced in static config
-//  endianness_t            m_endianness;           // endianness of palette RAM, if different from native
-//  bool                    m_endianness_supplied;  // true if endianness forced in static config
+	u32                       m_entries;              // number of entries in the palette
 
 	// palette RAM
-	memory_array            m_paletteram;           // base memory
-	memory_array            m_paletteram_ext;       // extended memory
+	memory_share_creator<u32> m_paletteram;
 
 	// dirty flag
-	std::unique_ptr<bool[]> m_dirty;
-	s32                     m_dirty_start;
-	s32                     m_dirty_end;
+	std::unique_ptr<bool[]>   m_dirty;
+	s32                       m_dirty_start;
+	s32                       m_dirty_end;
 };
 
 #endif  // MAME_DATAEAST_DECO_BUFPAL_H

--- a/src/mame/dataeast/dragngun.cpp
+++ b/src/mame/dataeast/dragngun.cpp
@@ -622,7 +622,7 @@ void dragngun_state::common_map(address_map &map)
 	map(0x100000, 0x11ffff).ram();
 	map(0x120000, 0x127fff).rw(FUNC(dragngun_state::ioprot_r), FUNC(dragngun_state::ioprot_w)).umask32(0x0000ffff);
 	map(0x128000, 0x12800f).m(m_deco_irq, FUNC(deco_irq_device::map)).umask32(0x000000ff);
-	map(0x130000, 0x131fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write32)).share("palette");
+	map(0x130000, 0x131fff).rw(m_palette, FUNC(deco_buffered_palette_device::read32), FUNC(deco_buffered_palette_device::write32));
 	map(0x138008, 0x13800b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	//  0x2xxxxx Namco Zooming Sprites
@@ -1022,7 +1022,7 @@ void dragngun_state::dragngun(machine_config &config)
 	//I82750DB(config, m_i82750db, XTAL(25'000'000));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_dragngun);
-	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048, ENDIANNESS_LITTLE);
 
 	DECO146PROT(config, m_ioprot);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -1114,7 +1114,7 @@ void dragngun_state::lockload(machine_config &config)
 	BUFFERED_SPRITERAM32(config, m_spriteram);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_dragngun);
-	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048, ENDIANNESS_LITTLE);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);

--- a/src/mame/dataeast/dragngun.cpp
+++ b/src/mame/dataeast/dragngun.cpp
@@ -103,6 +103,7 @@ from Dragon Gun.
 
 #include "emu.h"
 
+#include "deco_bufpal.h"
 #include "deco_irq.h"
 #include "deco16ic.h"
 #include "deco146.h"
@@ -119,7 +120,6 @@ from Dragon Gun.
 #include "sound/ymopm.h"
 #include "video/bufsprite.h"
 
-#include "emupal.h"
 #include "screen.h"
 
 #include "speaker.h"
@@ -154,7 +154,6 @@ public:
 		, m_sprite_cliptable(*this, "spclip")
 		, m_sprite_indextable(*this, "spindex")
 		, m_rowscroll32(*this, "rowscroll32_%u", 1)
-		, m_paletteram(*this, "paletteram")
 		, m_io_inputs(*this, "INPUTS")
 		, m_io_light_x(*this, "LIGHT%u_X", 0U)
 		, m_io_light_y(*this, "LIGHT%u_Y", 0U)
@@ -194,9 +193,6 @@ protected:
 
 	template<int Chip> void rowscroll_w(offs_t offset, u32 data, u32 mem_mask = ~0);
 
-	void buffered_palette_w(offs_t offset, u32 data, u32 mem_mask = ~0);
-	void palette_dma_w(u32 data);
-
 	int sprite_bank_callback(int sprite);
 	u16 read_spritetile(int lookupram_offset);
 	u16 read_spriteformat(int spriteformatram_offset, u8 attr);
@@ -232,7 +228,7 @@ protected:
 	required_device<buffered_spriteram32_device> m_spriteram;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
-	optional_device<palette_device> m_palette;
+	optional_device<deco_buffered_palette_device> m_palette;
 	optional_device<deco_irq_device> m_deco_irq;
 	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<deco146_device> m_ioprot;
@@ -248,13 +244,11 @@ protected:
 
 	// we use the pointers below to store a 32-bit copy..
 	required_shared_ptr_array<u32, 4> m_rowscroll32;
-	optional_shared_ptr<u32> m_paletteram;
 
 	optional_ioport m_io_inputs;
 	optional_ioport_array<2> m_io_light_x;
 	optional_ioport_array<2> m_io_light_y;
 
-	std::unique_ptr<u8[]> m_dirty_palette{};
 	std::unique_ptr<u16[]> m_rowscroll[4]{};
 
 	u32 m_sprite_ctrl = 0U;
@@ -369,33 +363,8 @@ void dragngun_state::video_start()
 
 		save_pointer(NAME(m_rowscroll[i]), size, i);
 	}
-	m_dirty_palette = make_unique_clear<u8[]>(2048);
 
 	save_item(NAME(m_sprite_ctrl));
-	save_pointer(NAME(m_dirty_palette), 2048);
-}
-
-void dragngun_state::buffered_palette_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	COMBINE_DATA(&m_paletteram[offset]);
-	m_dirty_palette[offset] = 1;
-}
-
-void dragngun_state::palette_dma_w(u32 data)
-{
-	for (int i = 0; i < m_palette->entries(); i++)
-	{
-		if (m_dirty_palette[i])
-		{
-			m_dirty_palette[i] = 0;
-
-			const u8 b = (m_paletteram[i] >> 16) & 0xff;
-			const u8 g = (m_paletteram[i] >>  8) & 0xff;
-			const u8 r = (m_paletteram[i] >>  0) & 0xff;
-
-			m_palette->set_pen_color(i, rgb_t(r, g, b));
-		}
-	}
 }
 
 void dragngun_state::sprite_control_w(u32 data)
@@ -653,8 +622,8 @@ void dragngun_state::common_map(address_map &map)
 	map(0x100000, 0x11ffff).ram();
 	map(0x120000, 0x127fff).rw(FUNC(dragngun_state::ioprot_r), FUNC(dragngun_state::ioprot_w)).umask32(0x0000ffff);
 	map(0x128000, 0x12800f).m(m_deco_irq, FUNC(deco_irq_device::map)).umask32(0x000000ff);
-	map(0x130000, 0x131fff).ram().w(FUNC(dragngun_state::buffered_palette_w)).share(m_paletteram);
-	map(0x138008, 0x13800b).w(FUNC(dragngun_state::palette_dma_w));
+	map(0x130000, 0x131fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write32)).share("palette");
+	map(0x138008, 0x13800b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	//  0x2xxxxx Namco Zooming Sprites
 	map(0x204800, 0x204fff).ram().share(m_sprite_cliptable);// (all entries set to 320x256 here)
@@ -1053,7 +1022,7 @@ void dragngun_state::dragngun(machine_config &config)
 	//I82750DB(config, m_i82750db, XTAL(25'000'000));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_dragngun);
-	PALETTE(config, m_palette).set_entries(2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
 
 	DECO146PROT(config, m_ioprot);
 	m_ioprot->port_a_cb().set_ioport("INPUTS");
@@ -1145,7 +1114,7 @@ void dragngun_state::lockload(machine_config &config)
 	BUFFERED_SPRITERAM32(config, m_spriteram);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_dragngun);
-	PALETTE(config, m_palette).set_entries(2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);

--- a/src/mame/dataeast/fghthist.cpp
+++ b/src/mame/dataeast/fghthist.cpp
@@ -631,7 +631,7 @@ void fghthist_common_state::common_map(address_map &map)
 void fghthist_state::fghthist_common_map(address_map &map)
 {
 	common_map(map);
-	map(0x168000, 0x169fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write32)).share("palette");
+	map(0x168000, 0x169fff).rw(m_palette, FUNC(deco_buffered_palette_device::read32), FUNC(deco_buffered_palette_device::write32));
 	map(0x16c008, 0x16c00b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 	map(0x16c010, 0x16c013).r(FUNC(fghthist_state::unk_status_r));
 	map(0x178000, 0x179fff).rw(FUNC(fghthist_state::spriteram_r<0>), FUNC(fghthist_state::spriteram_w<0>));
@@ -951,7 +951,7 @@ void fghthist_state::fghthisto(machine_config &config)
 	m_screen->set_screen_update(FUNC(fghthist_state::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fghthist);
-	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048, ENDIANNESS_LITTLE);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);

--- a/src/mame/dataeast/fghthist.cpp
+++ b/src/mame/dataeast/fghthist.cpp
@@ -631,8 +631,8 @@ void fghthist_common_state::common_map(address_map &map)
 void fghthist_state::fghthist_common_map(address_map &map)
 {
 	common_map(map);
-	map(0x168000, 0x169fff).ram().w(FUNC(fghthist_state::buffered_palette_w)).share(m_paletteram);
-	map(0x16c008, 0x16c00b).w(FUNC(fghthist_state::palette_dma_w));
+	map(0x168000, 0x169fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write32)).share("palette");
+	map(0x16c008, 0x16c00b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 	map(0x16c010, 0x16c013).r(FUNC(fghthist_state::unk_status_r));
 	map(0x178000, 0x179fff).rw(FUNC(fghthist_state::spriteram_r<0>), FUNC(fghthist_state::spriteram_w<0>));
 	map(0x17c010, 0x17c013).w(FUNC(fghthist_state::buffer_spriteram_w<0>));
@@ -951,7 +951,7 @@ void fghthist_state::fghthisto(machine_config &config)
 	m_screen->set_screen_update(FUNC(fghthist_state::screen_update));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_fghthist);
-	PALETTE(config, m_palette).set_entries(2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x32);

--- a/src/mame/dataeast/fghthist.h
+++ b/src/mame/dataeast/fghthist.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "deco_bufpal.h"
 #include "deco104.h"
 #include "deco146.h"
 #include "deco16ic.h"
@@ -19,7 +20,6 @@
 #include "sound/okim6295.h"
 #include "sound/ymopm.h"
 
-#include "emupal.h"
 #include "screen.h"
 
 
@@ -92,7 +92,6 @@ public:
 		: fghthist_common_state(mconfig, type, tag)
 		, m_palette(*this, "palette")
 		, m_soundlatch(*this, "soundlatch")
-		, m_paletteram(*this, "paletteram")
 		, m_io_in(*this, "IN%u", 0U)
 	{ }
 
@@ -106,22 +105,15 @@ protected:
 	virtual void video_start() override ATTR_COLD;
 
 private:
-	required_device<palette_device> m_palette;
+	required_device<deco_buffered_palette_device> m_palette;
 	optional_device<generic_latch_8_device> m_soundlatch;
 
-	required_shared_ptr<u32> m_paletteram;
-
 	required_ioport_array<2> m_io_in;
-
-	std::unique_ptr<u8[]> m_dirty_palette{};
 
 //  void sound_w(u32 data);
 	u32 unk_status_r();
 
 	void allocate_buffered_palette();
-
-	void buffered_palette_w(offs_t offset, u32 data, u32 mem_mask = ~0);
-	void palette_dma_w(u32 data);
 
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 

--- a/src/mame/dataeast/fghthist_v.cpp
+++ b/src/mame/dataeast/fghthist_v.cpp
@@ -12,34 +12,6 @@ void fghthist_common_state::pri_w(u32 data)
 
 /******************************************************************************/
 
-/* Later games have double buffered paletteram - the real palette ram is
-only updated on a DMA call */
-
-void fghthist_state::buffered_palette_w(offs_t offset, u32 data, u32 mem_mask)
-{
-	COMBINE_DATA(&m_paletteram[offset]);
-	m_dirty_palette[offset] = 1;
-}
-
-void fghthist_state::palette_dma_w(u32 data)
-{
-	for (int i = 0; i < m_palette->entries(); i++)
-	{
-		if (m_dirty_palette[i])
-		{
-			m_dirty_palette[i] = 0;
-
-			const u8 b = (m_paletteram[i] >> 16) & 0xff;
-			const u8 g = (m_paletteram[i] >>  8) & 0xff;
-			const u8 r = (m_paletteram[i] >>  0) & 0xff;
-
-			m_palette->set_pen_color(i, rgb_t(r, g, b));
-		}
-	}
-}
-
-/******************************************************************************/
-
 // sprite and BG2/3 color banks are changeable at run time
 void nslasher_state::tilemap_color_bank_w(u8 data)
 {
@@ -84,9 +56,6 @@ void fghthist_state::video_start()
 {
 	fghthist_common_state::allocate_spriteram(0);
 	fghthist_common_state::video_start();
-
-	m_dirty_palette = make_unique_clear<u8[]>(2048);
-	save_pointer(NAME(m_dirty_palette), 2048);
 }
 
 void nslasher_state::video_start()

--- a/src/mame/dataeast/rohga.cpp
+++ b/src/mame/dataeast/rohga.cpp
@@ -638,7 +638,7 @@ void rohga_state::rohga_map(address_map &map)
 	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
-	map(0x3e0000, 0x3e1fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x3e0000, 0x3e1fff).rw(m_palette, FUNC(deco_buffered_palette_device::read16<false>), FUNC(deco_buffered_palette_device::write16<false>));
 	map(0x3f0000, 0x3f3fff).ram(); // Main RAM
 }
 
@@ -668,7 +668,7 @@ void rohga_state::wizdfire_map(address_map &map)
 	map(0x360000, 0x3607ff).ram().share("spriteram2");
 	map(0x370000, 0x370001).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write)); // Triggers DMA for spriteram
 
-	map(0x380000, 0x381fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x380000, 0x381fff).rw(m_palette, FUNC(deco_buffered_palette_device::read16<false>), FUNC(deco_buffered_palette_device::write16<false>));
 	map(0x390008, 0x390009).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	map(0xfdc000, 0xfe3fff).ram();
@@ -703,7 +703,7 @@ void rohga_state::nitrobal_map(address_map &map)
 	map(0x360000, 0x3607ff).ram().share("spriteram2");
 	map(0x370000, 0x370001).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write)); // Triggers DMA for spriteram
 
-	map(0x380000, 0x381fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x380000, 0x381fff).rw(m_palette, FUNC(deco_buffered_palette_device::read16<false>), FUNC(deco_buffered_palette_device::write16<false>));
 	map(0x390008, 0x390009).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	map(0xfec000, 0xff3fff).ram();
@@ -739,7 +739,7 @@ void rohga_state::hotb_base_map(address_map &map)
 	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
-	map(0x3e0000, 0x3e1fff).mirror(0x2000).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x3e0000, 0x3e1fff).mirror(0x2000).rw(m_palette, FUNC(deco_buffered_palette_device::read16<false>), FUNC(deco_buffered_palette_device::write16<false>));
 }
 
 void rohga_state::schmeisr_map(address_map &map)
@@ -1331,7 +1331,7 @@ void rohga_state::rohga_base(machine_config &config)
 	screen.set_size(40*8, 32*8);
 	screen.set_visarea(0*8, 40*8-1, 1*8, 31*8-1);
 
-	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048, ENDIANNESS_BIG);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x64);

--- a/src/mame/dataeast/rohga.cpp
+++ b/src/mame/dataeast/rohga.cpp
@@ -117,6 +117,7 @@
 
 #include "emu.h"
 
+#include "deco_bufpal.h"
 #include "deco104.h"
 #include "deco146.h"
 #include "deco16ic.h"
@@ -129,7 +130,6 @@
 #include "sound/ymopm.h"
 #include "video/bufsprite.h"
 
-#include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
 
@@ -151,7 +151,6 @@ public:
 		m_oki(*this, "oki%u", 1),
 		m_spriteram(*this, "spriteram%u", 1),
 		m_sprgen(*this, "spritegen%u", 1),
-		m_paletteram(*this, "paletteram"),
 		m_rowscroll(*this, "rowscroll_%u", 1)
 	{ }
 
@@ -174,24 +173,20 @@ protected:
 private:
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
-	required_device<palette_device> m_palette;
+	required_device<deco_buffered_palette_device> m_palette;
 	required_device<deco_146_base_device> m_ioprot;
 	required_device_array<deco16ic_device, 2> m_tilegen;
 	required_device_array<okim6295_device, 2> m_oki;
 	optional_device_array<buffered_spriteram16_device, 2> m_spriteram;
 	optional_device_array<decospr_device, 2> m_sprgen;
 
-	required_shared_ptr<u16> m_paletteram;
 	optional_shared_ptr_array<u16, 4> m_rowscroll;
 
-	std::unique_ptr<u8[]> m_dirty_palette{};
 	u16 m_priority = 0;
 
 	u16 irq_ack_r();
 	void irq_ack_w(u16 data);
 	void rohga_buffer_spriteram16_w(u16 data);
-	void buffered_palette_w(offs_t offset, u16 data, u16 mem_mask = ~0);
-	void palette_dma_w(u16 data = 0);
 	void priority_w(u16 data);
 	void sound_bankswitch_w(u8 data);
 
@@ -230,11 +225,7 @@ void rohga_state::machine_reset()
 
 void rohga_state::video_start()
 {
-	const int entry = m_palette->entries();
-	m_dirty_palette = make_unique_clear<u8[]>(entry);
-
 	save_item(NAME(m_priority));
-	save_pointer(NAME(m_dirty_palette), entry);
 }
 
 void rohga_state::rohga_buffer_spriteram16_w(u16 data)
@@ -242,32 +233,6 @@ void rohga_state::rohga_buffer_spriteram16_w(u16 data)
 	// Spriteram seems to be triple buffered (no sprite lag on real PCB, but there
 	// is on driver with only double buffering)
 	m_spriteram[0]->copy();
-}
-
-void rohga_state::buffered_palette_w(offs_t offset, u16 data, u16 mem_mask)
-{
-	COMBINE_DATA(&m_paletteram[offset]);
-
-	m_dirty_palette[offset / 2] = 1;
-}
-
-void rohga_state::palette_dma_w(u16 data)
-{
-	const int m = m_palette->entries();
-
-	for (int i = 0; i < m; i++)
-	{
-		if (m_dirty_palette[i])
-		{
-			m_dirty_palette[i] = 0;
-
-			const u8 b = (m_paletteram[i * 2] >> 0) & 0xff;
-			const u8 g = (m_paletteram[i * 2 + 1] >> 8) & 0xff;
-			const u8 r = (m_paletteram[i * 2 + 1] >> 0) & 0xff;
-
-			m_palette->set_pen_color(i, rgb_t(r, g, b));
-		}
-	}
 }
 
 void rohga_state::priority_w(u16 data)
@@ -657,7 +622,7 @@ void rohga_state::rohga_map(address_map &map)
 
 	map(0x300000, 0x300001).w(FUNC(rohga_state::rohga_buffer_spriteram16_w)); // write 1 for sprite DMA
 	map(0x310000, 0x310009).nopw(); // Palette control?
-	map(0x31000a, 0x31000b).w(FUNC(rohga_state::palette_dma_w)); // Write 1111 for DMA?  (Or any value?)
+	map(0x31000a, 0x31000b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w)); // Write 1111 for DMA?  (Or any value?)
 	map(0x320000, 0x320001).nopw(); // ?
 	map(0x322000, 0x322001).w(FUNC(rohga_state::priority_w));
 	map(0x321100, 0x321101).r(FUNC(rohga_state::irq_ack_r)); // IRQ ack?  Value not used
@@ -673,7 +638,7 @@ void rohga_state::rohga_map(address_map &map)
 	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
-	map(0x3e0000, 0x3e1fff).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
+	map(0x3e0000, 0x3e1fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
 	map(0x3f0000, 0x3f3fff).ram(); // Main RAM
 }
 
@@ -703,8 +668,8 @@ void rohga_state::wizdfire_map(address_map &map)
 	map(0x360000, 0x3607ff).ram().share("spriteram2");
 	map(0x370000, 0x370001).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write)); // Triggers DMA for spriteram
 
-	map(0x380000, 0x381fff).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
-	map(0x390008, 0x390009).w(FUNC(rohga_state::palette_dma_w));
+	map(0x380000, 0x381fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x390008, 0x390009).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	map(0xfdc000, 0xfe3fff).ram();
 	map(0xfe4000, 0xfe7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
@@ -738,8 +703,8 @@ void rohga_state::nitrobal_map(address_map &map)
 	map(0x360000, 0x3607ff).ram().share("spriteram2");
 	map(0x370000, 0x370001).w(m_spriteram[1], FUNC(buffered_spriteram16_device::write)); // Triggers DMA for spriteram
 
-	map(0x380000, 0x381fff).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
-	map(0x390008, 0x390009).w(FUNC(rohga_state::palette_dma_w));
+	map(0x380000, 0x381fff).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
+	map(0x390008, 0x390009).w(m_palette, FUNC(deco_buffered_palette_device::dma_w));
 
 	map(0xfec000, 0xff3fff).ram();
 	map(0xff4000, 0xff7fff).rw(FUNC(rohga_state::ioprot_r), FUNC(rohga_state::ioprot_w)); // Protection device
@@ -759,7 +724,7 @@ void rohga_state::hotb_base_map(address_map &map)
 	map(0x300000, 0x300001).portr("DSW3").w(FUNC(rohga_state::rohga_buffer_spriteram16_w)); // write 1 for sprite DMA
 	map(0x310002, 0x310003).portr("SYSTEM");
 	map(0x310000, 0x310009).nopw(); // Palette control?
-	map(0x31000a, 0x31000b).w(FUNC(rohga_state::palette_dma_w)); // Write 1111 for DMA?  (Or any value?)
+	map(0x31000a, 0x31000b).w(m_palette, FUNC(deco_buffered_palette_device::dma_w)); // Write 1111 for DMA?  (Or any value?)
 	map(0x320000, 0x320001).nopw(); // bit 4: cleared on IRQ routine start, set on end
 	map(0x322000, 0x322001).w(FUNC(rohga_state::priority_w));
 	map(0x321100, 0x321101).w(FUNC(rohga_state::irq_ack_w));  // IRQ ack?  Value not used
@@ -774,7 +739,7 @@ void rohga_state::hotb_base_map(address_map &map)
 	map(0x3ce000, 0x3cefff).mirror(0x1000).ram().share(m_rowscroll[3]);
 
 	map(0x3d0000, 0x3d07ff).ram().share("spriteram1");
-	map(0x3e0000, 0x3e1fff).mirror(0x2000).ram().w(FUNC(rohga_state::buffered_palette_w)).share(m_paletteram);
+	map(0x3e0000, 0x3e1fff).mirror(0x2000).ram().w(m_palette, FUNC(deco_buffered_palette_device::write16)).share("palette");
 }
 
 void rohga_state::schmeisr_map(address_map &map)
@@ -1366,7 +1331,7 @@ void rohga_state::rohga_base(machine_config &config)
 	screen.set_size(40*8, 32*8);
 	screen.set_visarea(0*8, 40*8-1, 1*8, 31*8-1);
 
-	PALETTE(config, m_palette).set_entries(2048);
+	DECO_BUFFERED_PALETTE(config, m_palette, 0, 2048);
 
 	DECO16IC(config, m_tilegen[0]);
 	m_tilegen[0]->set_size<0>(deco16ic_device::DECO_64x64);


### PR DESCRIPTION
dataeast/rohga.cpp, dataeast/dragngun.cpp, dataeast/fghthist.cpp:
- Convert buffered palette hardware emulation into dataeast/deco_bufpal.cpp device