### PR TITLE
mc68340: Implement DMA transfers and external interrupt handling

### DIFF
--- a/src/devices/machine/68340.cpp
+++ b/src/devices/machine/68340.cpp
@@ -54,7 +54,8 @@ void m68340_cpu_device::update_ipl()
 		pit_irq_level(),
 		m_serial->irq_level(),
 		m_timer[0]->irq_level(),
-		m_timer[1]->irq_level()
+		m_timer[1]->irq_level(),
+		m_dma->irq_level()
 	});
 	if (m_ipl != new_ipl)
 	{
@@ -67,8 +68,9 @@ void m68340_cpu_device::update_ipl()
 	}
 }
 
-void m68340_cpu_device::internal_vectors_r(address_map &map)
+void m68340_cpu_device::cpu_space_map(address_map &map)
 {
+	map(0x0003ff00, 0x0003ff03).rw(FUNC(m68340_cpu_device::m68340_internal_base_r), FUNC(m68340_cpu_device::m68340_internal_base_w));
 	map(0xfffffff0, 0xffffffff).r(FUNC(m68340_cpu_device::int_ack)).umask16(0x00ff);
 }
 
@@ -79,8 +81,9 @@ uint8_t m68340_cpu_device::int_ack(offs_t offset)
 	uint8_t scu_iarb = m_serial->arbitrate(offset);
 	uint8_t t1_iarb = m_timer[0]->arbitrate(offset);
 	uint8_t t2_iarb = m_timer[1]->arbitrate(offset);
-	uint8_t iarb = std::max({pit_iarb, scu_iarb, t1_iarb, t2_iarb});
-	LOGMASKED(LOG_IPL, "Level %d interrupt arbitration: PIT = %X, SCU = %X, T1 = %X, T2 = %X\n", offset, pit_iarb, scu_iarb, t1_iarb, t2_iarb);
+	uint8_t dma_iarb = m_dma->arbitrate(offset);
+	uint8_t iarb = std::max({pit_iarb, scu_iarb, t1_iarb, t2_iarb, dma_iarb});
+	LOGMASKED(LOG_IPL, "Level %d interrupt arbitration: PIT = %X, SCU = %X, T1 = %X, T2 = %X, DMA = %X\n", offset, pit_iarb, scu_iarb, t1_iarb, t2_iarb, dma_iarb);
 	int response = 0;
 	uint8_t vector = 0x18; // Spurious interrupt
 
@@ -114,6 +117,24 @@ uint8_t m68340_cpu_device::int_ack(offs_t offset)
 			LOGMASKED(LOG_IPL, "PIT acknowledged interrupt with vector %02X\n", vector);
 			response++;
 		}
+
+		if (iarb == dma_iarb)
+		{
+			vector = m_dma->irq_vector(offset);
+			LOGMASKED(LOG_IPL, "DMA acknowledged interrupt with vector %02X\n", vector);
+			response++;
+		}
+	}
+
+	// The AVR selects autovectoring for external interrupts on levels 1-7.
+	// Internal modules always supply their programmed vector instead.
+	if ((response == 0) &&
+			(m_m68340SIM->m_mcr & m68340_sim::REG_MCR_ARBLV) &&
+			BIT(m_m68340SIM->m_avr_rsr, offset + 8))
+	{
+		vector = 0x18 + offset;
+		LOGMASKED(LOG_IPL, "External level %d interrupt autovectored with vector %02X\n", offset, vector);
+		response++;
 	}
 
 	if (response == 0)
@@ -130,85 +151,71 @@ uint8_t m68340_cpu_device::int_ack(offs_t offset)
 uint16_t m68340_cpu_device::m68340_internal_base_r(offs_t offset, uint16_t mem_mask)
 {
 	if (!machine().side_effects_disabled())
-		LOGMASKED(LOG_BASE, "%08x m68340_internal_base_r %08x, (%08x) (%08x)\n", m_ppc, offset*2,mem_mask, m_sfc);
+		LOGMASKED(LOG_BASE, "%08x m68340_internal_base_r %08x, (%08x)\n", m_ppc, offset * 2, mem_mask);
 
-	if (m_sfc==0x7)
-	{
-		return (!BIT(offset, 0) ? (m_m68340_base >> 16): m_m68340_base) & 0xffff;
-	}
-	else
-	{
-		return m_internal->unmap();
-	}
+	return (!BIT(offset, 0) ? (m_m68340_base >> 16) : m_m68340_base) & 0xffff;
 }
 
 void m68340_cpu_device::m68340_internal_base_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
 	LOGMASKED(LOG_BASE, "%08x m68340_internal_base_w %08x, %08x (%08x)\n", m_ppc, offset*2,data,mem_mask);
 
-	// other conditions?
-	if (m_dfc==0x7)
+	// unmap old modules
+	if (m_m68340_base & 1)
 	{
-		// unmap old modules
-		if (m_m68340_base&1)
-		{
-			int base = m_m68340_base & 0xfffff000;
+		int base = m_m68340_base & 0xfffff000;
 
-			m_internal->unmap_readwrite(base + 0x000, base + 0x05f);
-			m_internal->unmap_readwrite(base + 0x600, base + 0x67f);
-			m_internal->unmap_readwrite(base + 0x700, base + 0x723);
-			m_internal->unmap_readwrite(base + 0x780, base + 0x7bf);
+		m_internal->unmap_readwrite(base + 0x000, base + 0x05f);
+		m_internal->unmap_readwrite(base + 0x600, base + 0x67f);
+		m_internal->unmap_readwrite(base + 0x700, base + 0x723);
+		m_internal->unmap_readwrite(base + 0x780, base + 0x7bf);
 
-		}
-
-		uint32_t data32 = data;
-		uint32_t mem_mask32 = mem_mask;
-		if (!BIT(offset,0))
-		{
-			data32 <<= 16;
-			mem_mask32 <<= 16;
-		}
-
-		m_m68340_base = (m_m68340_base & ~mem_mask32) | (data32 & mem_mask32);
-		LOGMASKED(LOG_BASE, "%08x m68340_internal_base_w %08x, %08x (%08x) (m_m68340_base write)\n", pc(), offset*2,data,mem_mask);
-
-		// map new modules
-		if (m_m68340_base & 1)
-		{
-			int base = m_m68340_base & 0xfffff000;
-
-			m_internal->install_readwrite_handler(base + 0x000, base + 0x03f,
-					read16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_r)),
-					write16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_w)),0xffffffff);
-			m_internal->install_readwrite_handler(base + 0x010, base + 0x01f, // Intentionally punches a hole in previous address mapping
-					read8sm_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_ports_r)),
-					write8sm_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_ports_w)),0xffffffff);
-			m_internal->install_readwrite_handler(base + 0x040, base + 0x05f,
-					read16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_cs_r)),
-					write16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_cs_w)));
-			m_internal->install_readwrite_handler(base + 0x600, base + 0x63f,
-					read16s_delegate(*m_timer[0], FUNC(mc68340_timer_module_device::read)),
-					write16s_delegate(*m_timer[0], FUNC(mc68340_timer_module_device::write)),0xffffffff);
-			m_internal->install_readwrite_handler(base + 0x640, base + 0x67f,
-					read16s_delegate(*m_timer[1], FUNC(mc68340_timer_module_device::read)),
-					write16s_delegate(*m_timer[1], FUNC(mc68340_timer_module_device::write)),0xffffffff);
-			m_internal->install_readwrite_handler(base + 0x700, base + 0x723,
-					read8sm_delegate(*m_serial, FUNC(mc68340_serial_module_device::read)),
-					write8sm_delegate(*m_serial, FUNC(mc68340_serial_module_device::write)),0xffffffff);
-			m_internal->install_readwrite_handler(base + 0x780, base + 0x7bf,
-					read16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_dma_r)),
-					write16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_dma_w)));
-		}
 	}
-	else
+
+	uint32_t data32 = data;
+	uint32_t mem_mask32 = mem_mask;
+	if (!BIT(offset, 0))
 	{
-		LOGMASKED(LOG_BASE, "%08x m68340_internal_base_w %08x, %04x (%04x) (should fall through?)\n", pc(), offset*2,data,mem_mask);
+		data32 <<= 16;
+		mem_mask32 <<= 16;
+	}
+
+	m_m68340_base = (m_m68340_base & ~mem_mask32) | (data32 & mem_mask32);
+	LOGMASKED(LOG_BASE, "%08x m68340_internal_base_w %08x, %08x (%08x) (m_m68340_base write)\n", pc(), offset * 2, data, mem_mask);
+
+	// map new modules
+	if (m_m68340_base & 1)
+	{
+		int base = m_m68340_base & 0xfffff000;
+
+		m_internal->install_readwrite_handler(base + 0x000, base + 0x03f,
+				read16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_r)),
+				write16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_w)), 0xffffffff);
+		m_internal->install_readwrite_handler(base + 0x010, base + 0x01f, // Intentionally punches a hole in previous address mapping
+				read8sm_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_ports_r)),
+				write8sm_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_ports_w)), 0xffffffff);
+		m_internal->install_readwrite_handler(base + 0x040, base + 0x05f,
+				read16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_cs_r)),
+				write16s_delegate(*this, FUNC(m68340_cpu_device::m68340_internal_sim_cs_w)));
+		m_internal->install_readwrite_handler(base + 0x600, base + 0x63f,
+				read16s_delegate(*m_timer[0], FUNC(mc68340_timer_module_device::read)),
+				write16s_delegate(*m_timer[0], FUNC(mc68340_timer_module_device::write)), 0xffffffff);
+		m_internal->install_readwrite_handler(base + 0x640, base + 0x67f,
+				read16s_delegate(*m_timer[1], FUNC(mc68340_timer_module_device::read)),
+				write16s_delegate(*m_timer[1], FUNC(mc68340_timer_module_device::write)), 0xffffffff);
+		m_internal->install_readwrite_handler(base + 0x700, base + 0x723,
+				read8sm_delegate(*m_serial, FUNC(mc68340_serial_module_device::read)),
+				write8sm_delegate(*m_serial, FUNC(mc68340_serial_module_device::write)), 0xffffffff);
+		m_internal->install_readwrite_handler(base + 0x780, base + 0x7bf,
+				read16s_delegate(*m_dma, FUNC(mc68340_dma_module_device::read)),
+				write16s_delegate(*m_dma, FUNC(mc68340_dma_module_device::write)));
 	}
 }
 
-void m68340_cpu_device::m68340_internal_map(address_map &map)
+bool m68340_cpu_device::is_mbar_access(offs_t address) const
 {
-	map(0x0003ff00, 0x0003ff03).rw(FUNC(m68340_cpu_device::m68340_internal_base_r), FUNC(m68340_cpu_device::m68340_internal_base_w));
+	// The fixed MBAR window only responds to CPU-space accesses (function code 7).
+	return (m_mmu_tmp_fc == 7) && ((address & ~3) == 0x0003ff00);
 }
 
 
@@ -222,6 +229,7 @@ void m68340_cpu_device::device_add_mconfig(machine_config &config)
 	m_serial->irq_cb().set(m_serial, FUNC(mc68340_serial_module_device::irq_w));
 	MC68340_TIMER_MODULE(config, m_timer[0]);
 	MC68340_TIMER_MODULE(config, m_timer[1]);
+	MC68340_DMA_MODULE(config, m_dma);
 }
 
 
@@ -230,9 +238,10 @@ void m68340_cpu_device::device_add_mconfig(machine_config &config)
 //**************************************************************************
 
 m68340_cpu_device::m68340_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: fscpu32_device(mconfig, tag, owner, clock, M68340, address_map_constructor(FUNC(m68340_cpu_device::m68340_internal_map), this))
+	: fscpu32_device(mconfig, tag, owner, clock, M68340, address_map_constructor())
 	, m_serial(*this, "serial")
 	, m_timer(*this, "timer%u", 1U)
+	, m_dma(*this, "dma")
 	, m_clock_mode(0)
 	, m_crystal(0)
 	, m_extal(0)
@@ -242,10 +251,9 @@ m68340_cpu_device::m68340_cpu_device(const machine_config &mconfig, const char *
 	, m_pb_in_cb(*this, 0)
 {
 	m_m68340SIM = nullptr;
-	m_m68340DMA = nullptr;
 	m_m68340_base = 0;
 	m_ipl = 0;
-	m_cpu_space_config.m_internal_map = address_map_constructor(FUNC(m68340_cpu_device::internal_vectors_r), this);
+	m_cpu_space_config.m_internal_map = address_map_constructor(FUNC(m68340_cpu_device::cpu_space_map), this);
 }
 
 void m68340_cpu_device::device_reset()
@@ -266,11 +274,44 @@ void m68340_cpu_device::device_start()
 {
 	fscpu32_device::device_start();
 
+	auto const program_read8 = m_read8;
+	auto const program_read16 = m_read16;
+	auto const program_read32 = m_read32;
+	auto const program_write8 = m_write8;
+	auto const program_write16 = m_write16;
+	auto const program_write32 = m_write32;
+
+	m_read8 = [this, program_read8](offs_t address) -> u8 {
+		return is_mbar_access(address) ? m_cpu_space->read_byte(address) : program_read8(address);
+	};
+	m_read16 = [this, program_read16](offs_t address) -> u16 {
+		return is_mbar_access(address) ? m_cpu_space->read_word_unaligned(address) : program_read16(address);
+	};
+	m_read32 = [this, program_read32](offs_t address) -> u32 {
+		return is_mbar_access(address) ? m_cpu_space->read_dword_unaligned(address) : program_read32(address);
+	};
+	m_write8 = [this, program_write8](offs_t address, u8 data) {
+		if (is_mbar_access(address))
+			m_cpu_space->write_byte(address, data);
+		else
+			program_write8(address, data);
+	};
+	m_write16 = [this, program_write16](offs_t address, u16 data) {
+		if (is_mbar_access(address))
+			m_cpu_space->write_word_unaligned(address, data);
+		else
+			program_write16(address, data);
+	};
+	m_write32 = [this, program_write32](offs_t address, u32 data) {
+		if (is_mbar_access(address))
+			m_cpu_space->write_dword_unaligned(address, data);
+		else
+			program_write32(address, data);
+	};
+
 	m_m68340SIM    = new m68340_sim();
-	m_m68340DMA    = new m68340_dma();
 
 	m_m68340SIM->reset();
-	m_m68340DMA->reset();
 
 	start_68340_sim();
 
@@ -294,7 +335,7 @@ void m68340_cpu_device::reset_peripherals(int state)
 	if (state)
 	{
 		m_m68340SIM->module_reset();
-		m_m68340DMA->module_reset();
+		m_dma->module_reset();
 		m_serial->module_reset();
 		m_timer[0]->module_reset();
 		m_timer[1]->module_reset();

--- a/src/devices/machine/68340.h
+++ b/src/devices/machine/68340.h
@@ -18,6 +18,7 @@ class m68340_cpu_device : public fscpu32_device
 {
 	friend class mc68340_serial_module_device;
 	friend class mc68340_timer_module_device;
+	friend class mc68340_dma_module_device;
 
 public:
 	m68340_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
@@ -31,6 +32,10 @@ public:
 	auto tgate1_in_callback() { return m_timer[0]->m_tgate_in_cb.bind(); }
 	auto tout2_out_callback() { return m_timer[1]->m_tout_out_cb.bind(); }
 	auto tgate2_in_callback() { return m_timer[1]->m_tgate_in_cb.bind(); }
+	auto dma_dack1_out_callback() { return m_dma->dack_out_callback<0>(); }
+	auto dma_done1_out_callback() { return m_dma->done_out_callback<0>(); }
+	auto dma_dack2_out_callback() { return m_dma->dack_out_callback<1>(); }
+	auto dma_done2_out_callback() { return m_dma->done_out_callback<1>(); }
 
 	uint16_t get_cs(offs_t address);
 
@@ -41,6 +46,12 @@ public:
 	void tgate1_w(int state){ m_timer[0]->tgate_w(state); }
 	void tin2_w(int state)  { m_timer[1]->tin_w(state);  }
 	void tgate2_w(int state){ m_timer[1]->tgate_w(state); }
+
+	// DMA handshake inputs are active low.
+	void dma_dreq1_w(int state) { m_dma->dreq_w<0>(state); }
+	void dma_done1_w(int state) { m_dma->done_w<0>(state); }
+	void dma_dreq2_w(int state) { m_dma->dreq_w<1>(state); }
+	void dma_done2_w(int state) { m_dma->done_w<1>(state); }
 
 protected:
 	virtual void device_start() override ATTR_COLD;
@@ -53,9 +64,10 @@ protected:
 private:
 	required_device<mc68340_serial_module_device> m_serial;
 	required_device_array<mc68340_timer_module_device, 2> m_timer;
+	required_device<mc68340_dma_module_device> m_dma;
 
 	void update_ipl();
-	void internal_vectors_r(address_map &map) ATTR_COLD;
+	void cpu_space_map(address_map &map) ATTR_COLD;
 	uint8_t int_ack(offs_t offset);
 
 	TIMER_CALLBACK_MEMBER(periodic_interrupt_timer_callback);
@@ -68,6 +80,7 @@ private:
 
 	int calc_cs(offs_t address) const;
 	int get_timer_index(mc68340_timer_module_device *timer) { return (timer == m_timer[0].target()) ? 0 : 1; }
+	bool is_mbar_access(offs_t address) const;
 
 	int m_currentcs;
 	uint32_t m_clock_mode;
@@ -84,8 +97,6 @@ private:
 
 	uint16_t m68340_internal_base_r(offs_t offset, uint16_t mem_mask = ~0);
 	void m68340_internal_base_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t m68340_internal_dma_r(offs_t offset, uint16_t mem_mask = ~0);
-	void m68340_internal_dma_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t m68340_internal_sim_r(offs_t offset, uint16_t mem_mask = ~0);
 	uint8_t m68340_internal_sim_ports_r(offs_t offset);
 	uint16_t m68340_internal_sim_cs_r(offs_t offset, uint16_t mem_mask = ~0);
@@ -97,11 +108,8 @@ private:
 	void set_modck(int state);
 	void extal_w(int state);
 
-	void m68340_internal_map(address_map &map) ATTR_COLD;
-
 	/* 68340 peripheral modules */
 	m68340_sim*    m_m68340SIM;
-	m68340_dma*    m_m68340DMA;
 
 	uint32_t m_m68340_base;
 

--- a/src/devices/machine/68340dma.cpp
+++ b/src/devices/machine/68340dma.cpp
@@ -5,30 +5,403 @@
 #include "emu.h"
 #include "68340.h"
 
+#include <algorithm>
 
-uint16_t m68340_cpu_device::m68340_internal_dma_r(offs_t offset, uint16_t mem_mask)
+DEFINE_DEVICE_TYPE(MC68340_DMA_MODULE, mc68340_dma_module_device, "mc68340dma", "MC68340 DMA Module")
+
+
+namespace {
+
+constexpr uint8_t CSR_IRQ  = 0x80;
+constexpr uint8_t CSR_DONE = 0x40;
+constexpr uint8_t CSR_BES  = 0x20;
+constexpr uint8_t CSR_BED  = 0x10;
+constexpr uint8_t CSR_CONF = 0x08;
+constexpr uint8_t CSR_BRKP = 0x04;
+constexpr uint8_t CSR_CLEARABLE = CSR_DONE | CSR_BES | CSR_BED | CSR_CONF | CSR_BRKP;
+
+constexpr uint16_t MCR_STP = 0x8000;
+constexpr uint16_t MCR_SHARED = 0xe00f;
+
+constexpr uint16_t CCR_INTB = 0x8000;
+constexpr uint16_t CCR_INTN = 0x4000;
+constexpr uint16_t CCR_INTE = 0x2000;
+constexpr uint16_t CCR_ECO  = 0x1000;
+constexpr uint16_t CCR_SAPI = 0x0800;
+constexpr uint16_t CCR_DAPI = 0x0400;
+constexpr uint16_t CCR_REQ  = 0x0030;
+constexpr uint16_t CCR_SD   = 0x0002;
+constexpr uint16_t CCR_STR  = 0x0001;
+
+unsigned transfer_size(unsigned field)
 {
-	assert(m_m68340DMA);
-	//m68340_dma &dma = *m_m68340DMA;
-
-	logerror("%08x m68340_internal_dma_r %08x, (%08x)\n", m_ppc, offset*2,mem_mask);
-
-	return 0x00000000;
+	switch (field & 3)
+	{
+	case 0: return 4;
+	case 1: return 1;
+	case 2: return 2;
+	default: return 0;
+	}
 }
 
-void m68340_cpu_device::m68340_internal_dma_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	assert(m_m68340DMA);
-	//m68340_dma &dma = *m_m68340DMA;
+} // anonymous namespace
 
-	logerror("%08x m68340_internal_dma_w %08x, %08x (%08x)\n", m_ppc, offset*2,data,mem_mask);
+
+uint16_t mc68340_dma_module_device::read(offs_t offset, uint16_t)
+{
+	unsigned const byte_offset = offset * 2;
+	channel_state const &channel = m_channel[BIT(byte_offset, 5)];
+
+	switch (byte_offset & 0x1e)
+	{
+	case 0x00: return channel.mcr;
+	case 0x04: return channel.intr;
+	case 0x08: return channel.ccr;
+	case 0x0a: return (uint16_t(channel.csr) << 8) | channel.fcr;
+	case 0x0c: return channel.sar >> 16;
+	case 0x0e: return channel.sar;
+	case 0x10: return channel.dar >> 16;
+	case 0x12: return channel.dar;
+	case 0x14: return channel.btc >> 16;
+	case 0x16: return channel.btc;
+	default: return 0;
+	}
 }
 
-void m68340_dma::reset()
+
+void mc68340_dma_module_device::write(offs_t offset, uint16_t data, uint16_t mem_mask)
 {
-	module_reset();
+	unsigned const byte_offset = offset * 2;
+	unsigned const channel_number = BIT(byte_offset, 5);
+	channel_state &channel = m_channel[channel_number];
+	unsigned const reg = byte_offset & 0x1e;
+
+	auto combine16 = [data, mem_mask] (uint16_t &value)
+	{
+		value = (value & ~mem_mask) | (data & mem_mask);
+	};
+	auto combine32 = [reg, data, mem_mask] (uint32_t &value)
+	{
+		if (BIT(reg, 1))
+			value = (value & ~(uint32_t(mem_mask))) | (data & mem_mask);
+		else
+			value = (value & ~(uint32_t(mem_mask) << 16)) | (uint32_t(data & mem_mask) << 16);
+	};
+
+	switch (reg)
+	{
+	case 0x00:
+		combine16(channel.mcr);
+		m_channel[channel_number ^ 1].mcr = (m_channel[channel_number ^ 1].mcr & ~MCR_SHARED) | (channel.mcr & MCR_SHARED);
+		m_cpu->update_ipl();
+		break;
+
+	case 0x04:
+		combine16(channel.intr);
+		m_cpu->update_ipl();
+		break;
+
+	case 0x08:
+		combine16(channel.ccr);
+		if (channel.csr & CSR_IRQ)
+			channel.ccr &= ~CCR_STR;
+		m_cpu->update_ipl();
+		run(channel_number);
+		break;
+
+	case 0x0a:
+		if (ACCESSING_BITS_8_15)
+		{
+			channel.csr &= ~uint8_t((data >> 8) & CSR_CLEARABLE);
+			if (!(channel.csr & CSR_CLEARABLE))
+				channel.csr &= ~CSR_IRQ;
+		}
+		if (ACCESSING_BITS_0_7)
+			channel.fcr = data;
+		m_cpu->update_ipl();
+		break;
+
+	case 0x0c:
+	case 0x0e:
+		combine32(channel.sar);
+		break;
+
+	case 0x10:
+	case 0x12:
+		combine32(channel.dar);
+		break;
+
+	case 0x14:
+	case 0x16:
+		combine32(channel.btc);
+		break;
+	}
 }
 
-void m68340_dma::module_reset()
+
+void mc68340_dma_module_device::dreq_w(unsigned channel_number, int state)
+{
+	channel_state &channel = m_channel[channel_number];
+	uint8_t const old_state = channel.dreq;
+	channel.dreq = bool(state);
+
+	// DREQ is active low.  Burst requests are level-sensitive, while
+	// cycle-steal requests are recognized on the falling edge.
+	if (!channel.dreq && old_state)
+		run(channel_number);
+}
+
+
+void mc68340_dma_module_device::done_w(unsigned channel_number, int state)
+{
+	m_channel[channel_number].done_in = bool(state);
+}
+
+
+bool mc68340_dma_module_device::irq_pending(channel_state const &channel) const
+{
+	return ((channel.csr & CSR_DONE) && (channel.ccr & CCR_INTN)) ||
+		((channel.csr & (CSR_BES | CSR_BED | CSR_CONF)) && (channel.ccr & CCR_INTE)) ||
+		((channel.csr & CSR_BRKP) && (channel.ccr & CCR_INTB));
+}
+
+
+uint8_t mc68340_dma_module_device::irq_level() const
+{
+	uint8_t level = 0;
+	for (channel_state const &channel : m_channel)
+	{
+		if (irq_pending(channel))
+			level = std::max<uint8_t>(level, (channel.intr >> 8) & 7);
+	}
+	return level;
+}
+
+
+uint8_t mc68340_dma_module_device::arbitrate(uint8_t level) const
+{
+	for (channel_state const &channel : m_channel)
+	{
+		if (irq_pending(channel) && (((channel.intr >> 8) & 7) == level))
+			return channel.mcr & 0x0f;
+	}
+	return 0;
+}
+
+
+uint8_t mc68340_dma_module_device::irq_vector(uint8_t level) const
+{
+	// Channel 1 has priority when both channels use the same interrupt level.
+	for (channel_state const &channel : m_channel)
+	{
+		if (irq_pending(channel) && (((channel.intr >> 8) & 7) == level))
+			return channel.intr;
+	}
+	return 0x0f;
+}
+
+
+void mc68340_dma_module_device::run(unsigned channel_number)
+{
+	channel_state &channel = m_channel[channel_number];
+	if (!(channel.ccr & CCR_STR) || (channel.mcr & MCR_STP))
+		return;
+
+	unsigned const request_mode = channel.ccr & CCR_REQ;
+	if (!request_mode)
+	{
+		while (channel.ccr & CCR_STR)
+			transfer(channel_number);
+	}
+	else if (!channel.dreq)
+	{
+		// Burst mode continues while DREQ remains asserted; cycle-steal mode
+		// performs one operand transfer for each assertion.
+		do
+		{
+			transfer(channel_number);
+		}
+		while ((request_mode == 0x0020) && !channel.dreq && (channel.ccr & CCR_STR));
+	}
+}
+
+
+void mc68340_dma_module_device::transfer(unsigned channel_number)
+{
+	channel_state &channel = m_channel[channel_number];
+	unsigned const source_size = transfer_size(channel.ccr >> 8);
+	unsigned const destination_size = transfer_size(channel.ccr >> 6);
+	unsigned const transfer_bytes = std::max(source_size, destination_size);
+
+	// Single-address transfers require modelling the external DACK/DONE bus
+	// handshake.  Dual-address transfers include the DHR packing modes.
+	if ((channel.ccr & CCR_SD) || !source_size || !destination_size || !channel.btc ||
+		(channel.btc % transfer_bytes) || (channel.sar & (source_size - 1)) ||
+		(channel.dar & (destination_size - 1)))
+	{
+		set_status(channel, CSR_CONF);
+		return;
+	}
+
+	uint8_t const source_fc = (channel.fcr >> 4) & 7;
+	uint8_t const destination_fc = channel.fcr & 7;
+	bool const external_request = (channel.ccr & CCR_REQ) != 0;
+	bool const source_request = (channel.ccr & CCR_ECO) != 0;
+	bool const last_transfer = channel.btc == transfer_bytes;
+	uint32_t data = 0;
+
+	if (external_request && source_request)
+	{
+		set_done_output(channel_number, last_transfer ? 0 : 1);
+		set_dack(channel_number, 0);
+	}
+
+	for (unsigned byte = 0; byte < transfer_bytes; byte += source_size)
+	{
+		uint32_t source_data;
+		switch (source_size)
+		{
+		case 1: source_data = m_cpu->m68ki_read_8_fc(channel.sar, source_fc); break;
+		case 2: source_data = m_cpu->m68ki_read_16_fc(channel.sar, source_fc); break;
+		default: source_data = m_cpu->m68ki_read_32_fc(channel.sar, source_fc); break;
+		}
+		data |= source_data << ((transfer_bytes - source_size - byte) * 8);
+		if (channel.ccr & CCR_SAPI)
+			channel.sar += source_size;
+	}
+
+	if (external_request && source_request)
+	{
+		set_dack(channel_number, 1);
+		set_done_output(channel_number, 1);
+	}
+	else if (external_request)
+	{
+		set_done_output(channel_number, last_transfer ? 0 : 1);
+		set_dack(channel_number, 0);
+	}
+
+	for (unsigned byte = 0; byte < transfer_bytes; byte += destination_size)
+	{
+		unsigned const shift = (transfer_bytes - destination_size - byte) * 8;
+		switch (destination_size)
+		{
+		case 1: m_cpu->m68ki_write_8_fc(channel.dar, destination_fc, data >> shift); break;
+		case 2: m_cpu->m68ki_write_16_fc(channel.dar, destination_fc, data >> shift); break;
+		default: m_cpu->m68ki_write_32_fc(channel.dar, destination_fc, data); break;
+		}
+		if (channel.ccr & CCR_DAPI)
+			channel.dar += destination_size;
+	}
+
+	if (external_request && !source_request)
+	{
+		set_dack(channel_number, 1);
+		set_done_output(channel_number, 1);
+	}
+
+	channel.btc -= transfer_bytes;
+	if (!channel.btc || !channel.done_in)
+	{
+		set_status(channel, CSR_DONE);
+	}
+}
+
+
+void mc68340_dma_module_device::set_dack(unsigned channel_number, int state)
+{
+	channel_state &channel = m_channel[channel_number];
+	if (channel.dack != bool(state))
+	{
+		channel.dack = bool(state);
+		m_dack_out_cb[channel_number](state);
+	}
+}
+
+
+void mc68340_dma_module_device::set_done_output(unsigned channel_number, int state)
+{
+	channel_state &channel = m_channel[channel_number];
+	if (channel.done_out != bool(state))
+	{
+		channel.done_out = bool(state);
+		m_done_out_cb[channel_number](state);
+	}
+}
+
+
+void mc68340_dma_module_device::set_status(channel_state &channel, uint8_t status)
+{
+	channel.csr |= CSR_IRQ | status;
+	channel.ccr &= ~CCR_STR;
+	m_cpu->update_ipl();
+}
+
+
+void mc68340_dma_module_device::device_start()
+{
+	m_cpu = downcast<m68340_cpu_device *>(owner());
+
+	save_item(STRUCT_MEMBER(m_channel, mcr));
+	save_item(STRUCT_MEMBER(m_channel, intr));
+	save_item(STRUCT_MEMBER(m_channel, ccr));
+	save_item(STRUCT_MEMBER(m_channel, csr));
+	save_item(STRUCT_MEMBER(m_channel, fcr));
+	save_item(STRUCT_MEMBER(m_channel, sar));
+	save_item(STRUCT_MEMBER(m_channel, dar));
+	save_item(STRUCT_MEMBER(m_channel, btc));
+	save_item(STRUCT_MEMBER(m_channel, dreq));
+	save_item(STRUCT_MEMBER(m_channel, done_in));
+	save_item(STRUCT_MEMBER(m_channel, dack));
+	save_item(STRUCT_MEMBER(m_channel, done_out));
+	machine().save().register_postload(save_prepost_delegate(FUNC(mc68340_dma_module_device::restore_outputs), this));
+}
+
+
+void mc68340_dma_module_device::device_reset()
+{
+	for (channel_state &channel : m_channel)
+	{
+		channel = {};
+		channel.mcr = 0x0080;
+		channel.intr = 0x000f;
+		channel.dreq = 1;
+		channel.done_in = 1;
+		channel.dack = 1;
+		channel.done_out = 1;
+	}
+	restore_outputs();
+}
+
+
+void mc68340_dma_module_device::module_reset()
+{
+	for (unsigned channel_number = 0; channel_number < 2; channel_number++)
+	{
+		channel_state &channel = m_channel[channel_number];
+		channel.ccr &= ~CCR_STR;
+		channel.csr = 0;
+		channel.intr = 0x000f;
+		set_dack(channel_number, 1);
+		set_done_output(channel_number, 1);
+	}
+}
+
+
+void mc68340_dma_module_device::restore_outputs()
+{
+	for (unsigned channel_number = 0; channel_number < 2; channel_number++)
+	{
+		m_dack_out_cb[channel_number](m_channel[channel_number].dack);
+		m_done_out_cb[channel_number](m_channel[channel_number].done_out);
+	}
+}
+
+
+mc68340_dma_module_device::mc68340_dma_module_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, MC68340_DMA_MODULE, tag, owner, clock)
+	, m_cpu(nullptr)
+	, m_dack_out_cb(*this)
+	, m_done_out_cb(*this)
 {
 }

--- a/src/devices/machine/68340dma.h
+++ b/src/devices/machine/68340dma.h
@@ -5,12 +5,66 @@
 
 #pragma once
 
+class m68340_cpu_device;
 
-class m68340_dma
+
+class mc68340_dma_module_device : public device_t
 {
 public:
-	void reset();
+	mc68340_dma_module_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	// External handshake callbacks use physical pin levels; DREQ, DACK and DONE are active low.
+	template <unsigned Channel> auto dack_out_callback() { static_assert(Channel < 2); return m_dack_out_cb[Channel].bind(); }
+	template <unsigned Channel> auto done_out_callback() { static_assert(Channel < 2); return m_done_out_cb[Channel].bind(); }
+	template <unsigned Channel> void dreq_w(int state) { static_assert(Channel < 2); dreq_w(Channel, state); }
+	template <unsigned Channel> void done_w(int state) { static_assert(Channel < 2); done_w(Channel, state); }
+
+	uint16_t read(offs_t offset, uint16_t mem_mask = ~0);
+	void write(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint8_t irq_level() const;
+	uint8_t arbitrate(uint8_t level) const;
+	uint8_t irq_vector(uint8_t level) const;
 	void module_reset();
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	friend class m68340_cpu_device;
+
+	struct channel_state
+	{
+		uint16_t mcr;
+		uint16_t intr;
+		uint16_t ccr;
+		uint8_t csr;
+		uint8_t fcr;
+		uint32_t sar;
+		uint32_t dar;
+		uint32_t btc;
+		uint8_t dreq;
+		uint8_t done_in;
+		uint8_t dack;
+		uint8_t done_out;
+	};
+
+	channel_state m_channel[2];
+	m68340_cpu_device *m_cpu;
+	devcb_write_line::array<2> m_dack_out_cb;
+	devcb_write_line::array<2> m_done_out_cb;
+
+	bool irq_pending(channel_state const &channel) const;
+	void dreq_w(unsigned channel, int state);
+	void done_w(unsigned channel, int state);
+	void run(unsigned channel);
+	void transfer(unsigned channel);
+	void set_status(channel_state &channel, uint8_t status);
+	void set_dack(unsigned channel, int state);
+	void set_done_output(unsigned channel, int state);
+	void restore_outputs();
 };
+
+DECLARE_DEVICE_TYPE(MC68340_DMA_MODULE, mc68340_dma_module_device)
 
 #endif // MAME_MACHINE_68340DMA_H

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -82,7 +82,6 @@ protected:
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	void dma1_drq(int state);
 	void scc66470_irq(int state);
 
 	void bfm_cobra3_map(address_map &map) ATTR_COLD;
@@ -145,8 +144,7 @@ uint16_t bfm_cobra3_state::mem_r(offs_t offset, uint16_t mem_mask)
 
 					case 0x400:
 						{
-							//input reads, haven't got far enough to trigger any
-							return m_strobein[m_active_strobe]->read();
+							return m_strobein[m_active_strobe]->read() << 8;
 						}
 					case 0x500: //SCSI DMA
 						if (ACCESSING_BITS_8_15)
@@ -382,14 +380,9 @@ void bfm_cobra3_state::machine_start()
 }
 
 
-void bfm_cobra3_state::dma1_drq(int state)
-{
-//  m_maincpu->dma_dreq1_w(state);
-}
-
 void bfm_cobra3_state::scc66470_irq(int state)
 {
-	m_maincpu->set_input_line(5, !state);
+	m_maincpu->set_input_line(5, state);
 }
 
 uint32_t bfm_cobra3_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
@@ -490,7 +483,7 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 
 	NCR5380(config, m_scsic);
 	scsi.set_external_device(6, m_scsic);
-	m_scsic->drq_handler().set(DEVICE_SELF, FUNC(bfm_cobra3_state::dma1_drq));
+	m_scsic->drq_handler().set(m_maincpu, FUNC(m68340_cpu_device::dma_dreq1_w)).invert();
 
 	WATCHDOG_TIMER(config, m_watchdog).set_time(PERIOD_OF_555_MONOSTABLE(120000,100e-9)); //TODO: Check timings
 	METERS(config, m_meters).set_number(4);


### PR DESCRIPTION
## 1/5 for Telly Addicts for the Bellfruit Cobra 3.

This is the first of a series of changes to get Telly Addicts on the Bellfruit Cobra 3 machine through to working (or, as far as it can be in lieu of any photos or videos of it).

I intend to submit this as a series of independently reviewable changes, in dependency order:

1. MC68340 DMA, interrupt handling, and Cobra 3 board-level integration
2. TMS320AV110 MPEG audio, using MAME's existing [mpeg_audio](https://github.com/mamedev/mame/blob/master/src/devices/sound/mpeg_audio.cpp) implementation as the decoding backend
3. MPEG-1 video and STi3400 support, using a new decoder implemented directly from ISO/IEC 11172-2 and structured, where appropriate, after MAME's MPEG audio implementation
4. Telly Addicts controls, lamps, layout, and serial interfaces
5. Telly Addicts cash-handling hardware and meters

You can view the full set of changes here, these will be recreated into the more sensible set above for review.
https://github.com/MagikalUnicorn/mame/commits/cobra3-telly

Here's a video of the system with all the changes above so you have an idea of what the final stage completion looks like. 

https://github.com/user-attachments/assets/4744e4ab-47b8-47c9-81fd-86c91f755285

Unrelated to this particular change, but note that the 'RAM Error' at start-up (which actually refers to the NVRAM) cannot be removed without completing what I assume is a factory commissioning process which remains unknown, which initialises the zero'd NVRAM (no initialised dump is available). I assume this factory commissioning should also set the default volume to something more audible. As I've tried to keep this true to the hardware audio paths, you will need to enter the Refill/Volume setting mode (Press R) at start-up and turn up the volume manually to hear the game sounds. I've labelled the input for this so hopefully it's not completely non-obvious. As far as I can tell, the rest of the audio path matches the hardware. This is the only impact I can find from the uninitialised NVRAM.

## This Change

This implements the MC68340 functionality required by the Bellfruit Cobra 3 platform.

I have converted the DMA module into a proper device and supported the dual-address transfer modes currently required by the Cobra 3. This includes transfer sizing, address updates, byte-count handling, external request handshakes, completion status, and interrupt arbitration. Many thanks to James Wallace for providing his WIP to me for this.

This change also:

- exposes the active-low DREQ, DACK, and DONE signals;
- incorporates DMA requests into MC68340 interrupt arbitration;
- supports configured external interrupt autovectors;
- restricts MBAR accesses to CPU space;
- connects the Cobra 3 SCSI controller to DMA channel 1;
- corrects the Cobra 3 input-strobe byte lane; and
- corrects the video-controller interrupt polarity.

Single-address DMA modes and other currently unused functionality remain outside the implemented scope - it just covers what's needed for telly addicts (for now).

The MC68340 behaviour was implemented using the following manufacturer documentation:

- [MC68340 Integrated Processor with DMA User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68340UM.pdf), particularly sections 2.12, 3.4.4, 4.3 and 6.2–6.8
- [MC68340 User's Manual Addendum](https://www.nxp.com/docs/en/reference-manual/MC68340UMAD.pdf), particularly corrections 2, 8, 34–37, 45, 46 and 48

## Validation

MAME validation passed for the available set of cobra3 titles:

- `c3_telly`
- `c3_tellyns`
- `c3_rtime`
- `c3_totp`
- `c3_ppays`

All five sets also completed finite, unthrottled smoke tests without errors.

## AI assistance disclosure

I used OpenAI Codex (GPT-5) to carry out the investigations, and then do the majority of the implementation (usually around 80% of it, rising to 100% for the MPEG decoder backend), code reviews, clean-history reconstruction, and testing. I reviewed the resulting changes and test results, extensively tested myself, and shaped the code, overall approach and change structuring towards what I thought was cleanest and most MAME-like were I could see obvious issues in style or encapsulation.

For each change, with the exception of the MPEG video decoder backend, I am trying to learn exactly how it works to expand my own knowledge. It's been a very long time since I did C++, so please bear with me.

I take responsibility for the submitted changes and will disclose the extent of AI assistance separately for each subsequent submission.