### PR TITLE
avoid unnecessary `c_str()` calls

### DIFF
--- a/makefile
+++ b/makefile
@@ -1603,6 +1603,7 @@ doxygen:
 .PHONY: cppcheck
 
 CPPCHECK_PARAMS  = -Isrc/osd
+CPPCHECK_PARAMS += -Isrc/devices
 CPPCHECK_PARAMS += -Isrc/emu
 CPPCHECK_PARAMS += -Isrc/lib
 CPPCHECK_PARAMS += -Isrc/lib/util

--- a/makefile
+++ b/makefile
@@ -1633,6 +1633,8 @@ CPPCHECK_PARAMS += -DLUA_COMPAT_APIINTCASTS
 CPPCHECK_PARAMS += -DWIN32
 CPPCHECK_PARAMS += -D__GNUC__
 CPPCHECK_PARAMS += -D__x86_64__
+CPPCHECK_PARAMS += --suppress=missingIncludeSystem
+CPPCHECK_PARAMS += --suppress=normalCheckLevelMaxBranches
 ifndef VERBOSE
 CPPCHECK_PARAMS += --quiet
 endif

--- a/src/devices/bus/a2bus/a2corvus.cpp
+++ b/src/devices/bus/a2bus/a2corvus.cpp
@@ -111,7 +111,7 @@ a2bus_corvus_device::a2bus_corvus_device(const machine_config &mconfig, const ch
 
 void a2bus_corvus_device::device_start()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(CORVUS_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(CORVUS_ROM_REGION))->base();
 }
 
 void a2bus_corvus_device::device_reset()

--- a/src/devices/bus/a2bus/a2diskiing.cpp
+++ b/src/devices/bus/a2bus/a2diskiing.cpp
@@ -174,7 +174,7 @@ a2bus_agat9flop_device::a2bus_agat9flop_device(const machine_config &mconfig, co
 
 void diskiing_device::device_start()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(DISKII_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(DISKII_ROM_REGION))->base();
 }
 
 void diskiing_device::device_reset()

--- a/src/devices/bus/a2bus/a2iwm.cpp
+++ b/src/devices/bus/a2bus/a2iwm.cpp
@@ -88,7 +88,7 @@ void a2bus_iwm_device::device_start()
 void a2bus_iwm_card_device::device_start()
 {
 	a2bus_iwm_device::device_start();
-	m_rom = device().machine().root_device().memregion(this->subtag(DISKII_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(DISKII_ROM_REGION))->base();
 }
 
 void a2bus_iwm_device::device_reset()

--- a/src/devices/bus/a2bus/agat840k_hle.cpp
+++ b/src/devices/bus/a2bus/agat840k_hle.cpp
@@ -135,7 +135,7 @@ void a2bus_agat840k_hle_device::index_callback(int unit, int state)
 
 void a2bus_agat840k_hle_device::device_start()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(AGAT840K_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(AGAT840K_ROM_REGION))->base();
 
 	m_mxcs = MXCSR_SYNC;
 

--- a/src/devices/bus/a2bus/agat_fdc.cpp
+++ b/src/devices/bus/a2bus/agat_fdc.cpp
@@ -132,8 +132,8 @@ void a2bus_agat_fdc_device::device_start()
 {
 	set_unscaled_clock((XTAL(14'300'000) / 14.0) * 4.0);
 
-	m_rom = device().machine().root_device().memregion(this->subtag(AGAT_FDC_ROM_REGION).c_str())->base();
-	m_rom_d6 = device().machine().root_device().memregion(this->subtag(AGAT_FDC_ROM_D6_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(AGAT_FDC_ROM_REGION))->base();
+	m_rom_d6 = device().machine().root_device().memregion(this->subtag(AGAT_FDC_ROM_D6_REGION))->base();
 
 	floppy = nullptr;
 	if (floppy0)

--- a/src/devices/bus/a2bus/corvfdc01.cpp
+++ b/src/devices/bus/a2bus/corvfdc01.cpp
@@ -126,7 +126,7 @@ a2bus_corvfdc01_device::a2bus_corvfdc01_device(const machine_config &mconfig, co
 
 void a2bus_corvfdc01_device::device_start()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(FDC01_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(FDC01_ROM_REGION))->base();
 
 	save_item(NAME(m_fdc_local_status));
 	save_item(NAME(m_fdc_local_command));

--- a/src/devices/bus/a2bus/corvfdc02.cpp
+++ b/src/devices/bus/a2bus/corvfdc02.cpp
@@ -99,7 +99,7 @@ a2bus_corvfdc02_device::a2bus_corvfdc02_device(const machine_config &mconfig, co
 
 void a2bus_corvfdc02_device::device_start()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(FDC02_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(FDC02_ROM_REGION))->base();
 
 	m_timer = timer_alloc(FUNC(a2bus_corvfdc02_device::tc_tick), this);
 

--- a/src/devices/bus/hp_dio/hp98603a.cpp
+++ b/src/devices/bus/hp_dio/hp98603a.cpp
@@ -88,7 +88,7 @@ void dio16_98603a_device::device_start()
 
 void dio16_98603a_device::device_reset()
 {
-	m_rom = device().machine().root_device().memregion(this->subtag(HP98603A_ROM_REGION).c_str())->base();
+	m_rom = device().machine().root_device().memregion(this->subtag(HP98603A_ROM_REGION))->base();
 	dio().install_memory(0x80000, 0xfffff,
 			read16sm_delegate(*this, FUNC(dio16_98603a_device::rom_r)),
 			write16sm_delegate(*this, FUNC(dio16_98603a_device::rom_w)));

--- a/src/devices/bus/hp_dio/hp98603b.cpp
+++ b/src/devices/bus/hp_dio/hp98603b.cpp
@@ -83,7 +83,7 @@ void dio16_98603b_device::device_start()
 
 void dio16_98603b_device::device_reset()
 {
-		m_rom = device().machine().root_device().memregion(this->subtag(HP98603B_ROM_REGION).c_str())->base();
+		m_rom = device().machine().root_device().memregion(this->subtag(HP98603B_ROM_REGION))->base();
 		dio().install_memory(0x100000, 0x1fffff,
 				read16sm_delegate(*this, FUNC(dio16_98603b_device::rom_r)),
 				write16sm_delegate(*this, FUNC(dio16_98603b_device::rom_w)));

--- a/src/devices/bus/intv/ecs.cpp
+++ b/src/devices/bus/intv/ecs.cpp
@@ -49,7 +49,7 @@ void intv_ecs_device::device_start()
 	if (m_rom == nullptr)
 	{
 		std::string region_tag;
-		m_rom = memregion(region_tag.assign(tag()).append(":ecs").c_str())->base();
+		m_rom = memregion(region_tag.assign(tag()).append(":ecs"))->base();
 	}
 	if (m_ram.empty())
 	{

--- a/src/devices/bus/isa/cga.cpp
+++ b/src/devices/bus/isa/cga.cpp
@@ -358,7 +358,7 @@ void isa8_cga_device::device_start()
 		}
 	}
 
-	m_chr_gen_base = memregion(subtag("gfx1").c_str())->base();
+	m_chr_gen_base = memregion(subtag("gfx1"))->base();
 	m_chr_gen = m_chr_gen_base + m_chr_gen_offset[1];
 
 	save_item(NAME(m_framecnt));

--- a/src/devices/bus/isa/ega.cpp
+++ b/src/devices/bus/isa/ega.cpp
@@ -613,8 +613,8 @@ void isa8_ega_device::device_start()
 
 	if(m_default_bios_tag != "iskr3104")
 	{
-		uint8_t   *dst = memregion(subtag("user2").c_str())->base() + 0x0000;
-		uint8_t   *src = memregion(subtag("user1").c_str())->base() + 0x3fff;
+		uint8_t   *dst = memregion(subtag("user2"))->base() + 0x0000;
+		uint8_t   *src = memregion(subtag("user1"))->base() + 0x3fff;
 		int     i;
 
 		/* Perform the EGA bios address line swaps */
@@ -624,7 +624,7 @@ void isa8_ega_device::device_start()
 		}
 	}
 	else
-		memcpy(memregion(subtag("user2").c_str())->base(), memregion(subtag("user1").c_str())->base(), 0x4000);
+		memcpy(memregion(subtag("user2"))->base(), memregion(subtag("user1"))->base(), 0x4000);
 
 	/* Install 256KB Video ram on our EGA card */
 	m_vram = make_unique_clear<uint8_t[]>(256 * 1024);

--- a/src/devices/bus/isa/isa.cpp
+++ b/src/devices/bus/isa/isa.cpp
@@ -364,7 +364,7 @@ void isa8_device::install_rom(device_t *dev, offs_t start, offs_t end, const cha
 		uint8_t *dest = machine().root_device().memregion("isa")->base() + start - 0xc0000;
 		memcpy(dest,src, end - start + 1);
 	} else {
-		m_memspace->install_rom(start, end, machine().root_device().memregion(dev->subtag(region).c_str())->base());
+		m_memspace->install_rom(start, end, machine().root_device().memregion(dev->subtag(region))->base());
 		m_memspace->unmap_write(start, end);
 	}
 }

--- a/src/devices/bus/macpds/macpds.cpp
+++ b/src/devices/bus/macpds/macpds.cpp
@@ -166,8 +166,8 @@ void device_macpds_card_interface::install_bank(offs_t start, offs_t end, uint8_
 
 void device_macpds_card_interface::install_rom(device_t *dev, const char *romregion, uint32_t addr)
 {
-	uint8_t *rom = device().machine().root_device().memregion(dev->subtag(romregion).c_str())->base();
-	uint32_t romlen = device().machine().root_device().memregion(dev->subtag(romregion).c_str())->bytes();
+	uint8_t *rom = device().machine().root_device().memregion(dev->subtag(romregion))->base();
+	uint32_t romlen = device().machine().root_device().memregion(dev->subtag(romregion))->bytes();
 
 	m_macpds->install_bank(addr, addr+romlen-1, rom);
 }

--- a/src/devices/imagedev/diablo.cpp
+++ b/src/devices/imagedev/diablo.cpp
@@ -206,7 +206,7 @@ std::error_condition diablo_image_device::internal_load_dsk()
 	// open the CHD file
 	if (loaded_through_softlist())
 	{
-		m_chd = device().machine().rom_load().get_disk_handle(device().subtag("harddriv").c_str());
+		m_chd = device().machine().rom_load().get_disk_handle(device().subtag("harddriv"));
 	}
 	else
 	{

--- a/src/devices/imagedev/harddriv.cpp
+++ b/src/devices/imagedev/harddriv.cpp
@@ -247,7 +247,7 @@ std::error_condition harddisk_image_device::internal_load_hd()
 	// open the CHD file
 	if (loaded_through_softlist())
 	{
-		m_chd = machine().rom_load().get_disk_handle(device().subtag("harddriv").c_str());
+		m_chd = machine().rom_load().get_disk_handle(device().subtag("harddriv"));
 	}
 	else
 	{

--- a/src/devices/imagedev/mfmhd.cpp
+++ b/src/devices/imagedev/mfmhd.cpp
@@ -420,7 +420,7 @@ std::pair<std::error_condition, std::string> mfm_harddisk_device::call_load()
 	/* open the CHD file */
 	if (loaded_through_softlist())
 	{
-		m_chd = machine().rom_load().get_disk_handle(device().subtag("harddriv").c_str());
+		m_chd = machine().rom_load().get_disk_handle(device().subtag("harddriv"));
 	}
 	else
 	{

--- a/src/devices/machine/wozfdc.cpp
+++ b/src/devices/machine/wozfdc.cpp
@@ -78,7 +78,7 @@ appleiii_fdc_device::appleiii_fdc_device(const machine_config &mconfig, const ch
 
 void wozfdc_device::device_start()
 {
-	m_rom_p6 = machine().root_device().memregion(this->subtag(DISKII_P6_REGION).c_str())->base();
+	m_rom_p6 = machine().root_device().memregion(this->subtag(DISKII_P6_REGION))->base();
 
 	timer = timer_alloc(FUNC(wozfdc_device::generic_tick), this);
 	delay_timer = timer_alloc(FUNC(wozfdc_device::delayed_tick), this);

--- a/src/devices/sound/disc_inp.hxx
+++ b/src/devices/sound/disc_inp.hxx
@@ -64,7 +64,7 @@ DISCRETE_RESET(dss_adjustment)
 {
 	double min, max;
 
-	m_port = m_device->machine().root_device().ioport(m_device->siblingtag((const char *)this->custom_data()).c_str());
+	m_port = m_device->machine().root_device().ioport(m_device->siblingtag((const char *)this->custom_data()));
 	if (m_port == nullptr)
 		fatalerror("DISCRETE_ADJUSTMENT - NODE_%d has invalid tag\n", this->index());
 

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -767,7 +767,7 @@ void emu_options::reevaluate_default_card_software()
 				// values representing cartridge types and such
 				if (default_card_software.empty())
 				{
-					auto *opt = slot.option(slot_opt.default_card_software().c_str());
+					auto *opt = slot.option(slot_opt.default_card_software());
 					if (opt && opt->selectable())
 						continue;
 				}
@@ -986,11 +986,11 @@ emu_options::software_options emu_options::evaluate_initial_softlist_options(con
 								std::string slot_name = fi.name().substr(0, fi.name().size() - default_suffix.size());
 
 								// only add defaults if they exist in this configuration
-								device_t *device = config.root_device().subdevice(slot_name.c_str());
+								device_t *device = config.root_device().subdevice(slot_name);
 								if (device)
 								{
 									device_slot_interface *intf;
-									if (device->interface(intf) && intf->option(fi.value().c_str()))
+									if (device->interface(intf) && intf->option(fi.value()))
 										results.slot_defaults[slot_name] = fi.value();
 								}
 							}

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -300,7 +300,7 @@ bool image_manager::try_change_working_directory(std::string &working_directory,
 		bool done = false;
 		while (!done && (entry = directory->read()) != nullptr)
 		{
-			if (!core_stricmp(subdir.c_str(), entry->name))
+			if (!core_stricmp(subdir, entry->name))
 			{
 				done = true;
 				success = entry->type == osd::directory::entry::entry_type::DIR;

--- a/src/mame/acorn/bbc_m.cpp
+++ b/src/mame/acorn/bbc_m.cpp
@@ -207,7 +207,7 @@ void bbc_state::insert_device_rom(memory_region *rom)
 	for (int bank = 15; bank >= 0; bank--)
 	{
 		// if bank has socket and is empty
-		if (m_rom[bank] && !memregion(region_tag.assign(m_rom[bank]->tag()).append(BBC_ROM_REGION_TAG).c_str()))
+		if (m_rom[bank] && !memregion(region_tag.assign(m_rom[bank]->tag()).append(BBC_ROM_REGION_TAG)))
 		{
 			uint8_t *swr = m_region_rom->base() + (bank * 0x4000);
 			switch (rom->bytes())
@@ -264,7 +264,7 @@ void bbc_state::setup_device_roms()
 	// configure romslots
 	for (int i = 0; i < 16; i++)
 	{
-		if (m_rom[i] && (rom_region = memregion(region_tag.assign(m_rom[i]->tag()).append(BBC_ROM_REGION_TAG).c_str())))
+		if (m_rom[i] && (rom_region = memregion(region_tag.assign(m_rom[i]->tag()).append(BBC_ROM_REGION_TAG))))
 		{
 			if (m_rom[i]->get_rom_size())
 				memcpy(m_region_rom->base() + (i * 0x4000), rom_region->base(), std::min((int32_t)m_rom[i]->get_slot_size(), (int32_t)m_rom[i]->get_rom_size()));
@@ -276,7 +276,7 @@ void bbc_state::setup_device_roms()
 	// configure cartslots
 	for (int i = 0; i < 2; i++)
 	{
-		if (m_cart[i] && (rom_region = memregion(region_tag.assign(m_cart[i]->tag()).append(ELECTRON_CART_ROM_REGION_TAG).c_str())))
+		if (m_cart[i] && (rom_region = memregion(region_tag.assign(m_cart[i]->tag()).append(ELECTRON_CART_ROM_REGION_TAG))))
 		{
 			memcpy(m_region_rom->base() + (i * 0x8000), rom_region->base(), rom_region->bytes());
 		}

--- a/src/mame/amstrad/amstrad_m.cpp
+++ b/src/mame/amstrad/amstrad_m.cpp
@@ -2997,7 +2997,7 @@ MACHINE_START_MEMBER(amstrad_state,plus)
 	m_centronics->write_data7(0);
 
 	std::string region_tag;
-	m_region_cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_region_cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (!m_region_cart) // this should never happen, since we make carts mandatory!
 	{
 		m_region_cart = memregion("maincpu");
@@ -3044,7 +3044,7 @@ MACHINE_START_MEMBER(amstrad_state,gx4000)
 	m_system_type = SYSTEM_GX4000;
 
 	std::string region_tag;
-	m_region_cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_region_cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (!m_region_cart) // this should never happen, since we make carts mandatory!
 		m_region_cart = memregion("maincpu");
 }

--- a/src/mame/bandai/design_master.cpp
+++ b/src/mame/bandai/design_master.cpp
@@ -87,7 +87,7 @@ void bdsm_state::machine_start()
 	if (m_cartslot && m_cartslot->exists())
 	{
 		std::string region_tag;
-		m_cartslot_region = memregion(region_tag.assign(m_cartslot->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cartslot_region = memregion(region_tag.assign(m_cartslot->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cartslot_region->bytes() / 0x8000), m_cartslot_region->base(), 0x8000);
 
 		// Only the first bank seems to contain a valid reset vector '0x50' which points at the first code in the ROM.

--- a/src/mame/casio/pb1000.cpp
+++ b/src/mame/casio/pb1000.cpp
@@ -453,9 +453,9 @@ void pb1000_state::machine_start()
 	std::string region_tag;
 	m_rom_reg = memregion("rom");
 	if (m_card1)
-		m_card1_reg = memregion(region_tag.assign(m_card1->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_card1_reg = memregion(region_tag.assign(m_card1->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (m_card2)
-		m_card2_reg = memregion(region_tag.assign(m_card2->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_card2_reg = memregion(region_tag.assign(m_card2->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	membank("bank1")->set_base(m_rom_reg->base());
 

--- a/src/mame/casio/pv1000.cpp
+++ b/src/mame/casio/pv1000.cpp
@@ -501,7 +501,7 @@ void pv1000_state::machine_start()
 
 		// FIXME: this is needed for gfx decoding, but there is probably a cleaner solution!
 		std::string region_tag;
-		memcpy(memregion("gfxrom")->base(), memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str())->base(), m_cart->get_rom_size());
+		memcpy(memregion("gfxrom")->base(), memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG))->base(), m_cart->get_rom_size());
 	}
 
 	save_item(NAME(m_io_regs));

--- a/src/mame/dataeast/decrmc3.cpp
+++ b/src/mame/dataeast/decrmc3.cpp
@@ -166,7 +166,7 @@ void deco_rmc3_device::device_start()
 	{
 		// find the extended (split) memory, if present
 		std::string tag_ext = std::string(tag()).append("_ext");
-		const memory_share *share_ext = memshare(tag_ext.c_str());
+		const memory_share *share_ext = memshare(tag_ext);
 
 		// determine bytes per entry and configure
 		int bytes_per_entry = 2;

--- a/src/mame/handheld/gameking.cpp
+++ b/src/mame/handheld/gameking.cpp
@@ -268,7 +268,7 @@ DEVICE_IMAGE_LOAD_MEMBER(gameking_state::cart_load)
 void gameking_state::machine_start()
 {
 	std::string region_tag;
-	memory_region *cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	memory_region *cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (cart_rom)
 		m_maincpu->space(AS_DATA).install_rom(0x400000, 0x400000 + cart_rom->bytes() - 1, cart_rom->base()); // FIXME: gamekin3 wants Flash cartridges, not plain ROM
 

--- a/src/mame/koei/pasogo.cpp
+++ b/src/mame/koei/pasogo.cpp
@@ -536,7 +536,7 @@ void pasogo_state::machine_reset()
 {
 	std::string region_tag;
 	ioport_port *color = ioport("COLOR");
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (!m_cart_rom) // even with mandatory carts, debug will crash without anything at the boot vector
 		m_cart_rom = memregion("empty");
 

--- a/src/mame/kyocera/kyocera.cpp
+++ b/src/mame/kyocera/kyocera.cpp
@@ -1149,7 +1149,7 @@ void kc85_state::machine_start()
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 
 	std::string region_tag;
-	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	/* initialize RTC */
 	m_rtc->cs_w(1);
@@ -1192,7 +1192,7 @@ void pc8201_state::machine_start()
 	uint8_t *ram = m_ram->pointer();
 
 	std::string region_tag;
-	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	/* initialize RTC */
 	m_rtc->cs_w(1);
@@ -1228,7 +1228,7 @@ void trsm100_state::machine_start()
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 
 	std::string region_tag;
-	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_opt_region = memregion(region_tag.assign(m_opt_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	/* initialize RTC */
 	m_rtc->cs_w(1);

--- a/src/mame/leapfrog/leapster.cpp
+++ b/src/mame/leapfrog/leapster.cpp
@@ -434,7 +434,7 @@ DEVICE_IMAGE_LOAD_MEMBER( leapster_state::cart_load )
 void leapster_state::machine_start()
 {
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	if (m_cart_rom)
 	{

--- a/src/mame/microkey/primo_m.cpp
+++ b/src/mame/microkey/primo_m.cpp
@@ -214,8 +214,8 @@ void primo_state::machine_start()
 	save_item(NAME(m_nmi));
 
 	std::string region_tag;
-	m_cart1_rom = memregion(region_tag.assign(m_cart1->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
-	m_cart2_rom = memregion(region_tag.assign(m_cart2->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart1_rom = memregion(region_tag.assign(m_cart1->tag()).append(GENERIC_ROM_REGION_TAG));
+	m_cart2_rom = memregion(region_tag.assign(m_cart2->tag()).append(GENERIC_ROM_REGION_TAG));
 }
 
 void primo_state::machine_reset()

--- a/src/mame/nec/pc8401a.cpp
+++ b/src/mame/nec/pc8401a.cpp
@@ -783,7 +783,7 @@ INPUT_PORTS_END
 void pc8401a_state::machine_start()
 {
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	/* initialize RTC */
 	m_rtc->cs_w(1);

--- a/src/mame/olivetti/m24_z8000.cpp
+++ b/src/mame/olivetti/m24_z8000.cpp
@@ -100,7 +100,7 @@ uint16_t m24_z8000_device::pmem_r(offs_t offset, uint16_t mem_mask)
 {
 	offset <<= 1;
 	if(!m_z8000_mem)
-		return memregion(subtag("z8000").c_str())->as_u16(offset >> 1);
+		return memregion(subtag("z8000"))->as_u16(offset >> 1);
 
 	uint8_t hostseg = pmem_table[(offset >> 16) & 0xf][(offset >> 14) & 3];
 	if(hostseg == 255)

--- a/src/mame/pitronics/beta.cpp
+++ b/src/mame/pitronics/beta.cpp
@@ -327,7 +327,7 @@ void beta_state::machine_start()
 	else
 	{
 		std::string region_tag;
-		memcpy(&m_eprom_rom[0], memregion(region_tag.assign(m_eprom->tag()).append(GENERIC_ROM_REGION_TAG).c_str())->base(), 0x800);
+		memcpy(&m_eprom_rom[0], memregion(region_tag.assign(m_eprom->tag()).append(GENERIC_ROM_REGION_TAG))->base(), 0x800);
 	}
 
 	// state saving

--- a/src/mame/sinclair/timex.cpp
+++ b/src/mame/sinclair/timex.cpp
@@ -551,7 +551,7 @@ void ts2068_state::machine_reset()
 	m_port_f4_data = 0;
 
 	std::string region_tag;
-	m_dock_crt = memregion(region_tag.assign(m_dock->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_dock_crt = memregion(region_tag.assign(m_dock->tag()).append(GENERIC_ROM_REGION_TAG));
 	m_dock_cart_type = m_dock_crt ? TIMEX_CART_DOCK : TIMEX_CART_NONE;
 
 	ts2068_update_memory();

--- a/src/mame/skeleton/c2color.cpp
+++ b/src/mame/skeleton/c2color.cpp
@@ -90,7 +90,7 @@ void c2_color_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	}
 }
 

--- a/src/mame/snk/ngp.cpp
+++ b/src/mame/snk/ngp.cpp
@@ -660,7 +660,7 @@ void ngp_state::machine_start()
 	if (m_cart->exists())
 	{
 		std::string region_tag;
-		uint8_t *cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str())->base();
+		uint8_t *cart = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG))->base();
 
 		m_maincpu->space(AS_PROGRAM).install_rom(0x200000, 0x3fffff, cart);
 		m_maincpu->space(AS_PROGRAM).install_rom(0x800000, 0x9fffff, cart + 0x200000);

--- a/src/mame/sony/pockstat.cpp
+++ b/src/mame/sony/pockstat.cpp
@@ -893,7 +893,7 @@ void pockstat_state::machine_start()
 	m_rtc_regs.timer->adjust(attotime::from_hz(1), TIMER_COUNT);
 
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	save_item(NAME(m_ftlb_regs.control));
 	save_item(NAME(m_ftlb_regs.stat));

--- a/src/mame/svision/svision.cpp
+++ b/src/mame/svision/svision.cpp
@@ -634,7 +634,7 @@ void svision_state::machine_start()
 
 	std::string region_tag(m_cart->tag());
 	region_tag.append(GENERIC_ROM_REGION_TAG);
-	m_cart_rom = memregion(region_tag.c_str());
+	m_cart_rom = memregion(region_tag);
 
 	if (m_cart_rom)
 	{

--- a/src/mame/ti/cc40.cpp
+++ b/src/mame/ti/cc40.cpp
@@ -216,7 +216,7 @@ void cc40_state::machine_start()
 {
 	// init
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	m_sysbank->configure_entries(0, 4, memregion("system")->base(), 0x2000);
 	if (m_cart_rom)

--- a/src/mame/tiger/gamecom_m.cpp
+++ b/src/mame/tiger/gamecom_m.cpp
@@ -70,8 +70,8 @@ void gamecom_state::machine_reset()
 	m_sound1_cnt = 0x40;
 
 	std::string region_tag;
-	m_cart1_rom = memregion(region_tag.assign(m_cart1->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
-	m_cart2_rom = memregion(region_tag.assign(m_cart2->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart1_rom = memregion(region_tag.assign(m_cart1->tag()).append(GENERIC_ROM_REGION_TAG));
+	m_cart2_rom = memregion(region_tag.assign(m_cart2->tag()).append(GENERIC_ROM_REGION_TAG));
 }
 
 void gamecom_state::gamecom_set_mmu(uint8_t mmu, uint8_t data)

--- a/src/mame/tvgames/pubint_storyreader.cpp
+++ b/src/mame/tvgames/pubint_storyreader.cpp
@@ -108,7 +108,7 @@ void pi_storyreader_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	}
 }
 

--- a/src/mame/tvgames/spg2xx.cpp
+++ b/src/mame/tvgames/spg2xx.cpp
@@ -2651,7 +2651,7 @@ void spg2xx_game_smartcycle_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_ican.cpp
+++ b/src/mame/tvgames/spg2xx_ican.cpp
@@ -413,7 +413,7 @@ void icanguit_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_jakks_gkr.cpp
+++ b/src/mame/tvgames/spg2xx_jakks_gkr.cpp
@@ -436,7 +436,7 @@ void jakks_gkr_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(JAKKSSLOT_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(JAKKSSLOT_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_smarttv.cpp
+++ b/src/mame/tvgames/spg2xx_smarttv.cpp
@@ -179,7 +179,7 @@ void smarttv_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_telestory.cpp
+++ b/src/mame/tvgames/spg2xx_telestory.cpp
@@ -243,7 +243,7 @@ void telestory_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_tvgogo.cpp
+++ b/src/mame/tvgames/spg2xx_tvgogo.cpp
@@ -195,7 +195,7 @@ void tvgogo_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/tvgames/spg2xx_vii.cpp
+++ b/src/mame/tvgames/spg2xx_vii.cpp
@@ -82,7 +82,7 @@ void vii_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 		m_bank->configure_entries(0, (m_cart_region->bytes() + 0x7fffff) / 0x800000, m_cart_region->base(), 0x800000);
 		m_bank->set_entry(0);
 	}

--- a/src/mame/videoton/tvc.cpp
+++ b/src/mame/videoton/tvc.cpp
@@ -593,7 +593,7 @@ void tvc_state::machine_start()
 	m_vram_bank = 0;
 
 	std::string region_tag;
-	memory_region *cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	memory_region *cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	if (cart_rom != nullptr)
 	{
 		m_bank1->space(0).install_rom(0x4000, 0x7fff, cart_rom->base());

--- a/src/mame/vtech/clickstart.cpp
+++ b/src/mame/vtech/clickstart.cpp
@@ -157,7 +157,7 @@ void clickstart_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	}
 
 	save_item(NAME(m_mouse_x));

--- a/src/mame/vtech/prestige.cpp
+++ b/src/mame/vtech/prestige.cpp
@@ -675,7 +675,7 @@ void prestige_state::machine_start()
 	m_rom_bank_mask = m_num_rom_entries - 1;
 
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 
 	uint8_t *rom = memregion("maincpu")->base();
 	uint8_t *cart = nullptr;

--- a/src/mame/vtech/socrates.cpp
+++ b/src/mame/vtech/socrates.cpp
@@ -366,7 +366,7 @@ void socrates_state::machine_start()
 
 void socrates_state::machine_reset()
 {
-	m_cart_reg = m_cart ? memregion(util::string_format("%s%s", m_cart->tag(), GENERIC_ROM_REGION_TAG).c_str()) : nullptr;
+	m_cart_reg = m_cart ? memregion(util::string_format("%s%s", m_cart->tag(), GENERIC_ROM_REGION_TAG)) : nullptr;
 	kbmcu_sim_reset();
 	m_kb_spi_request = true;
 	m_oldkeyvalue = 0;

--- a/src/mame/vtech/storio.cpp
+++ b/src/mame/vtech/storio.cpp
@@ -76,7 +76,7 @@ void vtech_storio_state::machine_start()
 	if (m_cart && m_cart->exists())
 	{
 		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 	}
 }
 

--- a/src/mame/vtech/vtech2_m.cpp
+++ b/src/mame/vtech/vtech2_m.cpp
@@ -43,7 +43,7 @@ void vtech2_state::init_laser()
 
 	// check ROM expansion
 	std::string region_tag;
-	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	m_cart_rom = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG));
 }
 
 


### PR DESCRIPTION
This was initially detected by Cppcheck:
```
src/devices/bus/a2bus/a2corvus.cpp:114:43: performance: Passing the result of c_str() to a function that takes std::string_view as argument no. 1 is slow and redundant. [stlcstrParam]
 m_rom = device().machine().root_device().memregion(this->subtag(CORVUS_ROM_REGION).c_str())->base();
                                          ^
```

Given the long run-time of the analysis most of these have been identified by a manual search and review so it is possible some other cases have been missed.