### PR TITLE
aic6250: fix the 24-bit DMA byte counter and stop the prefetch at the transfer length

### DIFF
--- a/src/devices/machine/aic6250.cpp
+++ b/src/devices/machine/aic6250.cpp
@@ -172,6 +172,7 @@ void aic6250_device::device_start()
 	save_item(NAME(m_scsi_latch_data));
 
 	m_rev_cntrl = 0x02;
+	m_dma_count = 0;
 
 	m_state_timer = timer_alloc(FUNC(aic6250_device::state_loop), this);
 	m_state = IDLE;

--- a/src/devices/machine/aic6250.cpp
+++ b/src/devices/machine/aic6250.cpp
@@ -1016,7 +1016,8 @@ void aic6250_device::back_w(int state)
 	if (!(m_control_reg_0 & R07W_P_MEM_CYCLE_REQ))
 	{
 		if (m_dma_cntrl & R05W_TRANSFER_DIR)
-			if (m_fifo.full() || m_dma_count < 8)
+			// stop the prefetch once the FIFO holds the rest of the transfer
+			if (m_fifo.full() || m_fifo.queue_length() >= m_dma_count)
 				m_state_timer->adjust(attotime::zero);
 			else
 				m_breq_cb(1);


### PR DESCRIPTION
Two fixes to the AIC-6250 model, found while getting EP/IX 2.1.1 (Control Data's UNIX for the CDC 4000 series) to install and boot on `rs2030`.

*(Edited after review: the branch now carries only the counter fix and the prefetch stop. The original second commit also tightened the `DMA_IN`/`DMA_OUT` ACK conditions, which regressed the pc532's CPU-programmed pseudo-DMA path — see the discussion below. That part will be reworked separately.)*

### 1. `m_dma_count` is never initialised

The data sheet is explicit — *"24-Bit DMA Byte Counter"*, *"The 24-bit counter allows data transfers up to 16 Mbytes without a DMA wrap"* (registers 00-02). In the model that counter is never initialised (`m_dma_count` only ever appears in a `save_item`), and the byte-at-a-time register loads never touch bits 24-31, so the top byte keeps whatever was in the freshly allocated device object. On the Rx2030 this made the IOP's power-up diagnostic fail **about half the time**, which is what put me on to it: the intermittency tracks heap contents, not timing. A 6-byte SCSI command arrived as:

```
[:aic6250] dma_cntrl_w 0x03
[:aic6250] dma transfer from memory, count 1392508934      <- 0x53000006
```

The low 24 bits are the correct 6. Because the count never reaches zero, DMA BYTE COUNT ZERO (status register 0, bit 0) never comes on, the transfer never completes and the firmware gives up with `SCSI Power Up Failure: dma count 0 bit invalid`.

**Verification**: with the fix, eight consecutive `rc2030` boots produced byte-identical console snapshots, all reporting `SCSI Test...Passed`; before it, roughly half failed. `rs2030` with RISC/os 4.52 still boots to its login prompt, so the previously working case is unchanged.

This one is not specific to the MIPS driver — it affects any machine driving an AIC-6250, and has been confirmed independently on the pc532.

### 2. Stop the memory prefetch when the FIFO holds the rest of the transfer

Per the data sheet the chip *"will stop the memory prefetch when the number of bytes in the FIFO, plus the number of bytes already transferred on the SCSI bus, sums to the total transfer length"*. The code prefetched until the FIFO was full or fewer than 8 bytes remained, so bytes prefetched past the programmed count could be left in the FIFO and pushed onto the bus by a later transfer.

`m_dma_count` holds what is left to put on the SCSI bus, so the prefetch stops once `m_fifo.queue_length() >= m_dma_count`.

This changes no observed behaviour on the Rx2030 with RISC/os 4.52 or EP/IX 2.1.1, and boots System V R2 cleanly on the pc532's pseudo-DMA path.

### Testing

`rs2030` and `rc2030`, MAME 0.288 and current master, with:

* RISC/os 4.52 — boots to `exedra Console login:` before and after
* EP/IX 2.1.1 — installs from its own distribution media and boots to `epix Console login:` (re-verified with exactly the two commits on this branch)

Plus the reviewer's pc532 / System V R2 matrix in the comments below.

Background and the full trace-level analysis, including the disassembly of the Rx2030 IOP firmware that identified the polled transfer loop, are in <https://github.com/ajfa/epix-cdc4000-mame>.

A third fix was needed for EP/IX to get past device probe (`nscsi_hd` answers CHECK CONDITION to MODE SENSE page 0x38, the CCS cache page). That one is a judgement call about what the emulated disk should implement, so I have left it out of this PR and I am happy to raise it separately if there is interest.
