### PR TITLE
oberheim/xpander.cpp: Moved voice board logic into its own device.

### DIFF
--- a/src/mame/oberheim/xpander.cpp
+++ b/src/mame/oberheim/xpander.cpp
@@ -18,6 +18,8 @@ presses, drives the VFDs, interprets the digital and analog inputs (MIDI, CVs,
 triggers, etc.), and sends parameters to the voice computer.
 
 The voice board consists of 6 analog voices controlled by the voice computer.
+The main computer communicates with the voice board by accessing it's RAM after
+halting its CPU.
 
 Each voice is built around a CEM3374 (dual oscillator) and a CEM3372 (VCF and
 VCA). VCO2 can modulate either VCO1 or the VCF to produce FM effects. There is
@@ -41,7 +43,7 @@ mode which surpases 14 bits (see voice_dac_enable_w()). This is used for pitch
 CVs.
 
 The voice computer also selects VCO waveforms, switches between different VCF
-modes, etc., by controlling digital switches and multiplexers. Finally, it also
+modes, etc., by controlling switch and multiplexer ICs. Finally, it also
 controls the routing and amount of FM by configuring an MDAC (AD7523, one per
 voice).
 
@@ -90,54 +92,501 @@ intended as an educational tool. There is no attempt to emulate audio.
 
 #include "logmacro.h"
 
+
 namespace {
 
-constexpr const char MAINCPU_TAG[] = "main_68b09";
-constexpr const char VOICECPU_TAG[] = "voice_68b09";
-constexpr const char NVRAM_A_TAG[] = "nvram_a";
-constexpr const char NVRAM_B_TAG[] = "nvram_b";
-constexpr const char VOICERAM_TAG[] = "voiceram";
+// A single voice on the xpander voice board.
+// Note: the X in component designations refers to the voice number. For example,
+// UX03 refers to U103 for voice 1, U203 for voice 2, and so on. All component
+// designations apply to the voice board unless otherwise stated.
+class xpander_voice_device : public device_t
+{
+public:
+	xpander_voice_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
 
-constexpr const int NUM_ENCODER_POSITIONS = 30;
+	double cem3374_tempco_v() const;
+
+	void latch0_w(u8 data);
+	void latch1_w(u8 data);
+	void latch2_w(u8 data);
+
+	void set_cv(u8 cv_index, double cv, bool fast);
+	void set_res_cv(double cv);
+
+protected:
+	void device_start() override ATTR_COLD;
+
+private:
+	static inline constexpr int NUM_CVS = 9;
+	static inline constexpr int RES_CV_INDEX = 8;
+	static inline constexpr const char *CV_NAMES[NUM_CVS] =
+	{
+		"VCA", "PW1", "VOLA", "VCOF1", "VOLB", "VCFF", "PW2", "VCOF2", "RES"
+	};
+
+	output_finder<> m_fm_mdac;  // Latch connected to AD7523/MP7523.
+	output_finder<> m_filter_mode;
+	output_finder<> m_noise;
+	output_finder<> m_pan;
+	output_finder<> m_saw1;
+	output_finder<> m_saw2;
+	output_finder<> m_tri1;
+	output_finder<> m_tri2;
+	output_finder<> m_vcofm;
+	output_finder<> m_sync;
+
+	std::array<double, NUM_CVS> m_cv;
+	std::array<bool, NUM_CVS - 1> m_fast;  // `-1` because RES does not support fast updates.
+};
+
+}  // anonymous namespace
+
+DEFINE_DEVICE_TYPE(XPANDER_VOICE, xpander_voice_device, "xpander_voice", "Xpander voice")
+
+xpander_voice_device::xpander_voice_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, XPANDER_VOICE, tag, owner, 0)
+	, m_fm_mdac(*this, "fm_mdac")
+	, m_filter_mode(*this, "filter_mode")
+	, m_noise(*this, "noise")
+	, m_pan(*this, "pan")
+	, m_saw1(*this, "saw1")
+	, m_saw2(*this, "saw2")
+	, m_tri1(*this, "tri1")
+	, m_tri2(*this, "tri2")
+	, m_vcofm(*this, "vcofm")
+	, m_sync(*this, "sync")
+{
+	std::fill(m_cv.begin(), m_cv.end(), 0.0);
+	std::fill(m_fast.begin(), m_fast.end(), false);
+}
+
+double xpander_voice_device::cem3374_tempco_v() const
+{
+	// The CEM3374 has an on-chip temperature sensor which generates a voltage
+	// on pin 10. This can be used for temperature compensation of the
+	// oscillator frequency CVs. For now, just returning the nominal value
+	// according to the datasheet.
+	return 2.5;
+}
+
+void xpander_voice_device::latch0_w(u8 data)  // UX03, 74LS374.
+{
+	m_fm_mdac = data;
+}
+
+void xpander_voice_device::latch1_w(u8 data)  // UX02, 74HC174.
+{
+	m_vcofm = BIT(data, 0);
+	m_saw2 = BIT(data, 1);
+	m_tri1 = BIT(data, 2);
+	m_sync = BIT(data, 3);
+	m_tri2 = BIT(data, 4);
+	m_saw2 = BIT(data, 5);
+}
+
+void xpander_voice_device::latch2_w(u8 data)  // UX01, 74HC374.
+{
+	m_filter_mode = BIT(data, 0, 4);
+	m_noise = BIT(data, 4);
+	m_pan = BIT(data, 5, 3);
+}
+
+void xpander_voice_device::set_cv(u8 cv_index, double cv, bool fast)
+{
+
+	if (cv == m_cv[cv_index] && fast == m_fast[cv_index])
+		return;
+
+	m_cv[cv_index] = cv;
+	m_fast[cv_index] = fast;
+	LOGMASKED(LOG_DAC, "Voice %s - CV %s: %f, fast: %d\n", basetag(), CV_NAMES[cv_index], cv, fast);
+}
+
+void xpander_voice_device::set_res_cv(double cv)
+{
+	if (cv == m_cv[RES_CV_INDEX])
+		return;
+
+	m_cv[RES_CV_INDEX] = cv;
+	LOGMASKED(LOG_DAC, "Voice %s - CV %s: %f\n", basetag(), CV_NAMES[RES_CV_INDEX], cv);
+}
+
+void xpander_voice_device::device_start()
+{
+	save_item(NAME(m_cv));
+	save_item(NAME(m_fast));
+}
+
+
+namespace {
+
+// The xpander's voice board. Consists of 6 voices and a Z80-based computer for
+// controlling them.
+// All component designations apply to the voice board unless otherwise stated.
+class xpander_voiceboard_device : public device_t
+{
+public:
+	xpander_voiceboard_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+
+	void reset_w(int state);
+	void haltreq_w(int state);
+
+	int haltack_r() const { return m_haltack; }
+
+	auto haltack_cb() { return m_haltack_cb.bind(); }
+
+protected:
+	void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	void device_start() override ATTR_COLD;
+
+private:
+	void voicecpu_map(address_map &map) ATTR_COLD;
+
+	u8 datain_r();
+	void dataout_w(u8 data);
+	void latch0_w(offs_t offset, u8 data);
+	void latch1_w(offs_t offset, u8 data);
+	void latch2_w(offs_t offset, u8 data);
+
+	double get_dac_v() const;
+	void dac_enable_w(offs_t offset, u8 data);
+	void dac_clear_w(u8 data);
+	void dac_w(offs_t offset, u8 data);
+
+	void pit_out0_changed(int state);
+	void pit_out2_changed(int state);
+
+	void update_line_halt();
+
+	static inline constexpr u16 LOW7_MASK = 0x7f;
+	static inline constexpr u16 HIGH7_MASK = LOW7_MASK << 7;
+
+	// U815A (TL084), R851 and R852 scale the voltage reference selected by U805 (CD4051).
+	static inline constexpr double DAC_VREF_SCALER = 1.0 + RES_K(2.43) / RES_K(1);
+
+	// A 4V reference generated by D805, R856, R857, R854, U815C is then scaled
+	// by R853 and R855. This is the voltage reference used when generating CVs
+	// other than those for oscillator frequencies.
+	static inline constexpr double DEFAULT_DAC_VREF = 4.0 * RES_VOLTAGE_DIVIDER(RES_K(18.2), RES_K(10)) * DAC_VREF_SCALER;
+
+	required_device<mc6809_device> m_voicecpu;
+	required_device<pit8253_device> m_pit;
+	required_device_array<xpander_voice_device, 6> m_voices;
+	devcb_write_line m_haltack_cb;
+
+	// Many bool variables represent signals in the schematic (e.g. HALTREQ).
+	// Some of those signals are active low in the schematic (e.g. HALTREQ*).
+	// But the variables here are always active-high (active == true).
+
+	bool m_haltdis;  // Halt disable (HALTDS).
+	bool m_haltreq;  // Halt request (HALTREQ).
+	bool m_haltack;  // Halt acknowledge (HALTAKN).
+	bool m_autodone;  // Autotune done (AUTODNE).
+	u16 m_dac_data;
+	double m_dac_fine_v;
+	double m_dac_vref;  // Sampled in C806 and buffered and scaled by U815.
+	bool m_fast;  // Fast CV sampling enabled (FAST).
+};
+
+}  // anonymous namespace
+
+DEFINE_DEVICE_TYPE(XPANDER_VOICEBOARD, xpander_voiceboard_device, "xpander_voiceboard", "Xpander voice board")
+
+xpander_voiceboard_device::xpander_voiceboard_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, XPANDER_VOICEBOARD, tag, owner, 0)
+	, m_voicecpu(*this, "voicecpu")
+	, m_pit(*this, "pit")
+	, m_voices(*this, "voice_%u", 1U)
+	, m_haltack_cb(*this)
+	, m_haltdis(false)
+	, m_haltreq(false)
+	, m_haltack(false)
+	, m_autodone(true)
+	, m_dac_data(0.0)
+	, m_dac_fine_v(0.0)
+	, m_dac_vref(DEFAULT_DAC_VREF)
+	, m_fast(false)
+{
+}
+
+void xpander_voiceboard_device::device_add_mconfig(machine_config &config)
+{
+	MC6809(config, m_voicecpu, 16_MHz_XTAL / 2);  // 8 MHz
+	m_voicecpu->set_addrmap(AS_PROGRAM, &xpander_voiceboard_device::voicecpu_map);
+
+	PIT8253(config, m_pit);
+	// TODO: Set clk<0>. Connected to "OSC".
+	// Clock inputs 1 and 2 connected to CPU's Q signal, which is 4 times slower
+	// than the XTAL input to the CPU.
+	m_pit->set_clk<1>(16_MHz_XTAL / 2 / 4);  // 2 MHz
+	m_pit->set_clk<2>(16_MHz_XTAL / 2 / 4);  // 2 MHz
+	m_pit->out_handler<0>().set(FUNC(xpander_voiceboard_device::pit_out0_changed));
+	// Output 1 not connected.
+	m_pit->out_handler<2>().set(FUNC(xpander_voiceboard_device::pit_out2_changed));
+
+	for (int i = 0; i < m_voices.size(); ++i)
+		XPANDER_VOICE(config, m_voices[i]);
+}
+
+void xpander_voiceboard_device::device_start()
+{
+	save_item(NAME(m_haltdis));
+	save_item(NAME(m_haltreq));
+	save_item(NAME(m_haltack));
+	save_item(NAME(m_autodone));
+	save_item(NAME(m_dac_data));
+	save_item(NAME(m_dac_fine_v));
+	save_item(NAME(m_dac_vref));
+	save_item(NAME(m_fast));
+}
+
+void xpander_voiceboard_device::voicecpu_map(address_map &map)
+{
+	// Signal names (e.g. LATCH0*) are from the schematic.
+
+	map.unmap_value_high();  // Data bus pulled high by resistors in Voice Board.
+
+	// RAM's /CS connected to A15.
+	map(0x0000, 0x1fff).mirror(0x6000).ram().share("voiceram");  // 1 x 6264 (U917).
+
+	// ROM and port/peripheral decoding done by 1/2 LS139 (U915A).
+
+	// Ports / peripherals enabled when U915 O0 is low AND one of
+	// READ*, WRITE*, TIMER* is low. Additional decoding done by 74LS42 (U918).
+	map(0x8000, 0x8007).mirror(0x03f8).w(FUNC(xpander_voiceboard_device::latch0_w));  // LATCH0*
+	map(0x8400, 0x8407).mirror(0x03f8).w(FUNC(xpander_voiceboard_device::latch1_w));  // LATCH1*
+	map(0x8800, 0x8807).mirror(0x03f8).w(FUNC(xpander_voiceboard_device::latch2_w));  // LATCH2*
+	map(0x8c00, 0x8dff).mirror(0x0200).w(FUNC(xpander_voiceboard_device::dac_w));  // SDAC (inverted by LS04).
+	map(0x9000, 0x9000).mirror(0x03ff).w(FUNC(xpander_voiceboard_device::dataout_w));  // DATAOUT*
+	map(0x9400, 0x9400).mirror(0x03ff).r(FUNC(xpander_voiceboard_device::datain_r));  // DATAIN*
+	map(0x9800, 0x9803).mirror(0x03fc).rw(m_pit, FUNC(pit8253_device::read), FUNC(pit8253_device::write));  // TIMER*
+	map(0x9c00, 0x9c00).mirror(0x03ff).unmaprw();  // Unused. U918 output 7 not connected.
+
+	// ROMs only get enabled if BA* is high. I.e. disabled when main CPU has
+	// control of the voice cpu's bus.
+	map(0xa000, 0xffff).rom().region(":voicecpu", 0);  // 3 x 6264 (U909, U912, U914)
+}
+
+void xpander_voiceboard_device::reset_w(int state)
+{
+	const bool reset_voice = state;
+	const bool voice_resetting = (m_voicecpu->input_line_state(INPUT_LINE_RESET) == ASSERT_LINE);
+	if (reset_voice != voice_resetting)
+	{
+		m_voicecpu->set_input_line(INPUT_LINE_RESET, reset_voice ? ASSERT_LINE : CLEAR_LINE);
+		LOGMASKED(LOG_CPU_COMMS, "Voice CPU reset line asserted: %d\n", reset_voice);
+	}
+}
+
+void xpander_voiceboard_device::haltreq_w(int state)
+{
+	const bool haltreq = state;
+	if (haltreq == m_haltreq)
+		return;
+	m_haltreq = haltreq;
+	update_line_halt();
+}
+
+u8 xpander_voiceboard_device::datain_r()
+{
+	// D0 - AUTODNE*
+	const u8 d0 = m_autodone ? 0 : 1;
+	// D1 - OSC
+	const u8 d1 = 1;  // TODO: Implement.
+	// D2-D7 - Not connected (pulled up).
+	return 0xfc | (d1 << 1) | d0;
+}
+
+void xpander_voiceboard_device::dataout_w(u8 data)
+{
+	// D0 - HALTDS
+	const u8 d0 = BIT(data, 0);
+	if (m_haltdis != d0)
+	{
+		m_haltdis = d0;
+		LOGMASKED(LOG_CPU_COMMS, "Voice HALTDS: %d\n", m_haltdis);
+		update_line_halt();
+	}
+	// D1 - AUTOST
+	m_pit->write_gate0(BIT(data, 1));
+	// D2 - PW*
+	// TODO: pit gate2 is actually: PW* | OSC. For now, setting to PW*.
+	m_pit->write_gate2(BIT(data, 2));
+	// TODO: D3 - AUTO*
+	// D4-D5 - Not Connected.
+}
+
+void xpander_voiceboard_device::latch0_w(offs_t offset, u8 data)
+{
+	m_voices[offset]->latch0_w(data);
+}
+
+void xpander_voiceboard_device::latch1_w(offs_t offset, u8 data)
+{
+	m_voices[offset]->latch1_w(data);
+}
+
+void xpander_voiceboard_device::latch2_w(offs_t offset, u8 data)
+{
+	m_voices[offset]->latch2_w(data);
+}
+
+double xpander_voiceboard_device::get_dac_v() const  // Returns output of U812.
+{
+	constexpr u16 MAX_DAC_DATA = (1U << 14) - 1;
+	return -m_dac_data * m_dac_vref / MAX_DAC_DATA;
+}
+
+void xpander_voiceboard_device::dac_enable_w(offs_t offset, u8 data)
+{
+	LOGMASKED(LOG_DAC_VERBOSE, "DAC: %04x: %02x\n", offset, data);
+
+	// Updating the 7 LSBits for the DAC. Bit 0 is ignored.
+	m_dac_data = (m_dac_data & HIGH7_MASK) | (data  >> 1);
+
+	const bool is_hres = !BIT(offset, 8);
+	if (is_hres)
+	{
+		const u8 ref_mux_address = (offset >> 4) & 0x07;  // A4-A6 (U805).
+		if (ref_mux_address >= 1 && ref_mux_address <= 6)
+		{
+			// Selects the voiceX temperature compensation voltage.
+			m_dac_vref = m_voices[ref_mux_address - 1]->cem3374_tempco_v() * DAC_VREF_SCALER;
+		}
+		else if (ref_mux_address == 7)
+		{
+			m_dac_vref = DEFAULT_DAC_VREF;
+		}
+		// else: ref_mux_address == 0 disconnects the reference voltage.
+		// In that case, the last value sampled in C22 is used as the reference.
+		// So we keep the value of m_dac_vref the same.
+	}
+	else
+	{
+		// U805 disabled. But Y input of U014 (4053) enabled.
+		m_dac_vref = DEFAULT_DAC_VREF;
+	}
+
+	if (BIT(offset, 7))  // FTSH (fine-tune sample & hold) active.
+	{
+		// No S&H MUXes are selected, because input D on U803 is high.
+		// U814 is activated by FTSH, and samples the DAC voltage in C805/U815 (
+		// m_dac_fine_v). This "fine" voltage will be added to the coarser
+		// voltage in a future DAC write. This mode is used for generating
+		// voltages at a resolution greater than 14 bits.
+		m_dac_fine_v = get_dac_v();
+		return;
+	}
+
+	// FTSH low enables one of the first 8 outputs of U803 (controlled
+	// by A5-A7). Each of those outputs enables a 4051 mux, whose
+	// address is controlled by A1-A3.
+
+	const u8 selected_sh = (offset >> 4) & 0x07;  // A4-A6.
+	if (selected_sh == 0)  // U803 output 0 is not connected.
+		return;
+
+	double dac_v = -RES_K(10) / RES_K(10) * get_dac_v();
+	if (is_hres)  // Turns on U814.
+	{
+		dac_v += -RES_K(10) / RES_K(30.1) * m_dac_fine_v
+				 -RES_K(10) / RES_K(17.4) * m_dac_vref;
+	}
+
+	const u8 sh_address = (offset >> 1) & 0x07;  // A1-A3.
+	if (selected_sh == 7)
+	{
+		// Updates resonance (RES). In this case, the voice is selected by
+		// `sh_address` (U816). Note that RES is not affected by the FAST*
+		// signal.
+		m_voices[sh_address]->set_res_cv(dac_v);
+	}
+	else
+	{
+		// Voice is selected by `selected_sh` (output of U803). Need a -1
+		// because the first U803 output is not connected. The CV index for
+		// the given voice is selected by `sh_address`.
+		m_voices[selected_sh - 1]->set_cv(sh_address, dac_v, m_fast);
+	}
+}
+
+void xpander_voiceboard_device::dac_clear_w(u8 data)
+{
+	// (1) Clears latch U806. This results in:
+	// - No S&H mux selected (activates output 0 of U803, which is not
+	//   connected to anything)
+	// - S&H address 0 selected, but this is a no-op since no S&H mux is
+	//   selected (see above).
+	// - FTSH (active high) deactivated (set low).
+	// - HRES* (active low) activated (set low).
+	// - Mux U805 activated (by HRES* low), but address 0 selected.
+	//   input 0 is not connected.
+	//   - No active reference voltage to the DAC. Previously used reference
+	//     sampled in C806.
+	// None of the above affect the emulation. They will be set to valid
+	// values on the next invocation to voice_dac_w().
+
+	// (2) Activates latch for the 7 MSBits of the 14-bit DAC.
+	//     D0-D6 used for the 7 MSBits.
+	//     If D7 is set, it will enable fast mode on the next invocation to
+	//     voice_dac_w().
+	m_dac_data = ((u16(data) & LOW7_MASK) << 7) | (m_dac_data & LOW7_MASK);
+	m_fast = BIT(data, 7);
+
+	LOGMASKED(LOG_DAC_VERBOSE, "DAC clear %02x: %04x - %d\n", data, m_dac_data, m_fast);
+}
+
+void xpander_voiceboard_device::dac_w(offs_t offset, u8 data)
+{
+	if (BIT(offset, 0))  // VOICEN*  (A0 high)
+		dac_enable_w(offset, data);
+	else  // CLEAR* (A0 low)
+		dac_clear_w(data);
+}
+
+void xpander_voiceboard_device::pit_out0_changed(int state)
+{
+	// OUT0 -> AUTODNE* -> 74LS04 (inverted) -> GATE1
+	m_autodone = !state;
+	m_pit->write_gate1(state ? 0 : 1);
+	LOGMASKED(LOG_VOICE_TIMER, "PIT timer 0 out: %d\n", state);
+}
+
+void xpander_voiceboard_device::pit_out2_changed(int state)
+{
+	if (state)  // Interrupt triggered on positive transition of output.
+	{
+		// Using HOLD_LINE because there is circuitry that clears the IRQ* line
+		// when the CPU ACks the IRQ (U919 - 74LS74, U911 - 74LS08, using BS and
+		// BA* as inputs).
+		m_voicecpu->set_input_line(M6809_IRQ_LINE, HOLD_LINE);
+	}
+}
+
+void xpander_voiceboard_device::update_line_halt()
+{
+	if (m_haltreq && !m_haltdis)
+	{
+		m_voicecpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
+		m_haltack = true;
+	}
+	else
+	{
+		m_voicecpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE);
+		m_haltack = false;
+	}
+	m_haltack_cb(m_haltack ? 1 : 0);
+}
+
+
+namespace {
+
+constexpr int NUM_ENCODER_POSITIONS = 30;
 
 class xpander_state : public driver_device
 {
 public:
-	xpander_state(const machine_config &mconfig, device_type type, const char *tag) ATTR_COLD
-		: driver_device(mconfig, type, tag)
-		, m_maincpu(*this, MAINCPU_TAG)
-		, m_midiacia(*this, "midiacia")
-		, m_adc(*this, "adc")
-		, m_firq_timer(*this, "firq_timer")
-		, m_nvram_a_view(*this, "nvram_a_view")
-		, m_rom_0_view(*this, "rom_0_view")
-		, m_switch_io(*this, "switches_%d", 0U)
-		, m_memory_protect_io(*this, "memory_protect")
-		, m_gate_io(*this, "gate_inputs")
-		, m_cv_io(*this, "cv_in_%d", 1U)
-		, m_pedal_io(*this, "pedal_%d", 1U)
-		, m_vfd_devices(*this, "vfd_%d", 0U)
-		, m_vfd_outputs(*this, "vfd_%u_char_%u", 1U, 1U)
-		, m_cassmute(*this, "cassmute")
-		, m_voicecpu(*this, VOICECPU_TAG)
-		, m_voicepit(*this, "voice_pit_8253")
-		, m_voiceram(*this, VOICERAM_TAG)
-		, m_fm_mdac(*this, "voice_%u_fm_mdac", 1U)
-		, m_filter_mode(*this, "voice_%u_filter_mode", 1U)
-		, m_noise(*this, "voice_%u_noise", 1U)
-		, m_pan(*this, "voice_%u_pan", 1U)
-		, m_saw1(*this, "voice_%u_saw1", 1U)
-		, m_saw2(*this, "voice_%u_saw2", 1U)
-		, m_tri1(*this, "voice_%u_tri1", 1U)
-		, m_tri2(*this, "voice_%u_tri2", 1U)
-		, m_vcofm(*this, "voice_%u_vcofm", 1U)
-		, m_sync(*this, "voice_%u_sync", 1U)
-	{
-		for (auto &cv : m_cv)
-			std::fill(cv.begin(), cv.end(), 0.0F);
-		for (auto &fast : m_fast)
-			std::fill(fast.begin(), fast.end(), false);
-	}
+	xpander_state(const machine_config &mconfig, device_type type, const char *tag) ATTR_COLD;
 
 	void xpander(machine_config &config) ATTR_COLD;
 
@@ -161,45 +610,15 @@ private:
 	u8 adc_r(offs_t offset);
 	void adc_w(offs_t offset, u8 data);
 
-	void refresh_voicecpu_halt_line();
-
-	void cass_out_w(u8 data);
+	void haltack_changed(int state);
 	void haltset_w(u8 data);
 	void display_w(offs_t offset, u8 data);
 	void display_output_w(int display, offs_t offset, u32 data);
 
-	u8 voice_datain_r();
-	void voice_dataout_w(u8 data);
-	void voice_latch0_w(offs_t offset, u8 data);
-	void voice_latch1_w(offs_t offset, u8 data);
-	void voice_latch2_w(offs_t offset, u8 data);
-
-	float get_dac_v() const;
-	void voice_update_cv(u8 voice, u8 cv_index, float cv, bool fast);
-	void voice_update_resonance_cv(u8 voice, float cv);
-	void voice_dac_enable_w(offs_t offset, u8 data);
-	void voice_dac_clear_w(u8 data);
-	void voice_dac_w(offs_t offset, u8 data);
-
-	void voicepit_out0_changed(int state);
-	void voicepit_out2_changed(int state);
-
 	void maincpu_map(address_map &map) ATTR_COLD;
-	void voicecpu_map(address_map &map) ATTR_COLD;
 
-	static constexpr const u16 LOW7_MASK = 0x7f;
-	static constexpr const u16 HIGH7_MASK = LOW7_MASK << 7;
-	static constexpr const int NUM_VOICES = 6;
-	static constexpr const int NUM_CVS = 9;
-	static constexpr const int RES_CV_INDEX = 8;
-	static constexpr const char *CV_NAMES[NUM_CVS] =
-	{
-		"VCA", "PW1", "VOLA", "VCOF1", "VOLB", "VCFF", "PW2", "VCOF2", "RES"
-	};
-
-	// Main computer.
 	required_device<mc6809_device> m_maincpu;
-	required_device<acia6850_device> m_midiacia;
+	required_device<xpander_voiceboard_device> m_voiceboard;
 	required_device<adc0804_device> m_adc;
 	required_device<timer_device> m_firq_timer;  // 40103 presetable timer (U12).
 	memory_view m_nvram_a_view;
@@ -212,51 +631,46 @@ private:
 	required_device_array<pwm_display_device, 3> m_vfd_devices;
 	output_finder<3, 40> m_vfd_outputs;
 	output_finder<> m_cassmute;
+	output_finder<> m_cassout;
 
-	// Voice computer.
-	required_device<mc6809_device> m_voicecpu;
-	required_device<pit8253_device> m_voicepit;
-	required_shared_ptr<uint8_t> m_voiceram;
-	output_finder<NUM_VOICES> m_fm_mdac;  // Latch connected to AD7523/MP7523.
-	output_finder<NUM_VOICES> m_filter_mode;
-	output_finder<NUM_VOICES> m_noise;
-	output_finder<NUM_VOICES> m_pan;
-	output_finder<NUM_VOICES> m_saw1;
-	output_finder<NUM_VOICES> m_saw2;
-	output_finder<NUM_VOICES> m_tri1;
-	output_finder<NUM_VOICES> m_tri2;
-	output_finder<NUM_VOICES> m_vcofm;
-	output_finder<NUM_VOICES> m_sync;
-
-	// Many bool variables represent signals in the schematic (e.g. HALTREQ).
-	// Some of those signals are active low in the schematic (e.g. HALTREQ*).
-	// But the variables here are always active-high (active == true).
-
-	// Main computer state.
-	u8 m_firq_timer_preset = 0xff;  // Preset for 40103 timer. Pulled high.
-	u8 m_selected_cv_in = 0x07;  // MUX A-C inputs. Pulled high.
-	bool m_inhibit_cv_in = true;  // MUX INHibit input. Pulled high.
-	std::array<bool, 4> m_haltreq = { false, false, false, false };  // Halt request to the voice board (HALTREQ).
-	std::array<bool, 6> m_encoder_dir = { false, false, false, false, false, false };
-	std::array<bool, 6> m_encoder_changed = { false, false, false, false, false, false };
-	std::array<u64, 3> m_vfd_anode_masks = { 0, 0, 0 };
-
-	// Voice computer state.
-	bool m_haltdis = 0;  // Halt disable (HALTDS).
-	bool m_haltack = false;  // Halt acknowledge (HALTAKN).
-	bool m_autodone = true;  // Autotune done (AUTODNE).
-	u16 m_dac_data = 0;
-	float m_dac_fine_v = 0;
-	float m_dac_vref = 4.865F;  // Sampled in C806 and buffered and scaled by U815.
-	bool m_allow_fast = false;
-	std::array<std::array<float, NUM_CVS>, NUM_VOICES> m_cv;
-	std::array<std::array<bool, NUM_CVS - 1>, NUM_VOICES> m_fast;  // `-1` because RES does not support fast updates.
+	u8 m_firq_timer_preset;  // Preset for 40103 timer.
+	u8 m_selected_cv_in;  // MUX A-C inputs.
+	bool m_inhibit_cv_in;  // MUX INHibit input.
+	std::array<bool, 6> m_encoder_dir;
+	std::array<bool, 6> m_encoder_changed;
+	std::array<u64, 3> m_vfd_anode_masks;
 };
+
+xpander_state::xpander_state(const machine_config &mconfig, device_type type, const char *tag)
+	: driver_device(mconfig, type, tag)
+	, m_maincpu(*this, "maincpu")
+	, m_voiceboard(*this, "voiceboard")
+	, m_adc(*this, "adc")
+	, m_firq_timer(*this, "firq_timer")
+	, m_nvram_a_view(*this, "nvram_a_view")
+	, m_rom_0_view(*this, "rom_0_view")
+	, m_switch_io(*this, "switches_%d", 0U)
+	, m_memory_protect_io(*this, "memory_protect")
+	, m_gate_io(*this, "gate_inputs")
+	, m_cv_io(*this, "cv_in_%d", 1U)
+	, m_pedal_io(*this, "pedal_%d", 1U)
+	, m_vfd_devices(*this, "vfd_%d", 0U)
+	, m_vfd_outputs(*this, "vfd_%u_char_%u", 1U, 1U)
+	, m_cassmute(*this, "cassmute")
+	, m_cassout(*this, "cassout")
+	, m_firq_timer_preset(0xff)  // Pulled high.
+	, m_selected_cv_in(0x07)  // Pulled high.
+	, m_inhibit_cv_in(true)  // Pulled high.
+{
+	std::fill(m_encoder_dir.begin(), m_encoder_dir.end(), false);
+	std::fill(m_encoder_changed.begin(), m_encoder_changed.end(), false);
+	std::fill(m_vfd_anode_masks.begin(), m_vfd_anode_masks.end(), 0);
+}
 
 TIMER_DEVICE_CALLBACK_MEMBER(xpander_state::firq_timer_elapsed)
 {
 	// CPU clock divided by U10 (LS393,  processor board).
-	static constexpr const XTAL TIMER_CLOCK = 16_MHz_XTAL / 64;  // 250 KHz.
+	constexpr XTAL TIMER_CLOCK = 16_MHz_XTAL / 64;  // 250 KHz.
 
 	// The FIRQ timer is a 40103 timer (U12, processor board). It is configured
 	// to reset to its preset value when the count reaches 0 (/TC connected to
@@ -302,9 +716,9 @@ void xpander_state::firq_timer_preset_w(u8 data)
 
 u8 xpander_state::proc_datain_r()
 {
-	// LS367, U15 (progressor board)
+	// LS367, U15 (processor board)
 	// D0 - HALTAKN*
-	const u8 d0 = m_haltack ? 0 : 1;
+	const u8 d0 = m_voiceboard->haltack_r() ? 0 : 1;
 	// D1 - Memory write protect (low when protected)
 	const u8 d1 = BIT(m_memory_protect_io->read(), 0);
 	// D2 - Cassette DATA.
@@ -413,59 +827,31 @@ void xpander_state::adc_w(offs_t offset, u8 data)
 	m_adc->write(data);
 }
 
-void xpander_state::refresh_voicecpu_halt_line()
+void xpander_state::haltack_changed(int state)
 {
-	if (m_haltreq[0] && !m_haltdis)
-	{
-		m_voicecpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
-		m_haltack = true;
-		m_rom_0_view.select(1);
-	}
-	else
-	{
-		m_voicecpu->set_input_line(INPUT_LINE_HALT, CLEAR_LINE);
-		m_haltack = false;
-		m_rom_0_view.select(0);
-	}
-}
-
-void xpander_state::cass_out_w(u8 data)
-{
-	// TODO: Implement.
+	m_rom_0_view.select(state);
 }
 
 void xpander_state::haltset_w(u8 data)
 {
-	// Bits 0-3: HALTREQ* 0-3
-	for (int i = 0; i < 4; ++i)
-	{
-		m_haltreq[i] = !BIT(data, i);  // Active low.
-		if (i > 0 && m_haltreq[i])
-		{
-			// The voice board is wired (with a rotary switch) to HALTREQ0*.
-			// HALTREQ(1-3)* are not used in the xpander. They a provision for
-			// for extending to more voice boards. For example, the Oberheim
-			// Matrix 12 uses two of those.
-			LOGMASKED(LOG_CPU_COMMS, "Unexpected HALTREQ %d asserted\n", i);
-		}
-	}
-	refresh_voicecpu_halt_line();
+	// Bits 0-3: HALTREQ* 0-3. Active low.
+	// The voice board is wired (with a rotary switch) to HALTREQ0*. HALTREQ(1-3)*
+	// are not used in the xpander. They are provisioned for extending to more
+	// voice boards. For example, the Oberheim Matrix 12 uses two of those.
+	m_voiceboard->haltreq_w(!BIT(data, 0));
+	if (BIT(~data, 1, 3))
+		LOGMASKED(LOG_CPU_COMMS, "Unexpected HALTREQ asserted: %x\n", BIT(~data, 1, 3));
 
-	// Bit 4: RES* (voice cpu reset).
-	const bool reset_voice = !BIT(data, 4);  // Active low.
-	const bool voice_resetting = (m_voicecpu->input_line_state(INPUT_LINE_RESET) == ASSERT_LINE);
-	if (reset_voice != voice_resetting)
-	{
-		m_voicecpu->set_input_line(INPUT_LINE_RESET, reset_voice ? ASSERT_LINE : CLEAR_LINE);
-		if (reset_voice)
-			LOGMASKED(LOG_CPU_COMMS, "Asserting voice CPU reset line\n");
-		else
-			LOGMASKED(LOG_CPU_COMMS, "Clearing voice CPU reset line\n");
-	}
+	// Bit 4: RES* (voice cpu reset), active low.
+	m_voiceboard->reset_w(!BIT(data, 4));
 
-	m_cassmute = !BIT(data, 5);  // Bit 5: CASSMUTE*, active low.
+	// Bit 5: CASSMUTE*, active low.
+	m_cassmute = !BIT(data, 5);
+
 	// Bit 6 not connected.
-	cass_out_w(BIT(data, 7));  // Bit 7: CASS OUT.
+
+	// Bit 7: CASS OUT.
+	m_cassout = BIT(data, 7);
 }
 
 void xpander_state::display_w(offs_t offset, u8 data)
@@ -497,7 +883,7 @@ void xpander_state::display_w(offs_t offset, u8 data)
 	// decoder that translates the latched A3-A8 to a single selected grid.
 	// However, decoding is only enabled when U12 output 5 is high.
 	const bool grid_enabled = (offset & 0x07) == 5;
-	u8 grid_offset = (offset >> 3) & 0x3f;
+	const u8 grid_offset = (offset >> 3) & 0x3f;
 	u64 grid_mask = 0;
 	if (grid_enabled && grid_offset < 40)  // There are 40 grid signals.
 		grid_mask = u64(1) << grid_offset;
@@ -518,236 +904,12 @@ void xpander_state::display_output_w(int display, offs_t offset, u32 data)
 		bitswap<16>(data, 0, 1, 3, 6, 5, 4, 2, 7, 12, 11, 10, 13, 15, 14, 9, 8);
 }
 
-void xpander_state::voice_dataout_w(u8 data)
-{
-	// D0 - HALTDS
-	const u8 d0 = BIT(data, 0);
-	if (m_haltdis != d0)
-	{
-		m_haltdis = d0;
-		LOGMASKED(LOG_CPU_COMMS, "Voice HALTDS: %d\n", m_haltdis);
-		refresh_voicecpu_halt_line();
-	}
-	// D1 - AUTOST
-	m_voicepit->write_gate0(BIT(data, 1));
-	// D2 - PW*
-	// TODO: pit gate2 is actually: PW* | OSC. For now, setting to PW*, though
-	// this is wrong.
-	m_voicepit->write_gate2(BIT(data, 2));
-	// TODO: D3 - AUTO*
-	// D4-D5 - Not Connected.
-}
-
-u8 xpander_state::voice_datain_r()
-{
-	// D0 - AUTODNE*
-	const u8 d0 = m_autodone ? 0 : 1;
-	// D1 - OSC
-	const u8 d1 = 1;  // TODO: Implement.
-	// D2-D7 - Not connected (pulled up).
-	return 0xfc | (d1 << 1) | d0;
-}
-
-void xpander_state::voice_latch0_w(offs_t offset, u8 data)  // UX03, 74LS374.
-{
-	if (offset >= NUM_VOICES)
-		return;
-	m_fm_mdac[offset] = data;
-}
-
-void xpander_state::voice_latch1_w(offs_t offset, u8 data)  // UX02, 74HC174.
-{
-	if (offset >= NUM_VOICES)
-		return;
-	m_vcofm[offset] = BIT(data, 0);
-	m_saw2[offset] = BIT(data, 1);
-	m_tri1[offset] = BIT(data, 2);
-	m_sync[offset] = BIT(data, 3);
-	m_tri2[offset] = BIT(data, 4);
-	m_saw2[offset] = BIT(data, 5);
-}
-
-void xpander_state::voice_latch2_w(offs_t offset, u8 data)  // UX01, 74HC374.
-{
-	if (offset >= NUM_VOICES)
-		return;
-	m_filter_mode[offset] = data & 0x0f;
-	m_noise[offset] = BIT(data, 4);
-	m_pan[offset] = data >> 5;
-}
-
-float xpander_state::get_dac_v() const  // Returns output of U812.
-{
-	static constexpr const u16 MAX_DAC_DATA = (1U << 14) - 1;
-	return -m_dac_data * m_dac_vref / MAX_DAC_DATA;
-}
-
-void xpander_state::voice_update_cv(u8 voice, u8 cv_index, float cv, bool fast)
-{
-	assert(voice < NUM_VOICES);
-	if (m_cv[voice][cv_index] == cv && m_fast[voice][cv_index] == fast)
-		return;
-
-	m_cv[voice][cv_index] = cv;
-	m_fast[voice][cv_index] = fast;
-	LOGMASKED(LOG_DAC, "Voice %d - CV %s: %f, fast: %d\n",
-			voice, CV_NAMES[cv_index], cv, fast);
-}
-
-void xpander_state::voice_update_resonance_cv(u8 voice, float cv)
-{
-	if (voice >= NUM_VOICES)
-		return;
-	if (m_cv[voice][RES_CV_INDEX] == cv)
-		return;
-
-	m_cv[voice][RES_CV_INDEX] = cv;
-	LOGMASKED(LOG_DAC, "Voice %d - CV %s: %f\n",
-			voice, CV_NAMES[RES_CV_INDEX], cv);
-}
-
-void xpander_state::voice_dac_enable_w(offs_t offset, u8 data)
-{
-	// All component designations refer to the voice board.
-
-	// 4V reference used as a source for other reference voltages.
-	// Generated by D805, R856, R857, R854, U815.
-	static constexpr const float V_REF_U815 = 4;
-	static constexpr const float DEFAULT_UNSCALED_VREF =
-			V_REF_U815 * RES_VOLTAGE_DIVIDER(RES_K(18.2), RES_K(10));
-	static constexpr const float VREF_SCALER = 1 + RES_K(2.43) / RES_K(1);  // U815, R851, R852.
-	static constexpr const float DEFAULT_VREF = DEFAULT_UNSCALED_VREF * VREF_SCALER;
-	static constexpr const float CEM3374_NOMINAL_TEMPCO_V = 2.5;
-
-	LOGMASKED(LOG_DAC_VERBOSE, "DAC: %04x: %02x\n", offset, data);
-
-	// Updating the 7 LSBits for the DAC. Bit 0 is ignored.
-	m_dac_data = (m_dac_data & HIGH7_MASK) | (data  >> 1);
-
-	const bool is_hres = !BIT(offset, 8);
-	if (is_hres)
-	{
-		const u8 ref_mux_address = (offset >> 4) & 0x07;  // A4-A6 (U805).
-		if (ref_mux_address >= 1 && ref_mux_address <= 6)
-		{
-			// Selects the voiceX temperature compensation voltage.
-			m_dac_vref = CEM3374_NOMINAL_TEMPCO_V * VREF_SCALER;
-		}
-		else if (ref_mux_address == 7)
-		{
-			m_dac_vref = DEFAULT_VREF;
-		}
-		// else: ref_mux_address = 0 disconnects the reference voltage.
-		// In that case, the last value sampled in C22 is used. So we keep
-		// the value of m_dac_vref the same.
-	}
-	else
-	{
-		// U805 disabled. But Y input of U014 (4053) enabled.
-		m_dac_vref = DEFAULT_VREF;
-	}
-
-	if (BIT(offset, 7))  // FTSH (fine-tune sample & hold) active (active high).
-	{
-		// No S&H MUXes are selected, because input D on U803 is high.
-		// U814 is activated by FTSH, and samples the DAC voltage in C805/U815 (
-		// m_dac_fine_v). This "fine" voltage will be added to the coarser
-		// voltage in a future DAC write. This mode is used for generating
-		// voltages at a resolution greater than 14 bits.
-		m_dac_fine_v = get_dac_v();
-		return;
-	}
-
-	// FTSH low enables one of the first 8 outputs of U803 (controlled
-	// by A5-A7). Each of those outputs enables a 4051 mux, whose
-	// address is controlled by A1-A3.
-
-	const u8 selected_sh = (offset >> 4) & 0x07;  // A4-A6.
-	if (selected_sh == 0)  // U803 output 0 is not connected.
-		return;
-
-	float dac_v = -RES_K(10) / RES_K(10) * get_dac_v();
-	if (is_hres)  // Turns on U814.
-	{
-		dac_v += -RES_K(10) / RES_K(30.1) * m_dac_fine_v
-				 -RES_K(10) / RES_K(17.4) * m_dac_vref;
-	}
-
-	const u8 sh_address = (offset >> 1) & 0x07;  // A1-A3.
-	if (selected_sh == 7)
-	{
-		// Updates resonance (RES). In this case, the voice is selected by
-		// `sh_address` (U816). Note that RES is not affected by the FAST*
-		// signal.
-		voice_update_resonance_cv(sh_address, dac_v);
-	}
-	else
-	{
-		// Voice is selected by `selected_sh` (output of U803). Need a -1
-		// because the first U803 output is not connected. The CV index for
-		// the given voice is selected by `sh_address`.
-		voice_update_cv(selected_sh - 1, sh_address, dac_v, m_allow_fast);
-	}
-}
-
-void xpander_state::voice_dac_clear_w(u8 data)
-{
-	// (1) Clears latch U806. This results in:
-	// - No S&H mux selected (activates output 0 of U803, which is not
-	//   connected to anything)
-	// - S&H address 0 selected, but this is a no-op since no S&H mux is
-	//   selected (see above).
-	// - FTSH (active high) deactivated (set low).
-	// - HRES* (active low) activated (set low).
-	// - Mux U805 activated (by HRES* low), but address 0 selected.
-	//   input 0 is not connected.
-	//   - No active reference voltage to the DAC. Previously used reference
-	//     sampled in C806.
-	// None of the above affect emulation, since they will be set to valid
-	// values on the next invocation to voice_dac_w().
-
-	// (2) Activates latch for the 7 MSBits of the 14-bit DAC.
-	//     D0-D6 used for the 7 MSBits.
-	//     D7, if set, will enable fast mode on the next invocation to
-	//     voice_dac_w().
-	m_dac_data = ((data & LOW7_MASK) << 7) | (m_dac_data & LOW7_MASK);
-	m_allow_fast = BIT(data, 7);
-	LOGMASKED(LOG_DAC_VERBOSE, "DAC clear %02x: %04x - %d\n",
-				data, m_dac_data, m_allow_fast);
-}
-
-void xpander_state::voice_dac_w(offs_t offset, u8 data)
-{
-	if (BIT(offset, 0))  // VOICEN*  (A0 high)
-		voice_dac_enable_w(offset, data);
-	else  // CLEAR* (A0 low)
-		voice_dac_clear_w(data);
-}
-
-void xpander_state::voicepit_out0_changed(int state)
-{
-	// OUT0 -> AUTODNE* -> 74LS04 (inverted) -> GATE1
-	m_autodone = !state;
-	m_voicepit->write_gate1(state ? 0 : 1);
-	LOGMASKED(LOG_VOICE_TIMER, "PIT timer 0 out: %d\n", state);
-}
-
-void xpander_state::voicepit_out2_changed(int state)
-{
-	if (state)  // Interrupt triggered on positive transition of output.
-	{
-		// Using HOLD_LINE because there is circuitry that clears the IRQ* line
-		// when the CPU ACks the IRQ (U919 - 74LS74, U911 - 74LS08, looking
-		// at BS and BA*).
-		m_voicecpu->set_input_line(M6809_IRQ_LINE, HOLD_LINE);
-	}
-}
-
 void xpander_state::maincpu_map(address_map &map)
 {
 	// Component designations refer to the Processor board, unless otherwise
 	// noted. The signal names below (e.g. DISP*, HALTSET*) reference those in
 	// the schematics.
+
 	map.unmap_value_high();  // Data bus pulled high by resistors in Pot board.
 
 	// 1/2 74LS139 (U22, O0-O2) controls access to RAM and other ports.
@@ -756,10 +918,10 @@ void xpander_state::maincpu_map(address_map &map)
 	// NVRAM_A can be write-protected in hardware by a memory-protect switch
 	// (SW6, active-closed, disables /WR signal).
 	map(0x000, 0x3fff).view(m_nvram_a_view);
-	m_nvram_a_view[0](0x000, 0x3fff).ram().share(NVRAM_A_TAG);
-	m_nvram_a_view[1](0x000, 0x3fff).readonly().share(NVRAM_A_TAG);
+	m_nvram_a_view[0](0x000, 0x3fff).ram().share("nvram_a");
+	m_nvram_a_view[1](0x000, 0x3fff).readonly().share("nvram_a");
 	// NVRAM_B is not protected by SW6.
-	map(0x4000, 0x5fff).ram().share(NVRAM_B_TAG);  // 1 x 6264 (U4).
+	map(0x4000, 0x5fff).ram().share("nvram_b");  // 1 x 6264 (U4).
 
 	// The 74LS139 above (O3) along with an 74LS42 (U23) control access to all
 	// other ports / peripherals.
@@ -768,7 +930,7 @@ void xpander_state::maincpu_map(address_map &map)
 	map(0x6400, 0x6400).mirror(0x03ff).w(FUNC(xpander_state::firq_timer_preset_w));  // INTSET*
 	map(0x6800, 0x6800).mirror(0x03ff).w(FUNC(xpander_state::haltset_w));  // HALTSET*
 	// ACIA addressing: RS <- A0, CS1 <- A1, CS0 <- A2, /CS2 <- UART*.
-	map(0x6c06, 0x6c07).mirror(0x03f8).rw(m_midiacia, FUNC(acia6850_device::read), FUNC(acia6850_device::write));  // UART*
+	map(0x6c06, 0x6c07).mirror(0x03f8).rw("midiacia", FUNC(acia6850_device::read), FUNC(acia6850_device::write));  // UART*
 	map(0x7000, 0x7000).mirror(0x03ff).r(FUNC(xpander_state::proc_datain_r));  // DATAIN*
 	map(0x7400, 0x7400).mirror(0x03ff).w("latch_u24_proc", FUNC(output_latch_device::write));  // LED2*
 	map(0x7800, 0x7800).mirror(0x03ff).unmaprw();  // Unused. U23 output 6 not connected.
@@ -789,35 +951,9 @@ void xpander_state::maincpu_map(address_map &map)
 	// 2/4 LS32 (U20).
 	// (0x8000, 0x9fff) conditionally accesses VOICERAM, when HALTAKN* active.
 	map(0x8000, 0x9fff).view(m_rom_0_view);
-	m_rom_0_view[0](0x8000, 0x9fff).rom().region(MAINCPU_TAG, 0x0000);  // 1 x 2764 (U8).
-	m_rom_0_view[1](0x8000, 0x9fff).ram().share(VOICERAM_TAG);
-	map(0xa000, 0xffff).rom().region(MAINCPU_TAG, 0x2000);  // 3 x 2764 (U7 - U5).
-}
-
-void xpander_state::voicecpu_map(address_map &map)
-{
-	// All component designations refer to the Voice board.
-	// Signal names (e.g. LATCH0*) are from the schematic.
-	map.unmap_value_high();  // Data bus pulled high by resistors in Voice Board.
-
-	// RAM's /CS connected to A15.
-	map(0x0000, 0x1fff).mirror(0x6000).ram().share(VOICERAM_TAG);  // 1 x 6264 (U917).
-
-	// ROM and port/peripheral decoding done by 1/2 LS139 (U915).
-	// Ports / peripherals enabled when U915 O0 is low AND one of
-	// READ*, WRITE*, TIMER* is low. Additional decoding done by 74LS42 (U918).
-	map(0x8000, 0x8007).mirror(0x03f8).w(FUNC(xpander_state::voice_latch0_w));  // LATCH0*
-	map(0x8400, 0x8407).mirror(0x03f8).w(FUNC(xpander_state::voice_latch1_w));  // LATCH1*
-	map(0x8800, 0x8807).mirror(0x03f8).w(FUNC(xpander_state::voice_latch2_w));  // LATCH2*
-	map(0x8c00, 0x8dff).mirror(0x0200).w(FUNC(xpander_state::voice_dac_w));  // SDAC (inverted by LS04).
-	map(0x9000, 0x9000).mirror(0x03ff).w(FUNC(xpander_state::voice_dataout_w));  // DATAOUT*
-	map(0x9400, 0x9400).mirror(0x03ff).r(FUNC(xpander_state::voice_datain_r));  // DATAIN*
-	map(0x9800, 0x9803).mirror(0x03fc).rw(m_voicepit, FUNC(pit8253_device::read), FUNC(pit8253_device::write));  // TIMER*
-	map(0x9c00, 0x9c00).mirror(0x03ff).unmaprw();  // Unused. U918 output 7 not connected.
-
-	// ROMs only get enabled if BA* is high. I.e. disabled when main CPU has
-	// control of the voice cpu's bus.
-	map(0xa000, 0xffff).rom().region(VOICECPU_TAG, 0);  // 3 x 6264 (U909, U912, U914)
+	m_rom_0_view[0](0x8000, 0x9fff).rom().region("maincpu", 0x0000);  // 1 x 2764 (U8).
+	m_rom_0_view[1](0x8000, 0x9fff).ram().share("voiceboard:voiceram");
+	map(0xa000, 0xffff).rom().region("maincpu", 0x2000);  // 3 x 2764 (U7 - U5).
 }
 
 void xpander_state::machine_start()
@@ -827,43 +963,33 @@ void xpander_state::machine_start()
 	save_item(NAME(m_firq_timer_preset));
 	save_item(NAME(m_selected_cv_in));
 	save_item(NAME(m_inhibit_cv_in));
-	save_item(NAME(m_haltreq));
 	save_item(NAME(m_encoder_dir));
 	save_item(NAME(m_encoder_changed));
 	save_item(NAME(m_vfd_anode_masks));
-	save_item(NAME(m_haltdis));
-	save_item(NAME(m_haltack));
-	save_item(NAME(m_autodone));
-	save_item(NAME(m_dac_data));
-	save_item(NAME(m_dac_fine_v));
-	save_item(NAME(m_dac_vref));
-	save_item(NAME(m_allow_fast));
-	save_item(NAME(m_cv));
-	save_item(NAME(m_fast));
 }
 
 void xpander_state::xpander(machine_config &config)
 {
-	MC6809(config, m_maincpu, 16_MHz_XTAL / 2);
+	MC6809(config, m_maincpu, 16_MHz_XTAL / 2);  // 8 MHz
 	m_maincpu->set_addrmap(AS_PROGRAM, &xpander_state::maincpu_map);
 
 	TIMER(config, m_firq_timer).configure_generic(FUNC(xpander_state::firq_timer_elapsed));
 
-	NVRAM(config, NVRAM_A_TAG, nvram_device::DEFAULT_ALL_0);
-	NVRAM(config, NVRAM_B_TAG, nvram_device::DEFAULT_ALL_0);
+	NVRAM(config, "nvram_a", nvram_device::DEFAULT_ALL_0);
+	NVRAM(config, "nvram_b", nvram_device::DEFAULT_ALL_0);
 
-	ACIA6850(config, m_midiacia);
-	m_midiacia->txd_handler().set("mdout", FUNC(midi_port_device::write_txd));
-	m_midiacia->irq_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
+	auto &midiacia = ACIA6850(config, "midiacia");
+	midiacia.txd_handler().set("mdout", FUNC(midi_port_device::write_txd));
+	midiacia.irq_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
 
 	clock_device &acia_clock = CLOCK(config, "aciaclock", 16_MHz_XTAL / 32);  // 500 KHz.
-	acia_clock.signal_handler().set(m_midiacia, FUNC(acia6850_device::write_txc));
-	acia_clock.signal_handler().append(m_midiacia, FUNC(acia6850_device::write_rxc));
+	acia_clock.signal_handler().set("midiacia", FUNC(acia6850_device::write_txc));
+	acia_clock.signal_handler().append("midiacia", FUNC(acia6850_device::write_rxc));
 
 	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
 	MIDI_PORT(config, "mdthru", midiout_slot, "midiout");
 	midi_port_device &midi_in = MIDI_PORT(config, "mdin", midiin_slot, "midiin");
-	midi_in.rxd_handler().set(m_midiacia, FUNC(acia6850_device::write_rxd));
+	midi_in.rxd_handler().set("midiacia", FUNC(acia6850_device::write_rxd));
 	midi_in.rxd_handler().append("mdthru", FUNC(midi_port_device::write_txd));
 
 	ADC0804(config, m_adc, 16_MHz_XTAL / 32);  // 500 KHz.
@@ -878,22 +1004,12 @@ void xpander_state::xpander(machine_config &config)
 
 	config.set_default_layout(layout_oberheim_xpander);
 
-	MC6809(config, m_voicecpu, 16_MHz_XTAL / 2);
-	m_voicecpu->set_addrmap(AS_PROGRAM, &xpander_state::voicecpu_map);
-
-	PIT8253(config, m_voicepit);
-	// TODO: Set clk<0>. Connected to "OSC".
-	// Clock inputs 1 and 2 connected to CPU's Q signal, which is 4 times slower
-	// than the XTAL input to the CPU.
-	m_voicepit->set_clk<1>(16_MHz_XTAL / 2 / 4);  // 2 MHz.
-	m_voicepit->set_clk<2>(16_MHz_XTAL / 2 / 4);  // 2 MHz.
-	m_voicepit->out_handler<0>().set(FUNC(xpander_state::voicepit_out0_changed));
-	// Output 1 not connected.
-	m_voicepit->out_handler<2>().set(FUNC(xpander_state::voicepit_out2_changed));
+	XPANDER_VOICEBOARD(config, m_voiceboard);
+	m_voiceboard->haltack_cb().set(FUNC(xpander_state::haltack_changed));
 
 	// LED2*, U24 on Processor board. All outputs active low (connected to LED
 	// cathodes).
-	output_latch_device &u24(OUTPUT_LATCH(config, "latch_u24_proc"));
+	auto &u24 = OUTPUT_LATCH(config, "latch_u24_proc");
 	u24.bit_handler<0>().set_output("led_misc").invert();
 	u24.bit_handler<1>().set_output("led_ramp_x").invert();
 	u24.bit_handler<2>().set_output("led_lfo_x").invert();
@@ -905,7 +1021,7 @@ void xpander_state::xpander(machine_config &config)
 
 	// LED1*, U14 on Pot board. All outputs active low (connected to LED
 	// cathodes).
-	output_latch_device &u14(OUTPUT_LATCH(config, "latch_u14_pot"));
+	auto &u14 = OUTPUT_LATCH(config, "latch_u14_pot");
 	u14.bit_handler<0>().set_output("led_x_sel").invert();
 	u14.bit_handler<1>().set_output("led_mod_sorc").invert();
 	u14.bit_handler<2>().set_output("led_mod").invert();
@@ -918,7 +1034,7 @@ void xpander_state::xpander(machine_config &config)
 	// PULL*, U21 on Pot board.
 	// Configures the resting value for the gate inputs. Used to support both
 	// active low and active high inputs.
-	output_latch_device &u21(OUTPUT_LATCH(config, "latch_u21_pot"));
+	auto &u21 = OUTPUT_LATCH(config, "latch_u21_pot");
 	u21.bit_handler<0>().set_output("pull_1");  // Default for GATE 1
 	u21.bit_handler<1>().set_output("pull_2");  // Default for GATE 2
 	u21.bit_handler<2>().set_output("pull_3");  // Default for GATE 3
@@ -935,7 +1051,7 @@ DECLARE_INPUT_CHANGED_MEMBER(xpander_state::encoder_moved)
 	if (oldval != newval)
 		m_encoder_changed[encoder] = true;
 
-	static constexpr const int WRAP_BUFFER = 3;
+	constexpr int WRAP_BUFFER = 3;
 	const bool overflowed = newval <= WRAP_BUFFER &&
 			oldval >= NUM_ENCODER_POSITIONS - WRAP_BUFFER;
 	const bool underflowed = newval >= NUM_ENCODER_POSITIONS - WRAP_BUFFER &&
@@ -1112,7 +1228,7 @@ INPUT_PORTS_START(xpander)
 INPUT_PORTS_END
 
 ROM_START(xpander)
-	ROM_REGION(0x8000, MAINCPU_TAG, 0)  // 4 x 2764 8Kx8bit ROMs (U8 - U5, processor board).
+	ROM_REGION(0x8000, "maincpu", 0)  // 4 x 2764 8Kx8bit ROMs (U8 - U5, processor board).
 	ROM_DEFAULT_BIOS("1.2")
 
 	ROM_SYSTEM_BIOS(0, "1.2", "Xpander Main Processor Revision 1.2")
@@ -1127,7 +1243,7 @@ ROM_START(xpander)
 	ROMX_LOAD("exp1.0-2.u6", 0x004000, 0x002000, CRC(89e14d6e) SHA1(7aef67db9d78523777af6f1edf04fd6b0d11229b), ROM_BIOS(1))
 	ROMX_LOAD("exp1.0-3.u5", 0x006000, 0x002000, CRC(21794b92) SHA1(e544375c3fc29931497cb6429db7a2812f77c553), ROM_BIOS(1))
 
-	ROM_REGION(0x6000, VOICECPU_TAG, 0)  // 3 x 2764 8Kx8bit ROMs. Rev 1.4.
+	ROM_REGION(0x6000, "voicecpu", 0)  // 3 x 2764 8Kx8bit ROMs. Rev 1.4.
 	ROM_FILL(0x000000, 0x002000, 0xff)  // U909. Spare 2764 ROM slot. Not populated. Data bus pulled high.
 	ROM_LOAD("ca1.4-0.u912", 0x002000, 0x002000, CRC(79f4490a) SHA1(5ab13ccc3b75df313a447520ca54a492102b7e3b))
 	ROM_LOAD("ca1.4-1.u914", 0x004000, 0x002000, CRC(9b7a7914) SHA1(951bbc197a0140a93bb7621a7aedbe0f4037990c))


### PR DESCRIPTION
Mostly moving code around, to prepare for future work. No functional changes.

* Created a preliminary device for the xpander voice.
* Created a preliminary device for the xpander voice board.
  * Includes the 6 voices.
* Moved relevant logic from `xpander_state` into the two devices above.
* Switched from floats to doubles.
* Other minor code reorganization.
* Stylistic fixes.
