### PR TITLE
apple2gs: memory esoterica

### DIFF
--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -124,7 +124,6 @@ public:
 		  m_upperaux(*this, "inhaux"),
 		  m_upper00(*this, "inh00"),
 		  m_upper01(*this, "inh01"),
-		  m_megaii(*this, "megaii"),
 		  m_c300bank(*this, "c3bank"),
 		  m_b0_0000bank(*this, "b0r00bank"),
 		  m_b0_0200bank(*this, "b0r02bank"),
@@ -144,6 +143,7 @@ public:
 		  m_lc01(*this, "lc01"),
 		  m_bank0_atc(*this, "bnk0atc"),
 		  m_bank1_atc(*this, "bnk1atc"),
+		  m_megaii(*this, "megaii"),
 		  m_scc(*this, "scc"),
 		  m_doc(*this, "doc"),
 		  m_iwm(*this, "fdc"),
@@ -184,11 +184,12 @@ private:
 	required_device<apple2_gameio_device> m_gameio;
 	required_device<speaker_sound_device> m_speaker;
 	memory_view m_upperbank, m_upperaux, m_upper00, m_upper01;
-	required_device<address_map_bank_device> m_megaii;
 	required_device<address_map_bank_device> m_c300bank;
 	memory_view m_b0_0000bank, m_b0_0200bank, m_b0_0400bank, m_b0_0800bank, m_b0_2000bank, m_b0_4000bank;
 	memory_view m_e0_0000bank, m_e0_0200bank, m_e0_0400bank, m_e0_0800bank, m_e0_2000bank, m_e0_4000bank;
 	memory_view m_lcbank, m_lcaux, m_lc00, m_lc01, m_bank0_atc, m_bank1_atc;
+	required_device<address_map_bank_device> m_megaii;
+	memory_access<17, 0, 0, ENDIANNESS_LITTLE>::specific m_megaii_space;
 	required_device<z80scc_device> m_scc;
 	required_device<es5503_device> m_doc;
 	required_device<applefdintf_device> m_iwm;
@@ -646,6 +647,7 @@ void apple2gs_state::machine_start()
 	m_e0_2000bank.select(0);
 	m_b0_4000bank.select(0);
 	m_e0_4000bank.select(0);
+	m_megaii->space(AS_PROGRAM).specific(m_megaii_space);
 	m_inh_bank = 0;
 	std::fill(std::begin(m_megaii_ram), std::end(m_megaii_ram), 0);
 
@@ -2493,7 +2495,7 @@ void apple2gs_state::fastram_r(offs_t offset, u8 &data)
 		// I/O is shadowed from all RAM banks
 		if (!(m_shadow & SHAD_IOLC) && ((offset16 >> 12) == 0xc))
 		{
-			data = m_megaii->space().read_byte(offset16);
+			data = m_megaii_space.read_byte(offset16);
 		}
 	}
 }
@@ -2507,7 +2509,7 @@ void apple2gs_state::fastram_w(offs_t offset, u8 &data)
 		// I/O is shadowed from all RAM banks
 		if (!(m_shadow & SHAD_IOLC) && ((offset16 >> 12) == 0xc))
 		{
-			m_megaii->space().write_byte(offset16, data);
+			m_megaii_space.write_byte(offset16, data);
 		}
 		else if (offset & 0x10000)
 		{
@@ -3231,8 +3233,8 @@ void apple2gs_state::apple2gs_map(address_map &map)
 	// Unfortunately all I/O happens here, including new IIgs-specific stuff
 	map(0xe00000, 0xe0ffff).m(m_megaii, FUNC(address_map_bank_device::amap8));
 	map(0xe10000, 0xe1ffff).lrw8(
-		[this](offs_t offset)          { return m_megaii->space().read_byte(offset + m_banklatch); }, "e1_r",
-		[this](offs_t offset, u8 data) { m_megaii->space().write_byte(offset + m_banklatch, data); }, "e1_w");
+		[this](offs_t offset)          { return m_megaii_space.read_byte(offset + m_banklatch); }, "e1_r",
+		[this](offs_t offset, u8 data) { m_megaii_space.write_byte(offset + m_banklatch, data); }, "e1_w");
 
 	map(0xfe0000, 0xffffff).rom().region("maincpu", 0x20000);
 }

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -261,7 +261,7 @@ private:
 
 	static constexpr u8 SPEED_HIGH      = 0x80; // full 2.8 MHz speed when set, Apple II 1 MHz when clear
 	[[maybe_unused]] static constexpr u8 SPEED_POWERON = 0x40; // ROM 03 only; indicates machine turned on by power switch (as opposed to ?)
-	static constexpr u8 SPEED_ALLBANKS  = 0x10; // enables bank 0/1 shadowing in all banks (not supported)
+	static constexpr u8 SPEED_ALLBANKS  = 0x10; // enables bank 0/1 shadowing in all RAM banks
 	[[maybe_unused]] static constexpr u8 SPEED_DISKIISL7 = 0x08; // enable Disk II motor on detect for slot 7
 	[[maybe_unused]] static constexpr u8 SPEED_DISKIISL6 = 0x04; // enable Disk II motor on detect for slot 6
 	[[maybe_unused]] static constexpr u8 SPEED_DISKIISL5 = 0x02; // enable Disk II motor on detect for slot 5
@@ -389,15 +389,18 @@ private:
 	void lc_00_w(offs_t offset, u8 data);
 	u8 lc_01_r(offs_t offset);
 	void lc_01_w(offs_t offset, u8 data);
+	void bank0_0000_sh_w(offs_t offset, u8 data);
 	u8 bank0_c000_r(offs_t offset);
 	void bank0_c000_w(offs_t offset, u8 data);
 	u8 bank1_0000_r(offs_t offset);
+	void bank1_0000_w(offs_t offset, u8 data);
 	void bank1_0000_sh_w(offs_t offset, u8 data);
 	u8 bank1_c000_r(offs_t offset);
 	void bank1_c000_w(offs_t offset, u8 data);
 	u8 floatingbank_r(offs_t offset);
 	u8 ghostram_r(offs_t offset);
 	void ghostram_w(offs_t offset, u8 data);
+	void fastram_w(offs_t offset, u8 &data);
 	void a2bus_irq_w(int state);
 	void a2bus_nmi_w(int state);
 	void a2bus_inh_w(int state);
@@ -744,6 +747,14 @@ void apple2gs_state::machine_start()
 				space.nop_read(0xf00000, 0xfbffff);
 		}
 	}
+
+	// tap RAM writes for FPI shadow
+	space.install_write_tap(
+		0x020000, 0xdfffff, "fpi",
+		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_w(offset, data); });
+	space.install_write_tap(
+		0xe20000, 0xefffff, "fpi",
+		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_w(offset, data); });
 
 	// setup save states
 	save_item(NAME(m_speaker_state));
@@ -2052,11 +2063,6 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 
 		case 0x36:  // SPEED
 			m_speed = data; // bits 5-6 are not forced to zero
-
-			if (m_speed & SPEED_ALLBANKS)
-			{
-				logerror("apple2gs: Driver does not support shadowing in all banks\n");
-			}
 			update_speed();
 			break;
 
@@ -2150,13 +2156,14 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 						{
 							if(!machine().side_effects_disabled())
 							{
+								const u8 bank = offset >> 16;
 								bool iobank = false;
 
-								switch(offset >> 16)
+								switch(bank)
 								{
-									// default:
-									//  if (!(m_speed & SPEED_ALLBANKS)) break; // (not supported)
-									//  [[fallthrough]];
+									default: // I/O is never shadowed from ROM banks
+										if (!(m_speed & SPEED_ALLBANKS) || (bank >= 0xf0)) break;
+										[[fallthrough]];
 									case 0x00: case 0x01:
 										if (m_shadow & SHAD_IOLC) break;
 										[[fallthrough]];
@@ -2515,6 +2522,28 @@ void apple2gs_state::ghostram_w(offs_t offset, u8 data)
 
 	if (ghost_offset < m_ram_size)
 		m_ram_ptr[ghost_offset] = data;
+}
+
+void apple2gs_state::fastram_w(offs_t offset, u8 &data)
+{
+	if (m_speed & SPEED_ALLBANKS)
+	{
+		const u16 offset16 = offset & 0xffff;
+
+		// I/O is shadowed from all RAM banks
+		if (!(m_shadow & SHAD_IOLC) && ((offset16 >> 12) == 0xc))
+		{
+			m_megaii->space().write_byte(offset16, data);
+		}
+		else if (offset & 0x10000)
+		{
+			bank1_0000_sh_w(offset16, data);
+		}
+		else
+		{
+			bank0_0000_sh_w(offset16, data);
+		}
+	}
 }
 
 u8 apple2gs_state::inh_r(offs_t offset)
@@ -3054,13 +3083,52 @@ void apple2gs_state::bank0_c000_w(offs_t offset, u8 data)
 	m_ram_ptr[offset + 0xc000] = data;
 }
 
+void apple2gs_state::bank0_0000_sh_w(offs_t offset, u8 data)
+{
+	switch (offset >> 10)
+	{
+		case 0x01:  // text page 1
+			if (!(m_shadow & SHAD_TXTPG1))
+			{
+				slow_cycle();
+				m_megaii_ram[offset] = data;
+			}
+			break;
+
+		case 0x02:  // text page 2 (only shadowable on ROM 03)
+			if ((!(m_shadow & SHAD_TXTPG2)) && m_is_rom3)
+			{
+				slow_cycle();
+				m_megaii_ram[offset] = data;
+			}
+			break;
+
+		// hi-res page 1
+		case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
+			if (!(m_shadow & SHAD_HIRESPG1))
+			{
+				slow_cycle();
+				m_megaii_ram[offset] = data;
+			}
+			break;
+
+		// hi-res page 2
+		case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
+			if (!(m_shadow & SHAD_HIRESPG2))
+			{
+				slow_cycle();
+				m_megaii_ram[offset] = data;
+			}
+			break;
+	}
+}
+
 u8 apple2gs_state::bank1_0000_r(offs_t offset) { return m_ram_ptr[offset + 0x10000]; }
 u8 apple2gs_state::bank1_c000_r(offs_t offset) { if (offset & 0x2000) offset ^= 0x1000; return m_ram_ptr[offset + 0x1c000]; }
 void apple2gs_state::bank1_c000_w(offs_t offset, u8 data) { if (offset & 0x2000) offset ^= 0x1000; m_ram_ptr[offset + 0x1c000] = data; }
+void apple2gs_state::bank1_0000_w(offs_t offset, u8 data) { m_ram_ptr[offset + 0x10000] = data; bank1_0000_sh_w(offset, data); }
 void apple2gs_state::bank1_0000_sh_w(offs_t offset, u8 data)
 {
-	m_ram_ptr[offset + 0x10000] = data;
-
 	switch (offset>>10)
 	{
 		case 0x01:  // text page 1
@@ -3079,7 +3147,7 @@ void apple2gs_state::bank1_0000_sh_w(offs_t offset, u8 data)
 			}
 			break;
 
-			// hi-res page 1
+		// hi-res page 1
 		case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
 			if ((!(m_shadow & SHAD_HIRESPG1) && !(m_shadow & SHAD_AUXHIRES)) || !(m_shadow & SHAD_SUPERHIRES))
 			{
@@ -3087,7 +3155,7 @@ void apple2gs_state::bank1_0000_sh_w(offs_t offset, u8 data)
 			}
 			break;
 
-			// hi-res page 2
+		// hi-res page 2
 		case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
 			if ((!(m_shadow & SHAD_HIRESPG2) && !(m_shadow & SHAD_AUXHIRES)) || !(m_shadow & SHAD_SUPERHIRES))
 			{
@@ -3166,7 +3234,7 @@ void apple2gs_state::apple2gs_map(address_map &map)
 	m_lc00[2](0xd000, 0xffff).rom().region("maincpu", 0x39000).w(FUNC(apple2gs_state::lc_00_w));
 	m_lc00[3](0xd000, 0xffff).rw(FUNC(apple2gs_state::lc_00_r), FUNC(apple2gs_state::lc_00_w));
 
-	map(0x010000, 0x01bfff).rw(FUNC(apple2gs_state::bank1_0000_r), FUNC(apple2gs_state::bank1_0000_sh_w));
+	map(0x010000, 0x01bfff).rw(FUNC(apple2gs_state::bank1_0000_r), FUNC(apple2gs_state::bank1_0000_w));
 
 	map(0x01c000, 0x01ffff).view(m_bank1_atc);
 	m_bank1_atc[0](0x1c000, 0x1ffff).rw(FUNC(apple2gs_state::bank1_c000_r), FUNC(apple2gs_state::bank1_c000_w));

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -102,7 +102,7 @@ namespace {
 #define A2GS_AUXUPPER_TAG "inhaux"
 #define A2GS_00UPPER_TAG "inh00"
 #define A2GS_01UPPER_TAG "inh01"
-
+#define A2GS_MEGAII_TAG "megaii"
 #define A2GS_C300_TAG "c3bank"
 #define A2GS_LCBANK_TAG "lcbank"
 #define A2GS_LCAUX_TAG "lcaux"
@@ -145,6 +145,7 @@ public:
 		  m_upperaux(*this, A2GS_AUXUPPER_TAG),
 		  m_upper00(*this, A2GS_00UPPER_TAG),
 		  m_upper01(*this, A2GS_01UPPER_TAG),
+		  m_megaii(*this, A2GS_MEGAII_TAG),
 		  m_c300bank(*this, A2GS_C300_TAG),
 		  m_b0_0000bank(*this, A2GS_B00000_TAG),
 		  m_b0_0200bank(*this, A2GS_B00200_TAG),
@@ -204,6 +205,7 @@ private:
 	required_device<apple2_gameio_device> m_gameio;
 	required_device<speaker_sound_device> m_speaker;
 	memory_view m_upperbank, m_upperaux, m_upper00, m_upper01;
+	required_device<address_map_bank_device> m_megaii;
 	required_device<address_map_bank_device> m_c300bank;
 	memory_view m_b0_0000bank, m_b0_0200bank, m_b0_0400bank, m_b0_0800bank, m_b0_2000bank, m_b0_4000bank;
 	memory_view m_e0_0000bank, m_e0_0200bank, m_e0_0400bank, m_e0_0800bank, m_e0_2000bank, m_e0_4000bank;
@@ -320,6 +322,7 @@ private:
 	void palette_init(palette_device &palette);
 
 	void apple2gs_map(address_map &map) ATTR_COLD;
+	void megaii_map(address_map &map) ATTR_COLD;
 	void vectors_map(address_map &map) ATTR_COLD;
 	void a2gs_es5503_map(address_map &map) ATTR_COLD;
 	void c300bank_map(address_map &map) ATTR_COLD;
@@ -374,8 +377,6 @@ private:
 	u8 c300_r(offs_t offset);
 	u8 c300_int_r(offs_t offset);
 	void c300_w(offs_t offset, u8 data);
-	u8 c400_r(offs_t offset);
-	void c400_w(offs_t offset, u8 data);
 	u8 c800_r(offs_t offset);
 	void c800_w(offs_t offset, u8 data);
 	u8 inh_r(offs_t offset);
@@ -450,6 +451,7 @@ private:
 	bool m_ramrd = false, m_ramwrt = false;
 	bool m_lcram = false, m_lcram2 = false, m_lcprewrite = false, m_lcwriteenable = false;
 	bool m_rombank = false;
+	u32 m_banklatch = 0;
 
 	u8 m_shadow = 0, m_speed = 0;
 	u8 m_motors_active = 0, m_slotromsel = 0, m_intflag = 0, m_vgcint = 0, m_inten = 0;
@@ -770,6 +772,7 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_lcprewrite));
 	save_item(NAME(m_lcwriteenable));
 	save_item(NAME(m_rombank));
+	save_item(NAME(m_banklatch));
 	save_item(NAME(m_shadow));
 	save_item(NAME(m_speed));
 	save_item(NAME(m_clock_control));
@@ -835,6 +838,7 @@ void apple2gs_state::machine_reset()
 	m_ramwrt = false;
 	m_rombank = false;
 	m_video->set_newvideo(0x01); // verified on ROM03 hardware
+	m_banklatch = 1 << 16;
 	m_slot_irq = false;
 	m_clkdata = 0;
 	m_clock_control = 0;
@@ -1982,6 +1986,8 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 
 		case 0x29:  // NEWVIDEO
 			m_video->set_newvideo(data & 0xe1);
+			// Hardware Reference, Table 4-18 is backwards
+			m_banklatch = (data & 1) << 16;
 			break;
 
 		case 0x2b:  // LANGSEL
@@ -2443,28 +2449,6 @@ u8 apple2gs_state::c300_int_r(offs_t offset)
 u8 apple2gs_state::c300_r(offs_t offset)  { return read_slot_rom(3, offset); }
 void apple2gs_state::c300_w(offs_t offset, u8 data) { write_slot_rom(3, offset, data); }
 
-u8 apple2gs_state::c400_r(offs_t offset)
-{
-	const int slot = ((offset>>8) & 0xf) + 4;
-
-	if (m_intcxrom || !BIT(m_slotromsel, slot))
-	{
-		return read_int_rom(0x3c400, offset);
-	}
-
-	return read_slot_rom(4, offset);
-}
-
-void apple2gs_state::c400_w(offs_t offset, u8 data)
-{
-	const int slot = ((offset>>8) & 0xf) + 4;
-
-	if (!m_intcxrom && BIT(m_slotromsel, slot))
-	{
-		write_slot_rom(4, offset, data);
-	}
-}
-
 u8 apple2gs_state::c800_r(offs_t offset)
 {
 	const int slot = m_cnxx_slot;
@@ -2898,7 +2882,7 @@ u8 apple2gs_state::auxram0000_r(offs_t offset)
 			offset = ((offset - 0x2000) >> 1) + 0x2000;
 		}
 	}
-	return m_megaii_ram[offset+0x10000];
+	return m_megaii_ram[offset+0x10000]; // only reached via E1 forwarding, m_banklatch implicitly 0x10000
 }
 
 void apple2gs_state::auxram0000_w(offs_t offset, u8 data)
@@ -2907,7 +2891,8 @@ void apple2gs_state::auxram0000_w(offs_t offset, u8 data)
 
 	slow_cycle();
 
-	if ((offset >= 0x2000) && (offset < 0xa000) && ((m_video->get_newvideo() & 0xc0) != 0))
+	// linearization is skipped if bank latch redirects to E0
+	if (m_banklatch && (offset >= 0x2000) && (offset < 0xa000) && ((m_video->get_newvideo() & 0xc0) != 0))
 	{
 		if (offset & 1)
 		{
@@ -2919,9 +2904,9 @@ void apple2gs_state::auxram0000_w(offs_t offset, u8 data)
 		}
 	}
 
-	m_megaii_ram[offset+0x10000] = data;
+	m_megaii_ram[offset + m_banklatch] = data;
 
-	if ((orig_addr >= 0x9e00) && (orig_addr <= 0x9fff))
+	if (m_banklatch && (orig_addr >= 0x9e00) && (orig_addr <= 0x9fff))
 	{
 		int color = (orig_addr - 0x9e00) >> 1;
 		m_video->set_SHR_color(color, rgb_t(
@@ -2993,7 +2978,7 @@ void apple2gs_state::b1ram0400_w(offs_t offset, u8 data)
 	if (!(m_shadow & SHAD_TXTPG1))
 	{
 		slow_cycle();
-		m_megaii_ram[offset+0x10400] = data;
+		m_megaii_ram[offset + m_banklatch + 0x0400] = data;
 	}
 }
 u8 apple2gs_state::b1ram0800_r(offs_t offset) { return m_ram_ptr[offset+0x10800]; }
@@ -3005,7 +2990,7 @@ void apple2gs_state::b1ram0800_w(offs_t offset, u8 data)
 		if (!(m_shadow & SHAD_TXTPG2) && m_is_rom3)
 		{
 			slow_cycle();
-			m_megaii_ram[offset+0x10800] = data;
+			m_megaii_ram[offset + m_banklatch + 0x0800] = data;
 		}
 	}
 }
@@ -3082,15 +3067,15 @@ void apple2gs_state::bank1_0000_sh_w(offs_t offset, u8 data)
 			if (!(m_shadow & SHAD_TXTPG1))
 			{
 				slow_cycle();
-				m_megaii_ram[offset + 0x10000] = data;
+				m_megaii_ram[offset + m_banklatch] = data;
 			}
 			break;
 
 		case 0x02:  // text page 2 (only shadowable on ROM 03)
-			if ((!(m_shadow & SHAD_TXTPG2)) && (m_is_rom3))
+			if ((!(m_shadow & SHAD_TXTPG2)) && m_is_rom3)
 			{
 				slow_cycle();
-				m_megaii_ram[offset + 0x10000] = data;
+				m_megaii_ram[offset + m_banklatch] = data;
 			}
 			break;
 
@@ -3168,9 +3153,8 @@ void apple2gs_state::apple2gs_map(address_map &map)
 	m_bank0_atc[0](0xc000, 0xffff).rw(FUNC(apple2gs_state::bank0_c000_r), FUNC(apple2gs_state::bank0_c000_w));
 	m_bank0_atc[1](0xc000, 0xc07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
 	m_bank0_atc[1](0xc080, 0xc0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
-	m_bank0_atc[1](0xc100, 0xc2ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
+	m_bank0_atc[1](0xc100, 0xc7ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
 	m_bank0_atc[1](0xc300, 0xc3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
-	m_bank0_atc[1](0xc400, 0xc7ff).rw(FUNC(apple2gs_state::c400_r), FUNC(apple2gs_state::c400_w));
 	m_bank0_atc[1](0xc800, 0xcfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
 
 	m_bank0_atc[1](0xd000, 0xffff).view(m_upper00);
@@ -3188,9 +3172,8 @@ void apple2gs_state::apple2gs_map(address_map &map)
 	m_bank1_atc[0](0x1c000, 0x1ffff).rw(FUNC(apple2gs_state::bank1_c000_r), FUNC(apple2gs_state::bank1_c000_w));
 	m_bank1_atc[1](0x1c000, 0x1c07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
 	m_bank1_atc[1](0x1c080, 0x1c0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
-	m_bank1_atc[1](0x1c100, 0x1c2ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
+	m_bank1_atc[1](0x1c100, 0x1c7ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
 	m_bank1_atc[1](0x1c300, 0x1c3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
-	m_bank1_atc[1](0x1c400, 0x1c7ff).rw(FUNC(apple2gs_state::c400_r), FUNC(apple2gs_state::c400_w));
 	m_bank1_atc[1](0x1c800, 0x1cfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
 
 	m_bank1_atc[1](0x1d000, 0x1ffff).view(m_upper01);
@@ -3202,70 +3185,76 @@ void apple2gs_state::apple2gs_map(address_map &map)
 
 	// "Mega II side" - this is basically a 128K IIe on a chip that runs merrily at 1 MHz
 	// Unfortunately all I/O happens here, including new IIgs-specific stuff
-	map(0xe00000, 0xe001ff).view(m_e0_0000bank);
-	m_e0_0000bank[0](0xe00000, 0xe001ff).rw(FUNC(apple2gs_state::e0ram_r<0x0000>), FUNC(apple2gs_state::e0ram_w<0x0000>));
-	m_e0_0000bank[1](0xe00000, 0xe001ff).rw(FUNC(apple2gs_state::e1ram_r<0x0000>), FUNC(apple2gs_state::e1ram_w<0x0000>));
-
-	map(0xe00200, 0xe003ff).view(m_e0_0200bank);
-	m_e0_0200bank[0](0xe00200, 0xe003ff).rw(FUNC(apple2gs_state::e0ram_r<0x0200>), FUNC(apple2gs_state::e0ram_w<0x0200>)); // wr 0 rd 0
-	m_e0_0200bank[1](0xe00200, 0xe003ff).rw(FUNC(apple2gs_state::e1ram_r<0x0200>), FUNC(apple2gs_state::e0ram_w<0x0200>)); // wr 0 rd 1
-	m_e0_0200bank[2](0xe00200, 0xe003ff).rw(FUNC(apple2gs_state::e0ram_r<0x0200>), FUNC(apple2gs_state::e1ram_w<0x0200>)); // wr 1 rd 0
-	m_e0_0200bank[3](0xe00200, 0xe003ff).rw(FUNC(apple2gs_state::e1ram_r<0x0200>), FUNC(apple2gs_state::e1ram_w<0x0200>)); // wr 1 rd 1
-
-	map(0xe00400, 0xe007ff).view(m_e0_0400bank);
-	m_e0_0400bank[0](0xe00400, 0xe007ff).rw(FUNC(apple2gs_state::e0ram_r<0x0400>), FUNC(apple2gs_state::e0ram_w<0x0400>)); // wr 0 rd 0
-	m_e0_0400bank[1](0xe00400, 0xe007ff).rw(FUNC(apple2gs_state::e1ram_r<0x0400>), FUNC(apple2gs_state::e0ram_w<0x0400>)); // wr 0 rd 1
-	m_e0_0400bank[2](0xe00400, 0xe007ff).rw(FUNC(apple2gs_state::e0ram_r<0x0400>), FUNC(apple2gs_state::e1ram_w<0x0400>)); // wr 1 rd 0
-	m_e0_0400bank[3](0xe00400, 0xe007ff).rw(FUNC(apple2gs_state::e1ram_r<0x0400>), FUNC(apple2gs_state::e1ram_w<0x0400>)); // wr 1 rd 1
-
-	map(0xe00800, 0xe01fff).view(m_e0_0800bank);
-	m_e0_0800bank[0](0xe00800, 0xe01fff).rw(FUNC(apple2gs_state::e0ram_r<0x0800>), FUNC(apple2gs_state::e0ram_w<0x0800>));
-	m_e0_0800bank[1](0xe00800, 0xe01fff).rw(FUNC(apple2gs_state::e1ram_r<0x0800>), FUNC(apple2gs_state::e0ram_w<0x0800>));
-	m_e0_0800bank[2](0xe00800, 0xe01fff).rw(FUNC(apple2gs_state::e0ram_r<0x0800>), FUNC(apple2gs_state::e1ram_w<0x0800>));
-	m_e0_0800bank[3](0xe00800, 0xe01fff).rw(FUNC(apple2gs_state::e1ram_r<0x0800>), FUNC(apple2gs_state::e1ram_w<0x0800>));
-
-	map(0xe02000, 0xe03fff).view(m_e0_2000bank);
-	m_e0_2000bank[0](0xe02000, 0xe03fff).rw(FUNC(apple2gs_state::e0ram_r<0x2000>), FUNC(apple2gs_state::e0ram_w<0x2000>));
-	m_e0_2000bank[1](0xe02000, 0xe03fff).rw(FUNC(apple2gs_state::e1ram_r<0x2000>), FUNC(apple2gs_state::e0ram_w<0x2000>));
-	m_e0_2000bank[2](0xe02000, 0xe03fff).rw(FUNC(apple2gs_state::e0ram_r<0x2000>), FUNC(apple2gs_state::e1ram_w<0x2000>));
-	m_e0_2000bank[3](0xe02000, 0xe03fff).rw(FUNC(apple2gs_state::e1ram_r<0x2000>), FUNC(apple2gs_state::e1ram_w<0x2000>));
-
-	map(0xe04000, 0xe0bfff).view(m_e0_4000bank);
-	m_e0_4000bank[0](0xe04000, 0xe0bfff).rw(FUNC(apple2gs_state::e0ram_r<0x4000>), FUNC(apple2gs_state::e0ram_w<0x4000>));
-	m_e0_4000bank[1](0xe04000, 0xe0bfff).rw(FUNC(apple2gs_state::e1ram_r<0x4000>), FUNC(apple2gs_state::e0ram_w<0x4000>));
-	m_e0_4000bank[2](0xe04000, 0xe0bfff).rw(FUNC(apple2gs_state::e0ram_r<0x4000>), FUNC(apple2gs_state::e1ram_w<0x4000>));
-	m_e0_4000bank[3](0xe04000, 0xe0bfff).rw(FUNC(apple2gs_state::e1ram_r<0x4000>), FUNC(apple2gs_state::e1ram_w<0x4000>));
-
-	map(0xe0c000, 0xe0c07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
-	map(0xe0c080, 0xe0c0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
-	map(0xe0c100, 0xe0c2ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
-	map(0xe0c300, 0xe0c3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
-	map(0xe0c400, 0xe0c7ff).rw(FUNC(apple2gs_state::c400_r), FUNC(apple2gs_state::c400_w));
-	map(0xe0c800, 0xe0cfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
-
-	map(0xe0d000, 0xe0ffff).view(m_upperbank);
-	m_upperbank[0](0xe0d000, 0xe0ffff).view(m_lcbank);
-	m_upperbank[1](0xe0d000, 0xe0ffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
-
-	m_lcbank[0](0xe0d000, 0xe0ffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_w));
-	m_lcbank[1](0xe0d000, 0xe0ffff).rw(FUNC(apple2gs_state::lc_r), FUNC(apple2gs_state::lc_w));
-
-	map(0xe10000, 0xe1bfff).rw(FUNC(apple2gs_state::auxram0000_r), FUNC(apple2gs_state::auxram0000_w));
-	map(0xe1c000, 0xe1c07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
-	map(0xe1c080, 0xe1c0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
-	map(0xe1c100, 0xe1c2ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
-	map(0xe1c300, 0xe1c3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
-	map(0xe1c400, 0xe1c7ff).rw(FUNC(apple2gs_state::c400_r), FUNC(apple2gs_state::c400_w));
-	map(0xe1c800, 0xe1cfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
-
-	map(0xe1d000, 0xe1ffff).view(m_upperaux);
-	m_upperaux[0](0xe1d000, 0xe1ffff).view(m_lcaux);
-	m_upperaux[1](0xe1d000, 0xe1ffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
-
-	m_lcaux[0](0xe1d000, 0xe1ffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_aux_w));
-	m_lcaux[1](0xe1d000, 0xe1ffff).rw(FUNC(apple2gs_state::lc_aux_r), FUNC(apple2gs_state::lc_aux_w));
+	map(0xe00000, 0xe0ffff).m(m_megaii, FUNC(address_map_bank_device::amap8));
+	map(0xe10000, 0xe1ffff).lrw8(
+		[this](offs_t offset)          { return m_megaii->space().read_byte(offset + m_banklatch); }, "e1_r",
+		[this](offs_t offset, u8 data) { m_megaii->space().write_byte(offset + m_banklatch, data); }, "e1_w");
 
 	map(0xfe0000, 0xffffff).rom().region("maincpu", 0x20000);
+}
+
+void apple2gs_state::megaii_map(address_map &map)
+{
+	map(0x0000, 0x01ff).view(m_e0_0000bank);
+	m_e0_0000bank[0](0x0000, 0x01ff).rw(FUNC(apple2gs_state::e0ram_r<0x0000>), FUNC(apple2gs_state::e0ram_w<0x0000>));
+	m_e0_0000bank[1](0x0000, 0x01ff).rw(FUNC(apple2gs_state::e1ram_r<0x0000>), FUNC(apple2gs_state::e1ram_w<0x0000>));
+
+	map(0x0200, 0x03ff).view(m_e0_0200bank);
+	m_e0_0200bank[0](0x0200, 0x03ff).rw(FUNC(apple2gs_state::e0ram_r<0x0200>), FUNC(apple2gs_state::e0ram_w<0x0200>)); // wr 0 rd 0
+	m_e0_0200bank[1](0x0200, 0x03ff).rw(FUNC(apple2gs_state::e1ram_r<0x0200>), FUNC(apple2gs_state::e0ram_w<0x0200>)); // wr 0 rd 1
+	m_e0_0200bank[2](0x0200, 0x03ff).rw(FUNC(apple2gs_state::e0ram_r<0x0200>), FUNC(apple2gs_state::e1ram_w<0x0200>)); // wr 1 rd 0
+	m_e0_0200bank[3](0x0200, 0x03ff).rw(FUNC(apple2gs_state::e1ram_r<0x0200>), FUNC(apple2gs_state::e1ram_w<0x0200>)); // wr 1 rd 1
+
+	map(0x0400, 0x07ff).view(m_e0_0400bank);
+	m_e0_0400bank[0](0x0400, 0x07ff).rw(FUNC(apple2gs_state::e0ram_r<0x0400>), FUNC(apple2gs_state::e0ram_w<0x0400>)); // wr 0 rd 0
+	m_e0_0400bank[1](0x0400, 0x07ff).rw(FUNC(apple2gs_state::e1ram_r<0x0400>), FUNC(apple2gs_state::e0ram_w<0x0400>)); // wr 0 rd 1
+	m_e0_0400bank[2](0x0400, 0x07ff).rw(FUNC(apple2gs_state::e0ram_r<0x0400>), FUNC(apple2gs_state::e1ram_w<0x0400>)); // wr 1 rd 0
+	m_e0_0400bank[3](0x0400, 0x07ff).rw(FUNC(apple2gs_state::e1ram_r<0x0400>), FUNC(apple2gs_state::e1ram_w<0x0400>)); // wr 1 rd 1
+
+	map(0x0800, 0x1fff).view(m_e0_0800bank);
+	m_e0_0800bank[0](0x0800, 0x1fff).rw(FUNC(apple2gs_state::e0ram_r<0x0800>), FUNC(apple2gs_state::e0ram_w<0x0800>));
+	m_e0_0800bank[1](0x0800, 0x1fff).rw(FUNC(apple2gs_state::e1ram_r<0x0800>), FUNC(apple2gs_state::e0ram_w<0x0800>));
+	m_e0_0800bank[2](0x0800, 0x1fff).rw(FUNC(apple2gs_state::e0ram_r<0x0800>), FUNC(apple2gs_state::e1ram_w<0x0800>));
+	m_e0_0800bank[3](0x0800, 0x1fff).rw(FUNC(apple2gs_state::e1ram_r<0x0800>), FUNC(apple2gs_state::e1ram_w<0x0800>));
+
+	map(0x2000, 0x3fff).view(m_e0_2000bank);
+	m_e0_2000bank[0](0x2000, 0x3fff).rw(FUNC(apple2gs_state::e0ram_r<0x2000>), FUNC(apple2gs_state::e0ram_w<0x2000>));
+	m_e0_2000bank[1](0x2000, 0x3fff).rw(FUNC(apple2gs_state::e1ram_r<0x2000>), FUNC(apple2gs_state::e0ram_w<0x2000>));
+	m_e0_2000bank[2](0x2000, 0x3fff).rw(FUNC(apple2gs_state::e0ram_r<0x2000>), FUNC(apple2gs_state::e1ram_w<0x2000>));
+	m_e0_2000bank[3](0x2000, 0x3fff).rw(FUNC(apple2gs_state::e1ram_r<0x2000>), FUNC(apple2gs_state::e1ram_w<0x2000>));
+
+	map(0x4000, 0xbfff).view(m_e0_4000bank);
+	m_e0_4000bank[0](0x4000, 0xbfff).rw(FUNC(apple2gs_state::e0ram_r<0x4000>), FUNC(apple2gs_state::e0ram_w<0x4000>));
+	m_e0_4000bank[1](0x4000, 0xbfff).rw(FUNC(apple2gs_state::e1ram_r<0x4000>), FUNC(apple2gs_state::e0ram_w<0x4000>));
+	m_e0_4000bank[2](0x4000, 0xbfff).rw(FUNC(apple2gs_state::e0ram_r<0x4000>), FUNC(apple2gs_state::e1ram_w<0x4000>));
+	m_e0_4000bank[3](0x4000, 0xbfff).rw(FUNC(apple2gs_state::e1ram_r<0x4000>), FUNC(apple2gs_state::e1ram_w<0x4000>));
+
+	map(0xc000, 0xc07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
+	map(0xc080, 0xc0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
+	map(0xc100, 0xc7ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
+	map(0xc300, 0xc3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
+	map(0xc800, 0xcfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
+
+	map(0xd000, 0xffff).view(m_upperbank);
+	m_upperbank[0](0xd000, 0xffff).view(m_lcbank);
+	m_upperbank[1](0xd000, 0xffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
+
+	m_lcbank[0](0xd000, 0xffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_w));
+	m_lcbank[1](0xd000, 0xffff).rw(FUNC(apple2gs_state::lc_r), FUNC(apple2gs_state::lc_w));
+
+	map(0x10000, 0x1bfff).rw(FUNC(apple2gs_state::auxram0000_r), FUNC(apple2gs_state::auxram0000_w));
+	map(0x1c000, 0x1c07f).rw(FUNC(apple2gs_state::c000_r), FUNC(apple2gs_state::c000_w));
+	map(0x1c080, 0x1c0ff).rw(FUNC(apple2gs_state::c080_r), FUNC(apple2gs_state::c080_w));
+	map(0x1c100, 0x1c7ff).rw(FUNC(apple2gs_state::c100_r), FUNC(apple2gs_state::c100_w));
+	map(0x1c300, 0x1c3ff).m(m_c300bank, FUNC(address_map_bank_device::amap8));
+	map(0x1c800, 0x1cfff).rw(FUNC(apple2gs_state::c800_r), FUNC(apple2gs_state::c800_w));
+
+	map(0x1d000, 0x1ffff).view(m_upperaux);
+	m_upperaux[0](0x1d000, 0x1ffff).view(m_lcaux);
+	m_upperaux[1](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
+
+	m_lcaux[0](0x1d000, 0x1ffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_aux_w));
+	m_lcaux[1](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::lc_aux_r), FUNC(apple2gs_state::lc_aux_w));
 }
 
 void apple2gs_state::vectors_map(address_map &map)
@@ -3357,6 +3346,7 @@ void apple2gs_state::adbmicro_p2_out(u8 data)
 		if (m_accel_present)
 			accel_reset();
 		m_video->set_newvideo(0x41);
+		m_banklatch = 1 << 16;
 
 		m_lcram = false;
 		m_lcram2 = true;
@@ -3815,6 +3805,9 @@ void apple2gs_state::apple2gs(machine_config &config)
 
 	/* RAM */
 	RAM(config, m_ram).set_default_size("2M").set_extra_options("1M,3M,4M,5M,6M,7M,8M").set_default_value(0x00);
+
+	/* Mega II bank latching */
+	ADDRESS_MAP_BANK(config, A2GS_MEGAII_TAG).set_map(&apple2gs_state::megaii_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x20000);
 
 	/* C300 banking */
 	ADDRESS_MAP_BANK(config, A2GS_C300_TAG).set_map(&apple2gs_state::c300bank_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x100);

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -439,8 +439,6 @@ private:
 	int m_inh_slot = 0, m_cnxx_slot = 0;
 	int m_motoroff_time = 0;
 
-	bool m_romswitch = false;
-
 	bool m_an0 = false, m_an1 = false, m_an2 = false, m_an3 = false;
 
 	bool m_vbl = false;
@@ -454,7 +452,7 @@ private:
 	bool m_ramrd = false, m_ramwrt = false;
 	bool m_lcram = false, m_lcram2 = false, m_lcprewrite = false, m_lcwriteenable = false;
 	bool m_rombank = false;
-	u32 m_banklatch = 0;
+	u32 m_roma14_mask = 0, m_banklatch = 0;
 
 	u8 m_shadow = 0, m_speed = 0;
 	u8 m_motors_active = 0, m_slotromsel = 0, m_intflag = 0, m_vgcint = 0, m_inten = 0;
@@ -765,7 +763,6 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_inh_slot));
 	save_item(NAME(m_inh_bank));
 	save_item(NAME(m_cnxx_slot));
-	save_item(NAME(m_romswitch));
 	save_item(NAME(m_an0));
 	save_item(NAME(m_an1));
 	save_item(NAME(m_an2));
@@ -783,6 +780,7 @@ void apple2gs_state::machine_start()
 	save_item(NAME(m_lcprewrite));
 	save_item(NAME(m_lcwriteenable));
 	save_item(NAME(m_rombank));
+	save_item(NAME(m_roma14_mask));
 	save_item(NAME(m_banklatch));
 	save_item(NAME(m_shadow));
 	save_item(NAME(m_speed));
@@ -829,7 +827,6 @@ void apple2gs_state::machine_reset()
 {
 	m_adb_p2_last = m_adb_p3_last = 0;
 	m_adb_reset_freeze = 0;
-	m_romswitch = false;
 	m_video->scr_w(0);
 	m_video->set_GS_border(0x02);
 	m_video->set_GS_textcol(0xf2);
@@ -848,6 +845,7 @@ void apple2gs_state::machine_reset()
 	m_ramrd = false;
 	m_ramwrt = false;
 	m_rombank = false;
+	m_roma14_mask = 0xfffff;
 	m_video->set_newvideo(0x01); // verified on ROM03 hardware
 	m_banklatch = 1 << 16;
 	m_slot_irq = false;
@@ -1327,19 +1325,22 @@ void apple2gs_state::lc_update(int offset, bool writing)
 
 void apple2gs_state::lcrom_update()
 {
+	const u8 rombank = (m_rombank && !m_is_rom3) ? 2 : 0;
+	m_roma14_mask = (m_rombank && !m_is_rom3) ? 0xfbfff : 0xfffff;
+
 	if (m_lcram)
 	{
 		m_lcbank.select(1);
 		m_lcaux.select(1);
-		m_lc00.select(1 + (m_romswitch ? 2 : 0));
-		m_lc01.select(1);
+		m_lc00.select(1 + rombank);
+		m_lc01.select(1 + rombank);
 	}
 	else
 	{
 		m_lcbank.select(0);
 		m_lcaux.select(0);
-		m_lc00.select(0 + (m_romswitch ? 2 : 0));
-		m_lc01.select(0);
+		m_lc00.select(0 + rombank);
+		m_lc01.select(0 + rombank);
 	}
 }
 
@@ -1350,19 +1351,9 @@ void apple2gs_state::do_io(int offset)
 
 	switch (offset)
 	{
-		case 0x28:  // ROMSWITCH - not used by the IIgs firmware or SSW, but does exist at least on ROM 0/1 (need to test on ROM 3 hw)
-			if (!m_is_rom3)
-			{
-				m_romswitch = !m_romswitch;
-				if (m_lcram)
-				{
-					m_lc00.select(1 + (m_romswitch ? 2 : 0));
-				}
-				else
-				{
-					m_lc00.select(0 + (m_romswitch ? 2 : 0));
-				}
-			}
+		case 0x28:  // ROMBANK - not used by the IIgs firmware or SSW, but works on ROM 0/1
+			m_rombank = !m_rombank; // ROM 3 changes state, but banking is disabled
+			lcrom_update();
 			break;
 
 		case 0x2a:  // 16-bit access to NEWVIDEO
@@ -1815,7 +1806,7 @@ u8 apple2gs_state::c000_r(offs_t offset)
 			[[fallthrough]];
 		case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
 		case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7f:
-			return m_rom[offset + 0x3c000];
+			return m_rom[(offset + 0x3c000) & m_roma14_mask];
 
 		default:
 			/*
@@ -2256,20 +2247,7 @@ void apple2gs_state::c000_w(offs_t offset, u8 data)
 			auxbank_update();
 
 			// update LC state
-			if (m_lcram)
-			{
-				m_lcbank.select(1);
-				m_lcaux.select(1);
-				m_lc00.select(1);
-				m_lc01.select(1);
-			}
-			else
-			{
-				m_lcbank.select(0);
-				m_lcaux.select(0);
-				m_lc00.select(0);
-				m_lc01.select(0);
-			}
+			lcrom_update();
 			break;
 
 		default:
@@ -2419,7 +2397,7 @@ void apple2gs_state::write_slot_rom(int slotbias, int offset, u8 data)
 	}
 }
 
-u8 apple2gs_state::read_int_rom(int slotbias, int offset) { return m_rom[slotbias + offset]; }
+u8 apple2gs_state::read_int_rom(int slotbias, int offset) { return m_rom[(slotbias + offset) & m_roma14_mask]; }
 
 u8 apple2gs_state::c100_r(offs_t offset)
 {
@@ -2469,7 +2447,7 @@ u8 apple2gs_state::c800_r(offs_t offset)
 
 	if (internal)
 	{
-		return m_rom[offset + 0x3c800];
+		return read_int_rom(0x3c800, offset);
 	}
 
 	if ((slot > 0) && (m_slotdevice[slot] != nullptr))
@@ -3250,6 +3228,8 @@ void apple2gs_state::apple2gs_map(address_map &map)
 
 	m_lc01[0](0x1d000, 0x1ffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_01_w));
 	m_lc01[1](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::lc_01_r), FUNC(apple2gs_state::lc_01_w));
+	m_lc01[2](0x1d000, 0x1ffff).rom().region("maincpu", 0x39000).w(FUNC(apple2gs_state::lc_01_w));
+	m_lc01[3](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::lc_01_r), FUNC(apple2gs_state::lc_01_w));
 
 	// "Mega II side" - this is basically a 128K IIe on a chip that runs merrily at 1 MHz
 	// Unfortunately all I/O happens here, including new IIgs-specific stuff
@@ -3307,7 +3287,8 @@ void apple2gs_state::megaii_map(address_map &map)
 	m_upperbank[0](0xd000, 0xffff).view(m_lcbank);
 	m_upperbank[1](0xd000, 0xffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
 
-	m_lcbank[0](0xd000, 0xffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_w));
+	m_lcbank[0](0xd000, 0xffff).lr8(
+		NAME([this](offs_t offset) { slow_cycle(); return m_rom[(offset + 0x3d000) & m_roma14_mask]; })).w(FUNC(apple2gs_state::lc_w));
 	m_lcbank[1](0xd000, 0xffff).rw(FUNC(apple2gs_state::lc_r), FUNC(apple2gs_state::lc_w));
 
 	map(0x10000, 0x1bfff).rw(FUNC(apple2gs_state::auxram0000_r), FUNC(apple2gs_state::auxram0000_w));
@@ -3321,7 +3302,8 @@ void apple2gs_state::megaii_map(address_map &map)
 	m_upperaux[0](0x1d000, 0x1ffff).view(m_lcaux);
 	m_upperaux[1](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::inh_r), FUNC(apple2gs_state::inh_w));
 
-	m_lcaux[0](0x1d000, 0x1ffff).rom().region("maincpu", 0x3d000).w(FUNC(apple2gs_state::lc_aux_w));
+	m_lcaux[0](0x1d000, 0x1ffff).lr8(
+		NAME([this](offs_t offset) { slow_cycle(); return m_rom[(offset + 0x3d000) & m_roma14_mask]; })).w(FUNC(apple2gs_state::lc_aux_w));
 	m_lcaux[1](0x1d000, 0x1ffff).rw(FUNC(apple2gs_state::lc_aux_r), FUNC(apple2gs_state::lc_aux_w));
 }
 

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -400,6 +400,7 @@ private:
 	u8 floatingbank_r(offs_t offset);
 	u8 ghostram_r(offs_t offset);
 	void ghostram_w(offs_t offset, u8 data);
+	void fastram_r(offs_t offset, u8 &data);
 	void fastram_w(offs_t offset, u8 &data);
 	void a2bus_irq_w(int state);
 	void a2bus_nmi_w(int state);
@@ -746,12 +747,14 @@ void apple2gs_state::machine_start()
 		}
 	}
 
-	// tap RAM writes for FPI shadow
-	space.install_write_tap(
+	// tap RAM for FPI shadow
+	space.install_readwrite_tap(
 		0x020000, 0xdfffff, "fpi",
+		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_r(offset, data); },
 		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_w(offset, data); });
-	space.install_write_tap(
+	space.install_readwrite_tap(
 		0xe20000, 0xefffff, "fpi",
+		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_r(offset, data); },
 		[this](offs_t offset, u8 &data, u8 mem_mask) { fastram_w(offset, data); });
 
 	// setup save states
@@ -2500,6 +2503,20 @@ void apple2gs_state::ghostram_w(offs_t offset, u8 data)
 
 	if (ghost_offset < m_ram_size)
 		m_ram_ptr[ghost_offset] = data;
+}
+
+void apple2gs_state::fastram_r(offs_t offset, u8 &data)
+{
+	if (m_speed & SPEED_ALLBANKS)
+	{
+		const u16 offset16 = offset & 0xffff;
+
+		// I/O is shadowed from all RAM banks
+		if (!(m_shadow & SHAD_IOLC) && ((offset16 >> 12) == 0xc))
+		{
+			data = m_megaii->space().read_byte(offset16);
+		}
+	}
 }
 
 void apple2gs_state::fastram_w(offs_t offset, u8 &data)

--- a/src/mame/apple/apple2gs.cpp
+++ b/src/mame/apple/apple2gs.cpp
@@ -98,27 +98,6 @@ namespace {
 #define A2GS_2_8M   (A2GS_MASTER_CLOCK/10)
 #define A2GS_1M     (XTAL(1021800))
 
-#define A2GS_UPPERBANK_TAG "inhbank"
-#define A2GS_AUXUPPER_TAG "inhaux"
-#define A2GS_00UPPER_TAG "inh00"
-#define A2GS_01UPPER_TAG "inh01"
-#define A2GS_MEGAII_TAG "megaii"
-#define A2GS_C300_TAG "c3bank"
-#define A2GS_LCBANK_TAG "lcbank"
-#define A2GS_LCAUX_TAG "lcaux"
-#define A2GS_LC00_TAG "lc00"
-#define A2GS_LC01_TAG "lc01"
-#define A2GS_B0CXXX_TAG "bnk0atc"
-#define A2GS_B1CXXX_TAG "bnk1atc"
-#define A2GS_B00000_TAG "b0r00bank"
-#define A2GS_B00200_TAG "b0r02bank"
-#define A2GS_B00400_TAG "b0r04bank"
-#define A2GS_B00800_TAG "b0r08bank"
-#define A2GS_B02000_TAG "b0r20bank"
-#define A2GS_B04000_TAG "b0r40bank"
-
-#define A2GS_KBD_SPEC_TAG "keyb_special"
-
 class apple2gs_state : public driver_device
 {
 public:
@@ -141,30 +120,30 @@ public:
 		  //      m_a2host(*this, "a2host"),
 		  m_gameio(*this, "gameio"),
 		  m_speaker(*this, "speaker_sound"),
-		  m_upperbank(*this, A2GS_UPPERBANK_TAG),
-		  m_upperaux(*this, A2GS_AUXUPPER_TAG),
-		  m_upper00(*this, A2GS_00UPPER_TAG),
-		  m_upper01(*this, A2GS_01UPPER_TAG),
-		  m_megaii(*this, A2GS_MEGAII_TAG),
-		  m_c300bank(*this, A2GS_C300_TAG),
-		  m_b0_0000bank(*this, A2GS_B00000_TAG),
-		  m_b0_0200bank(*this, A2GS_B00200_TAG),
-		  m_b0_0400bank(*this, A2GS_B00400_TAG),
-		  m_b0_0800bank(*this, A2GS_B00800_TAG),
-		  m_b0_2000bank(*this, A2GS_B02000_TAG),
-		  m_b0_4000bank(*this, A2GS_B04000_TAG),
+		  m_upperbank(*this, "inhbank"),
+		  m_upperaux(*this, "inhaux"),
+		  m_upper00(*this, "inh00"),
+		  m_upper01(*this, "inh01"),
+		  m_megaii(*this, "megaii"),
+		  m_c300bank(*this, "c3bank"),
+		  m_b0_0000bank(*this, "b0r00bank"),
+		  m_b0_0200bank(*this, "b0r02bank"),
+		  m_b0_0400bank(*this, "b0r04bank"),
+		  m_b0_0800bank(*this, "b0r08bank"),
+		  m_b0_2000bank(*this, "b0r20bank"),
+		  m_b0_4000bank(*this, "b0r40bank"),
 		  m_e0_0000bank(*this, "e0_0000_bank"),
 		  m_e0_0200bank(*this, "e0_0200_bank"),
 		  m_e0_0400bank(*this, "e0_0400_bank"),
 		  m_e0_0800bank(*this, "e0_0800_bank"),
 		  m_e0_2000bank(*this, "e0_2000_bank"),
 		  m_e0_4000bank(*this, "e0_4000_bank"),
-		  m_lcbank(*this, A2GS_LCBANK_TAG),
-		  m_lcaux(*this, A2GS_LCAUX_TAG),
-		  m_lc00(*this, A2GS_LC00_TAG),
-		  m_lc01(*this, A2GS_LC01_TAG),
-		  m_bank0_atc(*this, A2GS_B0CXXX_TAG),
-		  m_bank1_atc(*this, A2GS_B1CXXX_TAG),
+		  m_lcbank(*this, "lcbank"),
+		  m_lcaux(*this, "lcaux"),
+		  m_lc00(*this, "lc00"),
+		  m_lc01(*this, "lc01"),
+		  m_bank0_atc(*this, "bnk0atc"),
+		  m_bank1_atc(*this, "bnk1atc"),
 		  m_scc(*this, "scc"),
 		  m_doc(*this, "doc"),
 		  m_iwm(*this, "fdc"),
@@ -3874,10 +3853,10 @@ void apple2gs_state::apple2gs(machine_config &config)
 	RAM(config, m_ram).set_default_size("2M").set_extra_options("1M,3M,4M,5M,6M,7M,8M").set_default_value(0x00);
 
 	/* Mega II bank latching */
-	ADDRESS_MAP_BANK(config, A2GS_MEGAII_TAG).set_map(&apple2gs_state::megaii_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x20000);
+	ADDRESS_MAP_BANK(config, m_megaii).set_map(&apple2gs_state::megaii_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x20000);
 
 	/* C300 banking */
-	ADDRESS_MAP_BANK(config, A2GS_C300_TAG).set_map(&apple2gs_state::c300bank_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x100);
+	ADDRESS_MAP_BANK(config, m_c300bank).set_map(&apple2gs_state::c300bank_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x100);
 
 	/* serial */
 	SCC85C30(config, m_scc, A2GS_7M);


### PR DESCRIPTION
(finish [side-quest](https://github.com/mamedev/mame/pull/15619) auditing memory banking)

This PR implements rarely-used and poorly-documented Apple IIgs memory behaviors:

* C029 bank latching
* C036 shadow all banks
* C028 ROMBANK

There are several documentation errors here to be wary of:
* Apple IIgs Hardware Reference [pg 90 Table 4-17 and pg 91 Table 4-18](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/90/mode/2up) have the description of C029 bit 0 bank latching backwards: Table 4-17 says "`0  0  Enable bank latch.  If this bit is 1...`"; the text describes the behavior for when bit 0 is on, but is positioned in the table for when bit 0 is off.  The actual hardware behavior is that the data bank LSB selects between E0/E1 only when C029 bit 0 is on (see also "[Mega II auxiliary memory bank access](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/16/mode/2up)" pg 16.)
* HWRef [pg 21 Table 2-1](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/20/mode/2up) describes C035 bit 4 as "`...shadowing is disabled for all Hi-Res graphics pages 1 and 2 (as determined by bits 0 through 3 in this register)`" but only bits 1-2 affect Hi-Res shadowing.
* HWRef [pg 23 Table 2-2](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/22/mode/2up) describes C036 bit 4 as "`Shadow register bits 0 through 4 will determine which portion...`" which implies that bits 5-6 are ignored, but the actual hardware behavior honors all bits (I/O is in all RAM banks.)
* The same description of bit 4 continues as "`To enable shadowing in all RAM banks, $00 through $7F, set this bit to 1`" but the actual hardware behavior affects banks $00 through $EF (not ROM $F0 through $FF.)
* Internet lore (such as [MG's Apple II I/O page](http://apple2.guidero.us/doku.php/mg_notes/general/io_page#:~:text=Switch%20%24D000%2DFFFF)) describes C028 as toggling the ROM bank visible at $D000-$FFFF.  The [actual hardware behavior](https://apple2infinitum.slack.com/archives/CPSGNGE05/p1784405481188889) matches the //c, toggling $C000-$FFFF, including the internal slot, expansion, and Mega II IRQ ROM, in banks 00/01/E0/E1 (but not direct ROM access in banks FE/FF.) Also the state is reflected in C068 on both ROM1 and ROM3 hardware, even though the actual banking is removed on ROM3.  N.B. testing of C028 must carefully avoid false-read cycles in i.e. STA,Y otherwise the state may toggle twice during one instruction ^_^;

(Thanks to @colinleroy and Kelvin Sherlock for ROM1 hardware testing.)
<br>
Code comments:<details>

For the C029 bank LSB latching, the FPI simply turns the 17th address bit off, and the Mega II may turn it back on depending on the state of AUX switches. To model this, I have added `m_megaii` as an `address_map_bank_device`; not to select banks, but merely to get a separate address space so that the 24-bit `apple2gs_map` can redirect without risk of recursion.  Derived state `m_banklatch` replaces some of the previously-hardcoded offset constants.

The `address_map`s are also slightly simplified by merging the `c100` and `c400` handlers, which (unlike apple2e) were identical.
<br>

For the shadowing, there are two parts.  First, logic decoding the bank 00 shadow-able ranges is added in `bank0_0000_sh_w()`.  `bank1_0000_sh_w()` is changed to purely shadow, and called from `bank1_0000_w()` which performs the usual write to fast ram.  Second, these shadow-only functions are called from a new `write_tap` set up after installing expansion RAM.  It may look excessive to always tap every fast RAM access, but a followup WIP PR uses the same tap to implement the fast RAM refresh FPI wait state.
<br>

For C028 ROMBANK, the previous implementation's `m_romswitch` and `m_rombank` are now merged.  Derived state `m_roma14_mask` models the FPI's [ROMA14 line to the 128k ROM](https://archive.org/details/Apple_IIgs_schematic/page/n5/mode/2up), and is used in `read_int_rom()` etc.  To maintain the slight efficiency of direct-map `.rom()` around this ~never used switch, the `m_lc00[]` view banking is expanded into `m_lc01[]`.  However, the E0/E1 `m_lcbank[]` and `m_lcaux[]` require a trampoline to apply the `slow_cycle() `penalty for ROM reads via the Mega II, so I have inlined `m_roma14_mask` into lambdas.

</details>
<br>

User-visible changes:<details>

The C036 shadow all banks feature is used by Ninjaforce.  After this PR, the BBS Demo portion of the [NFC Megademo](https://www.ninjaforce.com/html/products_megademo.html#:~:text=The%20BBS%20Demo) now correctly shows text and bouncing balls, [matching hardware](https://youtu.be/pVQQxmumWx0?list=RDpVQQxmumWx0&t=54):
<img width="704" height="462" alt="NFC_ShadowAllBanks" src="https://github.com/user-attachments/assets/4d45ce70-cfb3-4603-b763-e8d3d9729613" />
<br>

The C029 bank latching bit is generally not used ([Apple IIgs Firmware Reference pg 281](https://archive.org/details/Apple_IIgs_Firmware_Reference_HiRes/page/n301/mode/2up) warns to never change this bit) but accidentally clearing the low bit is an [easy programming mistake](https://apple2infinitum.slack.com/archives/CA8AT5886/p1572061151455400) to make.  If you do that from the Monitor, the IIgs instantly hangs:
```
]CALL -151
*C029:0
```
MAME now replicates this misbehavior, instead of silently ignoring the bit.
<br>

The C028 ROMBANK behavior is pedantic ([Apple IIgs Hardware Reference pg 40](https://archive.org/details/Apple_IIgs_Hardware_Reference_HiRes/page/40/mode/2up) warns to never change this bit) and the alternate bank Mega II IRQ ROM is non-functional, so no software can purposely depend on this behavior.  However MAME will no longer mask programming mistakes accidentally using it.

</details>
<br>
Testing:<details>

Two new unit tests verify the memory decode emulation (source included):
[MemState_260731.zip](https://github.com/user-attachments/files/30611102/MemState_260731.zip)

MEMSTATE verifies all legacy memory banking behavior:
* C08x ][+ Language Card
* C00x //e aux memory, 80STORE precedence
* C02x //c ROMBANK
And additional interactions on the IIgs:
* bank 00/01 E0/E1 independent LCs
* ROM 1/3 ROMBANK behavior
* C068 bit mirroring, LC writability
* C029 bank LSB latching

SHADOW verifies all memory shadowing behavior:
* each shadow-able region read/write (ROM1/3 TEXT2 behavior)
* C036 all banks interaction
* C029 bank LSB latching, linearization

Reference hardware results from an Apple IIgs ROM1 (showing ROMBANK in action):
<img width="720" height="540" alt="MEMSTATE_gsr1" src="https://github.com/user-attachments/assets/896632e8-eb8a-4a34-9610-efd199cb3013" />

and my Apple IIgs ROM3 (showing TEXT2 shadowing):
<img width="720" height="540" alt="SHADOW_gs" src="https://github.com/user-attachments/assets/f1336690-476f-4aaa-9692-2b310c137a11" />
<br>

There are several interacting bits here; to clarify the observed hardware logic precedence:
1) shadow all banks determines candidate banks (never ROM F0-FF)
2) even/odd bank shadowing ranges determine if the FPI forwards to the Mega II
3) the bank latch bit may redirect bank E1 to E0
4) AUX switches may forward bank E0 to E1
5) only within bank E1, SHR linearization may occur

These unit tests verify this precedence (fail if i.e. bank latching off causes SHR to shadow from bank 00, or if linearization occurs prior to bank latching.)
<br>

For one-stop memory testing, several older tests are also included in the MEMSTATE .po here:
[SWITCHES](https://github.com/mamedev/mame/pull/14307#:~:text=visualize%20the%20entire%20softswitch%20range%20at%20once)
[MUSTBE0](https://github.com/mamedev/mame/pull/15626#:~:text=MUSTBE0%20test%20verifies%20all%20the%20documented%20bits)
[BANKMAP](
https://github.com/mamedev/mame/pull/15335#:~:text=BANKMAP%20test%20visualizes%20the%20power%2Don%20memory%20detection)
[CLRROM](https://github.com/mamedev/mame/pull/15619#:~:text=CLRROM%20looks%20at%20the%20CFxx%20expansion%20disable%20behavior)
[SLOTROM](https://github.com/mamedev/mame/pull/15619#:~:text=SLOTROM%20shows%20the%20CSxx%20ROM%20plus%20the%20expansion%20ROM)
[INTC8ROM](https://github.com/mamedev/mame/pull/15619#:~:text=INTC8ROM%20shows%20a%20matrix%20of%20bus%20fights)
<br>

Before this PR, MAME's behavior deviated from hardware in several ways:
<img width="704" height="462" alt="MEMSTATE_gsr1_288_before" src="https://github.com/user-attachments/assets/ce7c2228-63fd-43ee-ad68-c02686935c1a" />

* C029 bank latching was unimplemented: bank E0 incorrectly accessed E1.
* ROMBANK was only partially implemented in bank 00, and only via C028 (not C068) and state changes were not mirrored to C068.

<img width="704" height="462" alt="SHADOW_gs_288_before" src="https://github.com/user-attachments/assets/f7417b80-f0a7-485e-9c6f-e0f5996ab956" />

* C036 shadow all banks was unimplemented: shadowing no-oped in banks other than 00/01.
* C029 bank latching was unimplemented: bank 01 incorrectly shadowed to E1 instead of E0.

After this PR everything matches hardware behavior.
Also, the SLOTROM test shows that slot and expansion ROM is now properly affected by ROMBANK on apple2gsr1.
Also, the timing of the E0/E1 LC ROM access now more closely matches a WIP hardware memory benchmark (compare E0/F800 "slow" and 00/F800 "fast" rows)
<img width="720" height="540" alt="MEMBENCH_signal" src="https://github.com/user-attachments/assets/18cef3a2-bbfb-4cdb-b8cb-7e317b32fc66" />

</details>
<br>
TODO:<details>

This PR makes the Mega II an `address_map_bank_device` for address space purposes, but otherwise leaves it strongly coupled to apple2gs.  It could be split into a standalone device, if the [Tiger Learning Computer ](https://www.youtube.com/watch?v=WZk-utRYrI0)or the Mac LC's [Apple IIe card](https://en.wikipedia.org/wiki/Apple_IIe_Card) are ever emulated.
<br>

After this PR, with the exception of [/INH](https://apple2.gs/technotes/tn-iigs-032/#:~:text=Only%20part%20of%20the%20first%20physical%20bank%20of%20RAM%20is%20inhibited) I think the apple2gs memory decode is now complete (possibly for the first time [in any emulator](https://apple2infinitum.slack.com/archives/CABEM8JFK/p1785962722725719?thread_ts=1785962628.703609&cid=CABEM8JFK)?), but that only means that the correct bytes are read and written.  The [timing is still wrong](https://github.com/mamedev/mame/pull/15464#:~:text=Accurate%20emulation%20of%20FPI%20stalls), and fixing the FPI wait states will require that memory is consistently accessed, which means teaching the g65816 about false reads.

</details>
<br>
AI disclosure: ChatGPT-5.5 was consulted about alternative methods of implementing the C029 bank latching, and for sanity code review.  All code and tests were written by me the old fashioned way (pressing the reeds into the clay with my BARE HANDS.)
