### PR TITLE
osd/netdev/pcap: capture inbound frames only (avoid reading our own transmissions)

### DIFF
--- a/src/osd/modules/netdev/pcap.cpp
+++ b/src/osd/modules/netdev/pcap.cpp
@@ -48,6 +48,7 @@ typedef int (*pcap_setfilter_fn)(pcap_t *, struct bpf_program *);
 typedef int (*pcap_sendpacket_fn)(pcap_t *, const u_char *, int);
 typedef int (*pcap_set_datalink_fn)(pcap_t *, int);
 typedef int (*pcap_dispatch_fn)(pcap_t *, int, pcap_handler, u_char *);
+typedef int (*pcap_setdirection_fn)(pcap_t *, pcap_direction_t);
 
 class pcap_module : public osd_module, public netdev_module
 {
@@ -55,7 +56,8 @@ public:
 	pcap_module() :
 		osd_module(OSD_NETDEV_PROVIDER, "pcap"), netdev_module(),
 		pcap_findalldevs_dl(nullptr), pcap_open_live_dl(nullptr), pcap_next_ex_dl(nullptr), pcap_compile_dl(nullptr),
-		pcap_close_dl(nullptr), pcap_setfilter_dl(nullptr), pcap_sendpacket_dl(nullptr), pcap_set_datalink_dl(nullptr), pcap_dispatch_dl(nullptr)
+		pcap_close_dl(nullptr), pcap_setfilter_dl(nullptr), pcap_sendpacket_dl(nullptr), pcap_set_datalink_dl(nullptr), pcap_dispatch_dl(nullptr),
+		pcap_setdirection_dl(nullptr)
 	{
 	}
 
@@ -77,6 +79,8 @@ public:
 		pcap_sendpacket_dl = pcap_dll->bind<pcap_sendpacket_fn>("pcap_sendpacket");
 		pcap_set_datalink_dl = pcap_dll->bind<pcap_set_datalink_fn>("pcap_set_datalink");
 		pcap_dispatch_dl = pcap_dll->bind<pcap_dispatch_fn>("pcap_dispatch");
+		// Optional: not present in every libpcap; a null pointer here is not an error.
+		pcap_setdirection_dl = pcap_dll->bind<pcap_setdirection_fn>("pcap_setdirection");
 
 		if (!pcap_findalldevs_dl || !pcap_open_live_dl    || !pcap_next_ex_dl   ||
 			!pcap_compile_dl     || !pcap_close_dl        || !pcap_setfilter_dl ||
@@ -114,6 +118,7 @@ private:
 	pcap_sendpacket_fn   pcap_sendpacket_dl;
 	pcap_set_datalink_fn pcap_set_datalink_dl;
 	pcap_dispatch_fn     pcap_dispatch_dl;
+	pcap_setdirection_fn pcap_setdirection_dl;
 };
 
 class pcap_module::netdev_pcap : public network_device_base
@@ -198,6 +203,15 @@ pcap_module::netdev_pcap::netdev_pcap(pcap_module &module, const char *name, net
 		(*m_module.pcap_close_dl)(m_p);
 		m_p = nullptr;
 		return;
+	}
+	// Avoid capturing our own outbound frames. On BSD-derived libpcap (macOS,
+	// FreeBSD) BPF captures both directions by default, which causes the guest
+	// to see its own ARP probes as remote conflicts over point-to-point virtual
+	// interfaces (feth, tap). Harmless on Linux (already the default).
+	if (m_module.pcap_setdirection_dl &&
+		(*m_module.pcap_setdirection_dl)(m_p, PCAP_D_IN) != 0)
+	{
+		osd_printf_warning("pcap_setdirection(PCAP_D_IN) failed on %s\n", name);
 	}
 
 #ifdef SDLMAME_MACOSX


### PR DESCRIPTION
## osd/netdev/pcap: capture inbound frames only (avoid reading our own transmissions)

### Problem

libpcap's default capture direction is `PCAP_D_INOUT` on every supported platform (per `pcap_setdirection(3PCAP)`: *"PCAP_D_INOUT is the default setting if this function is not called."*). MAME's pcap netdev takes the default, so every frame the emulated NIC transmits is also delivered back to the same handle as if it were inbound — the guest ends up reading its own outgoing frames. Real NICs do not deliver their own transmissions back to their driver, so bidirectional capture is the wrong semantics for an emulated NIC on **every** platform. It is only the *visible severity* that differs:

- **Linux (PF_PACKET)**: in many common kernel/driver configurations the tap suppresses locally-injected frames before they reach the capture handle, and on a real Ethernet NIC the guest's own MAC would otherwise dedup the echo. The bug is present but usually invisible.
- **macOS / FreeBSD (BPF)**: BPF unconditionally mirrors every frame the interface sees in both directions to every open handle. Over any point-to-point virtual interface (`feth` pair, `tap`) this is fatal — see reproduction below.
- **Windows (Npcap / WinPcap)**: same `PCAP_D_INOUT` default. Modern Npcap does deliver locally-injected frames back to capture handles; the guest MAC differing from the host MAC on typical setups masks it, but the misbehaviour is latent.

Concrete failure on macOS + `feth`:

1. Guest emits a gratuitous ARP for its own IP.
2. BPF echoes that frame back into MAME's capture handle.
3. Guest's stack sees "another device is announcing my MAC / IP" and refuses to bring up the interface. MacTCP surfaces this as `-23004 ipBadAddr` from `OpenDriver('.IPP')`; other stacks report duplicate-address errors.

### Fix

After `pcap_open_live` + `pcap_set_datalink`, call `pcap_setdirection(handle, PCAP_D_IN)`. `PCAP_D_IN` matches the semantics an emulated NIC actually wants, on every platform: a real NIC does not deliver its own transmissions back to its driver.

`pcap_setdirection` is bound dynamically as an **optional** symbol so older libpcap builds (or WinPcap variants that don't export it) continue to work — a null pointer or a non-zero return just logs a warning and leaves the existing behavior in place.

Prior art: tcpdump exposes the same knob as `-Q in|out|inout` precisely because capture applications that also inject frames need to filter out their own transmissions.

### Known tradeoff

Two MAME instances sharing a single host interface would previously see each other's transmissions via the reflected-outbound path; with `PCAP_D_IN` they will not. That configuration is not commonly used (MAC collisions, no host-side switching, contention for inbound frames) and running each instance against its own virtual interface pair remains the correct setup. Happy to expose direction as an OSD option if anyone depends on the old behavior.

### Reproduction (before the patch)

macOS host, `feth` pair, System 7.1 + MacTCP + Macintosh II emulation:

```sh
# feth setup — creates a point-to-point virtual Ethernet pair
sudo ifconfig feth0 create
sudo ifconfig feth1 create
sudo ifconfig feth0 peer feth1
sudo ifconfig feth0 10.0.2.2/24 up
sudo ifconfig feth1 up

# run MAME against feth1 (use whatever bootable disk / client image you have)
mame macii -nba enetnb -networkprovider pcap \
    -hard1 <system.chd> -flop1 <client.dsk>
```

Configure MacTCP for `10.0.2.15`. Before the patch, MacTCP raises a duplicate-address alert and the interface never comes up. After the patch, MacTCP applies the address, ARP resolves against `10.0.2.2` on the host, and any TCP client on the guest establishes connections normally (verifiable with `sudo tcpdump -i feth0 -n` on the host).

### Notes

- Diff is +15 / -1 in `src/osd/modules/netdev/pcap.cpp`.
- No changes to the higher-level netdev API.
- Full macOS build (`make -j6`) completes cleanly; resulting binary contains the new symbol reference (`nm | grep pcap_setdirection`).
- AI assistance disclosure: portions of the investigation and patch were drafted with Claude Opus 4.7 (model id `claude-opus-4-7`, 1M-context variant). Diagnosis, code, and testing were reviewed by me.
