### PR TITLE
vtech/crvision: Strobe PSG writes on PIA CB2

### DIFF
--- a/src/mame/vtech/crvision.cpp
+++ b/src/mame/vtech/crvision.cpp
@@ -630,6 +630,16 @@ uint8_t crvision_state::pia_pb_r()
 	return data;
 }
 
+void crvision_state::pia_pb_w(uint8_t data)
+{
+	m_psg_latch = data;
+}
+
+void crvision_state::pia_cb2_w(int state)
+{
+	if (!state) m_psg->write(m_psg_latch);
+}
+
 uint8_t laser2001_state::pia_pa_r()
 {
 	/*
@@ -752,7 +762,9 @@ void crvision_state::machine_start()
 {
 	// zerofill/state saving
 	m_keylatch = 0;
+	m_psg_latch = 0;
 	save_item(NAME(m_keylatch));
+	save_item(NAME(m_psg_latch));
 
 	if (m_cart->exists())
 	{
@@ -806,7 +818,8 @@ void crvision_state::creativision(machine_config &config)
 	m_pia->readpa_handler().set(FUNC(crvision_state::pia_pa_r));
 	m_pia->readpb_handler().set(FUNC(crvision_state::pia_pb_r));
 	m_pia->writepa_handler().set(FUNC(crvision_state::pia_pa_w));
-	m_pia->writepb_handler().set(SN76489_TAG, FUNC(sn76496_base_device::write));
+	m_pia->writepb_handler().set(FUNC(crvision_state::pia_pb_w));
+	m_pia->cb2_handler().set(FUNC(crvision_state::pia_cb2_w));
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/vtech/crvision.h
+++ b/src/mame/vtech/crvision.h
@@ -58,6 +58,7 @@ protected:
 
 	virtual void machine_start() override ATTR_COLD;
 	uint8_t m_keylatch = 0U;
+	uint8_t m_psg_latch = 0U;
 
 private:
 	void crvision_map(address_map &map) ATTR_COLD;
@@ -66,6 +67,8 @@ private:
 	void pia_pa_w(uint8_t data);
 	uint8_t pia_pa_r();
 	uint8_t pia_pb_r();
+	void pia_pb_w(uint8_t data);
+	void pia_cb2_w(int state);
 };
 
 class crvision_pal_state : public crvision_state


### PR DESCRIPTION
The CreatiVision driver currently sends PIA Port B writes directly to the SN76489A PSG. This produces severe glitching/crackling sounds in both normal audio output and WAVs captured using MAME's -wavwrite feature.

This change latches the PIA Port B value and performs the PSG write when CB2 goes low. The existing PSG READY-to-CB1 connection is unchanged.

This CB2-strobed PSG handling is similar to the implementation already used for the Laser 2001 and Salora Manager on the same driver.

Tested with multiple original CreatiVision cartridge games. The issue was reproduced using -wavwrite, and the affected software produced clean audio after the change.