### PR TITLE
prose2k: emulate uPD7720 DSP audio output

### DIFF
--- a/src/devices/cpu/upd7725/upd7725.cpp
+++ b/src/devices/cpu/upd7725/upd7725.cpp
@@ -21,15 +21,20 @@
 //**************************************************************************
 
 // device type definition
+DEFINE_DEVICE_TYPE(UPD7720,  upd7720_device,  "upd7720",  "NEC uPD7720")
 DEFINE_DEVICE_TYPE(UPD7725,  upd7725_device,  "upd7725",  "NEC uPD7725")
 DEFINE_DEVICE_TYPE(UPD96050, upd96050_device, "upd96050", "NEC uPD96050")
 
-necdsp_device::necdsp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint32_t abits, uint32_t dbits) :
+necdsp_device::necdsp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint32_t abits, uint32_t dbits, uint32_t rambits, uint32_t stackbits) :
 	cpu_device(mconfig, type, tag, owner, clock),
 	m_program_config("program", ENDIANNESS_BIG, 32, abits, -2), // data bus width, address bus width, -2 means DWORD-addressable
 	m_data_config("data", ENDIANNESS_BIG, 16, dbits, -1), m_icount(0),   // -1 for WORD-addressable
 	m_irq(0),
 	m_irq_firing(0),
+	m_program_mask((1U << abits) - 1),
+	m_data_rom_mask((1U << dbits) - 1),
+	m_data_ram_mask((1U << rambits) - 1),
+	m_stack_mask((1U << stackbits) - 1),
 	m_in_int_cb(*this, 0),
 	//m_in_si_cb(*this, 0),
 	//m_in_sck_cb(*this, 0),
@@ -37,21 +42,26 @@ necdsp_device::necdsp_device(const machine_config &mconfig, device_type type, co
 	//m_in_soen_cb(*this, 0),
 	//m_in_dack_cb(*this, 0),
 	m_out_p0_cb(*this),
-	m_out_p1_cb(*this)
-	//m_out_so_cb(*this),
+	m_out_p1_cb(*this),
+	m_out_so_cb(*this)
 	//m_out_sorq_cb(*this),
 	//m_out_drq_cb(*this)
 {
 }
 
+upd7720_device::upd7720_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: necdsp_device(mconfig, UPD7720, tag, owner, clock, 9, 9, 7, 2)
+{
+}
+
 
 upd7725_device::upd7725_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: necdsp_device(mconfig, UPD7725, tag, owner, clock, 11, 11)
+	: necdsp_device(mconfig, UPD7725, tag, owner, clock, 11, 11, 11, 4)
 {
 }
 
 upd96050_device::upd96050_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: necdsp_device(mconfig, UPD96050, tag, owner, clock, 14, 12)
+	: necdsp_device(mconfig, UPD96050, tag, owner, clock, 14, 12, 11, 4)
 {
 }
 
@@ -313,7 +323,7 @@ void necdsp_device::execute_run()
 		if (m_irq_firing == 0) // normal opcode
 		{
 			opcode = m_cache.read_dword(regs.pc) >> 8;
-			regs.pc++;
+			regs.pc = (regs.pc + 1) & m_program_mask;
 		}
 		else if (m_irq_firing == 1) // if we're in an interrupt cycle, execute a op 'nop' first...
 		{
@@ -363,8 +373,8 @@ void necdsp_device::exec_op(uint32_t opcode) {
 	case  2: regs.idb = regs.b; break;
 	case  3: regs.idb = regs.tr; break;
 	case  4: regs.idb = regs.dp; break;
-	case  5: regs.idb = regs.rp; break;
-	case  6: regs.idb = m_data.read_word(regs.rp); break;
+	case  5: regs.idb = regs.rp & m_data_rom_mask; break;
+	case  6: regs.idb = m_data.read_word(regs.rp & m_data_rom_mask); break;
 	case  7: regs.idb = 0x8000 - regs.flaga.s1; break;  //SGN
 	case  8: regs.idb = regs.dr; regs.sr.rqm = 1; break;
 	case  9: regs.idb = regs.dr; break;
@@ -373,7 +383,7 @@ void necdsp_device::exec_op(uint32_t opcode) {
 	case 12: regs.idb = bitswap<16>(regs.si, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15); break;  //LSB = first bit in from serial, 'reversed' SI register order
 	case 13: regs.idb = regs.k; break;
 	case 14: regs.idb = regs.l; break;
-	case 15: regs.idb = dataRAM[regs.dp & 0x07ff]; break;
+	case 15: regs.idb = dataRAM[regs.dp & m_data_ram_mask]; break;
 	}
 
 	if(alu) {
@@ -387,7 +397,7 @@ void necdsp_device::exec_op(uint32_t opcode) {
 	flag.ov1 = 0;
 
 	switch(pselect) {
-		case 0: p = dataRAM[regs.dp & 0x07ff]; break;
+		case 0: p = dataRAM[regs.dp & m_data_ram_mask]; break;
 		case 1: p = regs.idb; break;
 		case 2: p = regs.m; break;
 		case 3: p = regs.n; break;
@@ -467,15 +477,16 @@ void necdsp_device::exec_op(uint32_t opcode) {
 		}
 
 		regs.dp ^= dphm << 4;
+		regs.dp &= m_data_ram_mask;
 	}
 
-	if(rpdcr && (dst != 5)) regs.rp--;
+	if(rpdcr && (dst != 5)) regs.rp = (regs.rp - 1) & m_data_rom_mask;
 }
 
 void necdsp_device::exec_rt(uint32_t opcode) {
 	exec_op(opcode);
-	regs.pc = regs.stack[--regs.sp];
-	regs.sp &= 0xf;
+	regs.sp = (regs.sp - 1) & m_stack_mask;
+	regs.pc = regs.stack[regs.sp];
 }
 
 void necdsp_device::exec_jp(uint32_t opcode) {
@@ -483,8 +494,8 @@ void necdsp_device::exec_jp(uint32_t opcode) {
 	uint16_t na  =  (opcode >>  2) & 0x7ff;  //next address
 	uint16_t bank = (opcode >>  0) & 0x3;  //bank address
 
-	uint16_t jps = (regs.pc & 0x2000) | (bank << 11) | (na << 0);
-	uint16_t jpl = (bank << 11) | (na << 0);
+	uint16_t jps = ((regs.pc & 0x2000) | (bank << 11) | na) & m_program_mask;
+	uint16_t jpl = ((bank << 11) | na) & m_program_mask;
 
 	switch(brch) {
 		case 0x000: regs.pc = regs.so; return;  //JMPSO
@@ -533,10 +544,10 @@ void necdsp_device::exec_jp(uint32_t opcode) {
 		case 0x0be: if(regs.sr.rqm == 1) regs.pc = jps; return;  //JRQM
 
 		case 0x100: regs.pc = 0x0000 | jpl; return;  //LJMP
-		case 0x101: regs.pc = 0x2000 | jpl; return;  //HJMP
+		case 0x101: regs.pc = (0x2000 | jpl) & m_program_mask; return;  //HJMP
 
-		case 0x140: regs.stack[regs.sp++] = regs.pc; regs.pc = 0x0000 | jpl; regs.sp &= 0xf; return;  //LCALL
-		case 0x141: regs.stack[regs.sp++] = regs.pc; regs.pc = 0x2000 | jpl; regs.sp &= 0xf; return;  //HCALL
+		case 0x140: regs.stack[regs.sp] = regs.pc; regs.sp = (regs.sp + 1) & m_stack_mask; regs.pc = jpl; return;  //LCALL
+		case 0x141: regs.stack[regs.sp] = regs.pc; regs.sp = (regs.sp + 1) & m_stack_mask; regs.pc = (0x2000 | jpl) & m_program_mask; return;  //HCALL
 	}
 }
 
@@ -551,21 +562,21 @@ void necdsp_device::exec_ld(uint32_t opcode) {
 	case  1: regs.a = id; break;
 	case  2: regs.b = id; break;
 	case  3: regs.tr = id; break;
-	case  4: regs.dp = id; break;
-	case  5: regs.rp = id; break;
+	case  4: regs.dp = id & m_data_ram_mask; break;
+	case  5: regs.rp = id & m_data_rom_mask; break;
 	case  6: regs.dr = id; regs.sr.rqm = 1; break;
 	case  7: regs.sr = (regs.sr & 0x907c) | (id & ~0x907c);
 				m_out_p0_cb(regs.sr.p0);
 				m_out_p1_cb(regs.sr.p1);
 				break;
-	case  8: regs.so = bitswap<16>(id, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15); break;  //LSB first output, output tapped at bit 15 shifting left
-	case  9: regs.so = id; break;  //MSB first output, output tapped at bit 15 shifting left
+	case  8: regs.so = bitswap<16>(id, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15); m_out_so_cb(regs.so); break;  //LSB first output, output tapped at bit 15 shifting left
+	case  9: regs.so = id; m_out_so_cb(regs.so); break;  //MSB first output, output tapped at bit 15 shifting left
 	case 10: regs.k = id; break;
-	case 11: regs.k = id; regs.l = m_data.read_word(regs.rp); break;
-	case 12: regs.l = id; regs.k = dataRAM[(regs.dp & 0x7ff) | 0x40]; break;
+	case 11: regs.k = id; regs.l = m_data.read_word(regs.rp & m_data_rom_mask); break;
+	case 12: regs.l = id; regs.k = dataRAM[(regs.dp & m_data_ram_mask) | 0x40]; break;
 	case 13: regs.l = id; break;
 	case 14: regs.trb = id; break;
-	case 15: dataRAM[regs.dp & 0x7ff] = id; break;
+	case 15: dataRAM[regs.dp & m_data_ram_mask] = id; break;
 	}
 }
 

--- a/src/devices/cpu/upd7725/upd7725.h
+++ b/src/devices/cpu/upd7725/upd7725.h
@@ -35,6 +35,7 @@ class necdsp_device : public cpu_device
 public:
 	auto p0() { return m_out_p0_cb.bind(); }
 	auto p1() { return m_out_p1_cb.bind(); }
+	auto so() { return m_out_so_cb.bind(); }
 
 	uint8_t status_r();
 	uint8_t data_r();
@@ -42,7 +43,7 @@ public:
 
 protected:
 	// construction/destruction
-	necdsp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint32_t abits, uint32_t dbits);
+	necdsp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, uint32_t abits, uint32_t dbits, uint32_t rambits, uint32_t stackbits);
 
 	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
@@ -144,6 +145,10 @@ private:
 	// 1 = next opcode is the first half of int firing 'NOP'
 	// 2 = next opcode is the second half of int firing 'CALL 0100'
 	int m_irq_firing;
+	const uint16_t m_program_mask;
+	const uint16_t m_data_rom_mask;
+	const uint16_t m_data_ram_mask;
+	const uint8_t m_stack_mask;
 	memory_access<14, 2, -2, ENDIANNESS_BIG>::cache m_cache;
 	memory_access<14, 2, -2, ENDIANNESS_BIG>::specific m_program;
 	memory_access<12, 1, -1, ENDIANNESS_BIG>::specific m_data;
@@ -157,9 +162,15 @@ protected:
 	//devcb_read_line   m_in_dack_cb;
 	devcb_write_line    m_out_p0_cb;
 	devcb_write_line    m_out_p1_cb;
-	//devcb_write8      m_out_so_cb;
+	devcb_write16       m_out_so_cb;
 	//devcb_write_line  m_out_sorq_cb;
 	//devcb_write_line  m_out_drq_cb;
+};
+
+class upd7720_device : public necdsp_device
+{
+public:
+	upd7720_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 };
 
 class upd7725_device : public necdsp_device
@@ -183,6 +194,7 @@ public:
 };
 
 // device type definition
+DECLARE_DEVICE_TYPE(UPD7720,  upd7720_device)
 DECLARE_DEVICE_TYPE(UPD7725,  upd7725_device)
 DECLARE_DEVICE_TYPE(UPD96050, upd96050_device)
 

--- a/src/mame/skeleton/tsispch.cpp
+++ b/src/mame/skeleton/tsispch.cpp
@@ -145,6 +145,7 @@ public:
 		, m_dsp(*this, "dsp")
 		, m_pic(*this, "pic8259")
 		, m_uart(*this, "i8251a_u15")
+		, m_dac(*this, "dac")
 	{
 	}
 
@@ -158,6 +159,7 @@ private:
 	void dsp_status_w(uint8_t data);
 	void dsp_to_8086_p0_w(int state);
 	void dsp_to_8086_p1_w(int state);
+	void dsp_serial_w(uint16_t data);
 
 	void dsp_data_map(address_map &map) ATTR_COLD;
 	void dsp_prg_map(address_map &map) ATTR_COLD;
@@ -167,11 +169,13 @@ private:
 	virtual void machine_reset() override ATTR_COLD;
 
 	required_device<cpu_device> m_maincpu;
-	required_device<upd7725_device> m_dsp;
+	required_device<upd7720_device> m_dsp;
 	required_device<pic8259_device> m_pic;
 	required_device<i8251_device> m_uart;
+	required_device<dac_12bit_r2r_device> m_dac;
 
 	uint8_t m_paramReg = 0;           // status leds and resets and etc
+	bool m_dsp_p0 = false;
 };
 
 /*
@@ -203,6 +207,7 @@ void tsispch_state::peripheral_w(uint8_t data)
 	*/
 	m_paramReg = data;
 	m_dsp->set_input_line(INPUT_LINE_RESET, BIT(data, 6) ? CLEAR_LINE : ASSERT_LINE);
+	m_pic->ir0_w(!((m_paramReg & 0x01) && m_dsp_p0));
 	//LOGPRM("8086: Parameter Reg written: UNK7: %d, DSPRST6: %d; UNK5: %d; LED4: %d; LED3: %d; LED2: %d; LED1: %d; DSPIRQMASK: %d\n", BIT(data,7), BIT(data,6), BIT(data,5), BIT(data,4), BIT(data,3), BIT(data,2), BIT(data,1), BIT(data,0));
 	LOGPRM("8086: Parameter Reg written: UNK7: %d, DSPRST6: %d; UNK5: %d; LED4: %d; LED3: %d; LED2: %d; LED1: %d; DSPIRQMASK: %d\n", BIT(data,7), BIT(data,6), BIT(data,5), BIT(data,4), BIT(data,3), BIT(data,2), BIT(data,1), BIT(data,0));
 	popmessage("LEDS: 6/Talking:%d 5:%d 4:%d 3:%d\n", 1-BIT(data,1), 1-BIT(data,2), 1-BIT(data,3), 1-BIT(data,4));
@@ -220,7 +225,10 @@ void tsispch_state::dsp_status_w(uint8_t data)
 void tsispch_state::dsp_to_8086_p0_w(int state)
 {
 	LOG("upd772x changed p0 state to %d!\n",state);
-	//TODO: do stuff here!
+	m_dsp_p0 = bool(state);
+	// The DSP request is gated by parameter-register bit 0 and presented to
+	// the PIC as an active-low signal.
+	m_pic->ir0_w(!((m_paramReg & 0x01) && m_dsp_p0));
 }
 
 void tsispch_state::dsp_to_8086_p1_w(int state)
@@ -229,13 +237,23 @@ void tsispch_state::dsp_to_8086_p1_w(int state)
 	//TODO: do stuff here!
 }
 
+void tsispch_state::dsp_serial_w(uint16_t data)
+{
+	// The uPD7720 sends the least-significant bit first.  The board shifts the
+	// 13-bit sample into its output register and discards the least-significant
+	// bit when presenting it to the 12-bit DAC.
+	m_dac->write((bitswap<16>(data, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) & 0x1fff) >> 1);
+}
+
 /*****************************************************************************
  Reset and Driver Init
 *****************************************************************************/
 void tsispch_state::machine_reset()
 {
 	LOG("machine reset\n");
+	m_dsp_p0 = false;
 	m_dsp->set_input_line(INPUT_LINE_RESET, ASSERT_LINE); // starts in reset
+	m_dac->write(0x7f0);
 }
 
 void tsispch_state::init_prose2k()
@@ -280,6 +298,9 @@ void tsispch_state::init_prose2k()
 		*dspprg = byte1t<<24 | byte23t<<8;
 		dspprg++;
 	}
+	// The uPD77P20 programmer dump walks data ROM addresses downward.
+	u16 *const dspdata = &memregion("dspdata")->as_u16();
+	std::reverse(dspdata, dspdata + 0x200);
 	m_paramReg = 0x00; // on power up, all leds on, reset to upd7720 is high
 }
 
@@ -311,8 +332,8 @@ void tsispch_state::i8086_mem(address_map &map)
 	map(0x03200, 0x03203).mirror(0x341fc).rw(m_pic, FUNC(pic8259_device::read), FUNC(pic8259_device::write)).umask16(0x00ff); // AMD P8259 PIC @ U5 (reads as 04 and 7c, upper byte is open bus)
 	map(0x03400, 0x03400).mirror(0x341fe).r(FUNC(tsispch_state::dsw_r)); // verified, read from dipswitch s4
 	map(0x03401, 0x03401).mirror(0x341fe).w(FUNC(tsispch_state::peripheral_w)); // verified, write to the 4 leds, plus 4 control bits
-	map(0x03600, 0x03600).mirror(0x341fc).rw(m_dsp, FUNC(upd7725_device::data_r), FUNC(upd7725_device::data_w)); // verified; UPD77P20 data reg r/w
-	map(0x03602, 0x03602).mirror(0x341fc).r(m_dsp, FUNC(upd7725_device::status_r)).w(FUNC(tsispch_state::dsp_status_w)); // verified; UPD77P20 status reg r
+	map(0x03600, 0x03600).mirror(0x341fc).rw(m_dsp, FUNC(upd7720_device::data_r), FUNC(upd7720_device::data_w)); // verified; UPD77P20 data reg r/w
+	map(0x03602, 0x03602).mirror(0x341fc).r(m_dsp, FUNC(upd7720_device::status_r)).w(FUNC(tsispch_state::dsp_status_w)); // verified; UPD77P20 status reg r
 	map(0xc0000, 0xfffff).rom(); // verified
 }
 
@@ -376,14 +397,15 @@ void tsispch_state::prose2k(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &tsispch_state::i8086_io);
 	m_maincpu->set_irq_acknowledge_callback(m_pic, FUNC(pic8259_device::inta_cb));
 
-	/* TODO: the UPD7720 has a 10KHz clock to its INT pin */
 	/* TODO: the UPD7720 has a 2MHz clock to its SCK pin */
-	/* TODO: hook up p0, p1, int */
-	UPD7725(config, m_dsp, XTAL(16'000'000)/2); /* VERIFIED clock, unknown divider; correct dsp type is UPD77P20 (which xtal does this come from? guessed 16MHz) */
+	UPD7720(config, m_dsp, XTAL(16'000'000)/4); /* VERIFIED crystal; the uPD77P20 takes two input clocks per instruction */
 	m_dsp->set_addrmap(AS_PROGRAM, &tsispch_state::dsp_prg_map);
 	m_dsp->set_addrmap(AS_DATA, &tsispch_state::dsp_data_map);
 	m_dsp->p0().set(FUNC(tsispch_state::dsp_to_8086_p0_w));
 	m_dsp->p1().set(FUNC(tsispch_state::dsp_to_8086_p1_w));
+	m_dsp->so().set(FUNC(tsispch_state::dsp_serial_w));
+	clock_device &dsp_interrupt(CLOCK(config, "dspint", 10'000));
+	dsp_interrupt.signal_handler().set_inputline(m_dsp, NECDSP_INPUT_LINE_INT);
 
 	/* PIC 8259 */
 	PIC8259(config, m_pic);
@@ -404,7 +426,7 @@ void tsispch_state::prose2k(machine_config &config)
 
 	/* sound hardware */
 	SPEAKER(config, "speaker").front_center();
-	DAC_12BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0); // unknown DAC (TODO: correctly figure out how the DAC works; apparently it is connected to the serial output of the upd7720, which will be "fun" to connect up)
+	DAC_12BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 1.0);
 
 	rs232_port_device &rs232(RS232_PORT(config, "rs232", default_rs232_devices, "terminal"));
 	rs232.rxd_handler().set("i8251a_u15", FUNC(i8251_device::write_rxd));
@@ -547,5 +569,5 @@ ROM_END
 ******************************************************************************/
 
 //    YEAR  NAME      PARENT   COMPAT  MACHINE  INPUT    CLASS          INIT          COMPANY                                FULLNAME                  FLAGS
-COMP( 1987, prose2k,  0,       0,      prose2k, prose2k, tsispch_state, init_prose2k, "Telesensory Systems Inc/Speech Plus", "Prose 2000/2020 v3.4.1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-COMP( 1982, prose2ko, prose2k, 0,      prose2k, prose2k, tsispch_state, init_prose2k, "Telesensory Systems Inc/Speech Plus", "Prose 2000/2020 v1.1",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+COMP( 1987, prose2k,  0,       0,      prose2k, prose2k, tsispch_state, init_prose2k, "Telesensory Systems Inc/Speech Plus", "Prose 2000/2020 v3.4.1", MACHINE_NOT_WORKING )
+COMP( 1982, prose2ko, prose2k, 0,      prose2k, prose2k, tsispch_state, init_prose2k, "Telesensory Systems Inc/Speech Plus", "Prose 2000/2020 v1.1",   MACHINE_NOT_WORKING )


### PR DESCRIPTION
This adds working speech output to the Telesensory/Speech Plus Prose 2000/2020 driver.

The board uses a uPD77P20 with the smaller uPD7720 architecture. This change adds a uPD7720 device configuration with the appropriate program, data ROM, data RAM and stack widths while preserving the existing uPD7725 and uPD96050 dimensions. It also exposes the DSP serial-output register through a callback.

The Prose driver now:

- connects the gated DSP P0 request to PIC IR0;
- supplies the documented 10 kHz DSP interrupt and corrected instruction clock;
- reverses the address order of the uPD77P20 data-ROM programmer dump;
- converts the DSP serial output to the board's 12-bit DAC data;
- initializes the DAC at its neutral level; and
- removes MACHINE_NO_SOUND while retaining MACHINE_NOT_WORKING.

Validation performed:

- focused release and debug builds of the Prose target;
- `prose2k.exe -validate` and `prose2kd.exe -validate`;
- deterministic bitbanger input and WAV capture using the existing ROM definitions;
- comparison with an independent board-level emulator; and
- speech recognition of the captured sentence, which correctly returned "This is a test of the Prose 2000 speech synthesizer."

No ROM data or test firmware is included in this change.

AI assistance disclosure: OpenAI Codex (GPT-5) assisted with code investigation, implementation and test orchestration. The resulting changes were reviewed, built and validated against deterministic emulator output before submission.