### PR TITLE
On the MC68040 CACR reserved bits must read as 0

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.lst
+++ b/src/devices/cpu/m68000/m68k_in.lst
@@ -4929,7 +4929,8 @@ e3c0 ffc0 lsl      w A+-DXWL    01:8 7:14 24fc:5 3:4
 			REG_DA()[(word2 >> 12) & 15] = m_dfc;
 			break;
 		case 0x002:            /* CACR */
-			REG_DA()[(word2 >> 12) & 15] = m_cacr;
+			/* MC68040 reserved bits must read 0 or the Amiga CPU detection fails */
+			REG_DA()[(word2 >> 12) & 15] = m_cacr & M68K_CACR_040_MASK;
 			break;
 		case 0x800:            /* USP */
 			REG_DA()[(word2 >> 12) & 15] = REG_USP();
@@ -5315,12 +5316,8 @@ e3c0 ffc0 lsl      w A+-DXWL    01:8 7:14 24fc:5 3:4
 			m_dfc = REG_DA()[(word2 >> 12) & 15] & 7;
 			break;
 		case 0x002:            /* CACR */
-			/* 68030 can write all bits except 5-7, 040 can write all */
-			m_cacr = REG_DA()[(word2 >> 12) & 15];
-			if (m_cacr & (M68K_CACR_CI | M68K_CACR_CEI)) {
-				m68ki_ic_clear();
-				m_cacr &= ~(M68K_CACR_CI | M68K_CACR_CEI);
-			}
+			/* MC68040 reserved bits must read 0 or the Amiga CPU detection fails */
+			m_cacr = REG_DA()[(word2 >> 12) & 15] & M68K_CACR_040_MASK;
 			break;
 		case 0x800:            /* USP */
 			REG_USP() = REG_DA()[(word2 >> 12) & 15];
@@ -8463,4 +8460,3 @@ f400 ff20 cinv     l .          4:16
 
 f420 ff20 cpush    l .          4:16
 	//logerror("%s at %08x: called unimplemented instruction %04x (cpush)\n", tag(), m_ppc, m_ir);
-

--- a/src/devices/cpu/m68000/m68kcpu.h
+++ b/src/devices/cpu/m68000/m68kcpu.h
@@ -101,6 +101,10 @@ static constexpr int M68K_CACR_CEI = 0x04; // Clear Entry in Instruction Cache
 static constexpr int M68K_CACR_FI  = 0x02; // Freeze Instruction Cache
 static constexpr int M68K_CACR_EI  = 0x01; // Enable Instruction Cache
 
+static constexpr u32 M68K_CACR_040_DE   = 0x80000000; // Enable Data Cache
+static constexpr u32 M68K_CACR_040_IE   = 0x00008000; // Enable Instruction Cache
+static constexpr u32 M68K_CACR_040_MASK = M68K_CACR_040_DE | M68K_CACR_040_IE;
+
 /* ======================================================================== */
 /* ================================ MACROS ================================ */
 /* ======================================================================== */

--- a/src/devices/cpu/m68000/m68kops.cpp
+++ b/src/devices/cpu/m68000/m68kops.cpp
@@ -20402,7 +20402,8 @@ void m68000_musashi_device::x4e7a_movec_l_4()
 			REG_DA()[(word2 >> 12) & 15] = m_dfc;
 			break;
 		case 0x002:            /* CACR */
-			REG_DA()[(word2 >> 12) & 15] = m_cacr;
+			/* MC68040 reserved bits must read 0 or the Amiga CPU detection fails */
+			REG_DA()[(word2 >> 12) & 15] = m_cacr & M68K_CACR_040_MASK;
 			break;
 		case 0x800:            /* USP */
 			REG_DA()[(word2 >> 12) & 15] = REG_USP();
@@ -20798,12 +20799,8 @@ void m68000_musashi_device::x4e7b_movec_l_4()
 			m_dfc = REG_DA()[(word2 >> 12) & 15] & 7;
 			break;
 		case 0x002:            /* CACR */
-			/* 68030 can write all bits except 5-7, 040 can write all */
-			m_cacr = REG_DA()[(word2 >> 12) & 15];
-			if (m_cacr & (M68K_CACR_CI | M68K_CACR_CEI)) {
-				m68ki_ic_clear();
-				m_cacr &= ~(M68K_CACR_CI | M68K_CACR_CEI);
-			}
+			/* MC68040 reserved bits must read 0 or the Amiga CPU detection fails */
+			m_cacr = REG_DA()[(word2 >> 12) & 15] & M68K_CACR_040_MASK;
 			break;
 		case 0x800:            /* USP */
 			REG_USP() = REG_DA()[(word2 >> 12) & 15];
@@ -31884,7 +31881,6 @@ void m68000_musashi_device::xf400_cinv_l_4()
 void m68000_musashi_device::xf420_cpush_l_4()
 {
 	//logerror("%s at %08x: called unimplemented instruction %04x (cpush)\n", tag(), m_ppc, m_ir);
-
 }
 const m68000_musashi_device::opcode_handler_ptr m68000_musashi_device::m68k_handler_table[] =
 {


### PR DESCRIPTION
The Amiga Kickstart does the following to detect the CPU type:

```
00F80CC4: 08C0 0000      bset    #$0, D0
00F80CC8: 223C 0000 0A09 move.l  #$a09, D1
00F80CCE: 4E7B 1002      movec   D1, CACR; (2+)
00F80CD2: 4E7A 1002      movec   CACR, D1; (2+)
00F80CD6: 08C0 0001      bset    #$1, D0 ; 68020
00F80CDA: 0801 0009      btst    #$9, D1
00F80CDE: 6704           beq     $f80ce4
00F80CE0: 08C0 0002      bset    #$2, D0 ; 68030
00F80CE4: 0801 0000      btst    #$0, D1
00F80CE8: 6622           bne     $f80d0c
00F80CEA: 807C 000C      or.w    #$c, D0 ; 68040
```

Current MAME code looks like this (write to CACR):

```
case 0x002:            /* CACR */
	/* 68030 can write all bits except 5-7, 040 can write all */
	m_cacr = REG_DA()[(word2 >> 12) & 15];
	if (m_cacr & (M68K_CACR_CI | M68K_CACR_CEI)) {
		m68ki_ic_clear();
		m_cacr &= ~(M68K_CACR_CI | M68K_CACR_CEI);
	}
	break;
```

Bit 3 is cleared and we end up with `0a01` in CACR, taking the 68030 path. In the 68040 manual only bits 31 and 15 are defined, the rest is "reserved". There is no specific info what happens with the reserved bits here if you write them anyway, but there is a general comment:

> Some control registers have undefined bits reserved for future definition by Motorola. Those particular bits are read as zeros and must be written as zeros for future compatibility. 

Also the cache shouldn't be touched at this point. The manual states:

> The CACR contains two enable bits that allow the instruction and data caches to be independently enabled or disabled. Setting an enable bit enables the associated cache without affecting the state of any lines within the cache. A hardware reset clears the CACR, disabling both caches; however, the tags, state information, and data within the caches are not affected by reset and must be cleared by using the CINV instruction before enabling the caches.

Cross-checking with WinUAE: Here's the relevant part of `newcpu_common.cpp`:

```
case 2:
	{
		uae_u32 cacr_mask = 0;
		if (currprefs.cpu_model == 68020)
			cacr_mask = 0x0000000f;
		else if (currprefs.cpu_model == 68030)
			cacr_mask = 0x00003f1f;
		else if (currprefs.cpu_model == 68040)
			cacr_mask = 0x80008000;
		else if (currprefs.cpu_model == 68060)
			cacr_mask = 0xf8e0e000;
		regs.cacr = *regp & cacr_mask;
		set_cpu_caches (false);
	}
	break;
```

AI disclosure: gpt-5.6-sol was used as a research and debugging tool, all code was written by me.