### PR TITLE
chdman: fix GD-ROM createcd, extractcd (cue/gdi reversibility)

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -1070,30 +1070,31 @@ std::error_condition cdrom_file::write_metadata(chd_file *chd, const toc &toc)
 	/* write the metadata */
 	for (int i = 0; i < toc.numtrks; i++)
 	{
+		char submode[32];
+
+		if (toc.tracks[i].pgdatasize > 0)
+		{
+			strcpy(&submode[1], get_type_string(toc.tracks[i].pgtype));
+			submode[0] = 'V';   // indicate valid submode
+		}
+		else
+		{
+			strcpy(submode, get_type_string(toc.tracks[i].pgtype));
+		}
+
 		std::string metadata;
+
 		if (toc.flags & CD_FLAG_GDROM)
 		{
 			metadata = util::string_format(GDROM_TRACK_METADATA_FORMAT, i + 1, get_type_string(toc.tracks[i].trktype),
 					get_subtype_string(toc.tracks[i].subtype), toc.tracks[i].frames, toc.tracks[i].padframes,
-					toc.tracks[i].pregap, get_type_string(toc.tracks[i].pgtype),
+					toc.tracks[i].pregap, submode,
 					get_subtype_string(toc.tracks[i].pgsub), toc.tracks[i].postgap);
 
 			err = chd->write_metadata(GDROM_TRACK_METADATA_TAG, i, metadata);
 		}
 		else
 		{
-			char submode[32];
-
-			if (toc.tracks[i].pgdatasize > 0)
-			{
-				strcpy(&submode[1], get_type_string(toc.tracks[i].pgtype));
-				submode[0] = 'V';   // indicate valid submode
-			}
-			else
-			{
-				strcpy(submode, get_type_string(toc.tracks[i].pgtype));
-			}
-
 			metadata = util::string_format(CDROM_TRACK_METADATA2_FORMAT, i + 1, get_type_string(toc.tracks[i].trktype),
 					get_subtype_string(toc.tracks[i].subtype), toc.tracks[i].frames, toc.tracks[i].pregap,
 					submode, get_subtype_string(toc.tracks[i].pgsub),
@@ -2777,46 +2778,6 @@ std::error_condition cdrom_file::parse_cue(std::string_view tocfname, toc &outto
 		}
 	}
 
-	if (is_gdrom)
-	{
-		/*
-		* Strip pregaps from Redump tracks and adjust the LBA offset to match TOSEC layout
-		*/
-		for (trknum = 1; trknum < outtoc.numtrks; trknum++)
-		{
-			uint32_t this_pregap = outtoc.tracks[trknum].pregap;
-			uint32_t this_offset = this_pregap * (outtoc.tracks[trknum].datasize + outtoc.tracks[trknum].subsize);
-
-			outtoc.tracks[trknum-1].frames += this_pregap;
-			outtoc.tracks[trknum-1].splitframes += this_pregap;
-
-			outinfo.track[trknum].offset += this_offset;
-			outtoc.tracks[trknum].frames -= this_pregap;
-			outinfo.track[trknum].idx[1] -= this_pregap;
-
-			outtoc.tracks[trknum].pregap = 0;
-			outtoc.tracks[trknum].pgtype = 0;
-		}
-
-		/*
-		* TOC now matches TOSEC layout, set LBA for every track with HIGH-DENSITY area @ LBA 45000
-		*/
-		for (trknum = 1; trknum < outtoc.numtrks; trknum++)
-		{
-			if (outtoc.tracks[trknum].multicuearea == HIGH_DENSITY && outtoc.tracks[trknum-1].multicuearea == SINGLE_DENSITY)
-			{
-				outtoc.tracks[trknum].physframeofs = 45000;
-				int dif=outtoc.tracks[trknum].physframeofs-(outtoc.tracks[trknum-1].frames+outtoc.tracks[trknum-1].physframeofs);
-				outtoc.tracks[trknum-1].frames += dif;
-				outtoc.tracks[trknum-1].padframes = dif;
-			}
-			else
-			{
-				outtoc.tracks[trknum].physframeofs = outtoc.tracks[trknum-1].physframeofs + outtoc.tracks[trknum-1].frames;
-			}
-		}
-	}
-
 	if (EXTRA_VERBOSE)
 	{
 		for (trknum = 0; trknum < outtoc.numtrks; trknum++)
@@ -2836,6 +2797,107 @@ std::error_condition cdrom_file::parse_cue(std::string_view tocfname, toc &outto
 					outinfo.track[trknum].idx[0],
 					outinfo.track[trknum].idx[1],
 					outtoc.tracks[trknum].frames - outtoc.tracks[trknum].padframes);
+		}
+	}
+
+	return std::error_condition();
+}
+
+/*-------------------------------------------------
+    remove_pregap - strip pregaps and adjust the LBA offset
+-------------------------------------------------*/
+
+/**
+ * @fn  static std::error_condition remove_pregap(toc &outtoc, track_input_info &outinfo)
+ *
+ * @brief   Chdgd strip pregaps and adjust the LBA offset.
+ *
+ * @param [in,out]  outtoc  The outtoc.
+ * @param [in,out]  outinfo The outinfo.
+ *
+ * @return  A std::error_condition.
+ */
+
+std::error_condition cdrom_file::remove_pregap(toc &outtoc, track_input_info &outinfo)
+{
+	int trknum;
+
+	for (trknum = 0; trknum < outtoc.numtrks; trknum++)
+	{
+		if (outtoc.tracks[trknum].pregap > 0 && outtoc.tracks[trknum].pgdatasize > 0) // pregap in data
+		{
+			uint32_t this_pregap = outtoc.tracks[trknum].pregap;
+			uint32_t this_offset = this_pregap * (outtoc.tracks[trknum].datasize + outtoc.tracks[trknum].subsize);
+
+			outtoc.tracks[trknum - 1].frames += this_pregap;
+			outtoc.tracks[trknum - 1].splitframes += this_pregap;
+
+			outinfo.track[trknum].offset += this_offset;
+			outtoc.tracks[trknum].frames -= this_pregap;
+			outinfo.track[trknum].idx[1] -= this_pregap;
+
+			outtoc.tracks[trknum - 1].pregap = 0;
+			outtoc.tracks[trknum - 1].pgtype = 0;
+		}
+	}
+
+	if (EXTRA_VERBOSE)
+	{
+		for (trknum = 0; trknum < outtoc.numtrks; trknum++)
+		{
+			osd_printf_verbose("strip_pregap:\n");
+			osd_printf_verbose("session %d trk %d: %d frames @ offset %d, pad=%d, split=%d, area=%d, phys=%d, pregap=%d, pgtype=%d, pgdatasize=%d, idx0=%d, idx1=%d, dataframes=%d\n",
+				outtoc.tracks[trknum].session + 1,
+				trknum + 1,
+				outtoc.tracks[trknum].frames,
+				outinfo.track[trknum].offset,
+				outtoc.tracks[trknum].padframes,
+				outtoc.tracks[trknum].splitframes,
+				outtoc.tracks[trknum].multicuearea,
+				outtoc.tracks[trknum].physframeofs,
+				outtoc.tracks[trknum].pregap,
+				outtoc.tracks[trknum].pgtype,
+				outtoc.tracks[trknum].pgdatasize,
+				outinfo.track[trknum].idx[0],
+				outinfo.track[trknum].idx[1],
+				outtoc.tracks[trknum].frames - outtoc.tracks[trknum].padframes);
+		}
+	}
+
+	return std::error_condition();
+}
+
+/*-------------------------------------------------
+    adjust_high_density_area - Set LBA for every track with HIGH-DENSITY area @ LBA 45000
+-------------------------------------------------*/
+
+/**
+ * @fn  static std::error_condition remove_pregap(toc &outtoc, track_input_info &outinfo)
+ *
+ * @brief   Chdgd Set LBA for every track with HIGH-DENSITY area @ LBA 45000
+ *
+ * @param [in,out]  outtoc  The outtoc.
+ * @param [in,out]  outinfo The outinfo.
+ *
+ * @return  A std::error_condition.
+ */
+
+std::error_condition cdrom_file::adjust_high_density_area(toc &outtoc, track_input_info &outinfo)
+{
+	int trknum;
+
+	for (trknum = 1; trknum < outtoc.numtrks; trknum++)
+	{
+		if (outtoc.tracks[trknum].multicuearea == HIGH_DENSITY && outtoc.tracks[trknum - 1].multicuearea == SINGLE_DENSITY)
+		{
+			outtoc.tracks[trknum].physframeofs = 45000;
+			int dif = outtoc.tracks[trknum].physframeofs - (outtoc.tracks[trknum - 1].frames + outtoc.tracks[trknum - 1].physframeofs);
+			outtoc.tracks[trknum - 1].frames += dif;
+			outtoc.tracks[trknum - 1].padframes = dif;
+		}
+		else
+		{
+			outtoc.tracks[trknum].physframeofs = outtoc.tracks[trknum - 1].physframeofs + outtoc.tracks[trknum - 1].frames;
 		}
 	}
 

--- a/src/lib/util/cdrom.h
+++ b/src/lib/util/cdrom.h
@@ -161,6 +161,8 @@ public:
 	static std::error_condition parse_iso(std::string_view tocfname, toc &outtoc, track_input_info &outinfo);
 	static std::error_condition parse_gdi(std::string_view tocfname, toc &outtoc, track_input_info &outinfo);
 	static std::error_condition parse_cue(std::string_view tocfname, toc &outtoc, track_input_info &outinfo);
+	static std::error_condition remove_pregap(toc& outtoc, track_input_info& outinf);
+	static std::error_condition adjust_high_density_area(toc& outtoc, track_input_info& outinfo);
 	static bool is_gdicue(std::string_view tocfname);
 	static std::error_condition parse_toc(std::string_view tocfname, toc &outtoc, track_input_info &outinfo);
 	int get_last_session() const { return cdtoc.numsessions ? cdtoc.numsessions : 1; }

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -103,6 +103,8 @@ constexpr bool OSD_PRINTF_VERBOSE = false;
 #define OPTION_OUTPUT "output"
 #define OPTION_OUTPUT_BIN "outputbin"
 #define OPTION_OUTPUT_SPLITBIN "splitbin"
+#define OPTION_OUTPUT_REMOVEPREGAP "removepregap"
+#define OPTION_OUTPUT_ADDPREGAP "addpregap"
 #define OPTION_OUTPUT_FORCE "force"
 #define OPTION_INPUT_START_BYTE "inputstartbyte"
 #define OPTION_INPUT_START_HUNK "inputstarthunk"
@@ -676,6 +678,8 @@ static const option_description s_options[] =
 	{ OPTION_OUTPUT,                "o",    true, " <filename>: output file name" },
 	{ OPTION_OUTPUT_BIN,            "ob",   true, " <filename>: output file name for binary data" },
 	{ OPTION_OUTPUT_SPLITBIN,       "sb",   false, ": output one binary file per track" },
+	{ OPTION_OUTPUT_REMOVEPREGAP,   "rp",   false, ": modify TOC to match TOSEC format (GD-ROM only)" },
+	{ OPTION_OUTPUT_ADDPREGAP,      "ap",   false, ": modify TOC to match Redump format (GD-ROM only)" },
 	{ OPTION_OUTPUT_FORCE,          "f",    false, ": force overwriting an existing file" },
 	{ OPTION_OUTPUT_PARENT,         "op",   true, " <filename>: parent file name for output CHD" },
 	{ OPTION_INPUT_START_BYTE,      "isb",  true, " <offset>: starting byte offset within the input" },
@@ -764,6 +768,7 @@ static const command_description s_commands[] =
 			REQUIRED OPTION_OUTPUT,
 			OPTION_OUTPUT_PARENT,
 			OPTION_OUTPUT_FORCE,
+			OPTION_OUTPUT_REMOVEPREGAP,
 			REQUIRED OPTION_INPUT,
 			OPTION_HUNK_SIZE,
 			OPTION_COMPRESSION,
@@ -832,6 +837,7 @@ static const command_description s_commands[] =
 			OPTION_OUTPUT_BIN,
 			OPTION_OUTPUT_SPLITBIN,
 			OPTION_OUTPUT_FORCE,
+			OPTION_OUTPUT_ADDPREGAP,
 			REQUIRED OPTION_INPUT,
 			OPTION_INPUT_PARENT,
 		}
@@ -2176,6 +2182,25 @@ static void do_create_cd(parameters_map &params)
 			report_error(1, "Error parsing input file (%s: %s)\n", *input_file_str->second, err.message());
 	}
 
+	bool is_gdrom = toc.flags & cdrom_file::CD_FLAG_GDROM;
+
+	if (is_gdrom)
+	{
+		bool is_removepregap = params.find(OPTION_OUTPUT_REMOVEPREGAP) != params.end();
+
+		if (is_removepregap)
+		{
+			std::error_condition err = cdrom_file::remove_pregap(toc, track_info);
+		
+			if (err)
+				report_error(1, "Error stripping pregap: (%s: %s)\n", *input_file_str->second, err.message());
+		}
+
+		std::error_condition err = cdrom_file::adjust_high_density_area(toc, track_info);
+		if (err)
+			report_error(1, "Error adjusting high density area: (%s: %s)\n", *input_file_str->second, err.message());
+	}
+
 	// process output CHD
 	chd_file output_parent;
 	const auto output_chd_str = parse_output_chd_parameters(params, output_parent);
@@ -2849,7 +2874,9 @@ static void do_extract_cd(parameters_map &params)
 				output_toc_file->printf("CD_ROM\n\n\n");
 		}
 
-		if (cdrom->is_gdrom() && mode == MODE_CUEBIN)
+		bool is_addpregap = cdrom->is_gdrom() && mode == MODE_CUEBIN && params.find(OPTION_OUTPUT_ADDPREGAP) != params.end();
+
+		if (is_addpregap)
 		{
 			// modify TOC to match Redump cue/bin format as best as possible
 			cdrom_file::toc *trackinfo = (cdrom_file::toc*)&toc;


### PR DESCRIPTION
**chdman is a widely used tool today. A key requirement should be that the data conversion is reversible.**

expectation: CHD files can be created from CUE or GDI files. They can be extracted back into CUE **or** GDI format, with the binary data being identical to that of the original tracks. The problem is that chdman modifies the correctly parsed TOC again during both compression and extraction. However, this only happens with GD-ROMs.

**Test scenario: CHDMan 0.288**
```
Redump Cue: 18 Wheeler - American Pro Trucker (USA).cue
Redump GDI: 18 Wheeler - American Pro Trucker (USA).gdi
```

**Commands for Redump Dreamcast CUE/GDI** 
```
chdman createcd -i "18 Wheeler - American Pro Trucker (USA).cue" -o "18 Wheeler - American Pro Trucker (USA).chd"
chdman createcd -i "18 Wheeler - American Pro Trucker (USA).gdi" -o "18 Wheeler - American Pro Trucker (USA).chd"
chdman extractcd -sb -i "18 Wheeler - American Pro Trucker (USA).chd" -o "18 Wheeler - American Pro Trucker (USA).cue"
chdman extractcd -sb -i "18 Wheeler - American Pro Trucker (USA).chd" -o "18 Wheeler - American Pro Trucker (USA).gdi"
```

Redump Dreamcast CHD (created from CUE) to CUE: cue and tracks are correct
Redump Dreamcast CHD (created from CUE) to GDI: **gdi track2 has wrong offset, track 1 and 2 data is wrong**

Redump Dreamcast CHD (created from GDI) to CUE: **Track 1 and Track 2 data are wrong** 
Redump Dreamcast CHD (created from GDI) to GDI: gdi and tracks are correct

**After the fix, all four cases work perfectly.**

For parse_cue and parse_toc: I have moved the methods for removing the pregap to a separate location and made them optional accessible via parameters. The code for adjusting the high-density region has also been moved.

I tried to keep the change as small as possible because this change is the most important one.
The GDI parser also does not account for a virtual pregap (TOSEC); however, I will add this in a subsequent pull request if this change is accepted.
Another issue is that the functions for removing and adding pregaps in GDI don't make sense to me. They appear to be outdated functions that are no longer actually needed. If the metadata has been captured correctly, no tricky conversion should be necessary.