### PR TITLE
chdman: Return failure when CHD verification fails

### DIFF
--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1848,6 +1848,8 @@ static void do_verify(parameters_map &params)
 				report_error(1, "Error updating SHA1: %s", err.message());
 			util::stream_format(std::cout, "SHA1 updated to correct value in input CHD\n");
 		}
+		else
+			report_error(1, "CHD verification failed");
 	}
 	else
 	{
@@ -1872,6 +1874,8 @@ static void do_verify(parameters_map &params)
 						report_error(1, "Error updating SHA1: %s", err.message());
 					util::stream_format(std::cout, "SHA1 updated to correct value in input CHD\n");
 				}
+				else
+					report_error(1, "CHD verification failed");
 			}
 		}
 	}


### PR DESCRIPTION
Make chdman verify return an error when a raw or overall SHA-1 mismatch is found and --fix isn't being used.

Previously, chdman reported the mismatch but still exited successfully, which could cause scripts to treat a CHD that failed verification as valid. Scripts that previously continued after a failed verification will now receive a non-zero exit status.

The CHD itself is not modified unless --fix is used.

Used ChatGPT (GPT-5.6 Sol) to review the code, identify the issue, and help prepare the fix, which was applied manually.