### PR TITLE
sinclair/next/specnext.cpp: (Revert) Reads sprites data once per line, not immidiately (closer match FPGA) (#15674)

### DIFF
--- a/src/mame/sinclair/next/specnext.cpp
+++ b/src/mame/sinclair/next/specnext.cpp
@@ -211,7 +211,6 @@ protected:
 	void memory_change(u16 port, u8 data);
 	u16 get_layer2_active_page(u8 bank);
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void on_scanline(u32 scanline);
 
 	required_device<z80n_device> m_maincpu;
 
@@ -1035,15 +1034,6 @@ void specnext_state::update_video_mode()
 	m_eff_nr_03_machine_timing = m_nr_03_machine_timing;
 	m_eff_nr_05_5060 = m_nr_05_5060;
 	LOG("%s %dHz\n", machine_name, m_nr_05_5060 ? 60 : 50);
-}
-
-void specnext_state::on_scanline(u32 scanline)
-{
-	if (m_sprites->is_dirty())
-	{
-		m_screen->update_now();
-		m_sprites->update_cache_if_dirty();
-	}
 }
 
 u32 specnext_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
@@ -2371,10 +2361,12 @@ void specnext_state::reg_w(offs_t nr_wr_reg, u8 nr_wr_dat)
 		nr_33_lores_scrolly_w(nr_wr_dat);
 		break;
 	case 0x34:
+		m_screen->update_now();
 		m_sprites->mirror_data_w(nr_wr_dat);
 		break;
 	case 0x35: case 0x36:  case 0x37: case 0x38: case 0x39:
 	case 0x75: case 0x76:  case 0x77: case 0x78: case 0x79:
+		m_screen->update_now();
 		m_sprites->mirror_inc_w(BIT(nr_wr_reg, 6));
 		m_sprites->mirror_index_w((nr_wr_reg & 0x3f) - 0x35);
 		m_sprites->mirror_data_w(nr_wr_dat);
@@ -2422,6 +2414,7 @@ void specnext_state::reg_w(offs_t nr_wr_reg, u8 nr_wr_dat)
 		}
 		break;
 	case 0x4b:
+		m_screen->update_now();
 		nr_4b_sprite_transparent_index_w(nr_wr_dat);
 		break;
 	case 0x4c:
@@ -4250,7 +4243,6 @@ void specnext_state::tbblue(machine_config &config)
 
 	m_screen->set_raw(28_MHz_XTAL / 2, 456 << 1, 312,  { 0, (359 << 1) | 1, 0, 287 });
 	m_screen->set_screen_update(FUNC(specnext_state::screen_update));
-	m_screen->scanline().set(FUNC(specnext_state::on_scanline));
 	m_screen->set_no_palette();
 
 	PALETTE(config.replace(), m_palette, palette_device::BLACK, 512 * (3 + 1 * 2) + 1); // ula tm l2 s*2 +1 == fallback

--- a/src/mame/sinclair/next/specnext_sprites.cpp
+++ b/src/mame/sinclair/next/specnext_sprites.cpp
@@ -73,6 +73,7 @@ specnext_sprites_device &specnext_sprites_device::set_palette(const char *tag, u
 
 void specnext_sprites_device::draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 pmask)
 {
+	if (m_sprites_cache.empty()) update_sprites_cache();
 	const rectangle clipped = m_clip_window & cliprect;
 
 	for (auto i = 0; i < m_sprites_cache.size(); i++ )
@@ -205,7 +206,7 @@ void specnext_sprites_device::update_config()
 
 u8 specnext_sprites_device::status_r()
 {
-	if (m_cache_dirty) { update_sprites_cache(); m_cache_dirty = false; }
+	if (m_sprites_cache.empty()) update_sprites_cache();
 
 	bool max_sprites = 0; // TODO line reached max count allowed
 	bool collision = 0;
@@ -279,7 +280,7 @@ void specnext_sprites_device::io_w(offs_t addr, u8 data)
 	}
 	else if (addr == 0x57)
 	{
-		m_cache_dirty = true;
+		m_sprites_cache.clear();
 		m_sprite_attr_ram[m_attr_index] = data;
 
 		const bool index_inc_attr_by_8 = BIT(m_attr_index, 2) || ((BIT(m_attr_index, 0, 3) == 0b011) && (BIT(data, 6) == 0));
@@ -309,7 +310,7 @@ void specnext_sprites_device::mirror_data_w(u8 mirror_data)
 {
 	if (m_mirror_index <= 0b100)
 	{
-		m_cache_dirty = true;
+		m_sprites_cache.clear();
 		m_sprite_attr_ram[(BIT(m_mirror_sprite_q, 0, TOTAL_SPRITES_BITS) << 3) | m_mirror_index] = mirror_data;
 	}
 
@@ -371,13 +372,13 @@ void specnext_sprites_device::device_reset()
 	m_mirror_sprite_q = 0;
 
 	memset(m_sprite_attr_ram, 0, 128 * 8);
-	m_cache_dirty = true;
+	m_sprites_cache.clear();
 	update_config();
 }
 
 void specnext_sprites_device::device_post_load()
 {
-	m_cache_dirty = true;
+	m_sprites_cache.clear();
 	update_config();
 }
 

--- a/src/mame/sinclair/next/specnext_sprites.h
+++ b/src/mame/sinclair/next/specnext_sprites.h
@@ -15,8 +15,7 @@ public:
 
 	void set_raster_offset(u16 offset_h,  u16 offset_v) { m_offset_h = offset_h - (OVER_BORDER << 1); m_offset_v = offset_v - OVER_BORDER; update_config(); }
 
-	bool is_dirty() { return m_cache_dirty; }
-	void update_cache_if_dirty() { if (m_cache_dirty) { update_sprites_cache(); m_cache_dirty = false; } }
+	void update_sprites_cache();
 	void draw(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, u32 pmask);
 
 	void sprite_palette_select_w(bool sprite_palette_select) { m_sprite_palette_select = sprite_palette_select; update_config(); }
@@ -70,10 +69,7 @@ private:
 		u8 yscale; // u2
 	};
 
-	void update_sprites_cache();
-
 	std::vector<sprite_data> m_sprites_cache;
-	bool m_cache_dirty = false;
 	u16 m_offset_h, m_offset_v;
 	rectangle m_clip_window;
 	u16 m_palette_base_offset;


### PR DESCRIPTION
This reverts commit b54ac147d282ebb075cd7011b90804b69d5a005d.

Multiple issues identified with this change which need more careful work.