### PR TITLE
williams/seattle.cpp: Advance simulated wheel motor at a fixed time-based rate

### DIFF
--- a/src/mame/williams/seattle.cpp
+++ b/src/mame/williams/seattle.cpp
@@ -261,6 +261,10 @@ namespace {
 // Widget interrupts
 #define WINT_ETHERNET_SHIFT (2)
 
+// Simulated wheel motor speed, in ADC counts per second. The real motor
+// sweeps the wheel lock to lock (256 counts) in well under a second.
+#define WHEEL_MOTOR_SPEED   (512)
+
 /*************************************
 *  Structures
 *************************************/
@@ -396,6 +400,7 @@ private:
 	int8_t m_wheel_force = 0;
 	int m_wheel_offset = 0;
 	bool m_wheel_calibrated = false;
+	attotime m_wheel_last_update;
 
 	uint32_t interrupt_state_r();
 	uint32_t interrupt_state2_r();
@@ -426,6 +431,7 @@ private:
 	void widget_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void i40_w(uint32_t data);
 	void wheel_board_w(offs_t offset, uint32_t data);
+	void wheel_update();
 
 	void ide_interrupt(int state);
 	void vblank_assert(int state);
@@ -483,7 +489,10 @@ void seattle_state::machine_start()
 	save_item(NAME(m_output_mode));
 	save_item(NAME(m_i40_data));
 	save_item(NAME(m_gear));
+	save_item(NAME(m_wheel_force));
+	save_item(NAME(m_wheel_offset));
 	save_item(NAME(m_wheel_calibrated));
+	save_item(NAME(m_wheel_last_update));
 }
 
 
@@ -497,6 +506,7 @@ void seattle_state::machine_reset()
 	m_wheel_force = 0;
 	m_wheel_offset = 0;
 	m_wheel_calibrated = false;
+	m_wheel_last_update = attotime::zero;
 	m_ethernet_irq_num = 0;
 
 	// reset either the DCS2 board or the CAGE board
@@ -691,17 +701,40 @@ uint32_t seattle_state::analog_port_r()
 }
 
 
+// Simulate the movement of the motorized steering wheel. The wheel moves
+// at a fixed rate for as long as the game applies motor force, so the
+// sweep is independent of how often the game samples the ADC. Called on
+// every ADC access and whenever the commanded force changes.
+void seattle_state::wheel_update()
+{
+	attotime const now = machine().time();
+	if (!m_wheel_calibrated && ((m_wheel_force > 20) || (m_wheel_force < -20)))
+	{
+		// consume whole steps only, carrying the remainder forward
+		int64_t const steps = (now - m_wheel_last_update).as_ticks(WHEEL_MOTOR_SPEED);
+		if (steps > 0)
+		{
+			m_wheel_last_update += attotime::from_ticks(steps, WHEEL_MOTOR_SPEED);
+			if (m_wheel_force > 0)
+				m_wheel_offset = std::min<int64_t>(m_wheel_offset + steps, 128);
+			else
+				m_wheel_offset = std::max<int64_t>(m_wheel_offset - steps, -128);
+		}
+	}
+	else
+	{
+		m_wheel_last_update = now;
+	}
+}
+
 void seattle_state::analog_port_w(uint32_t data)
 {
 	if (data < 8 || data > 15)
 		logerror("%08X:Unexpected analog port select = %08X\n", m_maincpu->pc(), data);
 	int index = data & 7;
 	uint8_t currValue = m_io_analog[index].read_safe(0);
+	wheel_update();
 	if (!m_wheel_calibrated && ((m_wheel_force > 20) || (m_wheel_force < -20))) {
-		if (m_wheel_force > 0 && m_wheel_offset < 128)
-			m_wheel_offset++;
-		else if (m_wheel_offset > -128)
-			m_wheel_offset--;
 		int tmpVal = int(currValue) + m_wheel_offset;
 		if (tmpVal < m_io_analog[index]->field(0xff)->minval())
 			m_pending_analog_read = m_io_analog[index]->field(0xff)->minval();
@@ -745,6 +778,7 @@ void seattle_state::wheel_board_w(offs_t offset, uint32_t data)
 		else
 		{
 			m_wheel_driver = arg; // target wheel angle. signed byte.
+			wheel_update(); // integrate elapsed time at the previous force
 			m_wheel_force = int8_t(arg);
 		}
 	}
@@ -981,6 +1015,7 @@ void seattle_state::output_w(uint32_t data)
 
 			case 0x04:
 				m_wheel_motor = arg; // wheel motor delta. signed byte.
+				wheel_update(); // integrate elapsed time at the previous force
 				m_wheel_force = int8_t(~arg);
 				//logerror("wheel_board_w: data = %08x op: %02x arg: %02x\n", data, op, arg);
 				break;


### PR DESCRIPTION
### What this fixes

On a small fraction of clean-NVRAM boots (observed anywhere from ~1/20 to ~1/700 depending on host/config), `sfrush` / `sfrushrk` stop during the steering wheel power-on self test like:

<img width="511" height="444" alt="issueB-post-failure-red-text" src="https://github.com/user-attachments/assets/35ee709f-ac63-4e2b-ac61-72ac988082e9" />


(And waits for the Abort button forever)
On a real cabinet this screen means a broken wheel motor; under emulation the "motor" is the wheel simulation in this driver.

### Root cause

The simulated motorized wheel moved 1 ADC count per ADC select write (`analog_port_w`), only while the game applies motor force. How fast the wheel sweeps was therefore a function of how often the game happens to poll the ADC bank, which varies with boot timing. The game's wheel POST drives the motor one way for 180 frames, then the other way for 180 frames, and requires the observed pot sweep to reach the wheel's expected range; when boot timing yielded a low polling rate, the sweep came up short (the original report captured a failing sweep of 109 counts against the 0x10-0xf0 = 224 count travel) and the POST failed.

### The fix

Make the wheel move at a fixed rate in emulated time, independent of ADC polling: 512 ADC counts per second, i.e. full lock-to-lock (256 counts) in 0.5s. The real motor slams lock to lock in well under a second, and the POST windows are ~3s each, so there is ample margin.

Implementation: a small `wheel_update()` helper integrates elapsed `machine().time()` into the wheel offset (whole counts, remainder carried exactly) while force is applied and calibration has not finished. It is called from the ADC access path and from both wheel force outputs (`wheel_board_w` and `output_w` case 4) before the force changes, so each interval is integrated at the force that was actually commanded during it. Force thresholds, saturation bounds, the `m_wheel_calibrated` semantics (simulation stops after the first SYSTEM-port button press) and the sign conventions of both output paths are unchanged.

Also registers the wheel simulation state in save states (`m_wheel_force` / `m_wheel_offset` were previously not saved).

### Reproduction

Statistical only (the trigger is boot-timing sensitive; the ioasic seeds timing from the host clock, so back-to-back runs differ):

```sh
# snap.lua: periodic screenshots for headless pass/fail detection
cat > snap.lua <<'EOF'
local frame = 0
snap_sub = emu.add_machine_frame_notifier(function()
    frame = frame + 1
    if frame % 600 == 0 then manager.machine.video:snapshot() end
end)
EOF

# repeated clean-state boots; MALLOC_PERTURB_=255 pins the heap so the
# unrelated gt64xxx uninitialized-register bug cannot interfere
for i in $(seq 1 60); do
    rm -rf nvram/* cfg/* diff/* snap/*
    MALLOC_PERTURB_=255 mame sfrushrk -video none -sound none -nothrottle \
        -autoboot_script snap.lua -seconds_to_run 90
done
```

A boot that reached attract yields large (~200KB) snapshots; a POST failure shows the red-text screen (~8KB snapshots). On the failure screen, pressing Start 1 ("Abort") resumes boot, confirming it is the game's documented wait-for-Abort path rather than a hang.

### Evidence

* Wheel POST diagnostic (visible during clean-NVRAM boot): with the fix, the on-screen wheel pot readout sweeps `0x12 .. 0xF0` (222 of 224 counts, essentially full travel) well inside the test window, every boot.
* Soak: 50/50 consecutive clean-NVRAM `sfrushrk` boots reached attract with no red-text screen (`MALLOC_PERTURB_=255`, 90 emulated seconds each). Before the fix, the wheel sweep only completed if the game's ADC polling rate happened to be high enough; failure rates between ~1/20 and ~1/700 boots were observed across hosts in the original report (91 baseline boots on this particular host showed none, which is consistent with the low end of that range).
* In-game steering verified after the change: coin up, start a race, steer hard left / hard right / center via the paddle input; the car responds correctly (screenshot-verified at each step).
* Save/load smoke test: state saved mid-POST (wheel simulation active) and restored later in the same session; boot continued to attract.

### Testing scope / notes

* Runtime tested with `sfrushrk`. `sfrush` shares the same `wheel_board_w` path and POST. Note that I included the `output_w` case 4 path (widget-board games, `calspeed` / `hyprdriv`), as well, but I didn't explicitly test its behavior. If desired, I can remove from this path. It only differs while the wheel is uncalibrated and force is applied, as before, so it should be safe to include.
* `vegas.cpp` contains a copy of the same per-read wheel simulation pattern (`sf2049` family); it is intentionally left untouched here to keep this change scoped to the driver it was reproduced and tested on.

### AI Use Disclosure

I have partially debugged, and written some of these modifications with AI (Claude Fable 5) to assist with debug and development. All AI-produced output has been manually reviewed by myself.