### PR TITLE
sega/system16.cpp: fixed gfx in beautyb & iqpipe

### DIFF
--- a/src/mame/sega/system16.cpp
+++ b/src/mame/sega/system16.cpp
@@ -616,6 +616,21 @@ void segas1x_bootleg_state::s16bl_bgscrolly_w(uint16_t data)
 }
 
 
+void segas1x_bootleg_state::beautyb_fgscrollx_w(uint16_t data)
+{
+	int scroll = data & 0x1ff;
+	scroll -= 1;
+	m_fg_scrollx = -scroll;
+}
+
+void segas1x_bootleg_state::beautyb_bgscrollx_w(uint16_t data)
+{
+	int scroll = data & 0x1ff;
+	scroll += 1;
+	m_bg_scrollx = -scroll;
+}
+
+
 void segas1x_bootleg_state::goldnaxeb1_map(address_map &map)
 {
 	map(0x000000, 0x0bffff).rom();
@@ -1043,11 +1058,11 @@ void segas1x_bootleg_state::beautyb_map(address_map &map)
 	map(0x410000, 0x413fff).ram().w(FUNC(segas1x_bootleg_state::sys16_textram_w)).share("textram");
 
 	map(0x418000, 0x418001).w(FUNC(segas1x_bootleg_state::s16bl_bgscrolly_w));
-	map(0x418008, 0x418009).w(FUNC(segas1x_bootleg_state::s16bl_bgscrollx_w));
+	map(0x418008, 0x418009).w(FUNC(segas1x_bootleg_state::beautyb_bgscrollx_w));
 	map(0x418010, 0x418011).w(FUNC(segas1x_bootleg_state::s16bl_fgscrolly_w));
-	map(0x418018, 0x418019).w(FUNC(segas1x_bootleg_state::s16bl_fgscrollx_w));
-	map(0x418020, 0x418021).w(FUNC(segas1x_bootleg_state::s16bl_bgpage_w));
-	map(0x418028, 0x418029).w(FUNC(segas1x_bootleg_state::s16bl_fgpage_w));
+	map(0x418018, 0x418019).w(FUNC(segas1x_bootleg_state::beautyb_fgscrollx_w));
+	map(0x418020, 0x418021).w(FUNC(segas1x_bootleg_state::s16bl_fgpage_w));
+	map(0x418028, 0x418029).w(FUNC(segas1x_bootleg_state::s16bl_bgpage_w));
 
 	map(0x840000, 0x840fff).ram().w(FUNC(segas1x_bootleg_state::paletteram_w)).share("paletteram");
 
@@ -2532,6 +2547,8 @@ void segas1x_bootleg_state::beautyb(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &segas1x_bootleg_state::beautyb_map);
 	m_maincpu->set_addrmap(AS_OPCODES, &segas1x_bootleg_state::beautyb_opcodes_map);
 
+	MCFG_VIDEO_START_OVERRIDE(segas1x_bootleg_state,beautyb)
+
 	// no sprites
 
 	z80_ym2151(config);
@@ -2542,6 +2559,8 @@ void segas1x_bootleg_state::iqpipe(machine_config &config)
 	beautyb(config);
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &segas1x_bootleg_state::iqpipe_map);
+
+	MCFG_VIDEO_START_OVERRIDE(segas1x_bootleg_state,iqpipe)
 }
 
 /* System 18 Bootlegs */

--- a/src/mame/sega/system16.h
+++ b/src/mame/sega/system16.h
@@ -117,6 +117,9 @@ private:
 	void s16bl_fgscrolly_w(uint16_t data);
 	void s16bl_bgscrollx_w(uint16_t data);
 	void s16bl_bgscrolly_w(uint16_t data);
+	void beautyb_fgscrollx_w(uint16_t data);
+	void beautyb_bgscrollx_w(uint16_t data);
+
 	template<int Page> void datsu_page_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void goldnaxeb2_fgscrollx_w(uint16_t data);
 	void goldnaxeb2_bgscrollx_w(uint16_t data);
@@ -164,6 +167,9 @@ private:
 	DECLARE_VIDEO_START(s16a_bootleg_passsht);
 	DECLARE_VIDEO_START(s16a_bootleg_wb3bl);
 	DECLARE_VIDEO_START(s16a_bootleg);
+	DECLARE_VIDEO_START(beautyb);
+	DECLARE_VIDEO_START(iqpipe);
+
 	uint32_t screen_update_system16(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_system18old(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_s16a_bootleg(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/sega/system16_v.cpp
+++ b/src/mame/sega/system16_v.cpp
@@ -448,6 +448,17 @@ VIDEO_START_MEMBER(segas1x_bootleg_state,system18old)
 	m_system18 = 1;
 }
 
+VIDEO_START_MEMBER(segas1x_bootleg_state,iqpipe)
+{
+	VIDEO_START_CALL_MEMBER(system16);
+	m_text_layer->set_scrolldx(-3, 0);
+}
+
+VIDEO_START_MEMBER(segas1x_bootleg_state,beautyb)
+{
+	VIDEO_START_CALL_MEMBER(iqpipe);
+	m_text_layer->set_scrolldy( 1, 0); // correct for beautyb (compared to hw shots) but iqpipe wraps a line of text to the top
+}
 
 /*****************************************************************************************
  System 16A bootleg video


### PR DESCRIPTION
not the best code, but it's in the old system16 driver (used for bootlegs etc.) that needs a clean-up at some point

dipswitches need checking, demo sound is definitely the same as Tetris (the games even still use Tetris music) but the coinage is all over the place, with some setthings giving 60 credits.