### PR TITLE
KN5000: Make `Feature Presentation` demo run

### DIFF
--- a/src/devices/cpu/tlcs900/tmp94c241.cpp
+++ b/src/devices/cpu/tlcs900/tmp94c241.cpp
@@ -1343,13 +1343,29 @@ void tmp94c241_device::tlcs900_check_irqs()
 		// flags are continuously driven by the input level. Clearing the flag
 		// during dispatch has no lasting effect if the input is still asserted.
 		// Re-assert INT0 flag if input is still active in level-detect mode.
+		// Only the ISR-driven path may re-assert. When a micro-DMA channel is
+		// armed on the INT0 start vector the DMA engine consumes each request and
+		// manages the flag itself; re-asserting there makes it read stale latch
+		// data.
 		if (irq_vector_map[irq].reg == INTE0AD &&
 			irq_vector_map[irq].iff == 0x08 &&
 			!(m_iimc & 0x02) &&
 			m_level[TLCS900_INT0] == ASSERT_LINE)
 		{
-			m_int_reg[INTE0AD] |= 0x08;
-			m_check_irqs = 1;
+			bool hdma_steals_int0 = false;
+			for (int ch = 0; ch < 4; ch++)
+			{
+				if (m_dma_vector[ch] == 0x0a)
+				{
+					hdma_steals_int0 = true;
+					break;
+				}
+			}
+			if (!hdma_steals_int0)
+			{
+				m_int_reg[INTE0AD] |= 0x08;
+				m_check_irqs = 1;
+			}
 		}
 
 		// Compute the default priority index from the vector table.

--- a/src/devices/cpu/tlcs900/tmp94c241.cpp
+++ b/src/devices/cpu/tlcs900/tmp94c241.cpp
@@ -1467,6 +1467,9 @@ void tmp94c241_device::tlcs900_handle_timers()
 				    timer_id 6  =>  m_timer_16[1]  m_timer_change[5]
 				    timer_id 8  =>  m_timer_16[2]  m_timer_change[6]
 				    timer_id A  =>  m_timer_16[3]  m_timer_change[7]
+
+				    TREG_HIGH match generates the upper interrupt (e.g., INTTR5).
+				    TREG_LOW match generates the lower interrupt (e.g., INTTR4).
 				*/
 				uint8_t timer_index = (timer_id - 4)/2;
 
@@ -1474,11 +1477,18 @@ void tmp94c241_device::tlcs900_handle_timers()
 				{
 					m_timer_16[timer_index]++;
 					// TODO: also check for criteria of up counter matching CAPn registers
-					if (((m_timer_16[timer_index] == m_treg_16[timer_reg_high]) && BIT(tffcr, 3)) ||
-							((m_timer_16[timer_index] == m_treg_16[timer_reg_low]) && BIT(tffcr, 2)) )
+					if (m_timer_16[timer_index] == m_treg_16[timer_reg_high])
 					{
-						change_timer_flipflop(timer_id, FF_INVERT);
+						if (BIT(tffcr, 3))
+							change_timer_flipflop(timer_id, FF_INVERT);
 						m_timer_16[timer_index] = 0;
+						m_int_reg[interrupt] |= 0x80;
+						m_check_irqs = 1;
+					}
+					else if (m_timer_16[timer_index] == m_treg_16[timer_reg_low])
+					{
+						if (BIT(tffcr, 2))
+							change_timer_flipflop(timer_id, FF_INVERT);
 						m_int_reg[interrupt] |= 0x08;
 						m_check_irqs = 1;
 					}

--- a/src/mame/matsushita/kn5000.cpp
+++ b/src/mame/matsushita/kn5000.cpp
@@ -14,6 +14,7 @@
 #include "cpu/tlcs900/tmp94c241.h"
 #include "imagedev/floppy.h"
 #include "machine/gen_latch.h"
+#include "machine/nvram.h"
 #include "machine/upd765.h"
 #include "video/pc_vga.h"
 
@@ -151,7 +152,7 @@ void kn5000_state::maincpu_mem(address_map &map)
 	map(0x140000, 0x14ffff).w(m_subcpu_latch, FUNC(generic_latch_8_device::write)); // @ IC22
 	map(0x1703b0, 0x1703df).m("vga", FUNC(mn89304_vga_device::io_map)); // LCD controller @ IC206
 	map(0x1a0000, 0x1dffff).rw("vga", FUNC(mn89304_vga_device::mem_linear_r), FUNC(mn89304_vga_device::mem_linear_w));
-	map(0x1e0000, 0x1fffff).ram(); // 1Mbit SRAM @ IC21 (CS0)  Note: I think this is the message "ERROR in back-up SRAM"
+	map(0x1e0000, 0x1fffff).ram().share("nvram"); // 1Mbit SRAM @ IC21 (CS0)
 	map(0x300000, 0x3fffff).rom().region("custom_data", 0); // 8MBit FLASH ROM @ IC19 (CS5)
 	map(0x400000, 0x7fffff).rom().region("rhythm_data", 0); // 32MBit ROM @ IC14 (A22=1 and CS5)
 	//map(0x800000, 0x82ffff).rom().region("subprogram", 0); // not sure yet in which chip this is stored, but I suspect it should be IC19
@@ -666,6 +667,8 @@ void kn5000_state::kn5000(machine_config &config)
 	vga.set_vram_size(0x80000);
 	// iochrdy tied to refresh pin and SA19, A21 and A20 to GND
 	// TODO: VGA.A18 signal, banking? From maincpu thru a T7W139F decoder
+
+	NVRAM(config, "nvram");
 
 	config.set_default_layout(layout_kn5000);
 }

--- a/src/mame/matsushita/kn5000.cpp
+++ b/src/mame/matsushita/kn5000.cpp
@@ -727,7 +727,7 @@ ROM_START(kn5000)
 	ROMX_LOAD("kn5000_subprogram_v140_compressed.rom", 0x0e0000, 0x16bc4, CRC(5b182629) SHA1(13098dd150c5a6083a5d15a63d5d785802d8e8ae), ROM_BIOS(5)) // v5
 
 	ROM_REGION16_LE(0x400000, "rhythm_data", 0)
-	ROM_LOAD("kn5000_rhythm_data_rom.ic14", 0x000000, 0x400000, CRC(76d11a5e) SHA1(e4b572d318c9fe7ba00e5b44ea783e89da9c68bd))
+	ROM_LOAD("kn5000_rhythm_data_rom.ic14", 0x000000, 0x400000, CRC(aa4917ce) SHA1(fef7f1927935d8fdada2afbdbfac29aac56e1c3c))
 
 	ROM_REGION16_LE(0x1000000, "waveform", 0)
 	ROM_LOAD("kn5000_waveform_rom.ic304", 0x000000, 0x400000, NO_DUMP)


### PR DESCRIPTION
In this PR I am including four small independent fixes that are necessary to make the instrument's built-in Feature Presentation demo run. It does not play any sounds because the tone generator is not emulated yet.

In order to test this, press the following sequence of buttons:
**DEMO**, then **LCD LEFT 4** (`"FEATURE PRESENTATION"`) and finally **LCD LEFT 2** (`"Start the internal DEMO"`).

**Note:** A partial tone-generator implementation [already exists](https://www.youtube.com/watch?v=tM5xOidLLn4) and will follow in a later PR, as it is a lot of code and is better reviewed on its own.

<img width="1920" height="1080" alt="Screenshot From 2026-08-11 16-00-11" src="https://github.com/user-attachments/assets/22c3b169-c37c-4c04-be61-a1721b202307" />
<img width="1920" height="1080" alt="Screenshot From 2026-08-11 16-01-16" src="https://github.com/user-attachments/assets/21184756-c165-4080-8f0a-f141db5cc72c" />
<img width="1920" height="1080" alt="Screenshot From 2026-08-11 16-01-30" src="https://github.com/user-attachments/assets/d241d221-8257-4b51-b7b6-af68e4dc6ade" />
<img width="1920" height="1080" alt="Screenshot From 2026-08-11 16-00-59" src="https://github.com/user-attachments/assets/dcbb094b-d7b0-48fb-9ba3-02ed168cfe1d" />
<img width="1920" height="1080" alt="Screenshot From 2026-08-11 16-01-51" src="https://github.com/user-attachments/assets/17649f17-0ceb-4e09-b72a-93cde7ceca7d" />


### kn5000: correct the IC14 rhythm data ROM dump.

The previous dump had address lines A19 and A21 swapped, so it was bad. The service manual (page 32) shows IC14 wired straight, so the transposition was a bad dump.

### tmp94c241: fix 16-bit timer interrupt generation and flip-flop gating.

A TREG_HIGH match set the lower interrupt flag instead of the upper one, and the flip-flop control bits gated the match
itself rather than just the flip-flop toggle. INTTR5, the KN5000's sequencer clock never fired.

### kn5000: model the IC21 backup SRAM as NVRAM.

It is battery-backed; declared as plain RAM it was invalid at every boot, so the firmware failed its checksum check and skipped the sub-CPU payload transfer.

### tmp94c241: do not re-assert INT0 while micro-DMA owns it.

The level-detect re-assertion should apply only to the ISR-driven path: when a micro-DMA channel is armed on the INT0 start vector the DMA engine consumes each request and manages the flag itself, so re-asserting made it read stale latch data.