### PR TITLE
konami/twinkle: Configure XV-D701 for DVD media on IIDX 6th through 8th style

### DIFF
--- a/src/devices/bus/rs232/xvd701.cpp
+++ b/src/devices/bus/rs232/xvd701.cpp
@@ -17,7 +17,7 @@ jvc_xvd701_device::jvc_xvd701_device(const machine_config &mconfig, const char *
 	: device_t(mconfig, JVC_XVD701, tag, owner, clock),
 	device_serial_interface(mconfig, *this),
 	device_rs232_port_interface(mconfig, *this),
-	m_media_type(JVC_MEDIA_VCD), // TODO: This should be changed based on the type of disc inserted or else seeking won't work properly
+	m_media_type(media_type::VCD),
 	m_response_index(0),
 	m_timer_response(nullptr)
 {
@@ -182,7 +182,7 @@ void jvc_xvd701_device::rcv_complete()
 			// FF FF 21 0C 50 20 00 00 00 00 63 SEEK TO SPECIFIC CHAPTER
 			auto chapter = ((m_command[6] % 10) * 100) + ((m_command[7] % 10) * 10) + (m_command[8] % 10);
 
-			if (m_media_type == JVC_MEDIA_VCD)
+			if (m_media_type == media_type::VCD)
 			{
 				// VCD can only go to 99, so it sticks the data in the first two spots
 				chapter /= 10;

--- a/src/devices/bus/rs232/xvd701.h
+++ b/src/devices/bus/rs232/xvd701.h
@@ -11,7 +11,15 @@ class jvc_xvd701_device : public device_t,
 		public device_rs232_port_interface
 {
 public:
+	enum class media_type : u8
+	{
+		VCD,
+		DVD
+	};
+
 	jvc_xvd701_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	void set_media_type(media_type type) { m_media_type = type; }
 
 	virtual void input_txd(int state) override { device_serial_interface::rx_w(state); }
 protected:
@@ -25,12 +33,6 @@ protected:
 	virtual void rcv_complete() override;
 
 private:
-	enum jvc_xvd701_media_type : uint32_t
-	{
-		JVC_MEDIA_VCD = 0,
-		JVC_MEDIA_DVD = 1,
-	};
-
 	enum jvc_xvd701_playback_status : uint32_t
 	{
 		STATUS_STOP = 0,
@@ -44,7 +46,7 @@ private:
 
 	bool seek_chapter(int chapter);
 
-	jvc_xvd701_media_type m_media_type;
+	media_type m_media_type;
 
 	unsigned char m_command[11];
 	unsigned char m_response[11];

--- a/src/mame/konami/twinkle.cpp
+++ b/src/mame/konami/twinkle.cpp
@@ -328,6 +328,7 @@ public:
 	void twinklex(machine_config &config);
 	void twinklex2(machine_config &config);
 	void twinklei(machine_config &config);
+	void twinklei_dvd(machine_config &config);
 	void twinkle(machine_config &config);
 	void twinkle_dvd_type1(machine_config &config);
 	void twinkle_dvd_type2(machine_config &config);
@@ -1255,6 +1256,17 @@ void twinkle_state::twinklei(machine_config &config)
 	I2C_M24C02(config, "security"); // M24C02-W
 }
 
+void twinkle_state::twinklei_dvd(machine_config &config)
+{
+	twinklei(config);
+
+	// 6th through 8th style use DVD media; earlier versions use Video CD media.
+	subdevice<rs232_port_device>("rs232_dvd")->set_option_machine_config("xvd701", [] (device_t *device)
+	{
+		downcast<jvc_xvd701_device &>(*device).set_media_type(jvc_xvd701_device::media_type::DVD);
+	});
+}
+
 static INPUT_PORTS_START( twinkle )
 
 	PORT_START("IN0")
@@ -1655,8 +1667,8 @@ GAMEL( 2000, bmiidx3b, bmiidx3, twinklei, twinklei, twinkle_state, empty_init, R
 GAMEL( 2000, bmiidx3a, bmiidx3, twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 3rd style (GC992 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
 GAMEL( 2000, bmiidx4,  gq863,   twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 4th style (GCA03 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
 GAMEL( 2001, bmiidx5,  gq863,   twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 5th style (GCA17 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
-GAMEL( 2001, bmiidx6,  gq863,   twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 6th style (GCB4U JAB)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
-GAMEL( 2001, bmiidx6a, bmiidx6, twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 6th style (GCB4U JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
-GAMEL( 2002, bmiidx7,  gq863,   twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 7th style (GCB44 JAB)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
-GAMEL( 2002, bmiidx7a, bmiidx7, twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 7th style (GCB44 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
-GAMEL( 2002, bmiidx8,  gq863,   twinklei, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 8th style (GCC44 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
+GAMEL( 2001, bmiidx6,  gq863,   twinklei_dvd, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 6th style (GCB4U JAB)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
+GAMEL( 2001, bmiidx6a, bmiidx6, twinklei_dvd, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 6th style (GCB4U JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
+GAMEL( 2002, bmiidx7,  gq863,   twinklei_dvd, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 7th style (GCB44 JAB)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
+GAMEL( 2002, bmiidx7a, bmiidx7, twinklei_dvd, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 7th style (GCB44 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )
+GAMEL( 2002, bmiidx8,  gq863,   twinklei_dvd, twinklei, twinkle_state, empty_init, ROT0, "Konami", "beatmania IIDX 8th style (GCC44 JAA)", MACHINE_IMPERFECT_SOUND, layout_bmiidx )


### PR DESCRIPTION
The XV-D701 emulation currently always defaults to Video CD command semantics. For a chapter seek, Video CD commands place the two-digit chapter in the first two digit fields, so the device divides the received three-digit value by ten. DVD commands use all three digit fields directly.

beatmania IIDX 6th, 7th and 8th style use DVD video media. With the existing default, a DVD seek such as chapter `001` is decoded as chapter zero and rejected, while other DVD chapter numbers are truncated.

This change:

- makes the XV-D701 media type configurable;
- adds a DVD-specific Twinkle machine configuration for IIDX 6th through 8th style;
- leaves IIDX 2nd through 5th style on the existing Video CD behavior.

This is a prerequisite for native BGA playback. It does not add MPEG-2 decoding or video mixing.

## Testing

- `git diff --check` passes.
- Audited all `cdrom1` media declarations in `twinkle.cpp`: IIDX 2nd through 5th style are Video CD; IIDX 6th through 8th style are DVD.
- Built successfully with GCC 16.1.0 using `make SUBTARGET=twinkle SOURCES=src/mame/konami/twinkle.cpp REGENIE=1 -j5`.
- `twinkle.exe -validate` passes.
- `bmiidx6` and `bmiidx6a` both complete an eight-second headless startup test. The local `bmiidx6a` program CD has a known incorrect SHA-1, but its machine configuration initializes successfully.

## AI assistance disclosure

OpenAI Codex (GPT-5) was used to inspect the existing device and driver code and draft this change. The contributor is responsible for reviewing, testing and describing the submitted code.
