### PR TITLE
Fixed duplicate https typo in mamedev.org/tools URL on the Compiling MAME doc' page

### DIFF
--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -85,7 +85,7 @@ Microsoft Windows
 
 The information here is very detailed, and assumes you’re aware of the options
 available and what they mean.  As an alternative, we also provide `a tutorial
-for compiling MAME on Windows <https://https://www.mamedev.org/tools/>`_ on our
+for compiling MAME on Windows <https://www.mamedev.org/tools/>`_ on our
 web site.
 
 MAME for Windows is built using the MSYS2 environment.  You will need a 64-bit


### PR DESCRIPTION
I just noticed the link to MAMEdev tool page was broken in the compiling instructions pages.
A trivial change, so here's a PR.

I've quickly looked at the other URLs in the page and all seem fine, except maybe the link to libsdl.org which is http not https. Not sure if that one is a typo.