### PR TITLE
upd765: Deassert DRQ on terminal count and prevent FIFO handling from reasserting DRQ after the DMA transfer has completed

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -420,6 +420,7 @@ void upd765_family_device::tc_w(bool _tc)
 	if(tc != _tc && _tc) {
 		live_sync();
 		tc_done = true;
+		disable_transfer();
 		tc = _tc;
 		if(cur_live.fi)
 			general_continue(*cur_live.fi);
@@ -812,7 +813,7 @@ void upd765_family_device::fifo_expect(int size, bool write)
 {
 	fifo_expected = size;
 	fifo_write = write;
-	if(fifo_write)
+	if(fifo_write && !tc_done)
 		enable_transfer();
 }
 


### PR DESCRIPTION
Fixes #15853.

The `ct486` BIOS enables the FIFO:

```
[:board1:fdc_smc:fdc] command sense interrupt status (fid=0 c0 00) (':maincpu' (000FC758))
[:board1:fdc_smc:fdc] command specify df 02: step_rate=3 ms, head_unload=240 ms, head_load=2 ms, non_dma=false
[:board1:fdc_smc:fdc] command version
[:board1:fdc_smc:fdc] command dump regs
[:board1:fdc_smc:fdc] command configure 00 08 00
[:board1:fdc_smc:fdc] command perpendicular
[:board1:fdc_smc:fdc] command lock (on)
```

while `at486` doesn't, which means formatting failed in `ct486` but worked in `at486`.

The root cause are issues with FIFO handling. Logs from `ct486` (which additional DRQ logging added) follow.

The `FORMAT_TRACK` command is issued:

```
[:board1:fdc_smc:fdc] command format track mfm h=01 n=02 sc=12 gpl=6c d=f6
```

That's 18 sectors, each sector needing 4 bytes for the sector description, a total of 72 bytes.

`WRITE_TRACK_PRE_SECTORS` is called requesting 4 bytes: `fifo_expect(4, true)`.

DRQ is issued and the data begins to flow:

```
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=0/4 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=0 done=0 fifo=4/0 phase=2
```

The first 4 bytes are now buffered in the FIFO.

For each additional sector `WRITE_TRACK_SECTOR` is called, which then calls `fifo_expect(4, true)`

After writing sector 16, the FIFO contains all data that is needed and TC is set:

```
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=1 done=1 fifo=8/0 phase=2
```

However, after writing sector 17 DRQ is issued again requesting more data:

```
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=1 fifo=4/4 phase=2
```

This DRQ request continues into the next command:

```
[:board1:fdc_smc:fdc] command read data mt mfm sk cmd=e6 sel=1 chrn=(0, 0, 1, 512) eot=12 gpl=1b dtl=ff rate=500000
```

Data is read:

```
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=0 done=0 fifo=0/511 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=9/502 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=0 done=0 fifo=0/502 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=9/493 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=0 done=0 fifo=0/493 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=9/484 phase=2
```

But TC is now reached now too early:

```
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=9/431 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=0 done=0 fifo=0/431 phase=2
[:board1:fdc_smc:fdc] (no context) DRQ 0->1 tc=0 done=0 fifo=9/422 phase=2
[:board1:fdc_smc:fdc] tc=1
[:board1:fdc_smc:fdc] (no context) DRQ 1->0 tc=1 done=1 fifo=0/422 phase=2
[:board1:fdc_smc:fdc] tc=0
[:board1:fdc_smc:fdc] command done (data) - results=(01,00,00,00,00,10,02)
```

AI disclosure: gpt-5.6-sol was used as a research and debugging tool, all code was written by me.