### PR TITLE
chd: Validate compressed hunk lengths

### DIFF
--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -943,7 +943,7 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 				case COMPRESSION_TYPE_1:
 				case COMPRESSION_TYPE_2:
 				case COMPRESSION_TYPE_3:
-				{
+					{
 					uint32_t const blocklen = get_u24be(&rawmap[1]);
 					if (UNEXPECTED(blocklen > m_compressed.size()))
 						return std::error_condition(error::INVALID_DATA);

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -949,11 +949,11 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 						return std::error_condition(error::INVALID_DATA);
 
 					std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
-						if (UNEXPECTED(err))
-							return err;
-						auto &decompressor = *m_decompressor[rawmap[0]];
-						decompressor.process(m_compressed.data(), blocklen);
-						return std::error_condition();
+					if (UNEXPECTED(err))
+						return err;
+					auto &decompressor = *m_decompressor[rawmap[0]];
+					decompressor.process(m_compressed.data(), blocklen);
+					return std::error_condition();
 					}
 
 				case COMPRESSION_NONE:

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -903,6 +903,9 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 				case V34_MAP_ENTRY_TYPE_COMPRESSED:
 					{
 						uint32_t const blocklen = get_u16be(&rawmap[12]) | (uint32_t(rawmap[14]) << 16);
+						if (UNEXPECTED(blocklen > m_compressed.size()))
+							return std::error_condition(error::INVALID_DATA);
+
 						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
@@ -933,7 +936,6 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 
 				// compressed case
 				uint8_t const *const rawmap = &m_rawmap[m_mapentrybytes * hunknum];
-				uint32_t const blocklen = get_u24be(&rawmap[1]);
 				uint64_t const blockoffs = get_u48be(&rawmap[4]);
 				switch (rawmap[0])
 				{
@@ -941,8 +943,12 @@ std::error_condition chd_file::codec_process_hunk(uint32_t hunknum)
 				case COMPRESSION_TYPE_1:
 				case COMPRESSION_TYPE_2:
 				case COMPRESSION_TYPE_3:
-					{
-						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
+				{
+					uint32_t const blocklen = get_u24be(&rawmap[1]);
+					if (UNEXPECTED(blocklen > m_compressed.size()))
+						return std::error_condition(error::INVALID_DATA);
+
+					std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
 						auto &decompressor = *m_decompressor[rawmap[0]];
@@ -1029,6 +1035,9 @@ std::error_condition chd_file::read_hunk(uint32_t hunknum, void *buffer)
 				case V34_MAP_ENTRY_TYPE_COMPRESSED:
 					{
 						uint32_t const blocklen = get_u16be(&rawmap[12]) | (uint32_t(rawmap[14]) << 16);
+						if (UNEXPECTED(blocklen > m_compressed.size()))
+							return std::error_condition(error::INVALID_DATA);
+
 						std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 						if (UNEXPECTED(err))
 							return err;
@@ -1089,7 +1098,6 @@ std::error_condition chd_file::read_hunk(uint32_t hunknum, void *buffer)
 				else
 				{
 					// compressed case
-					uint32_t const blocklen = get_u24be(&rawmap[1]);
 					uint64_t const blockoffs = get_u48be(&rawmap[4]);
 					util::crc16_t const blockcrc = get_u16be(&rawmap[10]);
 					switch (rawmap[0])
@@ -1099,6 +1107,10 @@ std::error_condition chd_file::read_hunk(uint32_t hunknum, void *buffer)
 					case COMPRESSION_TYPE_2:
 					case COMPRESSION_TYPE_3:
 						{
+							uint32_t const blocklen = get_u24be(&rawmap[1]);
+							if (UNEXPECTED(blocklen > m_compressed.size()))
+								return std::error_condition(error::INVALID_DATA);
+
 							std::error_condition err = file_read(blockoffs, m_compressed.data(), blocklen);
 							if (UNEXPECTED(err))
 								return err;


### PR DESCRIPTION
I refined the V5 checks so the compressed-length field is only validated for codec-compressed map entries (COMPRESSION_TYPE_0–3). COMPRESSION_NONE, COMPRESSION_SELF, and COMPRESSION_PARENT don't use that field as a compressed-buffer length, so the check no longer applies to those entry types.

The original change adds bounds checks before compressed hunk data is read into the temporary compressed buffer. This prevents a malformed CHD map entry from specifying a compressed length larger than the available buffer and causing an out-of-bounds write. Malformed hunks with an oversized compressed length are now rejected as invalid data before the read occurs.

I rebuilt chd.cpp and chdman successfully with the updated branch.

I used ChatGPT (GPT-5.6 Sol) to help review the code, identify the missing bounds checks, and review the fix. I made and reviewed the changes manually.