### PR TITLE
M68hc05 - SCCR1 and BAUD registers

### DIFF
--- a/src/devices/cpu/m6805/m68hc05.cpp
+++ b/src/devices/cpu/m6805/m68hc05.cpp
@@ -160,6 +160,7 @@ m68hc05_device::m68hc05_device(
 	, m_port_irq_state(false)
 	, m_irq_line_state(false)
 	, m_irq_latch(0)
+	, m_sccr1(0x00)
 	, m_tcmp_cb(*this)
 	, m_tcap_state(false)
 	, m_tcr(0x00)
@@ -411,6 +412,18 @@ u8 m68hc05_device::timer_r(offs_t offset)
 }
 
 
+u8 m68hc05_device::sccr1_r()
+{
+	return m_sccr1 & 0xd1;
+}
+
+void m68hc05_device::sccr1_w(u8 data)
+{
+	if (BIT(data, 4) && !BIT(m_sccr1, 4))
+		logerror("m68hc05: 9-bit SCI characters selected (SCCR1 M), not supported\n");
+	m_sccr1 = (m_sccr1 & 0x80) | (data & 0x51);
+}
+
 void m68hc05_device::coprst_w(u8 data)
 {
 	LOGCOP("write COPRST=%02x%s\n", data, ((0xaa == data) && (0x55 == m_coprst)) ? ", reset" : "");
@@ -477,6 +490,7 @@ void m68hc05_device::device_start()
 	save_item(NAME(m_trl_buf));
 	save_item(NAME(m_trl_latched));
 
+	save_item(NAME(m_sccr1));
 	// save COP watchdogs
 	save_item(NAME(m_pcop_cnt));
 	save_item(NAME(m_ncop_cnt));
@@ -496,6 +510,9 @@ void m68hc05_device::device_start()
 	m_tsr = 0x00;
 	m_icr = 0x0000;
 	m_ocr = 0x0000;
+
+	// SCI state unaffected by reset
+	m_sccr1 = 0x00;
 
 	// COP watchdog state unaffected by reset
 	m_pcop_cnt = 0;
@@ -696,6 +713,11 @@ void m68hc05_device::add_port_state(std::array<bool, PORT_COUNT> const &ddr)
 	}
 }
 
+void m68hc05_device::add_sci_state()
+{
+	state_add(M68HC05_SCCR1, "SCCR1", m_sccr1).mask(0xd1);
+}
+
 void m68hc05_device::add_timer_state()
 {
 	state_add(M68HC05_TCR, "TCR", m_tcr).mask(0x7f);
@@ -780,7 +802,7 @@ void m68hc05c4_device::c4_map(address_map &map)
 	// 0x000b SPSR
 	// 0x000c SPDR
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc05c4_device::sccr1_r), FUNC(m68hc05c4_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR
@@ -848,7 +870,7 @@ void m68hc05c8_device::c8_map(address_map &map)
 	// 0x000b SPSR
 	// 0x000c SPDR
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc05c8_device::sccr1_r), FUNC(m68hc05c8_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR
@@ -888,6 +910,7 @@ void m68hc05c8_device::device_start()
 
 	add_port_state(std::array<bool, PORT_COUNT>{{ true, true, true, false }});
 	add_timer_state();
+	add_sci_state();
 }
 
 
@@ -915,7 +938,7 @@ void m68hc705c4a_device::c4a_map(address_map &map)
 	// 0x000b SPSR
 	// 0x000c SPDR
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc705c4a_device::sccr1_r), FUNC(m68hc705c4a_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR
@@ -1009,7 +1032,7 @@ void m68hc705c8a_device::c8a_map(address_map &map)
 	// 0x000b SPSR
 	// 0x000c SPDR
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc705c8a_device::sccr1_r), FUNC(m68hc705c8a_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR
@@ -1204,7 +1227,7 @@ void m68hc05l9_device::l9_map(address_map &map)
 	// 0x000b minute alarm
 	// 0x000c hour alarm
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc05l9_device::sccr1_r), FUNC(m68hc05l9_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR
@@ -1277,7 +1300,7 @@ void m68hc05l11_device::l11_map(address_map &map)
 	// 0x000b minute alarm
 	// 0x000c hour alarm
 	// 0x000d BAUD
-	// 0x000e SCCR1
+	map(0x000e, 0x000e).rw(FUNC(m68hc05l11_device::sccr1_r), FUNC(m68hc05l11_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
 	// 0x0011 SCDR

--- a/src/devices/cpu/m6805/m68hc05.cpp
+++ b/src/devices/cpu/m6805/m68hc05.cpp
@@ -160,6 +160,7 @@ m68hc05_device::m68hc05_device(
 	, m_port_irq_state(false)
 	, m_irq_line_state(false)
 	, m_irq_latch(0)
+	, m_baud(0x00)
 	, m_sccr1(0x00)
 	, m_tcmp_cb(*this)
 	, m_tcap_state(false)
@@ -412,6 +413,16 @@ u8 m68hc05_device::timer_r(offs_t offset)
 }
 
 
+u8 m68hc05_device::baud_r()
+{
+	return m_baud & 0x37;
+}
+
+void m68hc05_device::baud_w(u8 data)
+{
+	m_baud = data & 0x37;
+}
+
 u8 m68hc05_device::sccr1_r()
 {
 	return m_sccr1 & 0xd1;
@@ -490,6 +501,7 @@ void m68hc05_device::device_start()
 	save_item(NAME(m_trl_buf));
 	save_item(NAME(m_trl_latched));
 
+	save_item(NAME(m_baud));
 	save_item(NAME(m_sccr1));
 	// save COP watchdogs
 	save_item(NAME(m_pcop_cnt));
@@ -532,6 +544,9 @@ void m68hc05_device::device_reset()
 	std::fill(std::begin(m_port_ddr), std::end(m_port_ddr), 0x00);
 	m_irq_latch = 0;
 	update_port_irq();
+
+	// SCI reset
+	m_baud &= 0x07;
 
 	// timer reset
 	m_tcr &= 0x02;
@@ -715,6 +730,7 @@ void m68hc05_device::add_port_state(std::array<bool, PORT_COUNT> const &ddr)
 
 void m68hc05_device::add_sci_state()
 {
+	state_add(M68HC05_BAUD, "BAUD", m_baud).mask(0x37);
 	state_add(M68HC05_SCCR1, "SCCR1", m_sccr1).mask(0xd1);
 }
 
@@ -801,7 +817,7 @@ void m68hc05c4_device::c4_map(address_map &map)
 	// 0x000a SPCR
 	// 0x000b SPSR
 	// 0x000c SPDR
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc05c4_device::baud_r), FUNC(m68hc05c4_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc05c4_device::sccr1_r), FUNC(m68hc05c4_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
@@ -869,7 +885,7 @@ void m68hc05c8_device::c8_map(address_map &map)
 	// 0x000a SPCR
 	// 0x000b SPSR
 	// 0x000c SPDR
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc05c8_device::baud_r), FUNC(m68hc05c8_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc05c8_device::sccr1_r), FUNC(m68hc05c8_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
@@ -937,7 +953,7 @@ void m68hc705c4a_device::c4a_map(address_map &map)
 	// 0x000a SPCR
 	// 0x000b SPSR
 	// 0x000c SPDR
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc705c4a_device::baud_r), FUNC(m68hc705c4a_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc705c4a_device::sccr1_r), FUNC(m68hc705c4a_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
@@ -1031,7 +1047,7 @@ void m68hc705c8a_device::c8a_map(address_map &map)
 	// 0x000a SPCR
 	// 0x000b SPSR
 	// 0x000c SPDR
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc705c8a_device::baud_r), FUNC(m68hc705c8a_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc705c8a_device::sccr1_r), FUNC(m68hc705c8a_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
@@ -1226,7 +1242,7 @@ void m68hc05l9_device::l9_map(address_map &map)
 	// 0x0009-0x000a configuration
 	// 0x000b minute alarm
 	// 0x000c hour alarm
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc05l9_device::baud_r), FUNC(m68hc05l9_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc05l9_device::sccr1_r), FUNC(m68hc05l9_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR
@@ -1299,7 +1315,7 @@ void m68hc05l11_device::l11_map(address_map &map)
 	// 0x000a port F direction
 	// 0x000b minute alarm
 	// 0x000c hour alarm
-	// 0x000d BAUD
+	map(0x000d, 0x000d).rw(FUNC(m68hc05l11_device::baud_r), FUNC(m68hc05l11_device::baud_w));
 	map(0x000e, 0x000e).rw(FUNC(m68hc05l11_device::sccr1_r), FUNC(m68hc05l11_device::sccr1_w));
 	// 0x000f SCCR2
 	// 0x0010 SCSR

--- a/src/devices/cpu/m6805/m68hc05.h
+++ b/src/devices/cpu/m6805/m68hc05.h
@@ -72,6 +72,7 @@ protected:
 		M68HC05_PS,
 		M68HC05_TR,
 
+		M68HC05_BAUD,
 		M68HC05_SCCR1,
 
 		M68HC05_COPRST,
@@ -110,6 +111,8 @@ protected:
 	void ocr_w(offs_t offset, u8 data);
 	u8 timer_r(offs_t offset);
 
+	u8 baud_r();
+	void baud_w(u8 data);
 	u8 sccr1_r();
 	void sccr1_w(u8 data);
 	void set_ncope(bool state) { m_ncope = state ? 1 : 0; }
@@ -168,6 +171,7 @@ private:
 	u8                  m_irq_latch;
 
 	// serial communications interface
+	u8                  m_baud;
 	u8                  m_sccr1;
 	// timer/counter
 	devcb_write_line    m_tcmp_cb;

--- a/src/devices/cpu/m6805/m68hc05.h
+++ b/src/devices/cpu/m6805/m68hc05.h
@@ -72,6 +72,8 @@ protected:
 		M68HC05_PS,
 		M68HC05_TR,
 
+		M68HC05_SCCR1,
+
 		M68HC05_COPRST,
 		M68HC05_COPCR,
 		M68HC05_PCOP,
@@ -108,6 +110,8 @@ protected:
 	void ocr_w(offs_t offset, u8 data);
 	u8 timer_r(offs_t offset);
 
+	u8 sccr1_r();
+	void sccr1_w(u8 data);
 	void set_ncope(bool state) { m_ncope = state ? 1 : 0; }
 	void coprst_w(u8 data);
 	u8 copcr_r();
@@ -129,6 +133,7 @@ protected:
 
 	void add_port_state(std::array<bool, PORT_COUNT> const &ddr);
 	void add_timer_state();
+	void add_sci_state();
 	void add_pcop_state();
 	void add_ncop_state();
 
@@ -162,6 +167,8 @@ private:
 	bool                m_port_irq_state, m_irq_line_state;
 	u8                  m_irq_latch;
 
+	// serial communications interface
+	u8                  m_sccr1;
 	// timer/counter
 	devcb_write_line    m_tcmp_cb;
 	bool                m_tcap_state;


### PR DESCRIPTION
Adds the SCCR1 and BAUD r/w.

This relatively small change is to validate approach for adding additional features to this chipset. This is required for LLE for the CD-i.

Edit: Reference for behavior is `M68HC05 Microcontrollers / D Rev. 5, 4 / 2002`