### PR TITLE
cdrom: Handle short sector reads

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -420,15 +420,14 @@ std::error_condition cdrom_file::read_partial_sector(void *dest, uint32_t lbasec
 			osd_printf_verbose("Reading %u bytes from sector %d from track %d at offset %lu\n", (unsigned)length, chdsector, tracknum + 1, (unsigned long)sourcefileoffset);
 
 		result = srcfile.seek(sourcefileoffset, SEEK_SET);
-		size_t actual;
+		size_t actual = 0;
 		if (!result)
-		{
 			std::tie(result, actual) = read(srcfile, dest, length);
-			if (!result && (actual != length))
-				result = std::errc::io_error;
-		}
+		if (!result && (actual != length))
+			result = chd_file::error::INVALID_DATA;
 
-		needswap = cdtrack_info.track[tracknum].swap;
+		if (!result)
+			needswap = cdtrack_info.track[tracknum].swap;
 	}
 
 	if (!result && needswap)

--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -422,13 +422,16 @@ std::error_condition cdrom_file::read_partial_sector(void *dest, uint32_t lbasec
 		result = srcfile.seek(sourcefileoffset, SEEK_SET);
 		size_t actual;
 		if (!result)
+		{
 			std::tie(result, actual) = read(srcfile, dest, length);
-		// FIXME: if (!result && (actual < length)) report error
+			if (!result && (actual != length))
+				result = std::errc::io_error;
+		}
 
 		needswap = cdtrack_info.track[tracknum].swap;
 	}
 
-	if (needswap)
+	if (!result && needswap)
 	{
 		uint8_t *buffer = (uint8_t *)dest - startoffs;
 		for (int swapindex = startoffs; swapindex < 2352; swapindex += 2)


### PR DESCRIPTION
Treat short reads from CD image files as invalid data instead of reporting the sector read as successful, and avoid byte-swapping the buffer when the read failed.

**User-visible behavior:** if a CD image read returns fewer bytes than requested without reporting an underlying error, the sector read now fails instead of being treated as successful. This prevents partially read sector data from being returned to callers.

Used ChatGPT (GPT-5.6 Sol) to review the code, identify the short-read issue, and help prepare the fix.