### PR TITLE
namcos22_v.cpp: replace render_triangle_fan usages with render_polygon & render_triangle

### DIFF
--- a/src/devices/video/poly.h
+++ b/src/devices/video/poly.h
@@ -1243,8 +1243,16 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_polygon(re
 			if (istartx > istopx)
 				std::swap(istartx, istopx);
 
-			// compute parameter starting points and deltas
+			// apply left/right clipping BEFORE calculating parameter start
+			if (!(Flags & POLY_FLAG_NO_CLIPPING))
+			{
+				istartx = std::max(istartx, cliprect.left());
+				istopx = std::min(istopx, cliprect.right() + 1);
+			}
+
+			// set the extent
 			extent_t &extent = unit.extent[extnum];
+
 			if (ParamCount > 0)
 			{
 				BaseType ldy = fully - ledge->v1->y;
@@ -1256,24 +1264,12 @@ uint32_t poly_manager<BaseType, ObjectType, MaxParams, Flags>::render_polygon(re
 				{
 					BaseType lparam = ledge->v1->p[paramnum] + ldy * ledge->dpdy[paramnum];
 					BaseType rparam = redge->v1->p[paramnum] + rdy * redge->dpdy[paramnum];
+
 					BaseType dpdx = (rparam - lparam) * oox;
 
 					extent.param[paramnum].start = lparam + (BaseType(istartx) + BaseType(0.5) - startx) * dpdx;
 					extent.param[paramnum].dpdx = dpdx;
 				}
-			}
-
-			// apply left/right clipping
-			if (!(Flags & POLY_FLAG_NO_CLIPPING))
-			{
-				if (istartx < cliprect.left())
-				{
-					for (int paramnum = 0; paramnum < ParamCount; paramnum++)
-						extent.param[paramnum].start += (cliprect.left() - istartx) * extent.param[paramnum].dpdx;
-					istartx = cliprect.left();
-				}
-				if (istopx > cliprect.right())
-					istopx = cliprect.right() + 1;
 			}
 
 			// set the extent and update the total pixel count

--- a/src/mame/namco/namcos22.h
+++ b/src/mame/namco/namcos22.h
@@ -178,7 +178,7 @@ private:
 	void free_scenenode(struct namcos22_scenenode *node);
 	struct namcos22_scenenode *alloc_scenenode(running_machine &machine, struct namcos22_scenenode *node);
 
-	using scanline_func = void (*)(int32_t, extent_t const &, ObjectType const &, int);
+	using scanline_func = void (*)(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);
 
 	void dispatch_scanline_poly(scanline_func callback, int clipverts, vertex_t const *clipv);
 	void renderscanline_poly(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);

--- a/src/mame/namco/namcos22.h
+++ b/src/mame/namco/namcos22.h
@@ -178,6 +178,9 @@ private:
 	void free_scenenode(struct namcos22_scenenode *node);
 	struct namcos22_scenenode *alloc_scenenode(running_machine &machine, struct namcos22_scenenode *node);
 
+	using scanline_func = void (*)(int32_t, extent_t const &, ObjectType const &, int);
+
+	void dispatch_scanline_poly(scanline_func callback, int clipverts, vertex_t const *clipv);
 	void renderscanline_poly(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);
 	void renderscanline_poly_ss22(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);
 	void renderscanline_sprite(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);

--- a/src/mame/namco/namcos22.h
+++ b/src/mame/namco/namcos22.h
@@ -178,7 +178,7 @@ private:
 	void free_scenenode(struct namcos22_scenenode *node);
 	struct namcos22_scenenode *alloc_scenenode(running_machine &machine, struct namcos22_scenenode *node);
 
-	using scanline_func = void (*)(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);
+	using scanline_func = void (namcos22_renderer::*)(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);
 
 	void dispatch_scanline_poly(scanline_func callback, int clipverts, vertex_t const *clipv);
 	void renderscanline_poly(int32_t scanline, const extent_t &extent, const namcos22_object_data &extra, int threadid);

--- a/src/mame/namco/namcos22_v.cpp
+++ b/src/mame/namco/namcos22_v.cpp
@@ -284,10 +284,21 @@ inline void namcos22_renderer::dispatch_scanline_poly(scanline_func callback, in
 {
 	switch (clipverts)
 	{
-		case 3: render_triangle<4>(m_cliprect, render_delegate(callback, this), clipv[0], clipv[1], clipv[2]); break;
-		case 4: render_polygon<4,4>(m_cliprect, render_delegate(callback, this), clipv); break;
-		case 5: render_polygon<5,4>(m_cliprect, render_delegate(callback, this), clipv); break;
-		case 6: render_polygon<6,4>(m_cliprect, render_delegate(callback, this), clipv); break;
+		case 3:
+			render_triangle<4>(m_cliprect, render_delegate(callback, this), clipv[0], clipv[1], clipv[2]);
+			break;
+
+		case 4:
+			render_polygon<4,4>(m_cliprect, render_delegate(callback, this), clipv);
+			break;
+
+		case 5:
+			render_polygon<5,4>(m_cliprect, render_delegate(callback, this), clipv);
+			break;
+
+		case 6:
+			render_polygon<6,4>(m_cliprect, render_delegate(callback, this), clipv);
+			break;
 	}
 }
 

--- a/src/mame/namco/namcos22_v.cpp
+++ b/src/mame/namco/namcos22_v.cpp
@@ -452,18 +452,22 @@ void namcos22_renderer::poly3d_drawquad(screen_device &screen, bitmap_rgb32 &bit
 		extra.fogfactor = 0;
 	}
 
-	if (m_state.m_is_ss22)
-		render_triangle_fan<4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly_ss22, this), clipverts, clipv);
-	else
-	{
-		switch (clipverts)
-		{
-			case 3: render_triangle<4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv[0], clipv[1], clipv[2]); break;
-			case 4: render_polygon<4,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
-			case 5: render_polygon<5,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
-			case 6: render_polygon<6,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
-		}
+#define RENDER_SCANLINES(callback)\
+	switch (clipverts)\
+	{\
+		case 3: render_triangle<4>(m_cliprect, render_delegate(&callback, this), clipv[0], clipv[1], clipv[2]); break;\
+		case 4: render_polygon<4,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
+		case 5: render_polygon<5,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
+		case 6: render_polygon<6,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
 	}
+
+
+	if (m_state.m_is_ss22)
+		RENDER_SCANLINES(namcos22_renderer::renderscanline_poly_ss22)
+	else
+		RENDER_SCANLINES(namcos22_renderer::renderscanline_poly)
+
+#undef RENDER_SCANLINES
 }
 
 

--- a/src/mame/namco/namcos22_v.cpp
+++ b/src/mame/namco/namcos22_v.cpp
@@ -280,7 +280,16 @@ void namcos22_renderer::renderscanline_sprite(int32_t scanline, const extent_t &
 	}
 }
 
-
+inline void namcos22_renderer::dispatch_scanline_poly(scanline_func callback, int clipverts, vertex_t const *clipv)
+{
+	switch (clipverts)
+	{
+		case 3: render_triangle<4>(m_cliprect, render_delegate(callback, this), clipv[0], clipv[1], clipv[2]); break;
+		case 4: render_polygon<4,4>(m_cliprect, render_delegate(callback, this), clipv); break;
+		case 5: render_polygon<5,4>(m_cliprect, render_delegate(callback, this), clipv); break;
+		case 6: render_polygon<6,4>(m_cliprect, render_delegate(callback, this), clipv); break;
+	}
+}
 
 /*********************************************************************************************/
 
@@ -452,22 +461,10 @@ void namcos22_renderer::poly3d_drawquad(screen_device &screen, bitmap_rgb32 &bit
 		extra.fogfactor = 0;
 	}
 
-#define RENDER_SCANLINES(callback)\
-	switch (clipverts)\
-	{\
-		case 3: render_triangle<4>(m_cliprect, render_delegate(&callback, this), clipv[0], clipv[1], clipv[2]); break;\
-		case 4: render_polygon<4,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
-		case 5: render_polygon<5,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
-		case 6: render_polygon<6,4>(m_cliprect, render_delegate(&callback, this), clipv); break;\
-	}
-
-
 	if (m_state.m_is_ss22)
-		RENDER_SCANLINES(namcos22_renderer::renderscanline_poly_ss22)
+		dispatch_scanline_poly(&namcos22_renderer::renderscanline_poly_ss22, clipverts, clipv);
 	else
-		RENDER_SCANLINES(namcos22_renderer::renderscanline_poly)
-
-#undef RENDER_SCANLINES
+		dispatch_scanline_poly(&namcos22_renderer::renderscanline_poly, clipverts, clipv);
 }
 
 

--- a/src/mame/namco/namcos22_v.cpp
+++ b/src/mame/namco/namcos22_v.cpp
@@ -455,7 +455,15 @@ void namcos22_renderer::poly3d_drawquad(screen_device &screen, bitmap_rgb32 &bit
 	if (m_state.m_is_ss22)
 		render_triangle_fan<4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly_ss22, this), clipverts, clipv);
 	else
-		render_triangle_fan<4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipverts, clipv);
+	{
+		switch (clipverts)
+		{
+			case 3: render_triangle<4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv[0], clipv[1], clipv[2]); break;
+			case 4: render_polygon<4,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
+			case 5: render_polygon<5,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
+			case 6: render_polygon<6,4>(m_cliprect, render_delegate(&namcos22_renderer::renderscanline_poly, this), clipv); break;
+		}
+	}
 }
 
 


### PR DESCRIPTION
The changes gives me a consistent 10% speedup across all games on benchmarks:
```
victlapa
Before: 251.03% (119 seconds)
After: 260.57% (119 seconds)

alpinerd
Before: 110.34% (119 seconds)
After: 120.03% (119 seconds)

acedrive
Before: 145.08% (119 seconds)
After: 155.59% (119 seconds)

cybrcomm
Before: 178.60% (119 seconds)
After: 190.22% (119 seconds)

raverace
Before: 153.33% (119 seconds)
After: 160.76% (119 seconds)

ridgeracb
Before: 186.31% (119 seconds)
After: 205.57% (119 seconds)