### PR TITLE
cpu/tlcs90/tlcs90.cpp: Fixed CPIR infinitely looping

### DIFF
--- a/src/devices/cpu/tlcs90/tlcs90.cpp
+++ b/src/devices/cpu/tlcs90/tlcs90.cpp
@@ -1574,12 +1574,14 @@ void tlcs90_device::execute_run()
 				if ( m_bc.w.l )
 				{
 					F |= VF;
-				if ( m_bc.w.l && b8 != 0 )
-                {
-					m_pc.w.l -= 2;
-					Cyc();
+					if ( b8 != 0 )
+                	{
+						m_pc.w.l -= 2;
+						Cyc();
+						break;
+					}
 				}
-				else    Cyc_f();
+				Cyc_f();
 				break;
 
 			case PUSH:

--- a/src/devices/cpu/tlcs90/tlcs90.cpp
+++ b/src/devices/cpu/tlcs90/tlcs90.cpp
@@ -1506,49 +1506,50 @@ void tlcs90_device::execute_run()
 //              break;
 
 			case LDI:
-#define _LDI                                            \
-				WM8( m_de.w.l, RM8(m_hl.w.l) );     \
-				m_de.w.l++;                         \
-				m_hl.w.l++;                         \
-				m_bc.w.l--;                         \
-				F &= SF | ZF | IF | XCF | CF;           \
+			case LDIR:
+				WM8( m_de.w.l, RM8(m_hl.w.l) );
+				m_de.w.l++;
+				m_hl.w.l++;
+				m_bc.w.l--;
+				F &= SF | ZF | IF | XCF | CF;
 				if ( m_bc.w.l ) F |= VF;
 
-				_LDI
-				Cyc();
-				break;
-			case LDIR:
-				_LDI
-				if ( m_bc.w.l )
-				{
-					m_pc.w.l -= 2;
+				if ( m_op == LDI )
 					Cyc();
+				else
+				{
+					if ( m_bc.w.l )
+					{
+						m_pc.w.l -= 2;
+						Cyc();
+					}
+					else
+						Cyc_f();
 				}
-				else    Cyc_f();
 				break;
 
 			case LDD:
-#define _LDD                                            \
-				WM8( m_de.w.l, RM8(m_hl.w.l) );     \
-				m_de.w.l--;                         \
-				m_hl.w.l--;                         \
-				m_bc.w.l--;                         \
-				F &= SF | ZF | IF | XCF | CF;           \
+			case LDDR:
+				WM8( m_de.w.l, RM8(m_hl.w.l) );
+				m_de.w.l--;
+				m_hl.w.l--;
+				m_bc.w.l--;
+				F &= SF | ZF | IF | XCF | CF;
 				if ( m_bc.w.l ) F |= VF;
 
-				_LDD
-				Cyc();
-				break;
-			case LDDR:
-				_LDD
-				if ( m_bc.w.l )
-				{
-					m_pc.w.l -= 2;
+				if ( m_op == LDD )
 					Cyc();
+				else
+				{
+					if ( m_bc.w.l )
+					{
+						m_pc.w.l -= 2;
+						Cyc();
+					}
+					else
+						Cyc_f();
 				}
-				else    Cyc_f();
 				break;
-
 
 //          case CPD:
 //              Cyc();
@@ -1556,32 +1557,28 @@ void tlcs90_device::execute_run()
 //          case CPDR:
 //              Cyc();
 //              break;
+
 			case CPI:
-				a8 = RM8(m_hl.w.l);
-				b8 = m_af.b.h - a8;
-				m_hl.w.l++;
-				m_bc.w.l--;
-				F = (F & (IF | CF)) | SZ[b8] | ((m_af.b.h^a8^b8)&HF) | NF;
-				if ( m_bc.w.l ) F |= VF;
-				Cyc();
-				break;
 			case CPIR:
 				a8 = RM8(m_hl.w.l);
 				b8 = m_af.b.h - a8;
 				m_hl.w.l++;
 				m_bc.w.l--;
 				F = (F & (IF | CF)) | SZ[b8] | ((m_af.b.h^a8^b8)&HF) | NF;
-				if ( m_bc.w.l )
+				if ( m_bc.w.l ) F |= VF;
+
+				if ( m_op == CPI )
+					Cyc();
+				else
 				{
-					F |= VF;
-					if ( b8 != 0 )
-                	{
+					if ( m_bc.w.l && b8 != 0 )
+					{
 						m_pc.w.l -= 2;
 						Cyc();
-						break;
 					}
+					else
+						Cyc_f();
 				}
-				Cyc_f();
 				break;
 
 			case PUSH:
@@ -1617,7 +1614,6 @@ void tlcs90_device::execute_run()
 				}
 				else    Cyc_f();
 				break;
-
 
 			case CALL:
 				if ( Test( Read1_8() ) )
@@ -1704,10 +1700,10 @@ void tlcs90_device::execute_run()
 				F = SZP[A] | (F & (IF | NF));
 				if (cf || (lo <= 9 ? hi >= 10 : hi >= 9)) F |= XCF | CF;
 				if (nf ? hf && lo <= 5 : lo >= 10)  F |= HF;
-			}
+
 				Cyc();
 				break;
-
+			}
 
 			case CPL:
 				m_af.b.h ^= 0xff;
@@ -1796,7 +1792,6 @@ void tlcs90_device::execute_run()
 				if ((a16 ^ a32 ^ 1) & 0x1000)   F |= HF;    //??
 				Cyc();
 				break;
-
 
 			case DEC:
 				a8 = Read1_8() - 1;

--- a/src/devices/cpu/tlcs90/tlcs90.cpp
+++ b/src/devices/cpu/tlcs90/tlcs90.cpp
@@ -1574,6 +1574,8 @@ void tlcs90_device::execute_run()
 				if ( m_bc.w.l )
 				{
 					F |= VF;
+				if ( m_bc.w.l && b8 != 0 )
+                {
 					m_pc.w.l -= 2;
 					Cyc();
 				}


### PR DESCRIPTION
If BC is not zero and the values do not match (), it subtracts 2 from the PC register to repeat the instruction and calls . Otherwise, it calls  to finish.b8 != 0Cyc()Cyc_f()