### PR TITLE
video/mc6847.cpp: remove implicit screen setup default in device_config_complete

### DIFF
--- a/src/devices/video/mc6847.cpp
+++ b/src/devices/video/mc6847.cpp
@@ -641,39 +641,6 @@ void mc6847_base_device::setup_fixed_mode()
 
 
 //-------------------------------------------------
-//  device_config_complete - perform any
-//  operations now that the configuration is
-//  complete
-//-------------------------------------------------
-
-void mc6847_base_device::device_config_complete()
-{
-	if (!has_screen())
-		return;
-
-	if (!screen().configured())
-	{
-		// It is preferred to initialize the screen device using set_raw.
-		// Setting screen device's raw parameters requires values in terms of pixels.
-		// Multiplying the 6847's clock by 2 produces a pixel clock that allows
-		// 256 pixels of active video area per line, with apparently no roundoff
-		// error or drift.
-		screen().set_raw(
-				uint32_t(clock() * 2),
-				456,                                        // htotal
-				0,                                          // hbend
-				BMP_L_OR_R_BORDER * 2 + BMP_ACTIVE_VIDEO,   // hbstart
-				m_tpfs,                                     // vtotal
-				0,                                          // vbend
-				m_lines_until_retrace);                     // vbstart
-	}
-
-	if (!screen().has_screen_update())
-		screen().set_screen_update(*this, FUNC(mc6847_base_device::screen_update));
-}
-
-
-//-------------------------------------------------
 //  device_start - device-specific startup
 //-------------------------------------------------
 

--- a/src/devices/video/mc6847.h
+++ b/src/devices/video/mc6847.h
@@ -504,7 +504,6 @@ protected:
 	mc6847_base_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, const uint8_t *fontdata, double tpfs, bool pal);
 
 	// device_t overrides
-	virtual void device_config_complete() override;
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual ioport_constructor device_input_ports() const override ATTR_COLD;

--- a/src/mame/acorn/atom.cpp
+++ b/src/mame/acorn/atom.cpp
@@ -1142,7 +1142,9 @@ void atom_state::atom_base(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &atom_state::atom_mem);
 	config.set_perfect_quantum(m_maincpu); // required for Tube interface
 
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update("vdg", FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 3.579545_MHz_XTAL);
 	m_vdg->input_callback().set(FUNC(atom_state::vdg_videoram_r));

--- a/src/mame/apf/apf.cpp
+++ b/src/mame/apf/apf.cpp
@@ -548,7 +548,9 @@ void apf_state::apfm1000(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &apf_state::apfm1000_map);
 
 	/* video hardware */
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_crtc, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_crtc, 3.579545_MHz_XTAL);
 	m_crtc->fsync_wr_callback().set(m_pia0, FUNC(pia6821_device::cb1_w));

--- a/src/mame/bandai/sv8000.cpp
+++ b/src/mame/bandai/sv8000.cpp
@@ -298,7 +298,9 @@ void sv8000_state::sv8000(machine_config &config)
 	m_s68047p->set_palette(sv8000_palette);
 	m_s68047p->set_screen("screen");
 
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_s68047p, FUNC(s68047_device::screen_update));
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/cce/mc1000.cpp
+++ b/src/mame/cce/mc1000.cpp
@@ -569,7 +569,9 @@ void mc1000_state::mc1000(machine_config &config)
 	ne555assert.config_param(ASSERT_LINE);
 
 	/* video hardware */
-	SCREEN(config, SCREEN_TAG);
+	screen_device &screen(SCREEN(config, SCREEN_TAG));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, XTAL(3'579'545));
 	m_vdg->hsync_wr_callback().set(FUNC(mc1000_state::hs_w));

--- a/src/mame/misc/ctvboy.cpp
+++ b/src/mame/misc/ctvboy.cpp
@@ -245,6 +245,8 @@ void ctvboy_state::ctvboy(machine_config &config)
 	m_mc6847->set_screen(m_screen);
 
 	SCREEN(config, m_screen);
+	m_screen->set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	m_screen->set_screen_update(m_mc6847, FUNC(mc6847_base_device::screen_update));
 
 	// sound hardware
 	SPEAKER(config, "speaker").front_center();

--- a/src/mame/misc/z80ne.cpp
+++ b/src/mame/misc/z80ne.cpp
@@ -1406,7 +1406,9 @@ void z80net_state::z80net(machine_config &config)
 	lx387(config);
 
 	/* video hardware */
-	SCREEN(config, "lx388");
+	screen_device &screen(SCREEN(config, "lx388"));
+	screen.set_raw(XTAL(4'433'619) * 2, 456, 0, 372, 312, 0, 293);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 4.433619_MHz_XTAL, true);
 	m_vdg->set_screen("lx388");
@@ -1447,7 +1449,9 @@ void z80netb_state::z80netb(machine_config &config)
 	lx387(config);
 
 	/* video hardware */
-	SCREEN(config, "lx388");
+	screen_device &screen(SCREEN(config, "lx388"));
+	screen.set_raw(XTAL(4'433'619) * 2, 456, 0, 372, 312, 0, 293);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 4.433619_MHz_XTAL, true);
 	m_vdg->set_screen("lx388");
@@ -1489,7 +1493,9 @@ void z80netf_state::z80netf(machine_config &config)
 	lx387(config);
 
 	/* video hardware */
-	SCREEN(config, "lx388");
+	screen_device &screen(SCREEN(config, "lx388"));
+	screen.set_raw(XTAL(4'433'619) * 2, 456, 0, 372, 312, 0, 293);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 4.433619_MHz_XTAL, true);
 	m_vdg->set_screen("lx388");

--- a/src/mame/motorola/uchroma68.cpp
+++ b/src/mame/motorola/uchroma68.cpp
@@ -451,6 +451,9 @@ void uchroma68_state::uchroma68(machine_config &config)
 	m_cass->add_route(ALL_OUTPUTS, "mono", 0.05);
 
 	SCREEN(config, m_screen);
+	// NTSC
+	m_screen->set_raw(XTAL_UCHROMA68 * 2, 456, 0, 372, 262, 0, 243);
+	m_screen->set_screen_update(m_mc6847, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_mc6847, XTAL_UCHROMA68);
 	m_mc6847->set_screen(m_screen);

--- a/src/mame/samsung/spc1000.cpp
+++ b/src/mame/samsung/spc1000.cpp
@@ -482,7 +482,9 @@ void spc1000_state::spc1000(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &spc1000_state::io_map);
 
 	/* video hardware */
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, XTAL(3'579'545));
 	m_vdg->set_screen("screen");

--- a/src/mame/sanyo/phc20.cpp
+++ b/src/mame/sanyo/phc20.cpp
@@ -209,7 +209,9 @@ void phc20_state::phc20(machine_config &config)
 	Z80(config, m_maincpu, 3.579545_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &phc20_state::mem_map);
 
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(m5c6847p1_device::screen_update));
 
 	M5C6847P1(config, m_vdg, 3.579545_MHz_XTAL);
 	m_vdg->set_screen("screen");

--- a/src/mame/sanyo/phc25.cpp
+++ b/src/mame/sanyo/phc25.cpp
@@ -631,7 +631,9 @@ void phc25_state::phc25(machine_config &config)
 	m_maincpu->set_addrmap(AS_IO, &phc25_state::phc25_io);
 
 	/* video hardware */
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(4'433'619) * 2, 456, 0, 372, 312, 0, 293);
+	screen.set_screen_update(m_vdg, FUNC(m5c6847p1_device::screen_update));
 
 	M5C6847P1(config, m_vdg, XTAL(4'433'619), true);
 	m_vdg->set_screen("screen");
@@ -668,6 +670,10 @@ void phc25_state::phc25(machine_config &config)
 void phc25_state::phc25j(machine_config &config)
 {
 	phc25(config);
+
+	screen_device &screen(SCREEN(config.replace(), "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(m5c6847p1_device::screen_update));
 
 	M5C6847P1(config.replace(), m_vdg, XTAL(3'579'545));
 	m_vdg->set_screen("screen");

--- a/src/mame/skeleton/fc100.cpp
+++ b/src/mame/skeleton/fc100.cpp
@@ -523,7 +523,10 @@ void fc100_state::fc100(machine_config &config)
 	m_vdg->set_get_fixed_mode(m5c6847p1_device::MODE_INTEXT);
 	// other lines not connected
 
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(m5c6847p1_device::screen_update));
+
 	GFXDECODE(config, "gfxdecode", "f4palette", gfx_fc100);
 	PALETTE(config, "f4palette", palette_device::MONOCHROME);
 

--- a/src/mame/skeleton/shine.cpp
+++ b/src/mame/skeleton/shine.cpp
@@ -254,7 +254,9 @@ void shine_state::shine(machine_config &config)
 	INPUT_MERGER_ANY_HIGH(config, "irqs").output_handler().set_inputline("maincpu", M6502_IRQ_LINE);
 
 	/* video hardware */
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 3.579545_MHz_XTAL);
 	m_vdg->set_screen("screen");

--- a/src/mame/trs/agvision.cpp
+++ b/src/mame/trs/agvision.cpp
@@ -211,6 +211,8 @@ void agvision_state::agvision(machine_config &config)
 
 	// video hardware
 	SCREEN(config, m_screen);
+	m_screen->set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	m_screen->set_screen_update("vdg", FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, XTAL(14'318'181) / 4); // VClk output from MC6883
 	m_vdg->set_screen(m_screen);

--- a/src/mame/trs/coco12.cpp
+++ b/src/mame/trs/coco12.cpp
@@ -542,6 +542,8 @@ void coco12_state::coco(machine_config &config)
 
 	// video hardware
 	SCREEN(config, m_screen);
+	m_screen->set_raw(XTAL(14'318'181) / 2, 456, 0, 372, 262, 0, 243);
+	m_screen->set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, XTAL(14'318'181) / 4); // VClk output from MC6883
 	m_vdg->set_screen(m_screen);

--- a/src/mame/trs/dragon.cpp
+++ b/src/mame/trs/dragon.cpp
@@ -513,6 +513,8 @@ void dragon_state::dragon_base(machine_config &config)
 
 	// video hardware
 	SCREEN(config, m_screen);
+	m_screen->set_raw(XTAL(14'218'000) / 2, 456, 0, 372, 312, 0, 293);
+	m_screen->set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	MC6847(config, m_vdg, 14.218_MHz_XTAL / 4, true);
 	m_vdg->set_screen(m_screen);
@@ -624,6 +626,10 @@ void dragon64_state::tanodr64(machine_config &config)
 	this->set_clock(14.318181_MHz_XTAL / 16);
 
 	m_sam->set_clock(14.318181_MHz_XTAL);
+
+	SCREEN(config.replace(), m_screen);
+	m_screen->set_raw(XTAL(14'318'181) / 2, 456, 0, 372, 262, 0, 243);
+	m_screen->set_screen_update(m_vdg, FUNC(mc6847_base_device::screen_update));
 
 	// video hardware
 	MC6847(config.replace(), m_vdg, 14.318181_MHz_XTAL / 4);

--- a/src/mame/trs/mc10.cpp
+++ b/src/mame/trs/mc10.cpp
@@ -509,7 +509,9 @@ void mc10_state::mc10_video(machine_config &config)
 	RAM(config, m_ram).set_default_size("4K").set_extra_options("8K,20K,32K");
 
 	/* video hardware */
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
+	screen.set_screen_update("fillme", FUNC(mc6847_base_device::screen_update));
 
 	mc6847_device &vdg(MC6847(config, "mc6847", XTAL(3'579'545)));
 	vdg.set_screen("screen");

--- a/src/mame/trs/mc10.cpp
+++ b/src/mame/trs/mc10.cpp
@@ -511,7 +511,7 @@ void mc10_state::mc10_video(machine_config &config)
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen"));
 	screen.set_raw(XTAL(3'579'545) * 2, 456, 0, 372, 262, 0, 243);
-	screen.set_screen_update("fillme", FUNC(mc6847_base_device::screen_update));
+	screen.set_screen_update("mc6847", FUNC(mc6847_base_device::screen_update));
 
 	mc6847_device &vdg(MC6847(config, "mc6847", XTAL(3'579'545)));
 	vdg.set_screen("screen");

--- a/src/mame/vtech/vtech1.cpp
+++ b/src/mame/vtech/vtech1.cpp
@@ -484,7 +484,9 @@ void vtech1_base_state::vtech1(machine_config &config)
 	// GM2 = GND, GM0 = GND, INTEXT = GND
 	// other lines not connected
 
-	SCREEN(config, "screen");
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_raw(XTAL(4'433'619) * 2, 456, 0, 372, 312, 0, 293);
+	screen.set_screen_update(m_crtc, FUNC(mc6847_base_device::screen_update));
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
* video devices are never intended to have this kind of information, screen_device is an abstraction that emulates a monitor _connection_.
* In MC6847 case the device is normally paired with a MC6883 Synchronous Address Multiplexer (where the clock is actually generated) and a MC1372 RF modulator.
* fix recent regression with trs/coco12.cpp at least (setting a screen of 100x100)