### PR TITLE
osd/netdev/pcap.cpp: Fix inverted success/failure return from send()

### DIFF
--- a/src/osd/modules/netdev/pcap.cpp
+++ b/src/osd/modules/netdev/pcap.cpp
@@ -231,7 +231,7 @@ int pcap_module::netdev_pcap::send(void const *buf, int len)
 	}
 	int ret = (*m_module.pcap_sendpacket_dl)(m_p, reinterpret_cast<const u_char *>(buf), len);
 	printf("sent packet length %d, returned %d\n", len, ret);
-	return ret ? len : 0;
+	return !ret ? len : 0;
 	//return (!pcap_sendpacket_dl(m_p, reinterpret_cast<const u_char *>(buf), len)) ? len : 0;
 }
 

--- a/src/osd/modules/netdev/pcap.cpp
+++ b/src/osd/modules/netdev/pcap.cpp
@@ -232,7 +232,6 @@ int pcap_module::netdev_pcap::send(void const *buf, int len)
 	int ret = (*m_module.pcap_sendpacket_dl)(m_p, reinterpret_cast<const u_char *>(buf), len);
 	printf("sent packet length %d, returned %d\n", len, ret);
 	return !ret ? len : 0;
-	//return (!pcap_sendpacket_dl(m_p, reinterpret_cast<const u_char *>(buf), len)) ? len : 0;
 }
 
 int pcap_module::netdev_pcap::recv_dev(uint8_t **buf)


### PR DESCRIPTION
## Summary

`netdev_pcap::send()` inverted the return value from `pcap_sendpacket()`, returning the byte count only when libpcap *failed* and `0` on success. `dp8390::do_tx()` and other emulated NIC drivers treat a `0` return as "transmit aborted" (TSR bit 3 on the DP8390), so every successful outbound frame set the excessive-collisions bit on the emulated card.

On classic-Mac guests using MacTCP over an Asante MC3NB (`macii -nba enetnb -networkprovider pcap`), this surfaced as OSErr `-95` (`excessCollsns`) from every `UDPWrite`, even though libpcap had put the frame on the wire.

## Root cause

`pcap_sendpacket(3PCAP)` returns `0` on success and `PCAP_ERROR` on failure. Regression dates to 140163dcc775 (2015): the new inverted return was added above the original correct line without deleting it, and 4565368984af (2025) later turned the orphaned correct line into a `//` comment, making the wrong behaviour look intentional.

## Fix

- Commit 1: flip the return - `ret ? len : 0` -> `!ret ? len : 0`.
- Commit 2: delete the now-obsolete orphaned `//return (!pcap_sendpacket_dl(...))?len:0;`.

## Verification

- Repro on unfixed `master`: `macii -nba enetnb -networkprovider pcap` with MacTCP, run any UDP-write path (e.g. an mDNS query). Every `UDPWrite` returns `-95`.
- With the fix, the same path returns `noErr` and libpcap-visible traffic (`tcpdump -i <iface>`) matches guest expectations exactly.

## AI disclosure

Diagnosis and code change were prepared with AI assistance (Claude Code). Verification - reproducing the `-95` on unfixed `master`, confirming the fix against a live `macii` guest with tcpdump correlation, and testing downstream behaviour - was done by me.