### PR TITLE
i8291a: release bus outputs on reset, gate APT on TPAS/LPAS in mode 3

### DIFF
--- a/src/devices/machine/i8291a.cpp
+++ b/src/devices/machine/i8291a.cpp
@@ -140,6 +140,14 @@ void i8291a_device::device_reset()
 	update_state(m_sh_state, source_handshake_state::SIDS);
 	update_state(m_ah_state, acceptor_handshake_state::AIDS);
 	update_state(m_lp_state, listener_primary_state::LPIS);
+
+	// The clears above are the input shadows; the level this chip drives lives in m_*_out, which
+	// nothing here touches, so a line it was holding stays held.
+	set_nrfd(false);
+	set_ndac(false);
+	set_dav(false);
+	set_eoi(false);
+	m_dio_write_func(0xff);
 }
 
 void i8291a_device::device_start()

--- a/src/devices/machine/i8291a.cpp
+++ b/src/devices/machine/i8291a.cpp
@@ -737,7 +737,9 @@ void i8291a_device::handle_command()
 		if ((m_address_mode & 3) != 1 && m_rl_state == remote_local_state::LWLS)
 			update_state(m_rl_state, remote_local_state::RWLS);
 
-		if ((m_address_mode & 3) == 3) {
+		// APT: (TPAS + LPAS)*SCG*ACDS*MODE 3 (Table 4)
+		if ((m_address_mode & 3) == 3 &&
+				(m_tp_state == talker_primary_state::TPAS || m_lp_state == listener_primary_state::LPAS)) {
 			/* In address mode 3, MSA is passed to host for verification */
 			m_ints1 |= REG_INTS1_APT;
 			m_cpt = m_din;


### PR DESCRIPTION
Two independent fixes to the Intel 8291A GPIB talker/listener. Two commits; either can be dropped.
Only `src/devices/machine/i8291a.cpp` is touched. Page numbers are from the printed datasheet
(Order No. 205248-002, November 1986); line numbers refer to the file before this change.

## Fix 1 — a chip reset leaves the bus lines held

`device_reset()` clears the input shadows (`m_nrfd`, `m_ndac`, `m_dav`, `m_eoi`, l.124-129) and puts
the interface functions in their idle states, but it drives nothing. The level this chip is holding
lives in `m_*_out`, which the reset never touches, so a chip reset taken while the device is
addressed as a listener leaves NRFD and NDAC asserted. Both are wired-AND: the handshake stays
blocked for every device on the bus.

`run_ah_fsm()` would release the pair on `pon` (l.748-749), but that branch is guarded by
`m_ah_state != AIDS` (l.745) and `device_reset()` has already forced AIDS (l.141), so it is
unreachable. Same asymmetry, not a second bug.

Repro: address the chip as a listener (AH in ANRS/ACRS, NRFD/NDAC driven), then write $02 (Chip
Reset) to AUX MODE. The lines stay asserted.

Datasheet p. 3-14: Chip Reset has "the same effect as a pulse applied to the Reset pin"; the
power-up states are SIDS, AIDS, TIDS, LIDS, NPRS, LOCS, PPIS. Per Appendix A, AIDS drives NRFD and
NDAC false (p. 3-27) and SIDS drives DAV false (p. 3-26). EOI and the DIO drivers are not specified
there; they follow the idle source handshake.

SRQ is left out: `set_srq()` has no caller in the file. `m_dio_write_func()` is not change-gated
like the setters, so it emits one redundant write per reset.

## Fix 2 — APT raised unconditionally in address mode 3

In address mode 3, any secondary address on the bus raises APT and latches CPT, even when the chip
never matched a primary address: the `(m_address_mode & 3) == 3` branch has no condition on the
chip's own primary-address state.

Datasheet p. 3-10, Table 4: APT is "Set by (TPAS + LPAS)•SCG•ACDS•MODE 3". The fix gates the branch
on `TPAS || LPAS`, matching it.

The gate cannot suppress an APT the real part would raise: per Appendix A (p. 3-28) the chip leaves
TPAS on any PCG that is not MTA, while this implementation only clears it on a non-matching
0x40-0x5F, so it holds the state longer than the hardware does.

## Testing

This branch alone builds on a clean upstream tree: no warnings, full `mame` target links,
`mame -validate` passes.

Functionally, both fixes come from a work-in-progress HP-150 driver (not upstream) with an HP 9133XV
running its real controller firmware. That tree carries the driver and the peripheral as well, so it
does not isolate either fix; the argument for both is the static one above.

## Impact on other in-tree users

Three instantiations: `bus/ieee488/hp9122c.cpp` (l.497) and `bus/ieee488/hp9133.cpp` (l.838), which
wire the five bus outputs and DIO to the shared bus, and `natsemi/sys16.cpp` (l.236), which binds
only `int_write()`. `hp/hp7596a.cpp`'s instantiation is commented out (l.51).

`hp9122c` is the default IEEE-488 option on two hosts (`bus/hp_dio/human_interface.cpp` l.79,
`bus/isa/hpblp.cpp` l.86), so it is instantiated without being asked for — that is where a
regression would show. Fix 2 only fires in address mode 3. Fix 1 changes what those devices put on
the bus after a reset, in the releasing direction only.

One caveat: `device_reset()` now emits callbacks, which it did not before. MAME does not guarantee
reset order between the chip, the bus and its peers, so on a warm reset a write can reach a peer
before its own `device_reset()`. Releasing cannot mask another device's assertion on a wired-AND
bus, but the ordering is new behaviour.

Developed with AI assistance; all output manually reviewed, all datasheet citations checked against
the printed document.
