### PR TITLE
upd933: fix regression in interrupt timing

### DIFF
--- a/src/devices/sound/upd933.cpp
+++ b/src/devices/sound/upd933.cpp
@@ -199,9 +199,9 @@ void upd933_device::update_pending_irq()
 
 	for (int i = 0; i < 8; i++)
 	{
-		env_active |= (m_dca[i].calc_timeout(new_time)
-				   ||  m_dco[i].calc_timeout(new_time)
-				   ||  m_dcw[i].calc_timeout(new_time));
+		env_active |= m_dca[i].calc_timeout(new_time);
+		env_active |= m_dco[i].calc_timeout(new_time);
+		env_active |= m_dcw[i].calc_timeout(new_time);
 	}
 
 	if (env_active)


### PR DESCRIPTION
https://github.com/mamedev/mame/commit/cb26772f0f9294247671bd9b79122721ff9361f4 introduced incorrect short-circuiting to `upd933_device::update_pending_irq` that made envelope IRQs frequently happen much later than they should have. One noticeable example is CZ-1 preset B3 (ELEC.GUITAR) having a completely broken pitch envelope.