### PR TITLE
machine/ncr5380: restore base-part self-reset interrupt (regressed by #15658)

### DIFF
--- a/src/devices/machine/ncr5380.cpp
+++ b/src/devices/machine/ncr5380.cpp
@@ -322,12 +322,18 @@ void ncr5380_device::icmd_w(u8 data)
 	{
 		LOG("scsi reset issued\n");
 		device_reset();
-		// the chip is now driving R̅S̅T̅ itself; flag it so the resulting bus
-		// reset notification is not mistaken for an externally-initiated reset
-		// and does not raise a (self-)interrupt the host driver never expects
-		// (NetBSD/pc532 monitor asserts R̅S̅T̅, then aborts on the spurious IRQ).
+		// the chip is now driving R̅S̅T̅ itself; flag it so an externally-initiated
+		// reset can still be told apart in scsi_ctrl_changed().
 		m_rst_out = true;
 		m_scsi_bus->ctrl_w(m_scsi_refid, S_RST, S_RST);
+		// The nscsi bus does not reflect a device's own R̅S̅T̅ back to it, so
+		// scsi_ctrl_changed() is not re-entered here: the base NCR5380/53C80
+		// self-reset interrupt (SP-1051 8.3, "this interrupt also occurs after
+		// setting the ASSERT R̅S̅T̅ bit") must be raised explicitly.  The DP8490
+		// EASI suppresses it (m_rst_self_irq == false), leaving the NetBSD/pc532
+		// monitor -- which asserts R̅S̅T̅ then aborts on a spurious IRQ -- unaffected.
+		if (m_rst_self_irq)
+			set_irq(true);
 	}
 
 	m_icmd = (m_icmd & ~IC_WRITE) | (data & IC_WRITE);


### PR DESCRIPTION
The base NCR5380/53C80 stopped raising an interrupt on a host-commanded SCSI bus
reset (setting ASSERT /RST in the initiator command register).  Per SP-1051 8.3
this interrupt "also occurs after setting the ASSERT /RST bit" and cannot be
masked.

Root cause: `icmd_w()` drives /RST with `ctrl_w()`, but the nscsi bus does not
reflect a device's own control-line change back to it (`regen_ctrl()` skips the
initiating refid), so `scsi_ctrl_changed()` is never re-entered for a self-issued
reset.  #15658 relocated the self-reset interrupt decision into
`scsi_ctrl_changed()`, which a self-issued reset cannot reach, so the base part no
longer interrupts.

Fix: raise the interrupt explicitly in `icmd_w()`, gated on `m_rst_self_irq` so
the DP8490 EASI (which suppresses the self-reset interrupt for the NetBSD/pc532
ROM monitor) is unchanged.

Reported by Patrick Mackinlay.

Testing (pc532, et532, emax, macplus/macse built; full `-validate` clean):

* base NCR5380 (macplus): asserting ICR /RST sets BAS IRQACTIVE (0x08 -> 0x18);
  without the fix it stays 0x08 (the regression).  The neutralised-fix control is
  behaviourally identical to the DP8490 path, confirming the EASI suppression is
  intact.
* DP8490 (pc532, et532): boot clean, behaviour unchanged (the fix is a no-op when
  `m_rst_self_irq` is false).

Claude Opus 4.8 (via Claude Code) assisted with diagnosis and implementation;
reviewed and validated by me.
