### PR TITLE
moog/source.cpp: improved emulation of encoder wheel and made it interactive.

### DIFF
--- a/src/mame/layout/linn_linndrum.lay
+++ b/src/mame/layout/linn_linndrum.lay
@@ -648,7 +648,7 @@ copyright-holders:m1macrophage
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
-		-- version: 11
+		-- version: 12
 		-----------------------------------------------------------------------
 
 		-- Global configuration. Can be overwritten in the resolve_tags callback.
@@ -661,16 +661,31 @@ copyright-holders:m1macrophage
 
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
+		local frame_id = 0   -- Current frame identifier.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
 		function add_slider(view, clickarea_id, knob_id, port_name)
-			table.insert(widgets, {
-				clickarea   = get_layout_item(view, clickarea_id),
-				slider_knob = get_layout_item(view, knob_id),
-				field       = get_port_field(port_name),
-				is_knob     = false })
+			local field = get_port_field(port_name)
+			if not field or field.is_analog or field.analog_wraps then
+				emu.print_error("Slider port '" .. port_name .. "' must be " ..
+					"an IPT_ADJUSTER. It must not use PORT_WRAPS.")
+				return
+			end
+			add_slider_internal(view, clickarea_id, knob_id, field)
+		end
+
+		-- A spring-loaded slider or wheel.
+		-- See docs for `add_slider()`.
+		function add_sprung_slider(view, clickarea_id, knob_id, port_name)
+			local field = get_port_field(port_name)
+			if not field or not field.is_analog or not field.centerdelta or field.centerdelta == 0 or field.analog_wraps then
+				emu.print_error("Slider port '" .. port_name .. "' must be " ..
+					"an analog port that auto-centers. It must not use PORT_WRAPS.")
+				return
+			end
+			add_slider_internal(view, clickarea_id, knob_id, field)
 		end
 
 		-- A sweep between the attached field's min and max values requires
@@ -682,9 +697,40 @@ copyright-holders:m1macrophage
 		-- the center of `clickarea` will be preserved during rotation.
 		-- It is suggested you place the dot at the top-center of the knob.
 		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
+			local field = get_port_field(port_name)
+			if not field or field.is_analog or field.analog_wraps then
+				emu.print_error("Knob port '" .. port_name .."' must be an " ..
+					"IPT_ADJUSTER and must not use PORT_WRAPS.")
+				return
+			end
+			add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
+		end
+
+		-- See `add_knob()` for info on `scale` and `dot_id`.
+		-- It is assumed a full turn of the encoder changes the port value by:
+		-- (maxvalue - minvalue).
+		function add_encoder(view, clickarea_id, port_name, scale, drag_direction, dot_id)
+			local field = get_port_field(port_name)
+			if not field or not field.analog_wraps then
+				emu.print_error("Encoder port '" .. port_name .."' must either be " ..
+					"an IPT_ADJUSTER or IPT_POSITIONAL[_V], and it must use PORT_WRAPS.")
+				return
+			end
+			add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
+		end
+
+		function add_slider_internal(view, clickarea_id, knob_id, field)
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = field,
+				is_knob     = false })
+		end
+
+		function add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
 			table.insert(widgets, {
 				clickarea     = get_layout_item(view, clickarea_id),
-				field         = get_port_field(port_name),
+				field         = field,
 				is_knob       = true,
 				scale         = scale,
 				is_horizontal = (drag_direction == HORIZONTAL),
@@ -706,20 +752,30 @@ copyright-holders:m1macrophage
 				return nil
 			end
 			local field = nil
+			local num_fields = 0
 			for k, val in pairs(port.fields) do
 				field = val
-				break
+				num_fields = num_fields + 1
 			end
-			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
-			if field == nil then
-				emu.print_error("Port '" .. port_name .."' " .. field_msg)
-				return nil
+			if not field then
+				emu.print_error("Port '" .. port_name .. "' does not contain a field.")
+				return null
 			end
-			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
-				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+			if num_fields > 1 then
+				emu.print_error("Port '" .. port_name .. "' contains more than 1 field.")
 				return nil
 			end
 			return field
+		end
+
+		local function clamp(x, minval, maxval)
+			if x < minval then
+				return minval
+			elseif x > maxval then
+				return maxval
+			else
+				return x
+			end
 		end
 
 		local function set_click_state(widget, state)
@@ -737,7 +793,7 @@ copyright-holders:m1macrophage
 				local widget = widgets[pointers[pointer_id].selected_widget]
 				set_click_state(widget, 0)
 				local field = widget.field
-				if field.is_analog then
+				if field.is_analog and not field.analog_wraps then
 					field:clear_value()
 				end
 			end
@@ -764,12 +820,15 @@ copyright-holders:m1macrophage
 					end
 					if found then
 						set_click_state(widgets[i], 1)
+						local start_value = widgets[i].field.port:read()
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
 							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.port:read() }
+							start_value = start_value,
+							last_frame_value = start_value,
+							last_frame_id = frame_id }
 						break
 					end
 				end
@@ -798,6 +857,22 @@ copyright-holders:m1macrophage
 					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
 					new_value = pointer.start_value + (pointer.start_y - y) * step_y
 				end
+
+				-- Limit large changes for encoder inputs on a single frame, to ensure
+				-- that the direction of change is not ambiguous to the driver.
+				if widget.field.analog_wraps then
+					-- If frame tracking was perfect, the limit could be (value_range / 2 - 1).
+					-- But, occasionally, the frame boundary won't exactly match the change of
+					-- frame_id. Using the max_delta below ensures there is no ambiguity even
+					-- in those cases.
+					local max_delta = (value_range / 2.0 - 1.0) / 2.0
+					new_value = clamp(new_value, pointer.last_frame_value - max_delta, pointer.last_frame_value + max_delta)
+
+					if frame_id ~= pointer.last_frame_id then
+						pointer.last_frame_id = frame_id
+						pointer.last_frame_value = new_value
+					end
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -815,8 +890,11 @@ copyright-holders:m1macrophage
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < min_value then new_value = min_value end
-			if new_value > max_value then new_value = max_value end
+			if widget.field.analog_wraps then
+				new_value = (new_value - min_value) % (value_range + 1) + min_value
+			else
+				new_value = clamp(new_value, min_value, max_value)
+			end
 
 			if widget.field.is_analog then
 				widget.field:set_value(new_value)
@@ -825,6 +903,9 @@ copyright-holders:m1macrophage
 			end
 		end
 
+		-- Rotates the position of the knob indicator around the knob's center.
+		-- This will only work well for circular indicators (dots), since the
+		-- indicator itself is not being rotated.
 		local function get_knob_dot_bounds(widget)
 			local dot = widget.knob_dot_cache
 			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
@@ -847,7 +928,15 @@ copyright-holders:m1macrophage
 					local field = widgets[i].field
 					local knob_bounds = widgets[i].clickarea.bounds
 					local dot_bounds = dot.bounds
-					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					local angle_max, angle_min
+					if field.analog_wraps then
+						angle_max = 2.0 * math.pi
+						angle_min = 0
+					else
+						angle_max = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+						angle_min = -angle_max
+					end
 
 					-- Compute the distance of the knob dot from the knob center.
 					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
@@ -862,8 +951,8 @@ copyright-holders:m1macrophage
 						aspect      = dot_bounds.aspect,
 						value_min   = field.minvalue,
 						value_range = field.maxvalue - field.minvalue,
-						angle_min   = -max_angle,
-						angle_range = 2.0 * max_angle,
+						angle_min   = angle_min,
+						angle_range = angle_max - angle_min,
 						center_y    = -radius,
 						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
 						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
@@ -891,7 +980,14 @@ copyright-holders:m1macrophage
 			pointers = {}
 		end
 
+		local function track_frame_id()
+			frame_id = (frame_id + 1) % 1000000
+			-- 1M is arbitrary. Just need to ensure the same frame ID does not
+			-- repeat between a pointer press and release.
+		end
+
 		function install_slider_callbacks(view)
+			view:set_prepare_items_callback(track_frame_id)
 			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)

--- a/src/mame/layout/moog_source.lay
+++ b/src/mame/layout/moog_source.lay
@@ -290,15 +290,20 @@ copyright-holders:m1macrophage
 		<rect><color red="0" green="0" blue="0" alpha="0"/></rect>
 	</element>
 
-	<element name="encoder_knob">
+	<element name="encoder">
 		<disk>
 			<bounds x="0.0" y="0.0" width="1.0" height="1.0"/>
 			<color red="0.15" green="0.15" blue="0.15"/>
 		</disk>
 		<disk>
 			<bounds x="0.1" y="0.1" width="0.8" height="0.8"/>
-			<color red="0.80" green="0.80" blue="0.80"/>
+			<color state="0" red="0.80" green="0.80" blue="0.80"/>
+			<color state="1" red="0.55" green="0.55" blue="0.55"/>
 		</disk>
+	</element>
+
+	<element name="encoder_dot">
+		<disk state="1"><color red="0.15" green="0.15" blue="0.15"/></disk>
 	</element>
 
 	<element name="wheel_well">
@@ -480,8 +485,8 @@ copyright-holders:m1macrophage
 	<element name="text_control">
 		<text string="CONTROL"><color red="1.0" green="1.0" blue="1.0"/></text>
 	</element>
-	<element name="text_use_arrows">
-		<text string="[UP/DN KEYS]"><color red="0" green="0" blue="0"/></text>
+	<element name="text_use_arrows" defstate="1">
+		<text state="1" string="[UP/DN KEYS]"><color red="0" green="0" blue="0"/></text>
 	</element>
 
 	<element name="text_kb">
@@ -830,10 +835,13 @@ copyright-holders:m1macrophage
 		<element ref="digit" name="edit_digit_0">
 			<bounds x="124" y="136" width="12" height="18"/>
 		</element>
-		<element ref="encoder_knob">
+		<element ref="encoder" id="encoder">
 			<bounds x="70" y="162" width="50" height="50"/>
 		</element>
-		<element ref="text_use_arrows">
+		<element ref="encoder_dot" id="encoder_dot">
+			<bounds x="91" y="163" width="8" height="8"/>
+		</element>
+		<element ref="text_use_arrows" id="encoder_text">
 			<bounds x="80" y="183" width="30" height="7"/>
 		</element>
 
@@ -1417,7 +1425,7 @@ copyright-holders:m1macrophage
 				local view = file.views["Default Layout"]
 				install_slider_callbacks(view)
 
-				add_slider(view, "pitch_wheel", "pitch_wheel_hole", "pitch_wheel")
+				add_sprung_slider(view, "pitch_wheel", "pitch_wheel_hole", "pitch_wheel")
 				add_slider(view, "mod_wheel", "mod_wheel_hole", "mod_wheel")
 
 				add_knob(view, "volume_knob", "volume_knob", 1.6, VERTICAL, "volume_knob_dot")
@@ -1427,13 +1435,17 @@ copyright-holders:m1macrophage
 						return emu.render_color(0, 0, 0, 0)
 					end)
 
+				add_encoder(view, "encoder", "incremental_controller", 0.5, VERTICAL, "encoder_dot")
+				get_layout_item(view, "encoder_dot"):set_state(1)
+				get_layout_item(view, "encoder_text"):set_state(0)
+
 				view.items["plugin_warning"]:set_state(0)
 			end)
 
 		-----------------------------------------------------------------------
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
-		-- version: 11
+		-- version: 12
 		-----------------------------------------------------------------------
 
 		-- Global configuration. Can be overwritten in the resolve_tags callback.
@@ -1446,16 +1458,31 @@ copyright-holders:m1macrophage
 
 		local widgets = {}   -- Stores slider and knob information.
 		local pointers = {}  -- Tracks pointer state.
+		local frame_id = 0   -- Current frame identifier.
 
 		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
 		-- The click area's vertical size must exactly span the range of the
 		-- knob's movement.
 		function add_slider(view, clickarea_id, knob_id, port_name)
-			table.insert(widgets, {
-				clickarea   = get_layout_item(view, clickarea_id),
-				slider_knob = get_layout_item(view, knob_id),
-				field       = get_port_field(port_name),
-				is_knob     = false })
+			local field = get_port_field(port_name)
+			if not field or field.is_analog or field.analog_wraps then
+				emu.print_error("Slider port '" .. port_name .. "' must be " ..
+					"an IPT_ADJUSTER. It must not use PORT_WRAPS.")
+				return
+			end
+			add_slider_internal(view, clickarea_id, knob_id, field)
+		end
+
+		-- A spring-loaded slider or wheel.
+		-- See docs for `add_slider()`.
+		function add_sprung_slider(view, clickarea_id, knob_id, port_name)
+			local field = get_port_field(port_name)
+			if not field or not field.is_analog or not field.centerdelta or field.centerdelta == 0 or field.analog_wraps then
+				emu.print_error("Slider port '" .. port_name .. "' must be " ..
+					"an analog port that auto-centers. It must not use PORT_WRAPS.")
+				return
+			end
+			add_slider_internal(view, clickarea_id, knob_id, field)
 		end
 
 		-- A sweep between the attached field's min and max values requires
@@ -1467,9 +1494,40 @@ copyright-holders:m1macrophage
 		-- the center of `clickarea` will be preserved during rotation.
 		-- It is suggested you place the dot at the top-center of the knob.
 		function add_knob(view, clickarea_id, port_name, scale, drag_direction, dot_id)
+			local field = get_port_field(port_name)
+			if not field or field.is_analog or field.analog_wraps then
+				emu.print_error("Knob port '" .. port_name .."' must be an " ..
+					"IPT_ADJUSTER and must not use PORT_WRAPS.")
+				return
+			end
+			add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
+		end
+
+		-- See `add_knob()` for info on `scale` and `dot_id`.
+		-- It is assumed a full turn of the encoder changes the port value by:
+		-- (maxvalue - minvalue).
+		function add_encoder(view, clickarea_id, port_name, scale, drag_direction, dot_id)
+			local field = get_port_field(port_name)
+			if not field or not field.analog_wraps then
+				emu.print_error("Encoder port '" .. port_name .."' must either be " ..
+					"an IPT_ADJUSTER or IPT_POSITIONAL[_V], and it must use PORT_WRAPS.")
+				return
+			end
+			add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
+		end
+
+		function add_slider_internal(view, clickarea_id, knob_id, field)
+			table.insert(widgets, {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = field,
+				is_knob     = false })
+		end
+
+		function add_knob_internal(view, clickarea_id, field, scale, drag_direction, dot_id)
 			table.insert(widgets, {
 				clickarea     = get_layout_item(view, clickarea_id),
-				field         = get_port_field(port_name),
+				field         = field,
 				is_knob       = true,
 				scale         = scale,
 				is_horizontal = (drag_direction == HORIZONTAL),
@@ -1491,20 +1549,30 @@ copyright-holders:m1macrophage
 				return nil
 			end
 			local field = nil
+			local num_fields = 0
 			for k, val in pairs(port.fields) do
 				field = val
-				break
+				num_fields = num_fields + 1
 			end
-			local field_msg = "Needs to either be an IPT_ADJUSTER, or an analog port with auto-center."
-			if field == nil then
-				emu.print_error("Port '" .. port_name .."' " .. field_msg)
-				return nil
+			if not field then
+				emu.print_error("Port '" .. port_name .. "' does not contain a field.")
+				return null
 			end
-			if field.is_analog and (not field.centerdelta or field.centerdelta == 0) then
-				emu.print_error("Port '" .. port_name .."' " .. field_msg)
+			if num_fields > 1 then
+				emu.print_error("Port '" .. port_name .. "' contains more than 1 field.")
 				return nil
 			end
 			return field
+		end
+
+		local function clamp(x, minval, maxval)
+			if x < minval then
+				return minval
+			elseif x > maxval then
+				return maxval
+			else
+				return x
+			end
 		end
 
 		local function set_click_state(widget, state)
@@ -1522,7 +1590,7 @@ copyright-holders:m1macrophage
 				local widget = widgets[pointers[pointer_id].selected_widget]
 				set_click_state(widget, 0)
 				local field = widget.field
-				if field.is_analog then
+				if field.is_analog and not field.analog_wraps then
 					field:clear_value()
 				end
 			end
@@ -1549,12 +1617,15 @@ copyright-holders:m1macrophage
 					end
 					if found then
 						set_click_state(widgets[i], 1)
+						local start_value = widgets[i].field.port:read()
 						pointers[id] = {
 							selected_widget = i,
 							relative = relative,
 							start_x = x,
 							start_y = y,
-							start_value = widgets[i].field.port:read() }
+							start_value = start_value,
+							last_frame_value = start_value,
+							last_frame_id = frame_id }
 						break
 					end
 				end
@@ -1583,6 +1654,22 @@ copyright-holders:m1macrophage
 					local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
 					new_value = pointer.start_value + (pointer.start_y - y) * step_y
 				end
+
+				-- Limit large changes for encoder inputs on a single frame, to ensure
+				-- that the direction of change is not ambiguous to the driver.
+				if widget.field.analog_wraps then
+					-- If frame tracking was perfect, the limit could be (value_range / 2 - 1).
+					-- But, occasionally, the frame boundary won't exactly match the change of
+					-- frame_id. Using the max_delta below ensures there is no ambiguity even
+					-- in those cases.
+					local max_delta = (value_range / 2.0 - 1.0) / 2.0
+					new_value = clamp(new_value, pointer.last_frame_value - max_delta, pointer.last_frame_value + max_delta)
+
+					if frame_id ~= pointer.last_frame_id then
+						pointer.last_frame_id = frame_id
+						pointer.last_frame_value = new_value
+					end
+				end
 			else
 				local knob_half_height = widget.slider_knob.bounds.height / 2
 				local min_y = widget.clickarea.bounds.y0 + knob_half_height
@@ -1600,8 +1687,11 @@ copyright-holders:m1macrophage
 			end
 
 			new_value = math.floor(new_value + 0.5)
-			if new_value < min_value then new_value = min_value end
-			if new_value > max_value then new_value = max_value end
+			if widget.field.analog_wraps then
+				new_value = (new_value - min_value) % (value_range + 1) + min_value
+			else
+				new_value = clamp(new_value, min_value, max_value)
+			end
 
 			if widget.field.is_analog then
 				widget.field:set_value(new_value)
@@ -1610,6 +1700,9 @@ copyright-holders:m1macrophage
 			end
 		end
 
+		-- Rotates the position of the knob indicator around the knob's center.
+		-- This will only work well for circular indicators (dots), since the
+		-- indicator itself is not being rotated.
 		local function get_knob_dot_bounds(widget)
 			local dot = widget.knob_dot_cache
 			local value = (widget.field.port:read() - dot.value_min) / dot.value_range
@@ -1632,7 +1725,15 @@ copyright-holders:m1macrophage
 					local field = widgets[i].field
 					local knob_bounds = widgets[i].clickarea.bounds
 					local dot_bounds = dot.bounds
-					local max_angle = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+
+					local angle_max, angle_min
+					if field.analog_wraps then
+						angle_max = 2.0 * math.pi
+						angle_min = 0
+					else
+						angle_max = KNOB_DOT_ANGLE_SPAN * 2.0 * math.pi / 360.0
+						angle_min = -angle_max
+					end
 
 					-- Compute the distance of the knob dot from the knob center.
 					local dot_x = dot_bounds.x0 + dot_bounds.width / 2.0
@@ -1647,8 +1748,8 @@ copyright-holders:m1macrophage
 						aspect      = dot_bounds.aspect,
 						value_min   = field.minvalue,
 						value_range = field.maxvalue - field.minvalue,
-						angle_min   = -max_angle,
-						angle_range = 2.0 * max_angle,
+						angle_min   = angle_min,
+						angle_range = angle_max - angle_min,
 						center_y    = -radius,
 						dx = knob_bounds.x0 + (knob_bounds.width - dot_bounds.width) / 2.0,
 						dy = knob_bounds.y0 + (knob_bounds.height - dot_bounds.height) / 2.0 }
@@ -1676,7 +1777,14 @@ copyright-holders:m1macrophage
 			pointers = {}
 		end
 
+		local function track_frame_id()
+			frame_id = (frame_id + 1) % 1000000
+			-- 1M is arbitrary. Just need to ensure the same frame ID does not
+			-- repeat between a pointer press and release.
+		end
+
 		function install_slider_callbacks(view)
+			view:set_prepare_items_callback(track_frame_id)
 			view:set_recomputed_callback(configure_knob_dots)
 			view:set_pointer_updated_callback(pointer_updated)
 			view:set_pointer_left_callback(pointer_left)

--- a/src/mame/moog/source.cpp
+++ b/src/mame/moog/source.cpp
@@ -38,8 +38,10 @@ interactive layout, and is intended as an educational tool.
 #include "nl_source.h"
 
 #include "cpu/z80/z80.h"
+#include "machine/7474.h"
 #include "machine/netlist.h"
 #include "machine/nvram.h"
+#include "machine/quadmouse.h"
 #include "machine/rescap.h"
 #include "machine/timer.h"
 #include "sound/va_eg.h"
@@ -74,6 +76,10 @@ public:
 	source_state(const machine_config &mconfig, device_type type, const char *tag) ATTR_COLD
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, MAINCPU_TAG)
+		, m_encoder(*this, "encoder")
+		, m_enc_ff_top(*this, "encoder_flipflop_top")
+		, m_enc_ff_bottom(*this, "encoder_flipflop_bottom")
+		, m_enc_ff_irq(*this, "encoder_flipflop_irq")
 		, m_contour(*this, "contour_%d", 0)
 		, m_contour_comp(*this, "contour_comp_%d", 0)
 		, m_contour_rate(*this, "source_nl:cntr_rate_%d", 0)
@@ -85,7 +91,6 @@ public:
 		, m_button_a_io(*this, "button_group_a_%d", 0U)
 		, m_button_b_io(*this, "button_group_b_%d", 0U)
 		, m_keyboard_io(*this, "keyboard_oct_%d", 1U)
-		, m_encoder(*this, "incremental_controller")
 		, m_trigger_io(*this, "trigger_in")
 		, m_octave_led(*this, "octave_led_%d", 0U)
 		, m_lfo_rate_led(*this, "mod_rate_led")
@@ -106,7 +111,6 @@ public:
 	void source(machine_config &config) ATTR_COLD;
 
 	DECLARE_INPUT_CHANGED_MEMBER(octave_button_pressed);
-	DECLARE_INPUT_CHANGED_MEMBER(encoder_moved);
 
 protected:
 	void machine_start() override ATTR_COLD;
@@ -114,6 +118,9 @@ protected:
 
 private:
 	void update_octave_leds();
+
+	void enc_ph2_changed(int state);
+	void enc_ph1_changed(int state);
 
 	void edit_latch_w(u8 data);
 	void output_latch_a_w(u8 data);
@@ -142,6 +149,11 @@ private:
 
 	required_device<z80_device> m_maincpu;
 
+	required_device<quadencoder_device> m_encoder;  // Board 6
+	required_device<ttl7474_device> m_enc_ff_top;  // Board 3 U20A (CD4013B)
+	required_device<ttl7474_device> m_enc_ff_bottom;  // Board 3 U20B (CD4013B)
+	required_device<ttl7474_device> m_enc_ff_irq;  // Board 3 U15A (74LS74)
+
 	required_device_array<va_ota_eg_device, 2> m_contour;
 	required_device_array<va_comparator_device, 2> m_contour_comp;
 	required_device_array<netlist_mame_analog_input_device, 2> m_contour_rate;
@@ -155,7 +167,6 @@ private:
 	required_ioport_array<6> m_button_a_io;
 	required_ioport_array<6> m_button_b_io;
 	required_ioport_array<4> m_keyboard_io;
-	required_ioport m_encoder;
 	required_ioport m_trigger_io;
 
 	output_finder<2> m_octave_led;
@@ -173,7 +184,6 @@ private:
 
 	bool m_octave_hi = true;  // `true` due to internal pullups of 74LS367 and 7404.
 	u8 m_button_row_latch = 0xff;
-	bool m_encoder_incr = false;
 	bool m_lfo_state = false;  // Square output of the LFO. -14V (false) to 14V (true).
 
 	float m_lfo_cc = 0;  // Control current into the LFO OTA.
@@ -239,6 +249,30 @@ void source_state::update_octave_leds()
 {
 	m_octave_led[0] = m_octave_hi ? 0 : 1;
 	m_octave_led[1] = m_octave_hi ? 1 : 0;
+}
+
+void source_state::enc_ph2_changed(int state)
+{
+	// U19: CD40106B Schmitt-trigger inverter.
+	// U21: 74LS386 XOR.
+
+	const bool ph2_inv = !state;  // Inverted by U19B.
+	const bool ph2 = !ph2_inv;  // Inverted again by U19F.
+	const bool ph1_inv = !m_encoder->pl_r();  // Inverted by U19C.
+
+	m_enc_ff_top->clock_w(ph2_inv);
+	m_enc_ff_bottom->clock_w(ph2);
+	m_enc_ff_irq->clock_w(ph1_inv != ph2_inv);  // U21A XOR, ph2 inverted again by U19E.
+}
+
+void source_state::enc_ph1_changed(int state)
+{
+	const bool ph1_inv = !state;  // Inverted by U19C.
+	const bool ph2_inv = !!!m_encoder->mn_r();  // Inverted by U19B, U19F, U19E.
+
+	m_enc_ff_top->d_w(ph1_inv);
+	m_enc_ff_bottom->d_w(ph1_inv);
+	m_enc_ff_irq->clock_w(ph1_inv != ph2_inv);  // U21A XOR
 }
 
 void source_state::edit_latch_w(u8 data)
@@ -576,13 +610,23 @@ u8 source_state::buttons_b_r()
 
 u8 source_state::encoder_r()
 {
-	// D0 contains whether the encoder was last incremented or decremented.
-	LOGMASKED(LOG_ENCODER,
-			  "Encoder read: %d - %d\n", m_encoder->read(), m_encoder_incr);
 	// Reading the encoder's state also clears /INT (via U21B, U7A and U15A).
 	if (!machine().side_effects_disabled())
-		m_maincpu->set_input_line(INPUT_LINE_IRQ0, CLEAR_LINE);
-	return m_encoder_incr ? 1 : 0;
+	{
+		// Strobed on port read.
+		m_enc_ff_irq->clear_w(0);
+		m_enc_ff_irq->clear_w(1);
+	}
+
+	bool incr = false;
+	if (!m_encoder->mn_r())  // Inverted by U19B.
+		incr = m_enc_ff_top->output_comp_r();
+	else
+		incr = m_enc_ff_bottom->output_r();
+	LOGMASKED(LOG_ENCODER, "Encoder read - increment: %d\n", incr);
+
+	// D0: encoder incremented.
+	return incr ? 1 : 0;
 }
 
 template<int Which> NETDEV_ANALOG_CALLBACK_MEMBER(source_state::contour_cv_changed)
@@ -757,7 +801,6 @@ void source_state::machine_start()
 {
 	save_item(NAME(m_octave_hi));
 	save_item(NAME(m_button_row_latch));
-	save_item(NAME(m_encoder_incr));
 	save_item(NAME(m_lfo_state));
 	save_item(NAME(m_lfo_cc));
 	save_item(NAME(m_contour_cc));
@@ -788,6 +831,17 @@ void source_state::source(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &source_state::io_map);
 
 	NVRAM(config, NVRAM_TAG, nvram_device::DEFAULT_ALL_0);  // 2x6514: U27, U28.
+
+	// The encoder assembly is a custom design. There is a radial transparent
+	// film with black stripes attached to the wheel. 2 MCT8 optocouplers and
+	// supporting components generate the quadrature pulses. Logic gates and
+	// flipflops process those to produce the IRQ signal and a direction bit.
+	QUADENCODER(config, m_encoder);
+	m_encoder->write_mn().set(FUNC(source_state::enc_ph2_changed));
+	m_encoder->write_pl().set(FUNC(source_state::enc_ph1_changed));
+	TTL7474(config, m_enc_ff_top);
+	TTL7474(config, m_enc_ff_bottom);
+	TTL7474(config, m_enc_ff_irq).comp_output_cb().set_inputline(m_maincpu, INPUT_LINE_IRQ0).invert();
 
 	config.set_default_layout(layout_moog_source);
 
@@ -864,18 +918,6 @@ DECLARE_INPUT_CHANGED_MEMBER(source_state::octave_button_pressed)
 		// No buttons pressed. No change in selected octave.
 	}
 	update_octave_leds();
-}
-
-DECLARE_INPUT_CHANGED_MEMBER(source_state::encoder_moved)
-{
-	constexpr int WRAP_BUFFER = 10;
-	const bool overflowed = newval <= WRAP_BUFFER &&
-							oldval >= 240 - WRAP_BUFFER;
-	const bool underflowed = newval >= 240 - WRAP_BUFFER &&
-							 oldval <= WRAP_BUFFER;
-	m_encoder_incr = ((newval > oldval) || overflowed) && !underflowed;
-	m_maincpu->set_input_line(INPUT_LINE_IRQ0, ASSERT_LINE);
-	LOGMASKED(LOG_ENCODER, "Encoder changed: %d %d\n", newval, m_encoder_incr);
 }
 
 INPUT_PORTS_START(source)
@@ -981,11 +1023,13 @@ INPUT_PORTS_START(source)
 	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_OTHER) PORT_NAME("Octave +1")  // SW2 (Board 5).
 		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(source_state::octave_button_pressed), 0x02)
 
+	// Custom assembly on Board 6. A radial film around the knob has
+	// approximately 100 black stripes.
 	PORT_START("incremental_controller")
-	PORT_BIT(0xff, 0x00, IPT_POSITIONAL_V) PORT_POSITIONS(240) PORT_WRAPS
-		PORT_SENSITIVITY(25) PORT_KEYDELTA(3)
-		PORT_CODE_DEC(KEYCODE_DOWN) PORT_CODE_INC(KEYCODE_UP) PORT_FULL_TURN_COUNT(240)
-		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(source_state::encoder_moved), 1)
+	PORT_BIT(0xff, 0x00, IPT_POSITIONAL_V) PORT_POSITIONS(99) PORT_WRAPS
+		PORT_SENSITIVITY(30) PORT_KEYDELTA(5)
+		PORT_CODE_DEC(KEYCODE_DOWN) PORT_CODE_INC(KEYCODE_UP) PORT_FULL_TURN_COUNT(100)
+		PORT_CHANGED_MEMBER("encoder", FUNC(quadencoder_device::changed), 0)
 
 	PORT_START("keyboard_oct_1")
 	PORT_BIT(0x001, IP_ACTIVE_HIGH, IPT_OTHER) PORT_GM_C2


### PR DESCRIPTION
* `linn_linndrum.lay`: updates to the reference implementation of the "slider" script:
  * Added support for encoder wheels.
  * Made interface for adding sprung sliders explicit.
  * Added more validation for the different control types.
  * Other tidying.
* `source.cpp`: Improved emulation of encoder circuit.
* `moog_source.lay`: Used latest slider script and added interactive control of the encoder wheel.

Review can focus on `source.cpp` and `moog_source.lay`. `linn_linndrum.lay` just contains a copy of the slider script from `moog_source.lay`. 