### PR TITLE
psx.cpp: wrap CLUT fetch at the right edge of VRAM

### DIFF
--- a/src/devices/video/psx.cpp
+++ b/src/devices/video/psx.cpp
@@ -954,7 +954,8 @@ void psxgpu_device::decode_tpage( uint32_t tpage )
 #define TEXTURESETUP \
 	int n_tx = m_n_tx; \
 	int n_ty = m_n_ty; \
-	uint16_t *p_clut = p_p_vram[ n_cluty ] + n_clutx; \
+	uint16_t *p_clut_base = p_p_vram[ n_cluty ]; \
+	int n_clut_x = n_clutx; \
 	switch( n_tp ) \
 	{ \
 	case 0: \
@@ -1038,11 +1039,11 @@ void psxgpu_device::decode_tpage( uint32_t tpage )
 
 #define TEXTURE4BIT( TXV, TXU ) \
 	TEXTURE_LOOP \
-		uint16_t n_bgr = p_clut[ ( *( p_p_vram[ n_ty + TXV ] + n_tx + ( TXU >> 2 ) ) >> ( ( TXU & 0x03 ) << 2 ) ) & 0x0f ];
+		uint16_t n_bgr = p_clut_base[ ( n_clut_x + ( ( *( p_p_vram[ n_ty + TXV ] + n_tx + ( TXU >> 2 ) ) >> ( ( TXU & 0x03 ) << 2 ) ) & 0x0f ) ) & 1023 ];
 
 #define TEXTURE8BIT( TXV, TXU ) \
 	TEXTURE_LOOP \
-		uint16_t n_bgr = p_clut[ ( *( p_p_vram[ n_ty + TXV ] + n_tx + ( TXU >> 1 ) ) >> ( ( TXU & 0x01 ) << 3 ) ) & 0xff ];
+		uint16_t n_bgr = p_clut_base[ ( n_clut_x + ( ( *( p_p_vram[ n_ty + TXV ] + n_tx + ( TXU >> 1 ) ) >> ( ( TXU & 0x01 ) << 3 ) ) & 0xff ) ) & 1023 ];
 
 #define TEXTURE15BIT( TXV, TXU ) \
 	TEXTURE_LOOP \
@@ -1056,13 +1057,13 @@ void psxgpu_device::decode_tpage( uint32_t tpage )
 	TEXTURE_LOOP \
 		int n_xi = ( ( TXU >> 2 ) & ~0x3c ) + ( ( TXV << 2 ) & 0x3c ); \
 		int n_yi = ( TXV & ~0xf ) + ( ( TXU >> 4 ) & 0xf ); \
-		uint16_t n_bgr = p_clut[ ( *( p_p_vram[ n_ty + n_yi ] + n_tx + n_xi ) >> ( ( TXU & 0x03 ) << 2 ) ) & 0x0f ];
+		uint16_t n_bgr = p_clut_base[ ( n_clut_x + ( ( *( p_p_vram[ n_ty + n_yi ] + n_tx + n_xi ) >> ( ( TXU & 0x03 ) << 2 ) ) & 0x0f ) ) & 1023 ];
 
 #define TEXTUREINTERLEAVED8BIT( TXV, TXU ) \
 	TEXTURE_LOOP \
 		int n_xi = ( ( TXU >> 1 ) & ~0x78 ) + ( ( TXU << 2 ) & 0x40 ) + ( ( TXV << 3 ) & 0x38 ); \
 		int n_yi = ( TXV & ~0x7 ) + ( ( TXU >> 5 ) & 0x7 ); \
-		uint16_t n_bgr = p_clut[ ( *( p_p_vram[ n_ty + n_yi ] + n_tx + n_xi ) >> ( ( TXU & 0x01 ) << 3 ) ) & 0xff ];
+		uint16_t n_bgr = p_clut_base[ ( n_clut_x + ( ( *( p_p_vram[ n_ty + n_yi ] + n_tx + n_xi ) >> ( ( TXU & 0x01 ) << 3 ) ) & 0xff ) ) & 1023 ];
 
 #define TEXTUREINTERLEAVED15BIT( TXV, TXU ) \
 	TEXTURE_LOOP \


### PR DESCRIPTION
## Summary

`psxgpu_device`'s CLUT lookup indexes linearly from the palette base address, so an 8bpp CLUT positioned near the right edge of VRAM reads past the end of its own line and into the following line, returning wrong colours for the affected palette indices.

MAME is internally inconsistent here: the CPU->VRAM transfer path *does* mask the X coordinate, so the palette is stored wrapped, but the CLUT read path does not mask, so it fetches from somewhere the palette was never written.

## Affected code

`src/devices/video/psx.cpp`, `TEXTURESETUP` (line 957):

```cpp
uint16_t *p_clut = p_p_vram[ n_cluty ] + n_clutx;
```

used as `p_clut[ index ]` in `TEXTURE4BIT` / `TEXTURE8BIT` /
`TEXTUREINTERLEAVED4BIT` / `TEXTUREINTERLEAVED8BIT`.

With `n_clutx = 832` and an 8bpp (256-entry) palette, indices >= 192 exceed the 1024-halfword line and read from line `n_cluty + 1`.

Only 8bpp is affected: a 4bpp CLUT is 16 entries and `n_clutx` is a multiple of 16, so `1008 + 15 = 1023` can never cross the edge.

Compare the write path, which masks correctly (line 3160):

```cpp
p_vram = p_p_vram[ ( n_vramy + destY ) & 1023 ] + ( ( n_vramx + destX ) & 1023 );
```

## Reproduction

Driver `tgmj` (Tetris The Grand Master, ZN-1). During the "How to play." attract demo, the game uploads `T_ROGO8.TIM`'s 256-entry palette with CLUT id `0x7C34`, i.e. VRAM (832, 496). 832 + 256 = 1088 > 1024.

Dumping VRAM at that moment (via GP0(C0h)) shows:  entries 0-191 at x=832..1023, entries 192-255 wrapped to x=0..63 **of the same line 496**. Compared against the palette in the game's own TIM asset, all 256 entries match byte-for-byte, confirming the upload is correct and complete.

MAME then renders indices 192-255 using data from line 497.
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/c284fda1-b7e9-4623-bb9a-d82e85c51ca7" />

## Expected behavior

The CLUT fetch should wrap within the same VRAM line.

psx-spx, "Wrapping":

> If the Source/Dest starting points plus the width/height value exceed the addressable VRAM size, then the Copy/Fill operations wrap to the opposite memory edge (without any carry-out from X to Y, nor from Y to X).

The current behavior is precisely a carry-out from X to Y.

## Suggested fix

Minimal change: keep the line base and mask the index, so behavior is bit-identical to today whenever `n_clutx + index < 1024` and only differs in the previously-broken overflow case.

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/9ce12111-730e-49f8-ae6c-1cc75e5a7f60" />


## Version / testing

Reproduced on master, 0.288 (commit 5b249e7).

Fix built and verified in-game on that commit: with the patch applied, the affected image renders with its correct palette. Behavior is unchanged elsewhere, as expected given the masked expression is bit-identical to the existing one whenever `n_clutx + index < 1024`.
