### PR TITLE
machine/aic6250: restart the state machine on a bus-control change

### DIFF
--- a/src/devices/machine/aic6250.cpp
+++ b/src/devices/machine/aic6250.cpp
@@ -654,20 +654,27 @@ void aic6250_device::scsi_ctrl_changed()
 
 	int_check();
 
-	// TODO: in future, probably schedule scsi engine, not just interrupt checks
-	//m_state_timer->adjust(attotime::zero);
+	// restart the state machine if it is waiting for a bus control change
+	if (m_state != IDLE && !m_state_timer->enabled())
+		m_state_timer->adjust(attotime::zero);
 }
 
 
 TIMER_CALLBACK_MEMBER(aic6250_device::state_loop)
 {
 	// step state machine until delay, idle state or interrupt
+	state_t const prev_state = m_state;
 	int delay = state_step();
 
 	// check for interrupts
 	bool const interrupt = int_check();
 
 	if (delay < 0)
+		return;
+
+	// a no-progress step is waiting for a bus-control change; scsi_ctrl_changed()
+	// restarts it, so don't respin at delay 0 (that freezes emulated time)
+	if (delay == 0 && m_state == prev_state)
 		return;
 
 	/*


### PR DESCRIPTION
The AIC6250 state machine has several states (arbitration and the DMA handshake) that wait for a SCSI bus-control line to change. `state_loop` reschedules the step at `delay == 0` even when it made no progress, so a waiting state re-fires at the same instant and spins the scheduler with emulated time frozen. This hangs the machine whenever the target needs CPU time to respond (a bus-sharing coprocessor, as opposed to a synchronous disk that answers within the same time slice).

This restarts the engine from `scsi_ctrl_changed()` when a bus-control line changes, which is what the existing TODO there anticipated, and stops rescheduling a step that made no progress so it parks until that restart.

This surfaced while reviewing #15825: the `DMA_IN`/`DMA_OUT` rework there added the first state that genuinely waits for req/phase, and it spun on this latent issue on the pc532. The scheduler restart is independent of that PR (noted in the thread), and gives its follow-up rework a working event-driven base.

Testing (pc532, et532; full `-validate` clean):

* pc532 boots System V R2.0 off the AIC6250 disk to the single-user shell, unchanged. The synchronous disk path never enters a no-progress state, so the fix is a no-op there. Verified 4/4 with the AIC6250 counter fix from #15825 also applied, to keep that PR's known intermittent counter failure out of the signal.
* et532 boots unchanged.

Claude Opus 4.8 (via Claude Code) assisted with regression testing and PR preparation; reviewed and validated by me.
