### PR TITLE
wangpc: fix expansion memory window and EMB card banking (128K -> 640K)

### DIFF
--- a/src/devices/bus/wangpc/emb.cpp
+++ b/src/devices/bus/wangpc/emb.cpp
@@ -19,7 +19,7 @@
 
 #define OPTION_ID       0x3f
 
-#define RAM_SIZE        0x40000
+#define RAM_SIZE        0x80000
 
 #define A19_A18_A17     ((offset >> 16) & 0x07)
 #define BASE(bank)      ((m_option >> (bank * 4)) & 0x07)
@@ -108,7 +108,7 @@ void wangpc_emb_device::wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint1
 	{
 		if (ENABLE(bank) && (A19_A18_A17 == BASE(bank)))
 		{
-			RAM_BANK(bank) = data;
+			RAM_BANK(bank) = (RAM_BANK(bank) & ~mem_mask) | (data & mem_mask);
 		}
 	}
 }

--- a/src/devices/bus/wangpc/wangpc.cpp
+++ b/src/devices/bus/wangpc/wangpc.cpp
@@ -102,7 +102,7 @@ uint16_t wangpcbus_device::mrdc_r(offs_t offset, uint16_t mem_mask)
 	uint16_t data = 0xffff;
 
 	for (device_wangpcbus_card_interface &entry : m_device_list)
-		data &= entry.wangpcbus_mrdc_r(offset + 0x40000/2, mem_mask);
+		data &= entry.wangpcbus_mrdc_r(offset + 0x20000/2, mem_mask);
 
 	return data;
 }
@@ -115,7 +115,7 @@ uint16_t wangpcbus_device::mrdc_r(offs_t offset, uint16_t mem_mask)
 void wangpcbus_device::amwc_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	for (device_wangpcbus_card_interface &entry : m_device_list)
-		entry.wangpcbus_amwc_w(offset + 0x40000/2, mem_mask, data);
+		entry.wangpcbus_amwc_w(offset + 0x20000/2, mem_mask, data);
 }
 
 

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -724,7 +724,7 @@ void wangpc_state::wangpc_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x00000, 0x1ffff).ram();
-	map(0x40000, 0xf3fff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
+	map(0x20000, 0xf3fff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
 	map(0xfc000, 0xfffff).rom().region(I8086_TAG, 0);
 }
 


### PR DESCRIPTION
The POST tests the EMB memory expansion boards starting at physical 0x20000, but the driver mapped the expansion bus window at 0x40000-0xF3FFF: the test read open bus, failed, and the POST disabled the boards, leaving MS-DOS with 128KB only. Start the window at 0x20000 and adjust the offset bias in wangpcbus_device::mrdc_r/amwc_w to match.

wangpc_emb_device::wangpcbus_amwc_w also ignored mem_mask, so 8-bit writes clobbered the other half of the 16-bit word and the byte-wide POST test patterns never read back correctly; fixed COMBINE_DATA-style.

Finally, RAM_SIZE was 256KB but the common PM031-B extended memory board is 512KB (four 128KB banks, matching the POST bank walk).

With these changes the POST finds the EMB in slot 1, tests all banks, configures the option register on its own (0xCBA9) and MS-DOS reports 640KB. Verified by booting the Wang MS-DOS 2.10 OEM disk and the
software list boot disk with: mame wangpc -slot1 emb -flop1 <disk>


Per the contributing guidelines: this work was developed with
substantial assistance from Anthropic's Claude (model: Claude Fable 5,
via Claude Code), which I directed through the reverse engineering,
implementation and testing. All changes were verified against real
period software running on the emulated machine (BIOS POST diagnostics,
SPFORMAT, INITW, MS-DOS booting from the Winchester), and I take
responsibility for the contribution. The commits carry a matching
Co-Authored-By trailer.