### PR TITLE
util/chd: use data() instead of &container[0]

### DIFF
--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -120,11 +120,6 @@ struct chd_file::metadata_hash
 {
 	uint8_t                 tag[4];         // tag of the metadata in big-endian
 	util::sha1_t            sha1;           // hash data
-
-	bool operator<(const metadata_hash &other) const noexcept
-	{
-		return memcmp(this, &other, sizeof(*this)) < 0;
-	}
 };
 
 
@@ -1744,7 +1739,13 @@ util::sha1_t chd_file::compute_overall_sha1(util::sha1_t rawsha1)
 
 	// sort the array
 	if (!hasharray.empty())
-		std::sort(hasharray.begin(), hasharray.end());
+		std::sort(
+        hasharray.begin(),
+        hasharray.end(),
+        [] (metadata_hash const &a, metadata_hash const &b)
+        {
+            return memcmp(&a, &b, sizeof(metadata_hash)) < 0;
+        });
 
 	// read the raw data hash from our header and start a new SHA1 with that data
 	util::sha1_creator overall_sha1;

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -121,6 +121,11 @@ struct chd_file::metadata_hash
 {
 	uint8_t                 tag[4];         // tag of the metadata in big-endian
 	util::sha1_t            sha1;           // hash data
+
+	bool operator<(const metadata_hash &other) const noexcept
+	{
+		return memcmp(this, &other, sizeof(*this)) < 0;
+	}
 };
 
 
@@ -1740,7 +1745,7 @@ util::sha1_t chd_file::compute_overall_sha1(util::sha1_t rawsha1)
 
 	// sort the array
 	if (!hasharray.empty())
-		qsort(hasharray.data(), hasharray.size(), sizeof(hasharray[0]), metadata_hash_compare);
+		std::sort(hasharray.begin(), hasharray.end());
 
 	// read the raw data hash from our header and start a new SHA1 with that data
 	util::sha1_creator overall_sha1;
@@ -2906,23 +2911,6 @@ void chd_file::metadata_update_hash()
 		throw err;
 }
 
-/**
- * @fn  int CLIB_DECL chd_file::metadata_hash_compare(const void *elem1, const void *elem2)
- *
- * @brief   -------------------------------------------------
- *            metadata_hash_compare - compare two hash entries
- *          -------------------------------------------------.
- *
- * @param   elem1   The first element.
- * @param   elem2   The second element.
- *
- * @return  A CLIB_DECL.
- */
-
-int CLIB_DECL chd_file::metadata_hash_compare(const void *elem1, const void *elem2)
-{
-	return memcmp(elem1, elem2, sizeof(metadata_hash));
-}
 
 
 

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -919,10 +919,10 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 				case V34_MAP_ENTRY_TYPE_COMPRESSED:
 					{
 						uint32_t const blocklen = get_u16be(&rawmap[12]) | (uint32_t(rawmap[14]) << 16);
-						std::error_condition err = file_read(blockoffs, &m_compressed[0], blocklen);
+						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
-						m_decompressor[0]->process(&m_compressed[0], blocklen);
+						m_decompressor[0]->process(m_compressed.data(), blocklen);
 						return std::error_condition();
 					}
 
@@ -958,11 +958,11 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 				case COMPRESSION_TYPE_2:
 				case COMPRESSION_TYPE_3:
 					{
-						std::error_condition err = file_read(blockoffs, &m_compressed[0], blocklen);
+						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
 						auto &decompressor = *m_decompressor[rawmap[0]];
-						decompressor.process(&m_compressed[0], blocklen);
+						decompressor.process(m_compressed.data(), blocklen);
 						return std::error_condition();
 					}
 
@@ -1045,10 +1045,10 @@ std::error_condition chd_file::read_hunk(uint32_t hunknum, void *buffer)
 				case V34_MAP_ENTRY_TYPE_COMPRESSED:
 					{
 						uint32_t const blocklen = get_u16be(&rawmap[12]) | (uint32_t(rawmap[14]) << 16);
-						std::error_condition err = file_read(blockoffs, &m_compressed[0], blocklen);
+						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
-						m_decompressor[0]->decompress(&m_compressed[0], blocklen, dest, m_hunkbytes);
+						m_decompressor[0]->decompress(m_compressed.data(), blocklen, dest, m_hunkbytes);
 						if (UNEXPECTED(!nocrc && (util::crc32_creator::simple(dest, m_hunkbytes) != blockcrc)))
 							return std::error_condition(error::DECOMPRESSION_ERROR);
 						return std::error_condition();
@@ -1115,14 +1115,14 @@ std::error_condition chd_file::read_hunk(uint32_t hunknum, void *buffer)
 					case COMPRESSION_TYPE_2:
 					case COMPRESSION_TYPE_3:
 						{
-							std::error_condition err = file_read(blockoffs, &m_compressed[0], blocklen);
+							std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 							if (UNEXPECTED(err))
 								return err;
 							auto &decompressor = *m_decompressor[rawmap[0]];
-							decompressor.decompress(&m_compressed[0], blocklen, dest, m_hunkbytes);
+							decompressor.decompress(m_compressed.data(), blocklen, dest, m_hunkbytes);
 							util::crc16_t const calculated = !decompressor.lossy()
 									? util::crc16_creator::simple(dest, m_hunkbytes)
-									: util::crc16_creator::simple(&m_compressed[0], blocklen);
+									: util::crc16_creator::simple(m_compressed.data(), blocklen);
 							if (UNEXPECTED(calculated != blockcrc))
 								return std::error_condition(error::DECOMPRESSION_ERROR);
 							return std::error_condition();
@@ -1240,8 +1240,8 @@ std::error_condition chd_file::write_hunk(uint32_t hunknum, const void *buffer)
 			return err;
 
 		// update the cached hunk if we just wrote it
-		if (hunknum == m_cachehunk && buffer != &m_cache[0])
-			memcpy(&m_cache[0], buffer, m_hunkbytes);
+		if (hunknum == m_cachehunk && buffer != m_cache.data())
+			memcpy(m_cache.data(), buffer, m_hunkbytes);
 
 		return std::error_condition();
 	}
@@ -1329,7 +1329,7 @@ std::error_condition chd_file::read_bytes(uint64_t offset, void *buffer, uint32_
 			// otherwise, read from the cache
 			if (curhunk != m_cachehunk)
 			{
-				std::error_condition err = read_hunk(curhunk, &m_cache[0]);
+				std::error_condition err = read_hunk(curhunk, m_cache.data());
 				if (UNEXPECTED(err))
 					return err;
 				m_cachehunk = curhunk;
@@ -1381,13 +1381,13 @@ std::error_condition chd_file::write_bytes(uint64_t offset, const void *buffer, 
 			// otherwise, write from the cache
 			if (curhunk != m_cachehunk)
 			{
-				err = read_hunk(curhunk, &m_cache[0]);
+				err = read_hunk(curhunk, m_cache.data());
 				if (UNEXPECTED(err))
 					return err;
 				m_cachehunk = curhunk;
 			}
 			memcpy(&m_cache[startoffs], source, endoffs + 1 - startoffs);
-			err = write_hunk(curhunk, &m_cache[0]);
+			err = write_hunk(curhunk, m_cache.data());
 		}
 
 		// handle errors and advance
@@ -1425,7 +1425,7 @@ std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_
 	// read the metadata
 	try { output.assign(metaentry.length, '\0'); }
 	catch (std::bad_alloc const &) { return std::errc::not_enough_memory; }
-	return file_read(metaentry.offset + METADATA_HEADER_SIZE, &output[0], metaentry.length);
+	return file_read(metaentry.offset + METADATA_HEADER_SIZE, output.data(), metaentry.length);
 }
 
 /**
@@ -1453,7 +1453,7 @@ std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_
 	// read the metadata
 	try { output.resize(metaentry.length); }
 	catch (std::bad_alloc const &) { return std::errc::not_enough_memory; }
-	return file_read(metaentry.offset + METADATA_HEADER_SIZE, &output[0], metaentry.length);
+	return file_read(metaentry.offset + METADATA_HEADER_SIZE, output.data(), metaentry.length);
 }
 
 /**
@@ -1515,7 +1515,7 @@ std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_
 	// read the metadata
 	try { output.resize(metaentry.length); }
 	catch (std::bad_alloc const &) { return std::errc::not_enough_memory; }
-	err = file_read(metaentry.offset + METADATA_HEADER_SIZE, &output[0], metaentry.length);
+	err = file_read(metaentry.offset + METADATA_HEADER_SIZE, output.data(), metaentry.length);
 	if (UNEXPECTED(err))
 		return err;
 	resulttag = metaentry.metatag;
@@ -1678,12 +1678,12 @@ std::error_condition chd_file::clone_all_metadata(chd_file &source)
 		// read the metadata item
 		try { filedata.resize(metaentry.length); }
 		catch (std::bad_alloc const &) { return std::errc::not_enough_memory; }
-		err = source.file_read(metaentry.offset + METADATA_HEADER_SIZE, &filedata[0], metaentry.length);
+		err = source.file_read(metaentry.offset + METADATA_HEADER_SIZE, filedata.data(), metaentry.length);
 		if (UNEXPECTED(err))
 			return err;
 
 		// write it to the destination
-		err = write_metadata(metaentry.metatag, (uint32_t)-1, &filedata[0], metaentry.length, metaentry.flags);
+		err = write_metadata(metaentry.metatag, (uint32_t)-1, filedata.data(), metaentry.length, metaentry.flags);
 		if (UNEXPECTED(err))
 			return err;
 	}
@@ -1725,14 +1725,14 @@ util::sha1_t chd_file::compute_overall_sha1(util::sha1_t rawsha1)
 
 		// allocate memory and read the data
 		filedata.resize(metaentry.length);
-		err = file_read(metaentry.offset + METADATA_HEADER_SIZE, &filedata[0], metaentry.length);
+		err = file_read(metaentry.offset + METADATA_HEADER_SIZE, filedata.data(), metaentry.length);
 		if (UNEXPECTED(err))
 			throw err;
 
 		// create an entry for this metadata and add it
 		metadata_hash hashentry;
 		put_u32be(hashentry.tag, metaentry.metatag);
-		hashentry.sha1 = util::sha1_creator::simple(&filedata[0], metaentry.length);
+		hashentry.sha1 = util::sha1_creator::simple(filedata.data(), metaentry.length);
 		hasharray.push_back(hashentry);
 	}
 	if (err != error::METADATA_NOT_FOUND)
@@ -1740,13 +1740,13 @@ util::sha1_t chd_file::compute_overall_sha1(util::sha1_t rawsha1)
 
 	// sort the array
 	if (!hasharray.empty())
-		qsort(&hasharray[0], hasharray.size(), sizeof(hasharray[0]), metadata_hash_compare);
+		qsort(hasharray.data(), hasharray.size(), sizeof(hasharray[0]), metadata_hash_compare);
 
 	// read the raw data hash from our header and start a new SHA1 with that data
 	util::sha1_creator overall_sha1;
 	overall_sha1.append(&rawsha1, sizeof(rawsha1));
 	if (!hasharray.empty())
-		overall_sha1.append(&hasharray[0], hasharray.size() * sizeof(hasharray[0]));
+		overall_sha1.append(hasharray.data(), hasharray.size() * sizeof(hasharray[0]));
 	return overall_sha1.finish();
 }
 
@@ -2073,11 +2073,11 @@ std::error_condition chd_file::compress_v5_map()
 	try
 	{
 		// first get a CRC-16 of the original rawmap
-		util::crc16_t mapcrc = util::crc16_creator::simple(&m_rawmap[0], m_hunkcount * 12);
+		util::crc16_t mapcrc = util::crc16_creator::simple(m_rawmap.data(), m_hunkcount * 12);
 
 		// create a buffer to hold the RLE data
 		std::vector<uint8_t> compression_rle(m_hunkcount);
-		uint8_t *dest = &compression_rle[0];
+		uint8_t *dest = compression_rle.data();
 
 		// use a huffman encoder for 16 different codes, maximum length is 8 bits
 		huffman_encoder<16, 8> encoder;
@@ -2185,13 +2185,13 @@ std::error_condition chd_file::compress_v5_map()
 			throw std::error_condition(error::COMPRESSION_ERROR);
 
 		// encode the data
-		for (uint8_t *src = &compression_rle[0]; src < dest; src++)
+		for (uint8_t *src = compression_rle.data(); src < dest; src++)
 			encoder.encode_one(bitbuf, *src);
 
 		// for each compression type, output the relevant data
 		lastcomp = 0;
 		count = 0;
-		uint8_t *src = &compression_rle[0];
+		uint8_t *src = compression_rle.data();
 		uint64_t firstoffs = 0;
 		for (uint32_t hunknum = 0; hunknum < m_hunkcount; hunknum++)
 		{
@@ -2256,7 +2256,7 @@ std::error_condition chd_file::compress_v5_map()
 		// write the map header
 		uint32_t complen = bitbuf.flush();
 		assert(!bitbuf.overflow());
-		put_u32be(&compressed[0], complen);
+		put_u32be(compressed.data(), complen);
 		put_u48be(&compressed[4], firstoffs);
 		put_u16be(&compressed[10], mapcrc);
 		compressed[12] = lengthbits;
@@ -2265,7 +2265,7 @@ std::error_condition chd_file::compress_v5_map()
 		compressed[15] = 0;
 
 		// write the result
-		m_mapoffset = file_append(&compressed[0], complen + 16);
+		m_mapoffset = file_append(compressed.data(), complen + 16);
 
 		// then write the map offset
 		uint8_t rawbuf[sizeof(uint64_t)];
@@ -2298,7 +2298,7 @@ void chd_file::decompress_v5_map()
 	// if no offset, we haven't written it yet
 	if (m_mapoffset == 0)
 	{
-		memset(&m_rawmap[0], 0xff, m_rawmap.size());
+		memset(m_rawmap.data(), 0xff, m_rawmap.size());
 		return;
 	}
 
@@ -2317,10 +2317,10 @@ void chd_file::decompress_v5_map()
 
 	// now read the map
 	std::vector<uint8_t> compressed(mapbytes);
-	ioerr = file_read(m_mapoffset + 16, &compressed[0], mapbytes);
+	ioerr = file_read(m_mapoffset + 16, compressed.data(), mapbytes);
 	if (UNEXPECTED(ioerr))
 		throw ioerr;
-	bitstream_in bitbuf(&compressed[0], compressed.size());
+	bitstream_in bitbuf(compressed.data(), compressed.size());
 
 	// first decode the compression types
 	huffman_decoder<16, 8> decoder;
@@ -2409,7 +2409,7 @@ void chd_file::decompress_v5_map()
 	}
 
 	// verify the final CRC
-	if (UNEXPECTED(util::crc16_creator::simple(&m_rawmap[0], m_hunkcount * 12) != mapcrc))
+	if (UNEXPECTED(util::crc16_creator::simple(m_rawmap.data(), m_hunkcount * 12) != mapcrc))
 		throw std::error_condition(error::DECOMPRESSION_ERROR);
 }
 
@@ -2643,7 +2643,7 @@ void chd_file::create_open_common()
 	}
 	else
 	{
-		std::error_condition err = file_read(m_mapoffset, &m_rawmap[0], m_rawmap.size());
+		std::error_condition err = file_read(m_mapoffset, m_rawmap.data(), m_rawmap.size());
 		if (UNEXPECTED(err))
 			throw err;
 	}
@@ -3002,7 +3002,7 @@ void chd_file_compressor::compress_begin()
 
 	// reset work item state
 	m_work_buffer.resize(hunk_bytes() * (WORK_BUFFER_HUNKS + 1));
-	memset(&m_work_buffer[0], 0, m_work_buffer.size());
+	memset(m_work_buffer.data(), 0, m_work_buffer.size());
 	m_compressed_buffer.resize(hunk_bytes() * WORK_BUFFER_HUNKS);
 	for (int itemnum = 0; itemnum < WORK_BUFFER_HUNKS; itemnum++)
 	{
@@ -3306,8 +3306,8 @@ void chd_file_compressor::async_read()
 	if ((m_read_done_offset + numbytes) > logical_bytes())
 		numbytes = logical_bytes() - m_read_done_offset;
 
-	uint8_t *const dest = &m_work_buffer[0] + (m_read_done_offset % work_buffer_bytes);
-	assert((&m_work_buffer[0] == dest) || (&m_work_buffer[work_buffer_bytes / 2] == dest));
+	uint8_t *const dest = m_work_buffer.data() + (m_read_done_offset % work_buffer_bytes);
+	assert((m_work_buffer.data() == dest) || (&m_work_buffer[work_buffer_bytes / 2] == dest));
 	assert(!(m_read_done_offset % hunk_bytes()));
 	uint64_t const end_offset = m_read_done_offset + numbytes;
 

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -1724,12 +1724,12 @@ util::sha1_t chd_file::compute_overall_sha1(util::sha1_t rawsha1)
 	// sort the array
 	if (!hasharray.empty())
 		std::sort(
-        hasharray.begin(),
-        hasharray.end(),
-        [] (metadata_hash const &a, metadata_hash const &b)
-        {
-            return memcmp(&a, &b, sizeof(metadata_hash)) < 0;
-        });
+				hasharray.begin(),
+				hasharray.end(),
+				[] (metadata_hash const &a, metadata_hash const &b)
+				{
+					return memcmp(&a, &b, sizeof(metadata_hash)) < 0;
+				});
 
 	// read the raw data hash from our header and start a new SHA1 with that data
 	util::sha1_creator overall_sha1;

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -20,6 +20,7 @@
 #include <zlib.h>
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstring>
@@ -247,23 +248,6 @@ inline uint64_t chd_file::file_append(const void *source, uint32_t length, uint3
 	if (UNEXPECTED(err))
 		throw err;
 	return offset;
-}
-
-
-//-------------------------------------------------
-//  bits_for_value - return the number of bits
-//  necessary to represent all numbers 0..value
-//-------------------------------------------------
-
-inline uint8_t chd_file::bits_for_value(uint64_t value) noexcept
-{
-	uint8_t result = 0;
-	while (value != 0)
-	{
-		value >>= 1;
-		result++;
-	}
-	return result;
 }
 
 
@@ -2163,9 +2147,9 @@ std::error_condition chd_file::compress_v5_map()
 		}
 
 		// determine the number of bits we need to hold the a length and a hunk index
-		const uint8_t lengthbits = bits_for_value(max_complen);
-		const uint8_t selfbits = bits_for_value(max_self);
-		const uint8_t parentbits = bits_for_value(max_parent);
+		const uint8_t lengthbits = std::bit_width(max_complen);
+		const uint8_t selfbits = std::bit_width(max_self);
+		const uint8_t parentbits = std::bit_width(max_parent);
 
 		// determine the needed size of the output buffer
 		// 16 bytes is required for the header

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <new>

--- a/src/lib/util/chd.h
+++ b/src/lib/util/chd.h
@@ -376,7 +376,6 @@ private:
 	std::error_condition file_read(uint64_t offset, void *dest, uint32_t length) const noexcept;
 	std::error_condition file_write(uint64_t offset, const void *source, uint32_t length) noexcept;
 	uint64_t file_append(const void *source, uint32_t length, uint32_t alignment = 0);
-	static uint8_t bits_for_value(uint64_t value) noexcept;
 
 	// internal helpers
 	uint32_t guess_unitbytes();

--- a/src/lib/util/chd.h
+++ b/src/lib/util/chd.h
@@ -349,7 +349,7 @@ public:
 	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::vector<uint8_t> &output, chd_metadata_tag &resulttag, uint8_t &resultflags);
 	std::error_condition write_metadata(chd_metadata_tag metatag, uint32_t metaindex, const void *inputbuf, uint32_t inputlen, uint8_t flags = CHD_MDFLAGS_CHECKSUM);
 	std::error_condition write_metadata(chd_metadata_tag metatag, uint32_t metaindex, const std::string &input, uint8_t flags = CHD_MDFLAGS_CHECKSUM) { return write_metadata(metatag, metaindex, input.c_str(), input.length() + 1, flags); }
-	std::error_condition write_metadata(chd_metadata_tag metatag, uint32_t metaindex, const std::vector<uint8_t> &input, uint8_t flags = CHD_MDFLAGS_CHECKSUM) { return write_metadata(metatag, metaindex, &input[0], input.size(), flags); }
+	std::error_condition write_metadata(chd_metadata_tag metatag, uint32_t metaindex, const std::vector<uint8_t> &input, uint8_t flags = CHD_MDFLAGS_CHECKSUM) { return write_metadata(metatag, metaindex, input.data(), input.size(), flags); }
 	std::error_condition delete_metadata(chd_metadata_tag metatag, uint32_t metaindex);
 	std::error_condition clone_all_metadata(chd_file &source);
 

--- a/src/lib/util/chd.h
+++ b/src/lib/util/chd.h
@@ -395,7 +395,6 @@ private:
 	std::error_condition metadata_find(chd_metadata_tag metatag, int32_t metaindex, metadata_entry &metaentry, bool resume = false) const noexcept;
 	std::error_condition metadata_set_previous_next(uint64_t prevoffset, uint64_t nextoffset) noexcept;
 	void metadata_update_hash();
-	static int CLIB_DECL metadata_hash_compare(const void *elem1, const void *elem2);
 
 	// file characteristics
 	util::random_read_write::ptr m_file;        // handle to the open core file


### PR DESCRIPTION
Replaces &container[0] with container.data() where a pointer to the start of a standard library container is required. Uses that refer to an offset within a container are left unchanged.

This makes the intent clearer and avoids indexing the first element just to obtain the underlying data pointer. No functional change intended.

AI assistance: GPT-5.6 Sol (OpenAI) was used to help identify applicable instances and review the changes. Grok 4.5 was used as an additional code review.