### PR TITLE
cpu/mcs96: timers run three times too fast

### DIFF
--- a/src/devices/cpu/mcs96/i8x9x.cpp
+++ b/src/devices/cpu/mcs96/i8x9x.cpp
@@ -386,21 +386,25 @@ void i8x9x_device::serial_w(u8 val)
 	check_irq();
 }
 
+// Timer 1 increments once every eight state times, and a state time is three
+// oscillator periods on this family, so the divisor is 8 * 3 = 24.
+static constexpr u32 TIMER_DIVISOR = 24;
+
 u16 i8x9x_device::timer_value(int timer, u64 current_time) const
 {
 	if(timer == 2)
 		current_time -= base_timer2;
-	return current_time >> 3;
+	return u16(current_time / TIMER_DIVISOR);
 }
 
 u64 i8x9x_device::timer_time_until(int timer, u64 current_time, u16 timer_value) const
 {
 	u64 timer_base = timer == 2 ? base_timer2 : 0;
-	u64 delta = (current_time - timer_base) >> 3;
+	u64 delta = (current_time - timer_base) / TIMER_DIVISOR;
 	u32 tdelta = u16(timer_value - delta);
 	if(!tdelta)
 		tdelta = 0x10000;
-	return timer_base + ((delta + tdelta) << 3);
+	return timer_base + ((delta + tdelta) * TIMER_DIVISOR);
 }
 
 void i8x9x_device::timer2_reset(u64 current_time)


### PR DESCRIPTION
`timer_value()` and `timer_time_until()` divide the elapsed cycle count by 8, which would be
correct if that count were in state times. It is not: `device_start()` sets
`cycles_scaling = 3` precisely because the opcode tables are written in state times, so
`icount` and `total_cycles()` are in **oscillator periods**.

Timer 1 increments once every eight state times, and a state time is three oscillator
periods on this family, so the divisor should be 24. As it stands every on-chip timer runs
exactly three times too fast, and with it everything the firmware paces off them - including
the software timers, which sit on the HSO and are clocked from timer 1.

### How it shows up

On the Roland D-110 (`roland_d10.cpp`, `N8097BH` at 12 MHz) the firmware's own ROM demo
songs play at triple speed. Driving the machine and logging the note events it generates:

| | before | after |
| --- | --- | --- |
| note events land on | a ~60 ms grid | a ~180 ms grid |
| mean note length | 68 ms | 270 ms |
| note starts per second | 59.2 | 17.8 |

180 ms is exactly 3 x 60 ms, and the parts land on that grid consistently once corrected.

### Timer 2

Timer 2 counts an external clock on real hardware, but is modelled off the same time base
here, so it is scaled identically to keep the two consistent rather than left at a divisor
that no longer matches timer 1.

This is independent of #15807, which is against the same file but a different defect.
