### PR TITLE
upd765.cpp: Cleared the FIFO and any stale transfer state from a previous command.

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -787,7 +787,6 @@ void upd765_family_device::fifo_push(uint8_t data, bool internal)
 		disable_transfer();
 }
 
-
 uint8_t upd765_family_device::fifo_pop(bool internal)
 {
 	if(!fifo_pos) {
@@ -1506,6 +1505,12 @@ void upd765_family_device::start_command(int cmd)
 	result_pos = 0;
 	main_phase = PHASE_EXEC;
 	tc_done = false;
+	fifo_pos = 0;
+	if(internal_drq)
+	{
+		internal_drq = false;
+		check_irq();
+	}
 
 	execute_command(cmd);
 }


### PR DESCRIPTION
fixes strider from MT6957