### PR TITLE
Update release date for the latest Cruis'n Exotica version

### DIFF
--- a/src/mame/williams/midzeus.cpp
+++ b/src/mame/williams/midzeus.cpp
@@ -20,7 +20,7 @@ As of 2/12/2001 the latest software levels:
 
 Game Title       Level  Released
 ----------------------------------
-Cruis'n Exotica  v2.4   08/23/2000
+Cruis'n Exotica  v2.4   08/31/2000
 Invasion         v5.0   12/14/1999
 The Grid         v1.2   10/18/2000
 


### PR DESCRIPTION
According to a Midway service bulletin, the release date of Cruis'n Exotica v2.4 is actually 08.31.2000 https://arcarc.xmission.com/PDF_Misc/Midway%20Software%20Versions%20as%20of%2002-12-2001.pdf