### PR TITLE
votrax: fix unstable F2 noise-injection filter

### DIFF
--- a/src/devices/sound/votrax.cpp
+++ b/src/devices/sound/votrax.cpp
@@ -1025,7 +1025,7 @@ void votrax_sc01_device::build_injection_filter(double *a, double *b,
 {
 	// First compute the three coefficients of H(s) = (k0 + k2*s)/(k1 + k2*s)
 	double k0 = m_cclock * c2t;
-	double k1 = m_cclock * (c1b * c3 / c2t - c2t);
+	double k1 = m_cclock * (c1b * c3 / c2t + c2t);
 	double k2 = c2b;
 
 	// Don't pre-warp


### PR DESCRIPTION
Fix a sign error in `votrax_sc01_device::build_injection_filter` that can make the SC-01 F2 noise-injection filter unstable for valid internal ROM states.

The current calculation subtracts the `c2t` contribution from `k1`. 

```cpp
double k1 = m_cclock * (c1b * c3 / c2t - c2t);
```

This can make `k1` negative, placing the bilinear-transform pole outside the unit circle. The two capacitance contributions should be added:

```cpp
double k1 = m_cclock * (c1b * c3 / c2t + c2t);
```

Wizard of Wor English fragment $3C at game ROM address $9270 ("Now you
know the taste of my magic") contains a V -> M transition. With the current
subtraction, playback runs away at that transition, subsequent speech is
silent, and the Votrax channel may buzz on exit.

A standalone numerical probe that ports the relevant SC-01 state decoding,
interpolation, and filter path is attached as **[votrax_filter_probe.py](https://github.com/user-attachments/files/31117046/votrax_filter_probe.py)**

```bash
python3 votrax_filter_probe.py /path/to/sc01.bin
```

Results with the canonical SC-01 internal ROM
| Measurement | Current subtraction | Corrected addition |
| --- | ---: | ---: |
| Unstable F2/F2Q states | 91/512 | 0/512 |
| Maximum pole magnitude | 1.28911987 | 0.804286719 |
| Wizard of Wor `$9270` peak | `2.71337805e+279` | `0.937625282` |
| `P -> M` | non-finite | finite |
| `V -> M` | non-finite | finite |
| `V -> PA0 -> M` | non-finite | finite |

**AI assistance disclosure**
OpenAI Codex (GPT-5.6-sol) was used to help analyze the filter stability,
develop the standalone numerical probe. 

[votrax_filter_probe.py](https://github.com/user-attachments/files/31117055/votrax_filter_probe.py)
