### PR TITLE
bus/isa/cga.cpp: m24 mode2 bit 0 enables the 400 line mode, it does not select graphics

### DIFF
--- a/src/devices/bus/isa/cga.cpp
+++ b/src/devices/bus/isa/cga.cpp
@@ -1838,7 +1838,10 @@ uint8_t isa8_cga_m24_device::io_read(offs_t offset)
 
 MC6845_UPDATE_ROW(isa8_cga_m24_device::crtc_update_row)
 {
-	if (m_mode2 & 1)
+	// mode2 bit 0 only enables the 400 line mode; whether the display is text or
+	// graphics is still selected by bit 1 of the mode control register.  The OEM
+	// MS-DOS console driver leaves mode2 bit 0 set while in text mode.
+	if (BIT(m_mode2, 0) && BIT(m_mode_control, 1))
 	{
 		m24_gfx_1bpp_m24_update_row(bitmap, cliprect, ma, ra, y, x_count, cursor_x, de, hbp, vbp);
 		return;


### PR DESCRIPTION
On the Olivetti M24 video board, bit 0 of the mode2 register at 0x3DE enables the 400 line mode. It does not, on its own, put the display into graphics — text versus graphics is still selected by bit 1 of the CGA mode control register at 0x3D8.

`isa8_cga_m24_device::crtc_update_row` currently treats that bit alone as "graphics":

```c
if (m_mode2 & 1)
{
    m24_gfx_1bpp_m24_update_row(bitmap, cliprect, ma, ra, y, x_count, cursor_x, de, hbp, vbp);
    return;
}
```

so any software that leaves mode2 bit 0 set while in text mode gets its text page fed to the 1bpp renderer, and the screen goes to garbage or blank.

### Reproduction

Boot `m24` with a disk that reaches a text screen — the Xerox 6060 diagnostics disk (`6060diag`, from the publicly archived 6060 software set) shows the customer test program menu — then set the bit from the debugger:

```
iob@0x3de = 1
```

Before / after, same machine state, same VRAM contents, only the row renderer differs:

| current master | with this change |
| --- | --- |
| text page disappears | text page unchanged |

### Why this is the right condition

* 86Box's implementation of the same board (`src/video/vid_cga_olivetti.c`) keeps the two decisions separate. `ctrl_3de & 1` only selects the 400 line addressing inside the graphics path (line 347), while text versus graphics is decided by the CGA mode flag:

  ```c
  else if (!(ogc->cga.cgamode & CGA_MODE_FLAG_GRAPHICS)) {
  ```

* It is also what the rest of this device already assumes. The screen is configured for 400 lines (`screen.set_raw(XTAL(14'318'181), 912, 0, 640, 462, 0, 400)`) and the text paths render 16 line characters (`cga_text<..., 16>`), i.e. text mode here *is* the 400 line text mode. Taking mode2 bit 0 to mean "graphics" contradicts that.

### Where it turned up

The Xerox 6060 is a rebadged M24. Its OEM MS-DOS console driver (`XERBIO.COM`, the machine's IO.SYS equivalent) sets mode2 bit 0 and leaves it set while running in 80x25 text, so under current master nothing it draws is visible. With the change, ScreenMate — the bundled shell — renders exactly as printed in the operator's guide.

### Testing

`m24`, current master (`f6258eb`), Xerox 6060 OEM media:

* **640x400 graphics path unchanged.** The OEM boot logo (`LOGO.COM`) sets 0x3DE=0x01 *and* 0x3D8=0x1E (graphics), so it still takes `m24_gfx_1bpp_m24_update_row`; the logo is pixel identical before and after.
* **Standard CGA graphics unaffected.** The bundled X-Cel tutorial runs with 0x3DE=0x00 and 0x3D8=0x2A, which never reached the M24 path either way.
* **Text under the OEM console now renders**, matching the printed manual.

### One thing I could not test

`isa8_cga_cportiii_device` inherits this `crtc_update_row`, and its `port_23c6_w` sets the same `m_mode2` bit 0. I have no Compaq Portable III software to hand, so I cannot confirm the change is neutral there. If its hi-res mode is entered without also setting the CGA graphics bit, this would need to be scoped to the M24 device instead — happy to do that if a reviewer can check.
