### PR TITLE
olivetti/m20: add hard disk support and assorted fixes

### DIFF
--- a/src/devices/bus/zbi/s8k_cpu.cpp
+++ b/src/devices/bus/zbi/s8k_cpu.cpp
@@ -656,7 +656,6 @@ void zbi_s8k_cpu10_card_device::centronics_ack_w(uint8_t data)
 void zbi_s8k_cpu10_card_device::device_add_mconfig(machine_config &config)
 {
 	Z8001(config, m_maincpu, CLK_CPU);
-	m_maincpu->set_m20_hack(false);
 	m_maincpu->set_addrmap(AS_PROGRAM, &zbi_s8k_cpu10_card_device::addrmap_program);
 	m_maincpu->set_addrmap(AS_DATA, &zbi_s8k_cpu10_card_device::addrmap_data);
 	m_maincpu->set_addrmap(z8001_device::AS_STACK, &zbi_s8k_cpu10_card_device::addrmap_stack);
@@ -1228,7 +1227,6 @@ void zbi_s8k_hpcpu_card_device::device_resolve_objects()
 void zbi_s8k_hpcpu_card_device::device_add_mconfig(machine_config &config)
 {
 	Z8001(config, m_maincpu, CLK_HPCPU);
-	m_maincpu->set_m20_hack(false);
 	m_maincpu->set_addrmap(AS_PROGRAM, &zbi_s8k_hpcpu_card_device::addrmap_program);
 	m_maincpu->set_addrmap(AS_DATA, &zbi_s8k_hpcpu_card_device::addrmap_data);
 	m_maincpu->set_addrmap(z8001_device::AS_STACK, &zbi_s8k_hpcpu_card_device::addrmap_stack);

--- a/src/devices/cpu/z8000/z8000.cpp
+++ b/src/devices/cpu/z8000/z8000.cpp
@@ -42,7 +42,7 @@ z8002_device::z8002_device(const machine_config &mconfig, device_type type, cons
 	, m_ns_out(*this)
 	, m_busack_out(*this)
 	, m_ppc(0), m_pc(0), m_psapseg(0), m_psapoff(0), m_fcw(0), m_refresh(0), m_nspseg(0), m_nspoff(0), m_irq_req(0), m_irq_vec(0), m_op_valid(0), m_nmi_state(0), m_busreq_state(0), m_busack_state(0), m_mi(0), m_halt(false), m_icount(0)
-	, m_vector_mult(vecmult), m_m20_hack(true)
+	, m_vector_mult(vecmult)
 {
 }
 
@@ -202,11 +202,6 @@ uint16_t z8002_device::RDMEM_W(memory_access<23, 1, 0, ENDIANNESS_BIG>::specific
 {
 	addr = adjust_addr_for_nonseg_mode(addr);
 	addr &= ~1;
-	/* hack for m20 driver: BIOS accesses 0x7f0000 and expects a segmentation violation */
-	if (m_m20_hack && (addr >= 0x7f0000)) {
-		m_irq_req = Z8000_SEGTRAP;
-		return 0xffff;
-	}
 	return space.read_word(addr);
 }
 

--- a/src/devices/cpu/z8000/z8000.h
+++ b/src/devices/cpu/z8000/z8000.h
@@ -112,7 +112,6 @@ public:
 	auto ns() { return m_ns_out.bind(); }
 
 	bool is_ifetch1() const noexcept { return (m_op_valid == 0); }
-	void set_m20_hack(bool is_hack) { m_m20_hack = is_hack; }
 
 protected:
 	z8002_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock, int addrbits, int vecmult);
@@ -187,7 +186,6 @@ protected:
 	memory_access<16, 1, 0, ENDIANNESS_BIG>::specific m_sio;
 	int m_icount;
 	const int m_vector_mult;
-	bool m_m20_hack;
 
 	void clear_internal_state();
 	void register_debug_state();

--- a/src/devices/machine/wd1000.cpp
+++ b/src/devices/machine/wd1000.cpp
@@ -538,7 +538,7 @@ void wd1000_device::write(offs_t offset, uint8_t data)
 				// transferred, so just start the transfer
 				// here.
 				m_buffer_index = 0;
-				m_buffer_end = 512;
+				m_buffer_end = sector_bytes();
 				set_drq();
 				break;
 			}
@@ -572,7 +572,7 @@ void wd1000_device::cmd_read_sector()
 	file->read(get_lbasector(), m_buffer);
 
 	m_buffer_index = 0;
-	m_buffer_end = 512;
+	m_buffer_end = sector_bytes();
 
 	m_status &= ~S_BSY;
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36392,8 +36392,6 @@ celint2kss
 
 @source:olivetti/m20.cpp
 m20
-m40
-m44
 
 @source:olivetti/m24.cpp
 m21

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36392,6 +36392,8 @@ celint2kss
 
 @source:olivetti/m20.cpp
 m20
+m40
+m44
 
 @source:olivetti/m24.cpp
 m21

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -738,6 +738,7 @@ void m20_state::machine_reset()
 
 	memcpy(RAM, ROM, 8);  // we need only the reset vector
 	m_kbdi8251->write_cts(0);
+	m_ttyi8251->write_cts(0);
 	if (m_apb)
 		m_apb->halt();
 }

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -882,6 +882,6 @@ ROM_END
 
 
 //    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY     FULLNAME           FLAGS
-COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
+COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
 COMP( 1981, m40,  m20,    0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M40", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
 COMP( 1986, m44,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M44", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -856,4 +856,4 @@ ROM_END
 
 
 //    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY     FULLNAME           FLAGS
-COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
+COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -871,8 +871,36 @@ ROM_START(m20)
 	ROMX_LOAD("m20-20f.bin", 0x0000, 0x2000, CRC(db7198d8) SHA1(149d8513867081d31c73c2965dabb36d5f308041), ROM_BIOS(2))
 ROM_END
 
+ROM_START(m40)
+	ROM_REGION(0x14000,"maincpu", 0)
+	ROM_SYSTEM_BIOS( 0, "m40-81", "M40 15.dec.81" )
+	ROMX_LOAD( "m40rom-15-dec-81", 0x0000, 0x2000, CRC(e8e7df84) SHA1(e86018043bf5a23ff63434f9beef7ce2972d8153), ROM_BIOS(0))
+	ROM_SYSTEM_BIOS( 1, "m40-82", "M40 17.dec.82" )
+	ROMX_LOAD( "m40rom-17-dec-82", 0x0000, 0x2000, CRC(cf55681c) SHA1(fe4ae14a6751fef5d7bde49439286f1da3689437), ROM_BIOS(1))
+	ROM_SYSTEM_BIOS( 2, "m40-41", "M40 4.1" )
+	ROMX_LOAD( "m40rom-4.1", 0x0000, 0x2000, CRC(cf55681c) SHA1(fe4ae14a6751fef5d7bde49439286f1da3689437), ROM_BIOS(2))
+	ROM_SYSTEM_BIOS( 3, "m40-60", "M40 6.0" )
+	ROMX_LOAD( "m40rom-6.0", 0x0000, 0x4000, CRC(8114ebec) SHA1(4e2c65b95718c77a87dbee0288f323bd1c8837a3), ROM_BIOS(3))
+
+	ROM_REGION(0x4000, "apb_bios", ROMREGION_ERASEFF) // Processor board with 8086
+ROM_END
+
+// CPU board: Z8001BPS CPU, Z8010BPS MMU, 32MHz XTAL, P8253 PIT, MC68B50P ACIA, 1 4-dip bank, 512K RAM
+// FDC board: D765AC-2 FDC, D8237AC-5 DMAC, GA04-CF11051, TMP8253P-5, 1 4-dip bank, 1 barely readable chip (AMI8520JFT or something resembling it)
+// there are other undocumented PCBs. It uses 2x 8 inch floppy drives
+ROM_START(m44) // TODO: implement different hardware. Split to another driver?
+	ROM_REGION( 0x14000, "maincpu", 0 ) // 14 MAR. 86 REL B.1
+	ROM_LOAD16_BYTE( "pd30.128.c06", 0x0000, 0x4000, CRC(8155dc69) SHA1(ed65f842e2857ad10170c697d945745fd7d47f9c) )
+	ROM_LOAD16_BYTE( "pd29.128.a06", 0x0001, 0x4000, CRC(74d7de4b) SHA1(dd3a69ff29a2f1292f3a7db73bd2447bd664e54b) )
+
+	ROM_REGION( 0x114, "plds", 0 )
+	ROM_LOAD( "pl46.j09", 0x000, 0x114, NO_DUMP ) // PLD, chip type unknown
+ROM_END
+
 } // anonymous namespace
 
 
 //    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY     FULLNAME           FLAGS
 COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_SUPPORTS_SAVE )
+COMP( 1981, m40,  m20,    0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M40", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+COMP( 1986, m44,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M44", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -852,36 +852,8 @@ ROM_START(m20)
 	ROMX_LOAD("m20-20f.bin", 0x0000, 0x2000, CRC(db7198d8) SHA1(149d8513867081d31c73c2965dabb36d5f308041), ROM_BIOS(2))
 ROM_END
 
-ROM_START(m40)
-	ROM_REGION(0x14000,"maincpu", 0)
-	ROM_SYSTEM_BIOS( 0, "m40-81", "M40 15.dec.81" )
-	ROMX_LOAD( "m40rom-15-dec-81", 0x0000, 0x2000, CRC(e8e7df84) SHA1(e86018043bf5a23ff63434f9beef7ce2972d8153), ROM_BIOS(0))
-	ROM_SYSTEM_BIOS( 1, "m40-82", "M40 17.dec.82" )
-	ROMX_LOAD( "m40rom-17-dec-82", 0x0000, 0x2000, CRC(cf55681c) SHA1(fe4ae14a6751fef5d7bde49439286f1da3689437), ROM_BIOS(1))
-	ROM_SYSTEM_BIOS( 2, "m40-41", "M40 4.1" )
-	ROMX_LOAD( "m40rom-4.1", 0x0000, 0x2000, CRC(cf55681c) SHA1(fe4ae14a6751fef5d7bde49439286f1da3689437), ROM_BIOS(2))
-	ROM_SYSTEM_BIOS( 3, "m40-60", "M40 6.0" )
-	ROMX_LOAD( "m40rom-6.0", 0x0000, 0x4000, CRC(8114ebec) SHA1(4e2c65b95718c77a87dbee0288f323bd1c8837a3), ROM_BIOS(3))
-
-	ROM_REGION(0x4000, "apb_bios", ROMREGION_ERASEFF) // Processor board with 8086
-ROM_END
-
-// CPU board: Z8001BPS CPU, Z8010BPS MMU, 32MHz XTAL, P8253 PIT, MC68B50P ACIA, 1 4-dip bank, 512K RAM
-// FDC board: D765AC-2 FDC, D8237AC-5 DMAC, GA04-CF11051, TMP8253P-5, 1 4-dip bank, 1 barely readable chip (AMI8520JFT or something resembling it)
-// there are other undocumented PCBs. It uses 2x 8 inch floppy drives
-ROM_START(m44) // TODO: implement different hardware. Split to another driver?
-	ROM_REGION( 0x14000, "maincpu", 0 ) // 14 MAR. 86 REL B.1
-	ROM_LOAD16_BYTE( "pd30.128.c06", 0x0000, 0x4000, CRC(8155dc69) SHA1(ed65f842e2857ad10170c697d945745fd7d47f9c) )
-	ROM_LOAD16_BYTE( "pd29.128.a06", 0x0001, 0x4000, CRC(74d7de4b) SHA1(dd3a69ff29a2f1292f3a7db73bd2447bd664e54b) )
-
-	ROM_REGION( 0x114, "plds", 0 )
-	ROM_LOAD( "pl46.j09", 0x000, 0x114, NO_DUMP ) // PLD, chip type unknown
-ROM_END
-
 } // anonymous namespace
 
 
 //    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY     FULLNAME           FLAGS
 COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
-COMP( 1981, m40,  m20,    0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M40", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-COMP( 1986, m44,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M44", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -122,6 +122,8 @@ private:
 	void install_memory();
 
 	static void floppy_formats(format_registration &fr);
+	uint16_t segment_r();
+	uint16_t segtack_r();
 	uint16_t viack_r();
 	uint16_t nviack_r();
 };
@@ -330,12 +332,14 @@ void m20_state::m20_program_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x40000, 0x41fff).rom().region("maincpu", 0x00000);
+	map(0x7f0000, 0x7fffff).r(FUNC(m20_state::segment_r));
 }
 
 void m20_state::m20_data_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x40000, 0x41fff).rom().region("maincpu", 0x00000);
+	map(0x7f0000, 0x7fffff).r(FUNC(m20_state::segment_r));
 }
 
 
@@ -692,6 +696,20 @@ uint16_t m20_state::viack_r()
 	return m_i8259->acknowledge()<<1;
 }
 
+uint16_t m20_state::segment_r()
+{
+	if (!machine().side_effects_disabled())
+		m_maincpu->set_input_line(z8001_device::SEGT_LINE, ASSERT_LINE);
+
+	return 0xffff;
+}
+
+uint16_t m20_state::segtack_r()
+{
+	m_maincpu->set_input_line(z8001_device::SEGT_LINE, CLEAR_LINE);
+	return 0xffff;
+}
+
 uint16_t m20_state::nviack_r()
 {
 	m_maincpu->set_input_line(z8001_device::NVI_LINE, CLEAR_LINE);
@@ -770,6 +788,7 @@ void m20_state::m20(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &m20_state::m20_program_mem);
 	m_maincpu->set_addrmap(AS_DATA, &m20_state::m20_data_mem);
 	m_maincpu->set_addrmap(AS_IO, &m20_state::m20_io);
+	m_maincpu->segtack().set(FUNC(m20_state::segtack_r));
 	m_maincpu->viack().set(FUNC(m20_state::viack_r));
 	m_maincpu->nviack().set(FUNC(m20_state::nviack_r));
 

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -41,6 +41,8 @@ E I1     Vectored interrupt error
 #include "m20_kbd.h"
 
 #include "bus/rs232/rs232.h"
+#include "imagedev/harddriv.h"
+#include "machine/wd1000.h"
 #include "cpu/i86/i86.h"
 #include "cpu/z8000/z8000.h"
 #include "imagedev/floppy.h"
@@ -76,6 +78,7 @@ public:
 		m_floppy0(*this, "fd1797:0:5dd"),
 		m_floppy1(*this, "fd1797:1:5dd"),
 		m_apb(*this, "apb"),
+		m_hdc(*this, "hdc"),
 		m_palette(*this, "palette")
 	{
 	}
@@ -93,6 +96,7 @@ private:
 	required_device<floppy_image_device> m_floppy0;
 	required_device<floppy_image_device> m_floppy1;
 	optional_device<m20_8086_device> m_apb;
+	optional_device<wd1000_device> m_hdc;
 
 	required_device<palette_device> m_palette;
 
@@ -704,6 +708,17 @@ void m20_state::int_w(int state)
 void m20_state::machine_start()
 {
 	install_memory();
+
+	// Only install WD1000 HD controller I/O if a hard disk image is mounted
+	if (m_hdc)
+	{
+		harddisk_image_device *hd0 = m_hdc->subdevice<harddisk_image_device>("0");
+		harddisk_image_device *hd1 = m_hdc->subdevice<harddisk_image_device>("1");
+		if ((hd0 && hd0->exists()) || (hd1 && hd1->exists()))
+		{
+			m_maincpu->space(AS_IO).install_readwrite_handler(0x1c0, 0x1cf, read8sm_delegate(*m_hdc, FUNC(wd1000_device::read)), write8sm_delegate(*m_hdc, FUNC(wd1000_device::write)), 0x00ff);
+		}
+	}
 }
 
 void m20_state::machine_reset()
@@ -806,6 +821,19 @@ void m20_state::m20(machine_config &config)
 	rs232.rxd_handler().set(m_ttyi8251, FUNC(i8251_device::write_rxd));
 
 	M20_8086(config, m_apb, m_maincpu, m_i8259, RAM_TAG);
+
+	/*
+	 default hard drive is 9Mb (180,6,33), 256 bytes per sector
+	 Bad block table at CHS 0 0 1
+	 Format:
+	    1st byte = number of bad blocks
+	    2nd byte = 0xff
+	    List of Bad blocks (4 bytes per block) follows
+	    | CYL L | CYL H| x x x S1 S0 S4 S3 S2  |  HEAD |
+	*/
+	WD1000(config, m_hdc, 20_MHz_XTAL / 4);
+	HARDDISK(config, "hdc:0", 0);
+	HARDDISK(config, "hdc:1", 0);
 
 	SOFTWARE_LIST(config, "flop_list").set_original("m20");
 }

--- a/src/mame/olivetti/m20.cpp
+++ b/src/mame/olivetti/m20.cpp
@@ -719,6 +719,9 @@ void m20_state::machine_start()
 			m_maincpu->space(AS_IO).install_readwrite_handler(0x1c0, 0x1cf, read8sm_delegate(*m_hdc, FUNC(wd1000_device::read)), write8sm_delegate(*m_hdc, FUNC(wd1000_device::write)), 0x00ff);
 		}
 	}
+
+	save_item(NAME(m_memsize));
+	save_item(NAME(m_port21));
 }
 
 void m20_state::machine_reset()
@@ -879,6 +882,6 @@ ROM_END
 
 
 //    YEAR  NAME  PARENT  COMPAT  MACHINE  INPUT  CLASS      INIT        COMPANY     FULLNAME           FLAGS
-COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+COMP( 1981, m20,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M20", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
 COMP( 1981, m40,  m20,    0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M40", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
 COMP( 1986, m44,  0,      0,      m20,     0,     m20_state, empty_init, "Olivetti", "Olivetti L1 M44", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/olivetti/m20_8086.cpp
+++ b/src/mame/olivetti/m20_8086.cpp
@@ -23,6 +23,9 @@ void m20_8086_device::device_start()
 	membank("vram")->set_base(ram);
 	membank("vram2")->set_base(ram);
 
+	save_item(NAME(m_8086_halt));
+	save_item(NAME(m_nvi));
+	save_item(NAME(m_vi));
 }
 
 void m20_8086_device::device_reset()

--- a/src/mame/olivetti/m20_kbd.cpp
+++ b/src/mame/olivetti/m20_kbd.cpp
@@ -5,6 +5,7 @@
 #include "m20_kbd.h"
 
 #include "machine/keyboard.ipp"
+#include "speaker.h"
 
 
 namespace {
@@ -158,6 +159,8 @@ m20_keyboard_device::m20_keyboard_device(const machine_config& mconfig, const ch
 	: buffered_rs232_device(mconfig, M20_KEYBOARD, tag, owner, 0)
 	, device_matrix_keyboard_interface(mconfig, *this, "LINE0", "LINE1", "LINE2", "LINE3", "LINE4", "LINE5", "LINE6", "LINE7", "LINE8")
 	, m_modifiers(*this, "MODIFIERS")
+	, m_beeper(*this, "beeper")
+	, m_bell_timer(nullptr)
 {
 }
 
@@ -168,9 +171,29 @@ ioport_constructor m20_keyboard_device::device_input_ports() const
 }
 
 
+void m20_keyboard_device::device_add_mconfig(machine_config &config)
+{
+	SPEAKER(config, "mono").front_center();
+	BEEP(config, m_beeper, 2000); // TODO: unknown frequency
+	m_beeper->add_route(ALL_OUTPUTS, "mono", 1.0);
+}
+
+void m20_keyboard_device::device_start()
+{
+	buffered_rs232_device::device_start();
+	m_bell_timer = timer_alloc(FUNC(m20_keyboard_device::bell_off), this);
+}
+
+TIMER_CALLBACK_MEMBER(m20_keyboard_device::bell_off)
+{
+	m_beeper->set_state(0);
+}
+
 void m20_keyboard_device::device_reset()
 {
 	buffered_rs232_device::device_reset();
+
+	m_beeper->set_state(0);
 
 	reset_key_state();
 	clear_fifo();
@@ -217,7 +240,11 @@ void m20_keyboard_device::received_byte(uint8_t byte)
 	switch (byte)
 	{
 	case 0x03U:
-		transmit_byte(0x02U);
+		transmit_byte(0x0fU);
+		break;
+	case 0x0aU: // BEEP
+		m_beeper->set_state(1);
+		m_bell_timer->reset(attotime::from_msec(50));
 		break;
 	case 0x80U:
 		transmit_byte(0x80U);

--- a/src/mame/olivetti/m20_kbd.h
+++ b/src/mame/olivetti/m20_kbd.h
@@ -7,6 +7,7 @@
 
 #include "bus/rs232/rs232.h"
 #include "machine/keyboard.h"
+#include "sound/beep.h"
 
 class m20_keyboard_device : public buffered_rs232_device<16U>, protected device_matrix_keyboard_interface<9U>
 {
@@ -15,13 +16,19 @@ public:
 	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
 
 protected:
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void key_make(uint8_t row, uint8_t column) override;
 
 private:
 	virtual void received_byte(uint8_t byte) override;
 
+	TIMER_CALLBACK_MEMBER(bell_off);
+
 	required_ioport m_modifiers;
+	required_device<beep_device> m_beeper;
+	emu_timer *m_bell_timer;
 };
 
 DECLARE_DEVICE_TYPE(M20_KEYBOARD, m20_keyboard_device)


### PR DESCRIPTION
Recent Z8001 fixes from PR #15866 have cleared most of the known M20 issues, and everything now appears to be working.

This adds WD1000 hard disk support to the Olivetti M20 and includes several related fixes and cleanups:

- Add WD1000 hard disk controller support.
- Fix keyboard bell and serial clock handling.
- Add save-state support.
- Move the M20-specific segment trap handling from the generic Z8000 CPU core into the M20 driver.
- Remove M40 and M44 definitions, as these are different systems and do not belong in the M20 driver.
- Mark the M20 working.

Create an empty M20 hard-disk image with:

```sh
./chdman createhd \
  -o m20-empty.chd \
  -chs 180,6,33 \
  -ss 256
```

Regression testing uses `m20-cpm8000.chd` and `REL11A.IMG` from https://github.com/tpaxia/mame_disks:

```sh
mame m20 \
  -hard1 /path/to/mame_disks/m20-cpm8000.chd \
  -bios 2 -ramsize 512k \
  -flop1 /path/to/mame_disks/REL11A.IMG
```

At the CP/M prompt, run:

```text
C:
SUBMIT TICTAC
```

Verify that the sample program compiles successfully. Before the recent Z8001 fixes, the ZCC compiler crashed during this test.

An “invalid file” error during boot is expected. The original CP/M-8000 installation was not configured to coexist with the other M20 operating systems present on the disk.
