### PR TITLE
dataeast/backfire.cpp: Fix sound routing

### DIFF
--- a/src/mame/dataeast/backfire.cpp
+++ b/src/mame/dataeast/backfire.cpp
@@ -420,8 +420,8 @@ void backfire_state::backfire(machine_config &config)
 	SPEAKER(config, "rspeaker").front_center();
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", 28000000 / 2));
-	ymz.add_route(0, "lspeaker", 1.0, 0);
-	ymz.add_route(1, "rspeaker", 1.0, 1);
+	ymz.add_route(0, "lspeaker", 1.0);
+	ymz.add_route(1, "rspeaker", 1.0);
 }
 
 


### PR DESCRIPTION
This PR fixes https://github.com/mamedev/mame/issues/15796 .