### PR TITLE
fix(opwolf): latch TC0060DCA volume writes

### DIFF
--- a/src/mame/taito/opwolf.cpp
+++ b/src/mame/taito/opwolf.cpp
@@ -708,6 +708,13 @@ template<int N>
 void opwolf_state::adpcm_w(offs_t offset, uint8_t data)
 {
 	m_adpcm_regs[N][offset] = data;
+	if (offset == 0x05)
+	{
+		if (N)
+			m_tc0060dca[0]->volume2_w(data);
+		else
+			m_tc0060dca[0]->volume1_w(data);
+	}
 
 	if (offset == 0x04) // trigger?
 	{
@@ -716,11 +723,6 @@ void opwolf_state::adpcm_w(offs_t offset, uint8_t data)
 		m_adpcm_pos[N] = start << 4;
 		m_adpcm_end[N] = end << 4;
 		m_msm[N]->reset_w(0);
-
-		if (N)
-			m_tc0060dca[0]->volume2_w(m_adpcm_regs[N][5]);
-		else
-			m_tc0060dca[0]->volume1_w(m_adpcm_regs[N][5]);
 
 		//logerror("TRIGGER MSM%d\n", N + 1);
 	}

--- a/src/mame/taito/tc0060dca.cpp
+++ b/src/mame/taito/tc0060dca.cpp
@@ -24,13 +24,15 @@ tc0060dca_device::tc0060dca_device(const machine_config &mconfig, const char *ta
 void tc0060dca_device::volume1_w(u8 data)
 {
 	m_stream->update();
-	m_gain[0] = m_atten_table[data];
+	m_gain[0] = m_atten_table[m_volume[0]];
+	m_volume[0] = data;
 }
 
 void tc0060dca_device::volume2_w(u8 data)
 {
 	m_stream->update();
-	m_gain[1] = m_atten_table[data];
+	m_gain[1] = m_atten_table[m_volume[1]];
+	m_volume[1] = data;
 }
 
 void tc0060dca_device::device_start()
@@ -41,7 +43,9 @@ void tc0060dca_device::device_start()
 		m_atten_table[x] = 1.0 / (1.0 + exp(-10 * ((x / 256.0) - 0.6)));
 
 	m_gain[0] = m_gain[1] = m_atten_table[0xff];
+	m_volume[0] = m_volume[1] = 0xff;
 	save_item(NAME(m_gain));
+	save_item(NAME(m_volume));
 }
 
 void tc0060dca_device::sound_stream_update(sound_stream &stream)

--- a/src/mame/taito/tc0060dca.h
+++ b/src/mame/taito/tc0060dca.h
@@ -23,6 +23,7 @@ protected:
 private:
 	sound_stream *m_stream;
 	float m_gain[2];
+	u8 m_volume[2];
 	float m_atten_table[256];
 };
 


### PR DESCRIPTION
The current opwolf driver applies the TC0060DCA volume settings at the voice start command. It sounds fine but there is **no** connection in the schematic from "VA RUN" or "VB RUN" to the two TC0060DCA chips.

I implemented this on my FPGA core as a 1 write delay in the TC0060DCA. That works fine. This PR implements the same approach for MAME.

<img width="928" height="896" alt="image" src="https://github.com/user-attachments/assets/e75e96be-d575-460b-8db8-d9706acff89c" />

I know this is a bit speculative, but at least it does not use impossible connections like the current approach.

I tried doing it for `topspeed` but I didn't get a good result and because I don't have schematics for that one (or the PCB) I don't know if there is something else going on that just cannot be derived from the current driver. So this PR is just for opwolf.