### PR TITLE
cv1k.cpp : Remove outdated TODO about video timings

### DIFF
--- a/src/mame/cave/cv1k.cpp
+++ b/src/mame/cave/cv1k.cpp
@@ -186,7 +186,6 @@ Remaining Video issues
 
 Timing
  - Experimental SH7709S cache/memory timing
- - Requires to measure screen raw params for correct video timing?
 
 Removed games
  - 31/12/2021, Akai Katana and Dodonpachi Saidaioujou were removed at the request of the current


### PR DESCRIPTION
The raw screen params mentioned by this TODO was addressed by: https://github.com/mamedev/mame/commit/5b249e70145c9518485ca52513c3dacff5ee083a