### PR TITLE
chd: Handle short writes

### DIFF
--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -194,7 +194,11 @@ inline std::error_condition chd_file::file_write(uint64_t offset, const void *so
 	err = m_file->seek(offset, SEEK_SET);
 	if (UNEXPECTED(err))
 		return err;
-	return write(*m_file, source, length).first;
+	size_t count;
+	std::tie(err, count) = write(*m_file, source, length);
+	if (UNEXPECTED(!err && (count != length)))
+		return std::error_condition(std::errc::io_error);
+	return err;
 }
 
 
@@ -235,6 +239,8 @@ inline uint64_t chd_file::file_append(const void *source, uint32_t length, uint3
 				std::tie(err, count) = write(*m_file, buffer, bytes_to_write);
 				if (UNEXPECTED(err))
 					throw err;
+				if (UNEXPECTED(!count))
+					throw std::error_condition(std::errc::io_error);
 				delta -= count;
 			}
 		}
@@ -245,9 +251,12 @@ inline uint64_t chd_file::file_append(const void *source, uint32_t length, uint3
 	err = m_file->tell(offset);
 	if (UNEXPECTED(err))
 		throw err;
-	std::tie(err, std::ignore) = write(*m_file, source, length);
+	size_t count;
+	std::tie(err, count) = write(*m_file, source, length);
 	if (UNEXPECTED(err))
 		throw err;
+	if (UNEXPECTED(count != length))
+		throw std::error_condition(std::errc::io_error);
 	return offset;
 }
 


### PR DESCRIPTION
Check the number of bytes actually written by CHD file write operations and report an I/O error when a write returns success but does not transfer the full requested length.

Also, prevent the alignment padding loop in file_append from spinning forever if a write succeeds but makes no progress (zero bytes written).

Used ChatGPT (GPT-5.6 Sol) to review the code, identify the short-write issues, and help prepare the fix, manually applied. The fix was double-checked by Grok 4.5.

**User-visible behavior:** CHD creation or modification will now stop with an I/O error if the underlying write reports success but transfers fewer bytes than requested, rather than continuing with incomplete output. A zero-byte successful write during alignment padding will also fail instead of potentially looping indefinitely.