### PR TITLE
cpu/mcs96: MULB indexed byte operand, and HSO CAM entries lost to exact-equality matching

### DIFF
--- a/src/devices/cpu/mcs96/i8x9x.cpp
+++ b/src/devices/cpu/mcs96/i8x9x.cpp
@@ -131,6 +131,8 @@ void i8x9x_device::commit_hso_cam()
 				ios0 |= 0x40;
 			hso_info[i].command = hso_command;
 			hso_info[i].time = hso_time;
+			hso_info[i].fire_at = timer_time_until(BIT(hso_command, 6) ? 2 : 1,
+					total_cycles(), hso_time);
 			internal_update(total_cycles());
 			return;
 		}
@@ -406,6 +408,11 @@ u64 i8x9x_device::timer_time_until(int timer, u64 current_time, u16 timer_value)
 void i8x9x_device::timer2_reset(u64 current_time)
 {
 	base_timer2 = current_time;
+	// hso_info[].time holds a timer value, not a deadline, so timer2-relative
+	// entries need fire_at recomputed against the new base.
+	for(int i=0; i<8; i++)
+		if(BIT(hso_active, i) && BIT(hso_info[i].command, 6))
+			hso_info[i].fire_at = timer_time_until(2, current_time, hso_info[i].time);
 }
 
 void i8x9x_device::set_hsi_state(int pin, bool state)
@@ -479,18 +486,13 @@ void i8x9x_device::set_hso(u8 mask, bool state)
 
 void i8x9x_device::internal_update(u64 current_time)
 {
-	u16 current_timer1 = timer_value(1, current_time);
-	u16 current_timer2 = timer_value(2, current_time);
-
+	// Fire on "the deadline has been reached or passed" rather than on an
+	// exact match against the timer value sampled right now.
 	for(int i=0; i<8; i++)
-		if(BIT(hso_active, i)) {
-			u8 cmd = hso_info[i].command;
-			u16 t = hso_info[i].time;
-			if(((cmd & 0x40) && t == current_timer2) ||
-				(!(cmd & 0x40) && t == current_timer1)) {
-				//logerror("hso cam %02x %04x in slot %d triggered\n", cmd, t, i);
-				trigger_cam(i, current_time);
-			}
+		if(BIT(hso_active, i) && current_time >= hso_info[i].fire_at) {
+			//logerror("hso cam %02x %04x in slot %d triggered\n",
+			//      hso_info[i].command, hso_info[i].time, i);
+			trigger_cam(i, current_time);
 		}
 
 	if(ad_done && current_time >= ad_done) {
@@ -501,13 +503,17 @@ void i8x9x_device::internal_update(u64 current_time)
 		check_irq();
 	}
 
-	if(current_time == serial_send_timer)
+	if(serial_send_timer && current_time >= serial_send_timer)
 		serial_send_done();
 
 	u64 event_time = 0;
 	for(int i=0; i<8; i++) {
 		if(!BIT(hso_active, i) && BIT(ios0, 7)) {
 			hso_info[i] = hso_cam_hold;
+			// The holding register carries a timer value, so the deadline is
+			// only fixed once the entry actually reaches the CAM, i.e. here.
+			hso_info[i].fire_at = timer_time_until(BIT(hso_cam_hold.command, 6) ? 2 : 1,
+					current_time, hso_cam_hold.time);
 			hso_active |= 1 << i;
 			ios0 &= 0x7f;
 			if(hso_active == 0xff)

--- a/src/devices/cpu/mcs96/i8x9x.h
+++ b/src/devices/cpu/mcs96/i8x9x.h
@@ -124,6 +124,11 @@ private:
 	struct hso_cam_entry {
 		u8 command;
 		u16 time;
+		// Absolute cycle at which this entry is due. The real comparator runs
+		// every timer tick, so it cannot miss; emulation only evaluates at
+		// scheduled points, which an instruction can overrun. Caching the
+		// deadline lets internal_update fire on "reached or passed".
+		u64 fire_at;
 	};
 
 	devcb_read16::array<8> m_ach_cb;

--- a/src/devices/cpu/mcs96/mcs96ops.lst
+++ b/src/devices/cpu/mcs96/mcs96ops.lst
@@ -1040,7 +1040,7 @@ fe7e  mulb  indirect_2b
 
 fe7f  mulb  indexed_2b
 	OP2 &= 0xfe;
-	TMP = any_r16(OP1);
+	TMP = any_r8(OP1);
 	TMP = int8_t(reg_r8(OP2)) * int8_t(TMP);
 	reg_w16(OP2, TMP);
 	post_indexed 23 24 // +5 when external


### PR DESCRIPTION
Two independent defects in the shared MCS-96 core, one commit each so either can be taken without the other. Both were found while building an emulator around the Roland D-70 firmware, and both are stated with the measurements that identified them.

The core is shared by 14 machines across 7 drivers: `roland_mt32.cpp` (MT-32, MT-100, CM-32L), `roland_d10.cpp` (D-10, D-110), `roland_cm32p.cpp` (CM-32P), `roland_s50.cpp` (S-50, S-550, S-330, W-30), `roland_u20.cpp` (U-20, U-220), `roland_d70.cpp` and `misc/pntnpuzl.cpp`.

### 1. `fe7f mulb indexed_2b` read a word for a byte operand

```c
fe7f  mulb  indexed_2b
	OP2 &= 0xfe;
	TMP = any_r16(OP1);        // <-- byte operand
```

`any_r16()` starts with `adr &= 0xfffe`, so an operand at an **odd** address came from its even neighbour. Every sibling form already reads a byte — `7f mulub indexed_2b`, `fe7e mulb indirect_2b`, `fe5f mulb indexed_3e` all use `any_r8()`. The word read also issues an extra bus access.

The D-70 had **no velocity response at all**: its patch record base is odd, so the velocity-sensitivity byte at `+0x0C` was read from `+0x0B` (the curve selector, 0) and the whole deviation term collapsed to a constant. With the fix, the PCM gain register goes from bit-identical `0x1940` at every velocity to a monotonic 0..13948 over 1..127, and eight factory patches measured at velocity 20 vs 120 go from ratios of 0.89–1.22 (two inverted, i.e. noise) to 1.69–6.51.

The encoding is rare. Every MCS-96 firmware in the standard romsets was scanned and each candidate confirmed or dismissed by disassembly, since a raw byte-pair count is only an upper bound:

* **affected** — MT-32 v2.0.3/2.0.4/2.0.7, CM-32L, LAPC-I, D-110: the same instruction byte for byte, `mulb 74, 1709[76]` inside a key-follow computation
* **clean** — MT-32 v1.0.x (no such instruction), CM-32P (six real sites, all at even absolute addresses), U-20, U-220, Paint 'N Puzzle
* **false positives** — D-10 (inside a `scall` dispatch table), S-50 (inside `0xFF` filler), MT-100's own ROM (not MCS-96 code)

Those LA machines are `MACHINE_NO_SOUND` for unrelated reasons, so nothing becomes audible there; what changes is that the control side computes correctly.

Note that editing `mcs96ops.lst` regenerates only `mcs96.hxx` — `i8x9x.hxx` and `i8xc196.hxx` have to be removed to be regenerated too, or the build silently keeps the old opcode behaviour.

### 2. HSO CAM entries were lost when the CPU stepped past their time

`internal_update()` matched entries with `t == current_timer1`. The real part compares every entry on every tick in hardware and cannot miss one; emulation only evaluates at scheduled points, and `execute_run()`'s `while(icount > bcount)` lets an instruction overrun the end of a timeslice, so `total_cycles()` can land past the scheduled point. The equality then never held and `timer_time_until()` re-armed the entry a full **65536-tick wrap** later, while it kept occupying its CAM slot.

Each entry now carries an absolute `fire_at`, set in `commit_hso_cam()`, again when it leaves the holding register (which stores a timer *value*, not a deadline), and recomputed in `timer2_reset()` since restarting timer2 moves every timer2 deadline. A modular "close enough" window was considered and rejected: an entry legitimately scheduled 65535 ticks ahead is one tick *behind* in modular arithmetic and would fire immediately.

The same defect two lines below, on `serial_send_timer` — a missed transmit-complete leaves it set with nothing to clear it, stalling the transmitter. The A/D completion check immediately above already used `>=`.

On the D-70 this was a front panel that died at a random moment, every button dead and the display frozen, while the CPU, MIDI and audio carried on. That firmware arms an entry roughly every 2500 ticks, so a handful of misses fills all eight slots within milliseconds; from then on every command is diverted to the single holding register where the next one overwrites it, and when the destroyed command is the software timer's own reschedule the periodic chain stops for good. Attributed by counting interrupt dispatches per vector — classic 5 (`IRQ_SOFT`) stopped at the exact instant the panel died, and `IRQ_SOFT` has exactly one source on this part.

Measured over three minutes of continuous play with 120 patch changes:

| | before | after |
|---|---|---|
| CAM overflows | 39 | 0 |
| software-timer dispatches | froze at ~33 000 | 601 309, still rising |
| panel alive at 186 s | no | yes |
| residual RMS after all-notes-off | 0.216 (stuck voices) | 0.000000 |
| panel scan rate | ~860/s | ~2833/s |

That last row matters on its own: entries were being missed and delayed a wrap long before the CAM ever overflowed, so the machine was 3.3x less responsive than it should have been even while it appeared to work.

### Testing

Built and run with these two patches and nothing else: a `SUBTARGET=d110` build boots the Roland D-110 firmware, renders its LCD, drives its menus from the front panel and holds 100.11% of real time. The D-70 measurements above come from a separate driver not in this PR.

Happy to split this into two PRs if you would prefer them reviewed separately.

*Disclosure: this work was done with Claude Code assisting; every claim above is backed by a measurement I can reproduce.*
