### PR TITLE
machine/gt64xxx.cpp: Initialize register file and timer state at reset

### DIFF
--- a/src/devices/machine/gt64xxx.cpp
+++ b/src/devices/machine/gt64xxx.cpp
@@ -267,6 +267,11 @@ void gt64xxx_device::device_reset()
 {
 	pci_device::device_reset();
 
+	// clear the whole register file first; the chip powers up with everything
+	// cleared and software relies on that when it read-modify-writes registers
+	// it never fully initializes (e.g. interrupt mask, timer control)
+	std::fill(std::begin(m_reg), std::end(m_reg), 0);
+
 	// Configuration register defaults
 	m_reg[GREG_CPU_CONFIG] = m_be ? 0 : (1<<12);
 	m_reg[GREG_R1_0_LO] = 0x0;
@@ -315,6 +320,14 @@ void gt64xxx_device::device_reset()
 	m_retry_count = 0;
 	m_pci_cpu_stalled = 0;
 	m_stall_windex = 0;
+
+	// stop the countdown timers
+	for (galileo_timer &timer : m_timer)
+	{
+		timer.count = 0;
+		timer.active = 0;
+		timer.timer->adjust(attotime::never);
+	}
 
 	m_dma_active = 0;
 	m_dma_timer->adjust(attotime::never);


### PR DESCRIPTION
### What this fixes

On a small fraction of process invocations (~0.5-1%, heap dependent), `sfrushrk` and other GT-64010 based Atari GUTS games (`seattle.cpp` Rush family) hang at boot with a black screen forever, with the CPU stuck in the game's interrupt handler. Recorded-input playback cannot reproduce it because the trigger is host heap contents, not emulated state.

### Root cause

`gt64xxx_device` never initializes its register file `m_reg[0xd00/4]` or the countdown timer state (`m_timer[].count` / `.active`). `device_reset()` only sets ~30 documented registers (address decode windows, CPU config, PCI command), so for everything else, e.g. `GREG_INTR_CAUSE`, `GREG_CPU_MASK`, `GREG_TIMER_CONTROL` and the `GREG_TIMERx_COUNT` registers, whatever the heap allocator returned becomes the chip's power-on state. On real hardware these registers power up cleared and software relies on that.

The failure chain on `sfrushrk` (GUTS OS): ~2.2s into boot the game sets up its 1kHz tick on Galileo timer 3 using read-modify-writes (`CPU_MASK |= T3EXP`, `TIMER_CONTROL |= EnTC3|SelTC3`), inheriting every garbage bit. The `GREG_TIMER_CONTROL` write handler then arms every timer whose garbage `EnTC` bit is set, with garbage counts (24-bit timers expire within 0.34s at 50MHz). When one expires, its `T*EXP` cause bit latches; the game's handler only ever acks T3EXP, so a garbage-unmasked T0/T1/T2EXP keeps the IRQ asserted and the dispatch loop spins forever. Garbage `m_timer[].active` could also silently prevent a legitimate timer from ever being armed, since arming is gated on `!timer->active`.

### The fix

In `device_reset()`:
* clear the whole register file first, then apply the existing documented defaults unchanged (registers MAME already initialized behave byte-identically to before);
* clear `count`/`active` and cancel the four countdown timers (matching the existing `m_dma_timer` treatment).

No headers touched; behavior for every register previously initialized is unchanged. Zero-fill reproduces the real chip's cleared power-on state, i.e. every run now behaves like the previously-lucky case of the device object landing on fresh (zeroed) pages.

### Reproduction (deterministic, glibc hosts)

glibc's `MALLOC_PERTURB_=N` fills malloc'd chunks with byte `N ^ 0xff`, turning the heap lottery into a switch:

```sh
# 0xd5 fill: garbage arms timers and unmasks T2EXP -> hung every run before the fix
MALLOC_PERTURB_=42 mame sfrushrk
# 0x00 fill: equivalent to real cleared power-on state -> always booted, before and after
MALLOC_PERTURB_=255 mame sfrushrk
```

With the bad fill, the screen stays black forever (only the lamp artwork renders) and no input helps; healthy boots show the self test and reach attract in ~20 seconds. Add `-video none -sound none -nothrottle -seconds_to_run 90` plus a periodic-screenshot script for headless soak testing (snapshot size ~4.7KB black vs ~200KB attract).

### Evidence

Wedge fingerprint before the fix (1Hz Lua trace of PC + Galileo regs, `MALLOC_PERTURB_=42`, registers at physical 0x0c000000):

```
frame  60: pc=80001570 cause=d5d5d5d5 mask=d5d5d5d5 tctl=d5d5d5d5   <- heap fill visible end to end
frame 180: pc=800b3220 cause=40000001 mask=1415ddd4 tctl=d5d5d5d5   <- (0xd5d5d5d5|0x800)&0x3c1ffffe
frame 5400: pc=80081f84 cause=40000401 mask=1415ddd4                <- T2EXP latched, PC looping, screen black
```

After the fix, same command:

```
frame  60: pc=80001570 cause=00000000 mask=00000000 tctl=00000000   <- cleared power-on state
frame 180: pc=800b3220 cause=40000001 mask=00000800 tctl=000000c0   <- only T3EXP masked in, tick armed
game reaches attract
```

Results (90 emulated seconds per boot, clean NVRAM, pass = attract):

| Test | Before | After |
|---|---|---|
| `MALLOC_PERTURB_=42` x10 | 0/10 (black screen) | 10/10 |
| `MALLOC_PERTURB_` sweep 1,85,128,170,213,255 | n/t | 6/6 |
| natural boots (no perturb) | ~5 wedges in ~700 (per original triage) | 2/2 spot checks |

### Testing scope / notes

* Runtime tested with `sfrushrk` (ROM set + CHD); other GT64010 (`seattle.cpp` family) and GT64111 (`atlantis.cpp`) users get the same zero power-on state, which matches the previously-common fresh-page case, and all their previously-initialized registers are untouched.

### AI Use Disclosure

I have partially debugged, and written some of these modifications with AI (Claude Fable 5) to assist with debug and development. All AI-produced output has been manually reviewed by myself.