### PR TITLE
swim1.cpp: Set long cell error only when synched

### DIFF
--- a/src/devices/machine/swim1.cpp
+++ b/src/devices/machine/swim1.cpp
@@ -1059,8 +1059,17 @@ void swim1_device::ism_sync()
 			// Actually resolve the cell lengths according to the counts
 			int resolved_ls_count = 0;
 			int resolved_ls_type[2] = { 0, 0 };
-			if((sct == 4 || lct == 4) && !m_ism_error)
-				m_ism_error |= 0x20;
+
+			if(sct == 4 || lct == 4) {
+				// Slightly-over-RPT gaps (~5 µs on HD MFM) show up on real
+				// MOOF/MFI captures around write splices. Latching sticky 
+				// error 0x20 aborts and retries the whole sector. Only latch 
+				// long cell errors when synchronized to avoid this.
+				if(m_ism_csm_state == CSM_SYNCHRONIZED) {
+					if(!m_ism_error)
+						m_ism_error |= 0x20;
+				}
+			}
 
 			if(will_hit_edge) {
 				if(sct == 0) {


### PR DESCRIPTION
I was converting some of my DSHD Mac floppies to moof and MFI, but when I tried to run them on a SWIM1 device, like `macse30` I got "unreadable disk" errors. Converting the dumps to IMG made them work.

I think I figured out the reason, being that the dumps have some slightly too long cell lengths around write splices. There's already a comment in the source about too short ones causing issues, so the "too short" error has been overridden already. These don't happen on perfect timing IMGs as far as I know.

I know way too little about the SWIM to come up with a real fix, but am happy for input if this looks too dumb.