### PR TITLE
sound/tms320av110: Add preliminary MPEG audio decoder

### DIFF
--- a/scripts/src/sound.lua
+++ b/scripts/src/sound.lua
@@ -1535,6 +1535,18 @@ if SOUNDS["MPEG_AUDIO"] then
 end
 
 ---------------------------------------------------
+-- Texas Instruments TMS320AV110 MPEG audio decoder
+--@src/devices/sound/tms320av110.h,SOUNDS["TMS320AV110"] = true
+---------------------------------------------------
+
+if SOUNDS["TMS320AV110"] then
+	files {
+		MAME_DIR .. "src/devices/sound/tms320av110.cpp",
+		MAME_DIR .. "src/devices/sound/tms320av110.h",
+	}
+end
+
+---------------------------------------------------
 -- ZOOM ZSG-2
 --@src/devices/sound/zsg2.h,SOUNDS["ZSG2"] = true
 ---------------------------------------------------

--- a/src/devices/sound/mpeg_audio.cpp
+++ b/src/devices/sound/mpeg_audio.cpp
@@ -33,6 +33,12 @@ void mpeg_audio::clear()
 	m_audio_buffer_pos[1] = 16*32;
 }
 
+void mpeg_audio::register_save_state(device_t &device, int index)
+{
+	device.save_item(m_audio_buffer, "mpeg_audio_buffer", index);
+	device.save_item(m_audio_buffer_pos, "mpeg_audio_buffer_pos", index);
+}
+
 bool mpeg_audio::decode_buffer(int &pos, int limit, short *output,
 								int &output_samples, int &sample_rate, int &channels, int atbl)
 {

--- a/src/devices/sound/mpeg_audio.h
+++ b/src/devices/sound/mpeg_audio.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+class device_t;
+
 class mpeg_audio {
 public:
 	// Accepted layers.  Beware that AMM is incompatible with L2 (and
@@ -55,6 +57,9 @@ public:
 
 	// Clear audio buffer
 	void clear();
+
+	// Register persistent synthesis history with an owning device.
+	void register_save_state(device_t &device, int index = 0);
 
 private:
 	struct limit_hit {};

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -65,12 +65,6 @@ constexpr offs_t REG_PCM_DIV = 0x6e;  // PCM clock divider
 constexpr offs_t REG_DIF = 0x6f;      // 18-bit PCM justification
 constexpr offs_t REG_SIN_EN = 0x70;   // serial compressed-data input enable
 
-constexpr u8 SINGLE_BIT_MASK = 0x01;
-constexpr u8 TWO_BIT_MASK = 0x03;
-constexpr u8 THREE_BIT_MASK = 0x07;
-constexpr u8 FIVE_BIT_MASK = 0x1f;
-constexpr u8 SIX_BIT_MASK = 0x3f;
-
 // Without external DRAM, the on-chip compressed-data input SRAM is 256 bytes.
 constexpr unsigned INPUT_BUFFER_BYTES_WITHOUT_DRAM = 256;
 // The supported external DRAM is 256K locations by four bits.
@@ -501,24 +495,24 @@ void tms320av110_device::write(offs_t offset, u8 data)
 		break;
 
 	case REG_FREE_FORM_H:
-		m_decoder->registers[offset] = data & THREE_BIT_MASK;
+		m_decoder->registers[offset] = data & 0x07;
 		break;
 
 	case REG_SYNC_LCK:
 	case REG_CRC_ECM:
 	case REG_SYNC_ECM:
 	case REG_STR_SEL:
-		m_decoder->registers[offset] = data & TWO_BIT_MASK;
+		m_decoder->registers[offset] = data & 0x03;
 		break;
 
 	case REG_AUD_ID:
-		m_decoder->registers[offset] = data & FIVE_BIT_MASK;
+		m_decoder->registers[offset] = data & 0x1f;
 		break;
 
 	case REG_ATTEN_L:
 	case REG_ATTEN_R:
 	case REG_PCM_DIV:
-		m_decoder->registers[offset] = data & SIX_BIT_MASK;
+		m_decoder->registers[offset] = data & 0x3f;
 		break;
 
 	case REG_PCM_18:
@@ -531,16 +525,16 @@ void tms320av110_device::write(offs_t offset, u8 data)
 	case REG_LATENCY:
 	case REG_DIF:
 	case REG_SIN_EN:
-		m_decoder->registers[offset] = data & SINGLE_BIT_MASK;
+		m_decoder->registers[offset] = data & 0x01;
 		break;
 
 	case REG_RESET:
-		if (data & SINGLE_BIT_MASK)
+		if (data & 0x01)
 			start_reset(false);
 		break;
 
 	case REG_RESTART:
-		if (data & SINGLE_BIT_MASK)
+		if (data & 0x01)
 			start_restart();
 		break;
 

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -528,26 +528,30 @@ void tms320av110_device::map(address_map &map)
 void tms320av110_device::sound_stream_update(sound_stream &stream)
 {
 	const bool playing = BIT(m_registers[REG_PLAY], 0) && !m_reset_asserted && !m_reset_cycle;
+	stream.fill(LEFT_CHANNEL, 0);
+	stream.fill(RIGHT_CHANNEL, 0);
+	if (!playing)
+		return;
+
 	const bool muted = BIT(m_registers[REG_MUTE], 0);
 	const float left_gain = std::pow(10.0F, -float(m_registers[REG_ATTEN_L]) / 10.0F);
 	const float right_gain = std::pow(10.0F, -float(m_registers[REG_ATTEN_R]) / 10.0F);
 
 	for (int sample = 0; sample < stream.samples(); sample++)
 	{
-		if (!playing || ((m_pcm_position == m_pcm_count) && !decode_frame()))
-		{
-			stream.put(LEFT_CHANNEL, sample, 0.0F);
-			stream.put(RIGHT_CHANNEL, sample, 0.0F);
-			continue;
-		}
+		if ((m_pcm_position == m_pcm_count) && !decode_frame())
+			break;
 
 		const u32 position = m_pcm_position * m_pcm_channels;
 		const s16 left = m_pcm[position];
 		const s16 right = (m_pcm_channels == OUTPUT_CHANNELS)
 			? m_pcm[position + RIGHT_CHANNEL]
 			: left;
-		stream.put(LEFT_CHANNEL, sample, muted ? 0.0F : (float(left) / 32'768.0F) * left_gain);
-		stream.put(RIGHT_CHANNEL, sample, muted ? 0.0F : (float(right) / 32'768.0F) * right_gain);
+		if (!muted)
+		{
+			stream.put(LEFT_CHANNEL, sample, (float(left) / 32'768.0F) * left_gain);
+			stream.put(RIGHT_CHANNEL, sample, (float(right) / 32'768.0F) * right_gain);
+		}
 		m_pcm_position++;
 	}
 }

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -4,10 +4,9 @@
 /*
  * Texas Instruments TMS320AV110 MPEG-1 audio decoder (preliminary)
  *
- * The implemented subset consists of the host register window, memory-mapped
- * compressed-data input, reset-controlled REQ signalling, and MPEG-1 Audio
- * Layer II reconstruction.  Input-buffer-full backpressure and other
- * control/status register behaviour are not yet fully implemented.
+ * The implemented subset consists of the host register window, compressed-
+ * data buffering and the REQ handshake, reset/restart sequencing, PLAY and
+ * MUTE control, and MPEG-1 Audio Layer II reconstruction.
  *
  * Reference: Texas Instruments data sheet SCSS013C, revised August 1995.
  */
@@ -17,14 +16,74 @@
 
 #include "mpeg_audio.h"
 
+#include <cmath>
+
+#define LOG_REQUESTS (1U << 0)
+#define LOG_REGISTERS (1U << 1)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
 namespace {
 
 // The host interface has seven address pins, SADDR6 through SADDR0.
 constexpr unsigned HOST_ADDRESS_BITS = 7;
-constexpr offs_t HOST_ADDRESS_MASK = (1U << HOST_ADDRESS_BITS) - 1;
+constexpr unsigned HOST_REGISTER_COUNT = 1U << HOST_ADDRESS_BITS;
+constexpr offs_t HOST_ADDRESS_MASK = HOST_REGISTER_COUNT - 1;
 
-// DATAIN is the data sheet's memory-mapped compressed-audio input register.
-constexpr offs_t REG_DATAIN = 0x18;
+// Host-interface register addresses from the data sheet.
+constexpr offs_t REG_BUFF_L = 0x12;   // input buffer word count, bits 7:0
+constexpr offs_t REG_BUFF_H = 0x13;   // input buffer word count, bits 14:8
+constexpr offs_t REG_FREE_FORM_L = 0x14; // free-format frame length, bits 7:0
+constexpr offs_t REG_FREE_FORM_H = 0x15; // free-format frame length, bits 10:8
+constexpr offs_t REG_PCM_18 = 0x16;   // PCM output precision
+constexpr offs_t REG_DATAIN = 0x18;   // memory-mapped compressed-data input
+constexpr offs_t REG_INTR_L = 0x1a;   // interrupt status, bits 7:0
+constexpr offs_t REG_INTR_H = 0x1b;   // interrupt status, bits 15:8
+constexpr offs_t REG_INTR_EN_L = 0x1c; // interrupt enable, bits 7:0
+constexpr offs_t REG_INTR_EN_H = 0x1d; // interrupt enable, bits 15:8
+constexpr offs_t REG_ATTEN_L = 0x1e;  // left output attenuation
+constexpr offs_t REG_ATTEN_R = 0x20;  // right output attenuation
+constexpr offs_t REG_AUD_ID = 0x22;   // MPEG system/packet audio stream ID
+constexpr offs_t REG_AUD_ID_EN = 0x24; // audio stream ID filtering enable
+constexpr offs_t REG_SYNC_ST = 0x26;  // synchronization status
+constexpr offs_t REG_SYNC_LCK = 0x28; // required additional synchronization words
+constexpr offs_t REG_CRC_ECM = 0x2a;  // CRC error concealment mode
+constexpr offs_t REG_SYNC_ECM = 0x2c; // synchronization error concealment mode
+constexpr offs_t REG_PLAY = 0x2e;     // decoded audio output enable
+constexpr offs_t REG_MUTE = 0x30;     // decoded audio mute
+constexpr offs_t REG_SKIP = 0x32;     // skip next audio frame
+constexpr offs_t REG_REPEAT = 0x34;   // repeat next audio frame
+constexpr offs_t REG_STR_SEL = 0x36;  // compressed input stream format
+constexpr offs_t REG_PCM_ORD = 0x38;  // PCM output bit order
+constexpr offs_t REG_LATENCY = 0x3c;  // synchronization lookahead enable
+constexpr offs_t REG_DRAM_EXT = 0x3e; // external input-buffer DRAM present
+constexpr offs_t REG_RESET = 0x40;    // decoder reset command/status
+constexpr offs_t REG_RESTART = 0x42;  // data-buffer flush command/status
+constexpr offs_t REG_PCM_FS = 0x44;   // decoded sampling frequency
+constexpr offs_t REG_PCM_DIV = 0x6e;  // PCM clock divider
+constexpr offs_t REG_DIF = 0x6f;      // 18-bit PCM justification
+constexpr offs_t REG_SIN_EN = 0x70;   // serial compressed-data input enable
+
+constexpr u8 SINGLE_BIT_MASK = 0x01;
+constexpr u8 TWO_BIT_MASK = 0x03;
+constexpr u8 THREE_BIT_MASK = 0x07;
+constexpr u8 FIVE_BIT_MASK = 0x1f;
+constexpr u8 SIX_BIT_MASK = 0x3f;
+
+// Without external DRAM, the on-chip compressed-data input SRAM is 256 bytes.
+constexpr unsigned INPUT_BUFFER_BYTES_WITHOUT_DRAM = 256;
+// The supported external DRAM is 256K locations by four bits.
+constexpr unsigned INPUT_BUFFER_BYTES_WITH_DRAM = 256 * 1024 * 4 / 8;
+// The interface permits one further byte after REQ reports full, held
+// separately from the selected input buffer.
+constexpr unsigned INPUT_FIFO_BYTES = INPUT_BUFFER_BYTES_WITH_DRAM + 1;
+
+// A no-DRAM reset takes approximately 700 microseconds at the nominal 24 MHz
+// OSCIN frequency, corresponding to 16,800 oscillator clocks.
+constexpr unsigned RESET_CYCLES_WITHOUT_DRAM = 16'800;
+// With external DRAM, reset takes approximately 3.7 ms at 24 MHz.
+constexpr unsigned RESET_CYCLES_WITH_DRAM = 88'800;
 
 // MPEG audio is presented as left and right PCM output slots, including mono streams.
 constexpr unsigned LEFT_CHANNEL = 0;
@@ -45,8 +104,9 @@ constexpr unsigned MPEG_FRAME_PADDING_BYTES = 1;
 constexpr unsigned MAX_MPEG_AUDIO_FRAME_BYTES =
 	(MPEG1_LAYER_II_FRAME_SCALE * MAX_MPEG1_LAYER_II_BIT_RATE / MIN_MPEG1_SAMPLE_RATE) + MPEG_FRAME_PADDING_BYTES;
 
-// Retain two maximum-sized frames so the frame-based decoder can accept streaming input.
-constexpr unsigned INPUT_BUFFER_BYTES = 2 * MAX_MPEG_AUDIO_FRAME_BYTES;
+// This is private storage for adapting the streaming device to the frame-based
+// MPEG helper.  It is not the AV110's hardware-visible compressed-data SRAM.
+constexpr unsigned DECODER_INPUT_BYTES = 2 * MAX_MPEG_AUDIO_FRAME_BYTES;
 
 } // anonymous namespace
 
@@ -54,9 +114,14 @@ DEFINE_DEVICE_TYPE(TMS320AV110, tms320av110_device, "tms320av110", "Texas Instru
 
 struct tms320av110_device::decoder_state
 {
-	std::array<u8, INPUT_BUFFER_BYTES> input{};
+	std::array<u8, HOST_REGISTER_COUNT> registers{};
+	std::array<u8, INPUT_FIFO_BYTES> input_fifo{};
+	std::array<u8, DECODER_INPUT_BYTES> input{};
 	std::array<s16, MPEG_LAYER_II_SAMPLES_PER_FRAME * OUTPUT_CHANNELS> pcm{};
 	std::unique_ptr<mpeg_audio> decoder;
+	unsigned input_fifo_read = 0;
+	unsigned input_fifo_write = 0;
+	unsigned input_fifo_count = 0;
 	unsigned input_bytes = 0;
 	unsigned input_bit_position = 0;
 	unsigned pcm_position = 0;
@@ -70,7 +135,13 @@ tms320av110_device::tms320av110_device(const machine_config &mconfig, const char
 	m_stream(nullptr),
 	m_req_cb(*this),
 	m_decoder(std::make_unique<decoder_state>()),
-	m_reset_asserted(true)
+	m_external_dram(false),
+	m_input_timer(nullptr),
+	m_reset_timer(nullptr),
+	m_reset_asserted(false),
+	m_reset_cycle(false),
+	m_data_access(false),
+	m_req_state(CLEAR_LINE)
 {
 }
 
@@ -79,23 +150,42 @@ tms320av110_device::~tms320av110_device() = default;
 void tms320av110_device::device_start()
 {
 	m_stream = stream_alloc(0, OUTPUT_CHANNELS, INITIAL_SAMPLE_RATE);
+	m_input_timer = timer_alloc(FUNC(tms320av110_device::input_tick), this);
+	m_reset_timer = timer_alloc(FUNC(tms320av110_device::reset_complete), this);
 	decoder_create();
+	m_decoder->decoder->register_save_state(*this);
 
+	save_item(NAME(m_decoder->registers));
+	save_item(NAME(m_decoder->input_fifo));
 	save_item(NAME(m_decoder->input));
 	save_item(NAME(m_decoder->pcm));
+	save_item(NAME(m_decoder->input_fifo_read));
+	save_item(NAME(m_decoder->input_fifo_write));
+	save_item(NAME(m_decoder->input_fifo_count));
 	save_item(NAME(m_decoder->input_bytes));
 	save_item(NAME(m_decoder->input_bit_position));
 	save_item(NAME(m_decoder->pcm_position));
 	save_item(NAME(m_decoder->pcm_count));
 	save_item(NAME(m_decoder->pcm_channels));
 	save_item(NAME(m_reset_asserted));
+	save_item(NAME(m_reset_cycle));
+	save_item(NAME(m_data_access));
+	save_item(NAME(m_req_state));
 }
 
 void tms320av110_device::device_reset()
 {
-	decoder_reset();
-	m_reset_asserted = true;
-	update_req();
+	m_input_timer->adjust(attotime::never);
+	m_reset_timer->adjust(attotime::never);
+	m_decoder->registers.fill(0);
+	m_reset_asserted = false;
+	m_reset_cycle = false;
+	start_reset(true);
+}
+
+void tms320av110_device::device_post_load()
+{
+	m_req_cb(m_req_state);
 }
 
 void tms320av110_device::decoder_create()
@@ -118,7 +208,68 @@ void tms320av110_device::decoder_reset()
 	m_decoder->pcm_position = 0;
 	m_decoder->pcm_count = 0;
 	m_decoder->pcm_channels = 0;
-	decoder_create();
+	m_decoder->registers[REG_SYNC_ST] = 0;
+	m_decoder->registers[REG_PCM_FS] = 0;
+	m_decoder->decoder->clear();
+}
+
+void tms320av110_device::input_fifo_reset()
+{
+	m_input_timer->adjust(attotime::never);
+	m_decoder->input_fifo.fill(0);
+	m_decoder->input_fifo_read = 0;
+	m_decoder->input_fifo_write = 0;
+	m_decoder->input_fifo_count = 0;
+	m_data_access = false;
+}
+
+void tms320av110_device::start_reset(bool pin_reset)
+{
+	decoder_reset();
+	input_fifo_reset();
+	m_decoder->registers[REG_INTR_L] = 0;
+	m_decoder->registers[REG_INTR_H] = 0;
+	m_decoder->registers[REG_INTR_EN_L] = 0;
+	m_decoder->registers[REG_INTR_EN_H] = 0;
+	m_decoder->registers[REG_RESET] = 1;
+	m_decoder->registers[REG_RESTART] = 0;
+	if (pin_reset)
+	{
+		m_decoder->registers[REG_PLAY] = 0;
+		m_decoder->registers[REG_MUTE] = 0;
+		m_decoder->registers[REG_PCM_DIV] = 0;
+	}
+
+	m_reset_cycle = true;
+	m_reset_timer->adjust(clocks_to_attotime(
+		m_external_dram ? RESET_CYCLES_WITH_DRAM : RESET_CYCLES_WITHOUT_DRAM));
+	update_req();
+}
+
+void tms320av110_device::start_restart()
+{
+	decoder_reset();
+	input_fifo_reset();
+	m_decoder->registers[REG_INTR_L] = 0;
+	m_decoder->registers[REG_INTR_H] = 0;
+	m_decoder->registers[REG_INTR_EN_L] = 0;
+	m_decoder->registers[REG_INTR_EN_H] = 0;
+	m_decoder->registers[REG_RESTART] = 1;
+	m_reset_cycle = true;
+
+	// Restart completion timing is not specified.  Complete it on the next
+	// oscillator clock so the command and REQ transition remain observable.
+	m_reset_timer->adjust(clocks_to_attotime(1));
+	update_req();
+}
+
+TIMER_CALLBACK_MEMBER(tms320av110_device::reset_complete)
+{
+	m_decoder->registers[REG_RESET] = 0;
+	m_decoder->registers[REG_RESTART] = 0;
+	m_reset_cycle = false;
+	update_req();
+	start_input_timer();
 }
 
 bool tms320av110_device::decode_frame()
@@ -143,6 +294,7 @@ bool tms320av110_device::decode_frame()
 	m_decoder->pcm_position = 0;
 	m_decoder->pcm_count = sample_count;
 	m_decoder->pcm_channels = channels;
+	m_decoder->registers[REG_SYNC_ST] = 0x03;
 
 	const unsigned bytes_consumed = position / 8;
 	if (bytes_consumed)
@@ -154,40 +306,114 @@ bool tms320av110_device::decode_frame()
 		m_decoder->input_bytes -= bytes_consumed;
 	}
 	m_decoder->input_bit_position = position & 7;
-	update_req();
+	start_input_timer();
 
-	if (sample_rate && (sample_rate != m_stream->sample_rate()))
-		m_stream->set_sample_rate(sample_rate);
+	if (sample_rate)
+	{
+		switch (sample_rate)
+		{
+		case 44'100: m_decoder->registers[REG_PCM_FS] = 0; break;
+		case 48'000: m_decoder->registers[REG_PCM_FS] = 1; break;
+		case 32'000: m_decoder->registers[REG_PCM_FS] = 2; break;
+		default: break;
+		}
+
+		if (sample_rate != m_stream->sample_rate())
+			m_stream->set_sample_rate(sample_rate);
+	}
 
 	return true;
 }
 
+void tms320av110_device::start_input_timer()
+{
+	if (!m_reset_asserted && !m_reset_cycle && m_decoder->input_fifo_count &&
+		(m_data_access || (m_decoder->input_bytes != m_decoder->input.size())))
+	{
+		m_input_timer->adjust(clocks_to_attotime(1));
+	}
+}
+
+TIMER_CALLBACK_MEMBER(tms320av110_device::input_tick)
+{
+	LOGMASKED(LOG_REQUESTS, "%s: input tick, FIFO=%u staging=%u\n", machine().describe_context(),
+		m_decoder->input_fifo_count, m_decoder->input_bytes);
+	m_stream->update();
+	if (m_decoder->input_fifo_count && (m_decoder->input_bytes != m_decoder->input.size()))
+	{
+		m_decoder->input[m_decoder->input_bytes++] = m_decoder->input_fifo[m_decoder->input_fifo_read];
+		m_decoder->input_fifo_read = (m_decoder->input_fifo_read + 1) % m_decoder->input_fifo.size();
+		m_decoder->input_fifo_count--;
+	}
+	if ((m_decoder->pcm_position == m_decoder->pcm_count) &&
+		(m_decoder->input_bytes == m_decoder->input.size()))
+	{
+		decode_frame();
+	}
+
+	m_data_access = false;
+	update_req();
+	start_input_timer();
+}
+
 void tms320av110_device::fifo_w(u8 data)
 {
-	if (m_decoder->input_bytes == m_decoder->input.size())
+	LOGMASKED(LOG_REQUESTS, "%s: DATAIN %02x, FIFO=%u staging=%u\n", machine().describe_context(), data,
+		m_decoder->input_fifo_count, m_decoder->input_bytes);
+	if (m_reset_cycle)
+	{
+		LOGMASKED(LOG_REGISTERS, "%s: DATAIN write %02x during reset/restart\n", machine().describe_context(), data);
+		return;
+	}
+
+	m_stream->update();
+	const unsigned capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
+	if (m_decoder->input_fifo_count > capacity)
 	{
 		logerror("%s: compressed-audio input overflow\n", machine().describe_context());
 		return;
 	}
 
-	m_decoder->input[m_decoder->input_bytes++] = data;
+	m_decoder->input_fifo[m_decoder->input_fifo_write] = data;
+	m_decoder->input_fifo_write = (m_decoder->input_fifo_write + 1) % m_decoder->input_fifo.size();
+	m_decoder->input_fifo_count++;
+	m_data_access = true;
 	update_req();
+	start_input_timer();
+}
+
+void tms320av110_device::set_req(int state)
+{
+	if (m_req_state != state)
+	{
+		LOGMASKED(LOG_REQUESTS, "%s: REQ=%d\n", machine().describe_context(), state);
+		m_req_state = state;
+		m_req_cb(state);
+	}
 }
 
 void tms320av110_device::update_req()
 {
-	// REQ is active low and is held inactive during reset or while the input buffer is full.
-	m_req_cb((m_reset_asserted || (m_decoder->input_bytes == m_decoder->input.size())) ? ASSERT_LINE : CLEAR_LINE);
+	// REQ is active low.  DATAIN raises it for the access handshake, and it
+	// remains high while reset is active or the selected input buffer is full.
+	const unsigned capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
+	set_req((m_reset_asserted || m_reset_cycle || m_data_access ||
+		(m_decoder->input_fifo_count >= capacity)) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void tms320av110_device::reset_w(int state)
 {
 	const bool asserted = !state;
 	if (asserted && !m_reset_asserted)
-		decoder_reset();
-
-	m_reset_asserted = asserted;
-	update_req();
+	{
+		m_reset_asserted = true;
+		start_reset(true);
+	}
+	else if (!asserted && m_reset_asserted)
+	{
+		m_reset_asserted = false;
+		update_req();
+	}
 }
 
 u8 tms320av110_device::read(offs_t offset)
@@ -196,8 +422,50 @@ u8 tms320av110_device::read(offs_t offset)
 		return 0; // The data sheet specifies that RESET low disables host accesses.
 
 	offset &= HOST_ADDRESS_MASK;
+	switch (offset)
+	{
+	case REG_BUFF_L:
+		return (m_decoder->input_fifo_count / 4) & 0xff;
+
+	case REG_BUFF_H:
+		return (m_decoder->input_fifo_count / 4) >> 8;
+
+	case REG_DRAM_EXT:
+		return m_external_dram;
+
+	case REG_SYNC_ST:
+	case REG_PCM_FS:
+	case REG_FREE_FORM_L:
+	case REG_FREE_FORM_H:
+	case REG_PCM_18:
+	case REG_INTR_L:
+	case REG_INTR_H:
+	case REG_INTR_EN_L:
+	case REG_INTR_EN_H:
+	case REG_ATTEN_L:
+	case REG_ATTEN_R:
+	case REG_AUD_ID:
+	case REG_AUD_ID_EN:
+	case REG_SYNC_LCK:
+	case REG_CRC_ECM:
+	case REG_SYNC_ECM:
+	case REG_PLAY:
+	case REG_MUTE:
+	case REG_SKIP:
+	case REG_REPEAT:
+	case REG_STR_SEL:
+	case REG_PCM_ORD:
+	case REG_LATENCY:
+	case REG_RESET:
+	case REG_RESTART:
+	case REG_PCM_DIV:
+	case REG_DIF:
+	case REG_SIN_EN:
+		return m_decoder->registers[offset];
+	}
+
 	if (!machine().side_effects_disabled())
-		logerror("%s: unimplemented register read %02x\n", machine().describe_context(), offset);
+		LOGMASKED(LOG_REGISTERS, "%s: unimplemented register read %02x\n", machine().describe_context(), offset);
 	return 0;
 }
 
@@ -213,14 +481,84 @@ void tms320av110_device::write(offs_t offset, u8 data)
 		return;
 	}
 
-	logerror("%s: unimplemented register write %02x = %02x\n", machine().describe_context(), offset, data);
+	LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), offset, data);
+	switch (offset)
+	{
+	case REG_PLAY:
+	case REG_MUTE:
+	case REG_ATTEN_L:
+	case REG_ATTEN_R:
+		m_stream->update();
+		break;
+	}
+
+	switch (offset)
+	{
+	case REG_FREE_FORM_L:
+	case REG_INTR_EN_L:
+	case REG_INTR_EN_H:
+		m_decoder->registers[offset] = data;
+		break;
+
+	case REG_FREE_FORM_H:
+		m_decoder->registers[offset] = data & THREE_BIT_MASK;
+		break;
+
+	case REG_SYNC_LCK:
+	case REG_CRC_ECM:
+	case REG_SYNC_ECM:
+	case REG_STR_SEL:
+		m_decoder->registers[offset] = data & TWO_BIT_MASK;
+		break;
+
+	case REG_AUD_ID:
+		m_decoder->registers[offset] = data & FIVE_BIT_MASK;
+		break;
+
+	case REG_ATTEN_L:
+	case REG_ATTEN_R:
+	case REG_PCM_DIV:
+		m_decoder->registers[offset] = data & SIX_BIT_MASK;
+		break;
+
+	case REG_PCM_18:
+	case REG_AUD_ID_EN:
+	case REG_PLAY:
+	case REG_MUTE:
+	case REG_SKIP:
+	case REG_REPEAT:
+	case REG_PCM_ORD:
+	case REG_LATENCY:
+	case REG_DIF:
+	case REG_SIN_EN:
+		m_decoder->registers[offset] = data & SINGLE_BIT_MASK;
+		break;
+
+	case REG_RESET:
+		if (data & SINGLE_BIT_MASK)
+			start_reset(false);
+		break;
+
+	case REG_RESTART:
+		if (data & SINGLE_BIT_MASK)
+			start_restart();
+		break;
+
+	default:
+		break;
+	}
 }
 
 void tms320av110_device::sound_stream_update(sound_stream &stream)
 {
+	const bool playing = BIT(m_decoder->registers[REG_PLAY], 0) && !m_reset_asserted && !m_reset_cycle;
+	const bool muted = BIT(m_decoder->registers[REG_MUTE], 0);
+	const float left_gain = std::pow(10.0F, -float(m_decoder->registers[REG_ATTEN_L]) / 10.0F);
+	const float right_gain = std::pow(10.0F, -float(m_decoder->registers[REG_ATTEN_R]) / 10.0F);
+
 	for (int sample = 0; sample < stream.samples(); sample++)
 	{
-		if ((m_decoder->pcm_position == m_decoder->pcm_count) && !decode_frame())
+		if (!playing || ((m_decoder->pcm_position == m_decoder->pcm_count) && !decode_frame()))
 		{
 			stream.put(LEFT_CHANNEL, sample, 0.0F);
 			stream.put(RIGHT_CHANNEL, sample, 0.0F);
@@ -232,8 +570,8 @@ void tms320av110_device::sound_stream_update(sound_stream &stream)
 		const s16 right = (m_decoder->pcm_channels == OUTPUT_CHANNELS)
 			? m_decoder->pcm[position + RIGHT_CHANNEL]
 			: left;
-		stream.put_int(LEFT_CHANNEL, sample, left, 32'768);
-		stream.put_int(RIGHT_CHANNEL, sample, right, 32'768);
+		stream.put(LEFT_CHANNEL, sample, muted ? 0.0F : (float(left) / 32'768.0F) * left_gain);
+		stream.put(RIGHT_CHANNEL, sample, muted ? 0.0F : (float(right) / 32'768.0F) * right_gain);
 		m_decoder->pcm_position++;
 	}
 }

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -308,137 +308,221 @@ void tms320av110_device::reset_w(int state)
 	}
 }
 
-u8 tms320av110_device::read(offs_t offset)
+template <offs_t Register>
+u8 tms320av110_device::register_r()
 {
 	if (m_reset_asserted)
 		return 0; // The data sheet specifies that RESET low disables host accesses.
 
-	offset &= HOST_ADDRESS_MASK;
-	switch (offset)
-	{
-	case REG_BUFF_L:
-		return (m_input_fifo_count / 4) & 0xff;
-
-	case REG_BUFF_H:
-		return (m_input_fifo_count / 4) >> 8;
-
-	case REG_DRAM_EXT:
-		return m_external_dram;
-
-	case REG_SYNC_ST:
-	case REG_PCM_FS:
-	case REG_FREE_FORM_L:
-	case REG_FREE_FORM_H:
-	case REG_PCM_18:
-	case REG_INTR_L:
-	case REG_INTR_H:
-	case REG_INTR_EN_L:
-	case REG_INTR_EN_H:
-	case REG_ATTEN_L:
-	case REG_ATTEN_R:
-	case REG_AUD_ID:
-	case REG_AUD_ID_EN:
-	case REG_SYNC_LCK:
-	case REG_CRC_ECM:
-	case REG_SYNC_ECM:
-	case REG_PLAY:
-	case REG_MUTE:
-	case REG_SKIP:
-	case REG_REPEAT:
-	case REG_STR_SEL:
-	case REG_PCM_ORD:
-	case REG_LATENCY:
-	case REG_RESET:
-	case REG_RESTART:
-	case REG_PCM_DIV:
-	case REG_DIF:
-	case REG_SIN_EN:
-		return m_registers[offset];
-	}
-
-	if (!machine().side_effects_disabled())
-		LOGMASKED(LOG_REGISTERS, "%s: unimplemented register read %02x\n", machine().describe_context(), offset);
-	return 0;
+	return m_registers[Register];
 }
 
-void tms320av110_device::write(offs_t offset, u8 data)
+void tms320av110_device::store_register(offs_t reg, u8 data, u8 mask, bool update_stream)
 {
 	if (m_reset_asserted)
 		return; // The data sheet specifies that RESET low disables host accesses.
 
-	offset &= HOST_ADDRESS_MASK;
-	if (offset == REG_DATAIN)
-	{
-		fifo_w(data);
-		return;
-	}
-
-	LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), offset, data);
-	switch (offset)
-	{
-	case REG_PLAY:
-	case REG_MUTE:
-	case REG_ATTEN_L:
-	case REG_ATTEN_R:
+	LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), reg, data);
+	if (update_stream)
 		m_stream->update();
-		break;
-	}
+	m_registers[reg] = data & mask;
+}
 
-	switch (offset)
-	{
-	case REG_FREE_FORM_L:
-	case REG_INTR_EN_L:
-	case REG_INTR_EN_H:
-		m_registers[offset] = data;
-		break;
+void tms320av110_device::free_form_low_w(u8 data)
+{
+	store_register(REG_FREE_FORM_L, data, 0xff, false);
+}
 
-	case REG_FREE_FORM_H:
-		m_registers[offset] = data & 0x07;
-		break;
+void tms320av110_device::free_form_high_w(u8 data)
+{
+	store_register(REG_FREE_FORM_H, data, 0x07, false);
+}
 
-	case REG_SYNC_LCK:
-	case REG_CRC_ECM:
-	case REG_SYNC_ECM:
-	case REG_STR_SEL:
-		m_registers[offset] = data & 0x03;
-		break;
+void tms320av110_device::pcm_precision_w(u8 data)
+{
+	store_register(REG_PCM_18, data, 0x01, false);
+}
 
-	case REG_AUD_ID:
-		m_registers[offset] = data & 0x1f;
-		break;
+void tms320av110_device::interrupt_enable_w(offs_t offset, u8 data)
+{
+	store_register(REG_INTR_EN_L + offset, data, 0xff, false);
+}
 
-	case REG_ATTEN_L:
-	case REG_ATTEN_R:
-	case REG_PCM_DIV:
-		m_registers[offset] = data & 0x3f;
-		break;
+void tms320av110_device::left_attenuation_w(u8 data)
+{
+	store_register(REG_ATTEN_L, data, 0x3f, true);
+}
 
-	case REG_PCM_18:
-	case REG_AUD_ID_EN:
-	case REG_PLAY:
-	case REG_MUTE:
-	case REG_SKIP:
-	case REG_REPEAT:
-	case REG_PCM_ORD:
-	case REG_LATENCY:
-	case REG_DIF:
-	case REG_SIN_EN:
-		m_registers[offset] = data & 0x01;
-		break;
+void tms320av110_device::right_attenuation_w(u8 data)
+{
+	store_register(REG_ATTEN_R, data, 0x3f, true);
+}
 
-	case REG_RESET:
-		if (data & 0x01)
-			start_reset(false);
-		break;
+void tms320av110_device::audio_id_w(u8 data)
+{
+	store_register(REG_AUD_ID, data, 0x1f, false);
+}
 
-	case REG_RESTART:
-		if (data & 0x01)
-			start_restart();
-		break;
+void tms320av110_device::audio_id_enable_w(u8 data)
+{
+	store_register(REG_AUD_ID_EN, data, 0x01, false);
+}
 
-	default:
-		break;
-	}
+void tms320av110_device::sync_words_w(u8 data)
+{
+	store_register(REG_SYNC_LCK, data, 0x03, false);
+}
+
+void tms320av110_device::crc_error_concealment_w(u8 data)
+{
+	store_register(REG_CRC_ECM, data, 0x03, false);
+}
+
+void tms320av110_device::sync_error_concealment_w(u8 data)
+{
+	store_register(REG_SYNC_ECM, data, 0x03, false);
+}
+
+void tms320av110_device::play_w(u8 data)
+{
+	store_register(REG_PLAY, data, 0x01, true);
+}
+
+void tms320av110_device::mute_w(u8 data)
+{
+	store_register(REG_MUTE, data, 0x01, true);
+}
+
+void tms320av110_device::skip_w(u8 data)
+{
+	store_register(REG_SKIP, data, 0x01, false);
+}
+
+void tms320av110_device::repeat_w(u8 data)
+{
+	store_register(REG_REPEAT, data, 0x01, false);
+}
+
+void tms320av110_device::stream_select_w(u8 data)
+{
+	store_register(REG_STR_SEL, data, 0x03, false);
+}
+
+void tms320av110_device::pcm_order_w(u8 data)
+{
+	store_register(REG_PCM_ORD, data, 0x01, false);
+}
+
+void tms320av110_device::latency_w(u8 data)
+{
+	store_register(REG_LATENCY, data, 0x01, false);
+}
+
+void tms320av110_device::pcm_divider_w(u8 data)
+{
+	store_register(REG_PCM_DIV, data, 0x3f, false);
+}
+
+void tms320av110_device::pcm_justification_w(u8 data)
+{
+	store_register(REG_DIF, data, 0x01, false);
+}
+
+void tms320av110_device::serial_input_enable_w(u8 data)
+{
+	store_register(REG_SIN_EN, data, 0x01, false);
+}
+
+u8 tms320av110_device::buffer_low_r()
+{
+	return m_reset_asserted ? 0 : (m_input_fifo_count / 4) & 0xff;
+}
+
+u8 tms320av110_device::buffer_high_r()
+{
+	return m_reset_asserted ? 0 : (m_input_fifo_count / 4) >> 8;
+}
+
+u8 tms320av110_device::external_dram_r()
+{
+	return m_reset_asserted ? 0 : m_external_dram;
+}
+
+void tms320av110_device::data_w(u8 data)
+{
+	if (!m_reset_asserted)
+		fifo_w(data);
+}
+
+void tms320av110_device::reset_command_w(u8 data)
+{
+	if (m_reset_asserted)
+		return;
+
+	LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), REG_RESET, data);
+	if (data & 0x01)
+		start_reset(false);
+}
+
+void tms320av110_device::restart_command_w(u8 data)
+{
+	if (m_reset_asserted)
+		return;
+
+	LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), REG_RESTART, data);
+	if (data & 0x01)
+		start_restart();
+}
+
+u8 tms320av110_device::unimplemented_r(offs_t offset)
+{
+	if (!m_reset_asserted && !machine().side_effects_disabled())
+		LOGMASKED(LOG_REGISTERS, "%s: unimplemented register read %02x\n", machine().describe_context(), offset);
+	return 0;
+}
+
+void tms320av110_device::unimplemented_w(offs_t offset, u8 data)
+{
+	if (!m_reset_asserted)
+		LOGMASKED(LOG_REGISTERS, "%s: register write %02x = %02x\n", machine().describe_context(), offset, data);
+}
+
+void tms320av110_device::map(address_map &map)
+{
+	map(0x00, 0x7f).rw(FUNC(tms320av110_device::unimplemented_r), FUNC(tms320av110_device::unimplemented_w));
+	map(0x12, 0x12).r(FUNC(tms320av110_device::buffer_low_r));
+	map(0x13, 0x13).r(FUNC(tms320av110_device::buffer_high_r));
+	map(0x14, 0x14).rw(FUNC(tms320av110_device::register_r<REG_FREE_FORM_L>), FUNC(tms320av110_device::free_form_low_w));
+	map(0x15, 0x15).rw(FUNC(tms320av110_device::register_r<REG_FREE_FORM_H>), FUNC(tms320av110_device::free_form_high_w));
+	map(0x16, 0x16).rw(FUNC(tms320av110_device::register_r<REG_PCM_18>), FUNC(tms320av110_device::pcm_precision_w));
+	map(0x18, 0x18).w(FUNC(tms320av110_device::data_w));
+	map(0x1a, 0x1a).r(FUNC(tms320av110_device::register_r<REG_INTR_L>));
+	map(0x1b, 0x1b).r(FUNC(tms320av110_device::register_r<REG_INTR_H>));
+	map(0x1c, 0x1d).w(FUNC(tms320av110_device::interrupt_enable_w));
+	map(0x1c, 0x1c).r(FUNC(tms320av110_device::register_r<REG_INTR_EN_L>));
+	map(0x1d, 0x1d).r(FUNC(tms320av110_device::register_r<REG_INTR_EN_H>));
+	map(0x1e, 0x1e).rw(FUNC(tms320av110_device::register_r<REG_ATTEN_L>), FUNC(tms320av110_device::left_attenuation_w));
+	map(0x20, 0x20).rw(FUNC(tms320av110_device::register_r<REG_ATTEN_R>), FUNC(tms320av110_device::right_attenuation_w));
+	map(0x22, 0x22).rw(FUNC(tms320av110_device::register_r<REG_AUD_ID>), FUNC(tms320av110_device::audio_id_w));
+	map(0x24, 0x24).rw(FUNC(tms320av110_device::register_r<REG_AUD_ID_EN>), FUNC(tms320av110_device::audio_id_enable_w));
+	map(0x26, 0x26).r(FUNC(tms320av110_device::register_r<REG_SYNC_ST>));
+	map(0x28, 0x28).rw(FUNC(tms320av110_device::register_r<REG_SYNC_LCK>), FUNC(tms320av110_device::sync_words_w));
+	map(0x2a, 0x2a).rw(FUNC(tms320av110_device::register_r<REG_CRC_ECM>), FUNC(tms320av110_device::crc_error_concealment_w));
+	map(0x2c, 0x2c).rw(FUNC(tms320av110_device::register_r<REG_SYNC_ECM>), FUNC(tms320av110_device::sync_error_concealment_w));
+	map(0x2e, 0x2e).rw(FUNC(tms320av110_device::register_r<REG_PLAY>), FUNC(tms320av110_device::play_w));
+	map(0x30, 0x30).rw(FUNC(tms320av110_device::register_r<REG_MUTE>), FUNC(tms320av110_device::mute_w));
+	map(0x32, 0x32).rw(FUNC(tms320av110_device::register_r<REG_SKIP>), FUNC(tms320av110_device::skip_w));
+	map(0x34, 0x34).rw(FUNC(tms320av110_device::register_r<REG_REPEAT>), FUNC(tms320av110_device::repeat_w));
+	map(0x36, 0x36).rw(FUNC(tms320av110_device::register_r<REG_STR_SEL>), FUNC(tms320av110_device::stream_select_w));
+	map(0x38, 0x38).rw(FUNC(tms320av110_device::register_r<REG_PCM_ORD>), FUNC(tms320av110_device::pcm_order_w));
+	map(0x3c, 0x3c).rw(FUNC(tms320av110_device::register_r<REG_LATENCY>), FUNC(tms320av110_device::latency_w));
+	map(0x3e, 0x3e).r(FUNC(tms320av110_device::external_dram_r));
+	map(0x40, 0x40).rw(FUNC(tms320av110_device::register_r<REG_RESET>), FUNC(tms320av110_device::reset_command_w));
+	map(0x42, 0x42).rw(FUNC(tms320av110_device::register_r<REG_RESTART>), FUNC(tms320av110_device::restart_command_w));
+	map(0x44, 0x44).r(FUNC(tms320av110_device::register_r<REG_PCM_FS>));
+	map(0x6e, 0x6e).rw(FUNC(tms320av110_device::register_r<REG_PCM_DIV>), FUNC(tms320av110_device::pcm_divider_w));
+	map(0x6f, 0x6f).rw(FUNC(tms320av110_device::register_r<REG_DIF>), FUNC(tms320av110_device::pcm_justification_w));
+	map(0x70, 0x70).rw(FUNC(tms320av110_device::register_r<REG_SIN_EN>), FUNC(tms320av110_device::serial_input_enable_w));
 }
 
 void tms320av110_device::sound_stream_update(sound_stream &stream)

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -14,121 +14,29 @@
 #include "emu.h"
 #include "tms320av110.h"
 
-#include "mpeg_audio.h"
-
 #include <cmath>
 
-#define LOG_REQUESTS (1U << 0)
-#define LOG_REGISTERS (1U << 1)
+#define LOG_REQUESTS (1U << 1)
+#define LOG_REGISTERS (1U << 2)
 
 #define VERBOSE (0)
 #include "logmacro.h"
 
-namespace {
-
-// The host interface has seven address pins, SADDR6 through SADDR0.
-constexpr unsigned HOST_ADDRESS_BITS = 7;
-constexpr unsigned HOST_REGISTER_COUNT = 1U << HOST_ADDRESS_BITS;
-constexpr offs_t HOST_ADDRESS_MASK = HOST_REGISTER_COUNT - 1;
-
-// Host-interface register addresses from the data sheet.
-constexpr offs_t REG_BUFF_L = 0x12;   // input buffer word count, bits 7:0
-constexpr offs_t REG_BUFF_H = 0x13;   // input buffer word count, bits 14:8
-constexpr offs_t REG_FREE_FORM_L = 0x14; // free-format frame length, bits 7:0
-constexpr offs_t REG_FREE_FORM_H = 0x15; // free-format frame length, bits 10:8
-constexpr offs_t REG_PCM_18 = 0x16;   // PCM output precision
-constexpr offs_t REG_DATAIN = 0x18;   // memory-mapped compressed-data input
-constexpr offs_t REG_INTR_L = 0x1a;   // interrupt status, bits 7:0
-constexpr offs_t REG_INTR_H = 0x1b;   // interrupt status, bits 15:8
-constexpr offs_t REG_INTR_EN_L = 0x1c; // interrupt enable, bits 7:0
-constexpr offs_t REG_INTR_EN_H = 0x1d; // interrupt enable, bits 15:8
-constexpr offs_t REG_ATTEN_L = 0x1e;  // left output attenuation
-constexpr offs_t REG_ATTEN_R = 0x20;  // right output attenuation
-constexpr offs_t REG_AUD_ID = 0x22;   // MPEG system/packet audio stream ID
-constexpr offs_t REG_AUD_ID_EN = 0x24; // audio stream ID filtering enable
-constexpr offs_t REG_SYNC_ST = 0x26;  // synchronization status
-constexpr offs_t REG_SYNC_LCK = 0x28; // required additional synchronization words
-constexpr offs_t REG_CRC_ECM = 0x2a;  // CRC error concealment mode
-constexpr offs_t REG_SYNC_ECM = 0x2c; // synchronization error concealment mode
-constexpr offs_t REG_PLAY = 0x2e;     // decoded audio output enable
-constexpr offs_t REG_MUTE = 0x30;     // decoded audio mute
-constexpr offs_t REG_SKIP = 0x32;     // skip next audio frame
-constexpr offs_t REG_REPEAT = 0x34;   // repeat next audio frame
-constexpr offs_t REG_STR_SEL = 0x36;  // compressed input stream format
-constexpr offs_t REG_PCM_ORD = 0x38;  // PCM output bit order
-constexpr offs_t REG_LATENCY = 0x3c;  // synchronization lookahead enable
-constexpr offs_t REG_DRAM_EXT = 0x3e; // external input-buffer DRAM present
-constexpr offs_t REG_RESET = 0x40;    // decoder reset command/status
-constexpr offs_t REG_RESTART = 0x42;  // data-buffer flush command/status
-constexpr offs_t REG_PCM_FS = 0x44;   // decoded sampling frequency
-constexpr offs_t REG_PCM_DIV = 0x6e;  // PCM clock divider
-constexpr offs_t REG_DIF = 0x6f;      // 18-bit PCM justification
-constexpr offs_t REG_SIN_EN = 0x70;   // serial compressed-data input enable
-
-// Without external DRAM, the on-chip compressed-data input SRAM is 256 bytes.
-constexpr unsigned INPUT_BUFFER_BYTES_WITHOUT_DRAM = 256;
-// The supported external DRAM is 256K locations by four bits.
-constexpr unsigned INPUT_BUFFER_BYTES_WITH_DRAM = 256 * 1024 * 4 / 8;
-// The interface permits one further byte after REQ reports full, held
-// separately from the selected input buffer.
-constexpr unsigned INPUT_FIFO_BYTES = INPUT_BUFFER_BYTES_WITH_DRAM + 1;
-
-// A no-DRAM reset takes approximately 700 microseconds at the nominal 24 MHz
-// OSCIN frequency, corresponding to 16,800 oscillator clocks.
-constexpr unsigned RESET_CYCLES_WITHOUT_DRAM = 16'800;
-// With external DRAM, reset takes approximately 3.7 ms at 24 MHz.
-constexpr unsigned RESET_CYCLES_WITH_DRAM = 88'800;
-
-// MPEG audio is presented as left and right PCM output slots, including mono streams.
-constexpr unsigned LEFT_CHANNEL = 0;
-constexpr unsigned RIGHT_CHANNEL = 1;
-constexpr unsigned OUTPUT_CHANNELS = 2;
-
-// Used for sound scheduling until an MPEG header supplies the stream rate.
-constexpr u32 INITIAL_SAMPLE_RATE = 44'100;
-
-// MPEG-1 Layer II produces 1,152 samples per channel for each decoded frame.
-constexpr unsigned MPEG_LAYER_II_SAMPLES_PER_FRAME = 1'152;
-
-// A Layer II frame is largest at the maximum bit rate and minimum sample rate.
-constexpr unsigned MAX_MPEG1_LAYER_II_BIT_RATE = 384'000;
-constexpr unsigned MIN_MPEG1_SAMPLE_RATE = 32'000;
-constexpr unsigned MPEG1_LAYER_II_FRAME_SCALE = 144;
-constexpr unsigned MPEG_FRAME_PADDING_BYTES = 1;
-constexpr unsigned MAX_MPEG_AUDIO_FRAME_BYTES =
-	(MPEG1_LAYER_II_FRAME_SCALE * MAX_MPEG1_LAYER_II_BIT_RATE / MIN_MPEG1_SAMPLE_RATE) + MPEG_FRAME_PADDING_BYTES;
-
-// This is private storage for adapting the streaming device to the frame-based
-// MPEG helper.  It is not the AV110's hardware-visible compressed-data SRAM.
-constexpr unsigned DECODER_INPUT_BYTES = 2 * MAX_MPEG_AUDIO_FRAME_BYTES;
-
-} // anonymous namespace
-
 DEFINE_DEVICE_TYPE(TMS320AV110, tms320av110_device, "tms320av110", "Texas Instruments TMS320AV110 MPEG Audio Decoder")
-
-struct tms320av110_device::decoder_state
-{
-	std::array<u8, HOST_REGISTER_COUNT> registers{};
-	std::array<u8, INPUT_FIFO_BYTES> input_fifo{};
-	std::array<u8, DECODER_INPUT_BYTES> input{};
-	std::array<s16, MPEG_LAYER_II_SAMPLES_PER_FRAME * OUTPUT_CHANNELS> pcm{};
-	std::unique_ptr<mpeg_audio> decoder;
-	unsigned input_fifo_read = 0;
-	unsigned input_fifo_write = 0;
-	unsigned input_fifo_count = 0;
-	unsigned input_bytes = 0;
-	unsigned input_bit_position = 0;
-	unsigned pcm_position = 0;
-	unsigned pcm_count = 0;
-	unsigned pcm_channels = 0;
-};
 
 tms320av110_device::tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
 	device_t(mconfig, TMS320AV110, tag, owner, clock),
 	device_sound_interface(mconfig, *this),
 	m_stream(nullptr),
 	m_req_cb(*this),
-	m_decoder(std::make_unique<decoder_state>()),
+	m_input_fifo_read(0),
+	m_input_fifo_write(0),
+	m_input_fifo_count(0),
+	m_input_bytes(0),
+	m_input_bit_position(0),
+	m_pcm_position(0),
+	m_pcm_count(0),
+	m_pcm_channels(0),
 	m_external_dram(false),
 	m_input_timer(nullptr),
 	m_reset_timer(nullptr),
@@ -139,28 +47,27 @@ tms320av110_device::tms320av110_device(const machine_config &mconfig, const char
 {
 }
 
-tms320av110_device::~tms320av110_device() = default;
-
 void tms320av110_device::device_start()
 {
 	m_stream = stream_alloc(0, OUTPUT_CHANNELS, INITIAL_SAMPLE_RATE);
 	m_input_timer = timer_alloc(FUNC(tms320av110_device::input_tick), this);
 	m_reset_timer = timer_alloc(FUNC(tms320av110_device::reset_complete), this);
-	decoder_create();
-	m_decoder->decoder->register_save_state(*this);
+	m_input_fifo = std::make_unique<u8[]>(INPUT_FIFO_BYTES);
+	m_decoder = std::make_unique<mpeg_audio>(m_input, mpeg_audio::L2, false, 0);
+	m_decoder->register_save_state(*this);
 
-	save_item(NAME(m_decoder->registers));
-	save_item(NAME(m_decoder->input_fifo));
-	save_item(NAME(m_decoder->input));
-	save_item(NAME(m_decoder->pcm));
-	save_item(NAME(m_decoder->input_fifo_read));
-	save_item(NAME(m_decoder->input_fifo_write));
-	save_item(NAME(m_decoder->input_fifo_count));
-	save_item(NAME(m_decoder->input_bytes));
-	save_item(NAME(m_decoder->input_bit_position));
-	save_item(NAME(m_decoder->pcm_position));
-	save_item(NAME(m_decoder->pcm_count));
-	save_item(NAME(m_decoder->pcm_channels));
+	save_item(NAME(m_registers));
+	save_pointer(NAME(m_input_fifo), INPUT_FIFO_BYTES);
+	save_item(NAME(m_input));
+	save_item(NAME(m_pcm));
+	save_item(NAME(m_input_fifo_read));
+	save_item(NAME(m_input_fifo_write));
+	save_item(NAME(m_input_fifo_count));
+	save_item(NAME(m_input_bytes));
+	save_item(NAME(m_input_bit_position));
+	save_item(NAME(m_pcm_position));
+	save_item(NAME(m_pcm_count));
+	save_item(NAME(m_pcm_channels));
 	save_item(NAME(m_reset_asserted));
 	save_item(NAME(m_reset_cycle));
 	save_item(NAME(m_data_access));
@@ -171,7 +78,7 @@ void tms320av110_device::device_reset()
 {
 	m_input_timer->adjust(attotime::never);
 	m_reset_timer->adjust(attotime::never);
-	m_decoder->registers.fill(0);
+	std::fill(std::begin(m_registers), std::end(m_registers), 0);
 	m_reset_asserted = false;
 	m_reset_cycle = false;
 	start_reset(true);
@@ -182,11 +89,6 @@ void tms320av110_device::device_post_load()
 	m_req_cb(m_req_state);
 }
 
-void tms320av110_device::decoder_create()
-{
-	m_decoder->decoder = std::make_unique<mpeg_audio>(m_decoder->input.data(), mpeg_audio::L2, false, 0);
-}
-
 void tms320av110_device::decoder_reset()
 {
 	if (m_stream)
@@ -195,25 +97,25 @@ void tms320av110_device::decoder_reset()
 		m_stream->set_sample_rate(INITIAL_SAMPLE_RATE);
 	}
 
-	m_decoder->input.fill(0);
-	m_decoder->pcm.fill(0);
-	m_decoder->input_bytes = 0;
-	m_decoder->input_bit_position = 0;
-	m_decoder->pcm_position = 0;
-	m_decoder->pcm_count = 0;
-	m_decoder->pcm_channels = 0;
-	m_decoder->registers[REG_SYNC_ST] = 0;
-	m_decoder->registers[REG_PCM_FS] = 0;
-	m_decoder->decoder->clear();
+	std::fill(std::begin(m_input), std::end(m_input), 0);
+	std::fill(std::begin(m_pcm), std::end(m_pcm), 0);
+	m_input_bytes = 0;
+	m_input_bit_position = 0;
+	m_pcm_position = 0;
+	m_pcm_count = 0;
+	m_pcm_channels = 0;
+	m_registers[REG_SYNC_ST] = 0;
+	m_registers[REG_PCM_FS] = 0;
+	m_decoder->clear();
 }
 
 void tms320av110_device::input_fifo_reset()
 {
 	m_input_timer->adjust(attotime::never);
-	m_decoder->input_fifo.fill(0);
-	m_decoder->input_fifo_read = 0;
-	m_decoder->input_fifo_write = 0;
-	m_decoder->input_fifo_count = 0;
+	std::fill_n(m_input_fifo.get(), INPUT_FIFO_BYTES, 0);
+	m_input_fifo_read = 0;
+	m_input_fifo_write = 0;
+	m_input_fifo_count = 0;
 	m_data_access = false;
 }
 
@@ -221,17 +123,17 @@ void tms320av110_device::start_reset(bool pin_reset)
 {
 	decoder_reset();
 	input_fifo_reset();
-	m_decoder->registers[REG_INTR_L] = 0;
-	m_decoder->registers[REG_INTR_H] = 0;
-	m_decoder->registers[REG_INTR_EN_L] = 0;
-	m_decoder->registers[REG_INTR_EN_H] = 0;
-	m_decoder->registers[REG_RESET] = 1;
-	m_decoder->registers[REG_RESTART] = 0;
+	m_registers[REG_INTR_L] = 0;
+	m_registers[REG_INTR_H] = 0;
+	m_registers[REG_INTR_EN_L] = 0;
+	m_registers[REG_INTR_EN_H] = 0;
+	m_registers[REG_RESET] = 1;
+	m_registers[REG_RESTART] = 0;
 	if (pin_reset)
 	{
-		m_decoder->registers[REG_PLAY] = 0;
-		m_decoder->registers[REG_MUTE] = 0;
-		m_decoder->registers[REG_PCM_DIV] = 0;
+		m_registers[REG_PLAY] = 0;
+		m_registers[REG_MUTE] = 0;
+		m_registers[REG_PCM_DIV] = 0;
 	}
 
 	m_reset_cycle = true;
@@ -244,11 +146,11 @@ void tms320av110_device::start_restart()
 {
 	decoder_reset();
 	input_fifo_reset();
-	m_decoder->registers[REG_INTR_L] = 0;
-	m_decoder->registers[REG_INTR_H] = 0;
-	m_decoder->registers[REG_INTR_EN_L] = 0;
-	m_decoder->registers[REG_INTR_EN_H] = 0;
-	m_decoder->registers[REG_RESTART] = 1;
+	m_registers[REG_INTR_L] = 0;
+	m_registers[REG_INTR_H] = 0;
+	m_registers[REG_INTR_EN_L] = 0;
+	m_registers[REG_INTR_EN_H] = 0;
+	m_registers[REG_RESTART] = 1;
 	m_reset_cycle = true;
 
 	// Restart completion timing is not specified.  Complete it on the next
@@ -259,8 +161,8 @@ void tms320av110_device::start_restart()
 
 TIMER_CALLBACK_MEMBER(tms320av110_device::reset_complete)
 {
-	m_decoder->registers[REG_RESET] = 0;
-	m_decoder->registers[REG_RESTART] = 0;
+	m_registers[REG_RESET] = 0;
+	m_registers[REG_RESTART] = 0;
 	m_reset_cycle = false;
 	update_req();
 	start_input_timer();
@@ -268,14 +170,14 @@ TIMER_CALLBACK_MEMBER(tms320av110_device::reset_complete)
 
 bool tms320av110_device::decode_frame()
 {
-	int position = m_decoder->input_bit_position;
+	int position = m_input_bit_position;
 	int sample_count = 0;
 	int sample_rate = 0;
 	int channels = 0;
-	if (!m_decoder->decoder->decode_buffer(
+	if (!m_decoder->decode_buffer(
 			position,
-			m_decoder->input_bytes * 8,
-			m_decoder->pcm.data(),
+			m_input_bytes * 8,
+			m_pcm,
 			sample_count,
 			sample_rate,
 			channels))
@@ -285,30 +187,27 @@ bool tms320av110_device::decode_frame()
 
 	assert(sample_count <= MPEG_LAYER_II_SAMPLES_PER_FRAME);
 	assert((channels == 1) || (channels == OUTPUT_CHANNELS));
-	m_decoder->pcm_position = 0;
-	m_decoder->pcm_count = sample_count;
-	m_decoder->pcm_channels = channels;
-	m_decoder->registers[REG_SYNC_ST] = 0x03;
+	m_pcm_position = 0;
+	m_pcm_count = sample_count;
+	m_pcm_channels = channels;
+	m_registers[REG_SYNC_ST] = 0x03;
 
-	const unsigned bytes_consumed = position / 8;
+	const u32 bytes_consumed = position / 8;
 	if (bytes_consumed)
 	{
-		std::move(
-			m_decoder->input.begin() + bytes_consumed,
-			m_decoder->input.begin() + m_decoder->input_bytes,
-			m_decoder->input.begin());
-		m_decoder->input_bytes -= bytes_consumed;
+		std::move(m_input + bytes_consumed, m_input + m_input_bytes, m_input);
+		m_input_bytes -= bytes_consumed;
 	}
-	m_decoder->input_bit_position = position & 7;
+	m_input_bit_position = position & 7;
 	start_input_timer();
 
 	if (sample_rate)
 	{
 		switch (sample_rate)
 		{
-		case 44'100: m_decoder->registers[REG_PCM_FS] = 0; break;
-		case 48'000: m_decoder->registers[REG_PCM_FS] = 1; break;
-		case 32'000: m_decoder->registers[REG_PCM_FS] = 2; break;
+		case 44'100: m_registers[REG_PCM_FS] = 0; break;
+		case 48'000: m_registers[REG_PCM_FS] = 1; break;
+		case 32'000: m_registers[REG_PCM_FS] = 2; break;
 		default: break;
 		}
 
@@ -321,8 +220,8 @@ bool tms320av110_device::decode_frame()
 
 void tms320av110_device::start_input_timer()
 {
-	if (!m_reset_asserted && !m_reset_cycle && m_decoder->input_fifo_count &&
-		(m_data_access || (m_decoder->input_bytes != m_decoder->input.size())))
+	if (!m_reset_asserted && !m_reset_cycle && m_input_fifo_count &&
+		(m_data_access || (m_input_bytes != DECODER_INPUT_BYTES)))
 	{
 		m_input_timer->adjust(clocks_to_attotime(1));
 	}
@@ -331,16 +230,15 @@ void tms320av110_device::start_input_timer()
 TIMER_CALLBACK_MEMBER(tms320av110_device::input_tick)
 {
 	LOGMASKED(LOG_REQUESTS, "%s: input tick, FIFO=%u staging=%u\n", machine().describe_context(),
-		m_decoder->input_fifo_count, m_decoder->input_bytes);
+		m_input_fifo_count, m_input_bytes);
 	m_stream->update();
-	if (m_decoder->input_fifo_count && (m_decoder->input_bytes != m_decoder->input.size()))
+	if (m_input_fifo_count && (m_input_bytes != DECODER_INPUT_BYTES))
 	{
-		m_decoder->input[m_decoder->input_bytes++] = m_decoder->input_fifo[m_decoder->input_fifo_read];
-		m_decoder->input_fifo_read = (m_decoder->input_fifo_read + 1) % m_decoder->input_fifo.size();
-		m_decoder->input_fifo_count--;
+		m_input[m_input_bytes++] = m_input_fifo[m_input_fifo_read];
+		m_input_fifo_read = (m_input_fifo_read + 1) % INPUT_FIFO_BYTES;
+		m_input_fifo_count--;
 	}
-	if ((m_decoder->pcm_position == m_decoder->pcm_count) &&
-		(m_decoder->input_bytes == m_decoder->input.size()))
+	if ((m_pcm_position == m_pcm_count) && (m_input_bytes == DECODER_INPUT_BYTES))
 	{
 		decode_frame();
 	}
@@ -353,7 +251,7 @@ TIMER_CALLBACK_MEMBER(tms320av110_device::input_tick)
 void tms320av110_device::fifo_w(u8 data)
 {
 	LOGMASKED(LOG_REQUESTS, "%s: DATAIN %02x, FIFO=%u staging=%u\n", machine().describe_context(), data,
-		m_decoder->input_fifo_count, m_decoder->input_bytes);
+		m_input_fifo_count, m_input_bytes);
 	if (m_reset_cycle)
 	{
 		LOGMASKED(LOG_REGISTERS, "%s: DATAIN write %02x during reset/restart\n", machine().describe_context(), data);
@@ -361,16 +259,16 @@ void tms320av110_device::fifo_w(u8 data)
 	}
 
 	m_stream->update();
-	const unsigned capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
-	if (m_decoder->input_fifo_count > capacity)
+	const u32 capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
+	if (m_input_fifo_count > capacity)
 	{
 		logerror("%s: compressed-audio input overflow\n", machine().describe_context());
 		return;
 	}
 
-	m_decoder->input_fifo[m_decoder->input_fifo_write] = data;
-	m_decoder->input_fifo_write = (m_decoder->input_fifo_write + 1) % m_decoder->input_fifo.size();
-	m_decoder->input_fifo_count++;
+	m_input_fifo[m_input_fifo_write] = data;
+	m_input_fifo_write = (m_input_fifo_write + 1) % INPUT_FIFO_BYTES;
+	m_input_fifo_count++;
 	m_data_access = true;
 	update_req();
 	start_input_timer();
@@ -390,9 +288,9 @@ void tms320av110_device::update_req()
 {
 	// REQ is active low.  DATAIN raises it for the access handshake, and it
 	// remains high while reset is active or the selected input buffer is full.
-	const unsigned capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
+	const u32 capacity = m_external_dram ? INPUT_BUFFER_BYTES_WITH_DRAM : INPUT_BUFFER_BYTES_WITHOUT_DRAM;
 	set_req((m_reset_asserted || m_reset_cycle || m_data_access ||
-		(m_decoder->input_fifo_count >= capacity)) ? ASSERT_LINE : CLEAR_LINE);
+		(m_input_fifo_count >= capacity)) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void tms320av110_device::reset_w(int state)
@@ -419,10 +317,10 @@ u8 tms320av110_device::read(offs_t offset)
 	switch (offset)
 	{
 	case REG_BUFF_L:
-		return (m_decoder->input_fifo_count / 4) & 0xff;
+		return (m_input_fifo_count / 4) & 0xff;
 
 	case REG_BUFF_H:
-		return (m_decoder->input_fifo_count / 4) >> 8;
+		return (m_input_fifo_count / 4) >> 8;
 
 	case REG_DRAM_EXT:
 		return m_external_dram;
@@ -455,7 +353,7 @@ u8 tms320av110_device::read(offs_t offset)
 	case REG_PCM_DIV:
 	case REG_DIF:
 	case REG_SIN_EN:
-		return m_decoder->registers[offset];
+		return m_registers[offset];
 	}
 
 	if (!machine().side_effects_disabled())
@@ -491,28 +389,28 @@ void tms320av110_device::write(offs_t offset, u8 data)
 	case REG_FREE_FORM_L:
 	case REG_INTR_EN_L:
 	case REG_INTR_EN_H:
-		m_decoder->registers[offset] = data;
+		m_registers[offset] = data;
 		break;
 
 	case REG_FREE_FORM_H:
-		m_decoder->registers[offset] = data & 0x07;
+		m_registers[offset] = data & 0x07;
 		break;
 
 	case REG_SYNC_LCK:
 	case REG_CRC_ECM:
 	case REG_SYNC_ECM:
 	case REG_STR_SEL:
-		m_decoder->registers[offset] = data & 0x03;
+		m_registers[offset] = data & 0x03;
 		break;
 
 	case REG_AUD_ID:
-		m_decoder->registers[offset] = data & 0x1f;
+		m_registers[offset] = data & 0x1f;
 		break;
 
 	case REG_ATTEN_L:
 	case REG_ATTEN_R:
 	case REG_PCM_DIV:
-		m_decoder->registers[offset] = data & 0x3f;
+		m_registers[offset] = data & 0x3f;
 		break;
 
 	case REG_PCM_18:
@@ -525,7 +423,7 @@ void tms320av110_device::write(offs_t offset, u8 data)
 	case REG_LATENCY:
 	case REG_DIF:
 	case REG_SIN_EN:
-		m_decoder->registers[offset] = data & 0x01;
+		m_registers[offset] = data & 0x01;
 		break;
 
 	case REG_RESET:
@@ -545,27 +443,27 @@ void tms320av110_device::write(offs_t offset, u8 data)
 
 void tms320av110_device::sound_stream_update(sound_stream &stream)
 {
-	const bool playing = BIT(m_decoder->registers[REG_PLAY], 0) && !m_reset_asserted && !m_reset_cycle;
-	const bool muted = BIT(m_decoder->registers[REG_MUTE], 0);
-	const float left_gain = std::pow(10.0F, -float(m_decoder->registers[REG_ATTEN_L]) / 10.0F);
-	const float right_gain = std::pow(10.0F, -float(m_decoder->registers[REG_ATTEN_R]) / 10.0F);
+	const bool playing = BIT(m_registers[REG_PLAY], 0) && !m_reset_asserted && !m_reset_cycle;
+	const bool muted = BIT(m_registers[REG_MUTE], 0);
+	const float left_gain = std::pow(10.0F, -float(m_registers[REG_ATTEN_L]) / 10.0F);
+	const float right_gain = std::pow(10.0F, -float(m_registers[REG_ATTEN_R]) / 10.0F);
 
 	for (int sample = 0; sample < stream.samples(); sample++)
 	{
-		if (!playing || ((m_decoder->pcm_position == m_decoder->pcm_count) && !decode_frame()))
+		if (!playing || ((m_pcm_position == m_pcm_count) && !decode_frame()))
 		{
 			stream.put(LEFT_CHANNEL, sample, 0.0F);
 			stream.put(RIGHT_CHANNEL, sample, 0.0F);
 			continue;
 		}
 
-		const unsigned position = m_decoder->pcm_position * m_decoder->pcm_channels;
-		const s16 left = m_decoder->pcm[position];
-		const s16 right = (m_decoder->pcm_channels == OUTPUT_CHANNELS)
-			? m_decoder->pcm[position + RIGHT_CHANNEL]
+		const u32 position = m_pcm_position * m_pcm_channels;
+		const s16 left = m_pcm[position];
+		const s16 right = (m_pcm_channels == OUTPUT_CHANNELS)
+			? m_pcm[position + RIGHT_CHANNEL]
 			: left;
 		stream.put(LEFT_CHANNEL, sample, muted ? 0.0F : (float(left) / 32'768.0F) * left_gain);
 		stream.put(RIGHT_CHANNEL, sample, muted ? 0.0F : (float(right) / 32'768.0F) * right_gain);
-		m_decoder->pcm_position++;
+		m_pcm_position++;
 	}
 }

--- a/src/devices/sound/tms320av110.cpp
+++ b/src/devices/sound/tms320av110.cpp
@@ -1,0 +1,239 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+
+/*
+ * Texas Instruments TMS320AV110 MPEG-1 audio decoder (preliminary)
+ *
+ * The implemented subset consists of the host register window, memory-mapped
+ * compressed-data input, reset-controlled REQ signalling, and MPEG-1 Audio
+ * Layer II reconstruction.  Input-buffer-full backpressure and other
+ * control/status register behaviour are not yet fully implemented.
+ *
+ * Reference: Texas Instruments data sheet SCSS013C, revised August 1995.
+ */
+
+#include "emu.h"
+#include "tms320av110.h"
+
+#include "mpeg_audio.h"
+
+namespace {
+
+// The host interface has seven address pins, SADDR6 through SADDR0.
+constexpr unsigned HOST_ADDRESS_BITS = 7;
+constexpr offs_t HOST_ADDRESS_MASK = (1U << HOST_ADDRESS_BITS) - 1;
+
+// DATAIN is the data sheet's memory-mapped compressed-audio input register.
+constexpr offs_t REG_DATAIN = 0x18;
+
+// MPEG audio is presented as left and right PCM output slots, including mono streams.
+constexpr unsigned LEFT_CHANNEL = 0;
+constexpr unsigned RIGHT_CHANNEL = 1;
+constexpr unsigned OUTPUT_CHANNELS = 2;
+
+// Used for sound scheduling until an MPEG header supplies the stream rate.
+constexpr u32 INITIAL_SAMPLE_RATE = 44'100;
+
+// MPEG-1 Layer II produces 1,152 samples per channel for each decoded frame.
+constexpr unsigned MPEG_LAYER_II_SAMPLES_PER_FRAME = 1'152;
+
+// A Layer II frame is largest at the maximum bit rate and minimum sample rate.
+constexpr unsigned MAX_MPEG1_LAYER_II_BIT_RATE = 384'000;
+constexpr unsigned MIN_MPEG1_SAMPLE_RATE = 32'000;
+constexpr unsigned MPEG1_LAYER_II_FRAME_SCALE = 144;
+constexpr unsigned MPEG_FRAME_PADDING_BYTES = 1;
+constexpr unsigned MAX_MPEG_AUDIO_FRAME_BYTES =
+	(MPEG1_LAYER_II_FRAME_SCALE * MAX_MPEG1_LAYER_II_BIT_RATE / MIN_MPEG1_SAMPLE_RATE) + MPEG_FRAME_PADDING_BYTES;
+
+// Retain two maximum-sized frames so the frame-based decoder can accept streaming input.
+constexpr unsigned INPUT_BUFFER_BYTES = 2 * MAX_MPEG_AUDIO_FRAME_BYTES;
+
+} // anonymous namespace
+
+DEFINE_DEVICE_TYPE(TMS320AV110, tms320av110_device, "tms320av110", "Texas Instruments TMS320AV110 MPEG Audio Decoder")
+
+struct tms320av110_device::decoder_state
+{
+	std::array<u8, INPUT_BUFFER_BYTES> input{};
+	std::array<s16, MPEG_LAYER_II_SAMPLES_PER_FRAME * OUTPUT_CHANNELS> pcm{};
+	std::unique_ptr<mpeg_audio> decoder;
+	unsigned input_bytes = 0;
+	unsigned input_bit_position = 0;
+	unsigned pcm_position = 0;
+	unsigned pcm_count = 0;
+	unsigned pcm_channels = 0;
+};
+
+tms320av110_device::tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	device_t(mconfig, TMS320AV110, tag, owner, clock),
+	device_sound_interface(mconfig, *this),
+	m_stream(nullptr),
+	m_req_cb(*this),
+	m_decoder(std::make_unique<decoder_state>()),
+	m_reset_asserted(true)
+{
+}
+
+tms320av110_device::~tms320av110_device() = default;
+
+void tms320av110_device::device_start()
+{
+	m_stream = stream_alloc(0, OUTPUT_CHANNELS, INITIAL_SAMPLE_RATE);
+	decoder_create();
+
+	save_item(NAME(m_decoder->input));
+	save_item(NAME(m_decoder->pcm));
+	save_item(NAME(m_decoder->input_bytes));
+	save_item(NAME(m_decoder->input_bit_position));
+	save_item(NAME(m_decoder->pcm_position));
+	save_item(NAME(m_decoder->pcm_count));
+	save_item(NAME(m_decoder->pcm_channels));
+	save_item(NAME(m_reset_asserted));
+}
+
+void tms320av110_device::device_reset()
+{
+	decoder_reset();
+	m_reset_asserted = true;
+	update_req();
+}
+
+void tms320av110_device::decoder_create()
+{
+	m_decoder->decoder = std::make_unique<mpeg_audio>(m_decoder->input.data(), mpeg_audio::L2, false, 0);
+}
+
+void tms320av110_device::decoder_reset()
+{
+	if (m_stream)
+	{
+		m_stream->update();
+		m_stream->set_sample_rate(INITIAL_SAMPLE_RATE);
+	}
+
+	m_decoder->input.fill(0);
+	m_decoder->pcm.fill(0);
+	m_decoder->input_bytes = 0;
+	m_decoder->input_bit_position = 0;
+	m_decoder->pcm_position = 0;
+	m_decoder->pcm_count = 0;
+	m_decoder->pcm_channels = 0;
+	decoder_create();
+}
+
+bool tms320av110_device::decode_frame()
+{
+	int position = m_decoder->input_bit_position;
+	int sample_count = 0;
+	int sample_rate = 0;
+	int channels = 0;
+	if (!m_decoder->decoder->decode_buffer(
+			position,
+			m_decoder->input_bytes * 8,
+			m_decoder->pcm.data(),
+			sample_count,
+			sample_rate,
+			channels))
+	{
+		return false;
+	}
+
+	assert(sample_count <= MPEG_LAYER_II_SAMPLES_PER_FRAME);
+	assert((channels == 1) || (channels == OUTPUT_CHANNELS));
+	m_decoder->pcm_position = 0;
+	m_decoder->pcm_count = sample_count;
+	m_decoder->pcm_channels = channels;
+
+	const unsigned bytes_consumed = position / 8;
+	if (bytes_consumed)
+	{
+		std::move(
+			m_decoder->input.begin() + bytes_consumed,
+			m_decoder->input.begin() + m_decoder->input_bytes,
+			m_decoder->input.begin());
+		m_decoder->input_bytes -= bytes_consumed;
+	}
+	m_decoder->input_bit_position = position & 7;
+	update_req();
+
+	if (sample_rate && (sample_rate != m_stream->sample_rate()))
+		m_stream->set_sample_rate(sample_rate);
+
+	return true;
+}
+
+void tms320av110_device::fifo_w(u8 data)
+{
+	if (m_decoder->input_bytes == m_decoder->input.size())
+	{
+		logerror("%s: compressed-audio input overflow\n", machine().describe_context());
+		return;
+	}
+
+	m_decoder->input[m_decoder->input_bytes++] = data;
+	update_req();
+}
+
+void tms320av110_device::update_req()
+{
+	// REQ is active low and is held inactive during reset or while the input buffer is full.
+	m_req_cb((m_reset_asserted || (m_decoder->input_bytes == m_decoder->input.size())) ? ASSERT_LINE : CLEAR_LINE);
+}
+
+void tms320av110_device::reset_w(int state)
+{
+	const bool asserted = !state;
+	if (asserted && !m_reset_asserted)
+		decoder_reset();
+
+	m_reset_asserted = asserted;
+	update_req();
+}
+
+u8 tms320av110_device::read(offs_t offset)
+{
+	if (m_reset_asserted)
+		return 0; // The data sheet specifies that RESET low disables host accesses.
+
+	offset &= HOST_ADDRESS_MASK;
+	if (!machine().side_effects_disabled())
+		logerror("%s: unimplemented register read %02x\n", machine().describe_context(), offset);
+	return 0;
+}
+
+void tms320av110_device::write(offs_t offset, u8 data)
+{
+	if (m_reset_asserted)
+		return; // The data sheet specifies that RESET low disables host accesses.
+
+	offset &= HOST_ADDRESS_MASK;
+	if (offset == REG_DATAIN)
+	{
+		fifo_w(data);
+		return;
+	}
+
+	logerror("%s: unimplemented register write %02x = %02x\n", machine().describe_context(), offset, data);
+}
+
+void tms320av110_device::sound_stream_update(sound_stream &stream)
+{
+	for (int sample = 0; sample < stream.samples(); sample++)
+	{
+		if ((m_decoder->pcm_position == m_decoder->pcm_count) && !decode_frame())
+		{
+			stream.put(LEFT_CHANNEL, sample, 0.0F);
+			stream.put(RIGHT_CHANNEL, sample, 0.0F);
+			continue;
+		}
+
+		const unsigned position = m_decoder->pcm_position * m_decoder->pcm_channels;
+		const s16 left = m_decoder->pcm[position];
+		const s16 right = (m_decoder->pcm_channels == OUTPUT_CHANNELS)
+			? m_decoder->pcm[position + RIGHT_CHANNEL]
+			: left;
+		stream.put_int(LEFT_CHANNEL, sample, left, 32'768);
+		stream.put_int(RIGHT_CHANNEL, sample, right, 32'768);
+		m_decoder->pcm_position++;
+	}
+}

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -9,10 +9,13 @@
 class tms320av110_device : public device_t, public device_sound_interface
 {
 public:
+	static constexpr feature_type imperfect_features() { return feature::SOUND; }
+
 	tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
 	virtual ~tms320av110_device();
 
 	auto req() { return m_req_cb.bind(); } // active-low compressed-data request output
+	void set_external_dram(bool external) { m_external_dram = external; }
 
 	void reset_w(int state); // active-low RESET input
 	u8 read(offs_t offset);
@@ -21,6 +24,7 @@ public:
 protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
+	virtual void device_post_load() override ATTR_COLD;
 	virtual void sound_stream_update(sound_stream &stream) override;
 
 private:
@@ -30,12 +34,25 @@ private:
 	void decoder_reset();
 	bool decode_frame();
 	void fifo_w(u8 data);
+	void input_fifo_reset();
+	void start_input_timer();
+	void start_reset(bool pin_reset);
+	void start_restart();
+	void set_req(int state);
 	void update_req();
+	TIMER_CALLBACK_MEMBER(input_tick);
+	TIMER_CALLBACK_MEMBER(reset_complete);
 
 	sound_stream *m_stream;
 	devcb_write_line m_req_cb;
 	std::unique_ptr<decoder_state> m_decoder;
+	bool m_external_dram;
+	emu_timer *m_input_timer;
+	emu_timer *m_reset_timer;
 	bool m_reset_asserted;
+	bool m_reset_cycle;
+	bool m_data_access;
+	int m_req_state;
 };
 
 DECLARE_DEVICE_TYPE(TMS320AV110, tms320av110_device)

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -13,7 +13,7 @@ class tms320av110_device : public device_t, public device_sound_interface
 public:
 	static constexpr feature_type imperfect_features() { return feature::SOUND; }
 
-	tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+	tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
 
 	auto req() { return m_req_cb.bind(); } // active-low compressed-data request output
 	void set_external_dram(bool external) { m_external_dram = external; }

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -154,7 +154,7 @@ private:
 	bool m_reset_asserted;
 	bool m_reset_cycle;
 	bool m_data_access;
-	int m_req_state;
+	u8 m_req_state;
 };
 
 DECLARE_DEVICE_TYPE(TMS320AV110, tms320av110_device)

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include "mpeg_audio.h"
+
 class tms320av110_device : public device_t, public device_sound_interface
 {
 public:
 	static constexpr feature_type imperfect_features() { return feature::SOUND; }
 
 	tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
-	virtual ~tms320av110_device();
 
 	auto req() { return m_req_cb.bind(); } // active-low compressed-data request output
 	void set_external_dram(bool external) { m_external_dram = external; }
@@ -28,9 +29,69 @@ protected:
 	virtual void sound_stream_update(sound_stream &stream) override;
 
 private:
-	struct decoder_state;
+	// The host interface has seven address pins, SADDR6 through SADDR0.
+	static constexpr u32 HOST_REGISTER_COUNT = 0x80;
+	static constexpr offs_t HOST_ADDRESS_MASK = HOST_REGISTER_COUNT - 1;
 
-	void decoder_create();
+	// Host-interface register addresses from the data sheet.
+	static constexpr offs_t REG_BUFF_L = 0x12;   // input buffer word count, bits 7:0
+	static constexpr offs_t REG_BUFF_H = 0x13;   // input buffer word count, bits 14:8
+	static constexpr offs_t REG_FREE_FORM_L = 0x14; // free-format frame length, bits 7:0
+	static constexpr offs_t REG_FREE_FORM_H = 0x15; // free-format frame length, bits 10:8
+	static constexpr offs_t REG_PCM_18 = 0x16;   // PCM output precision
+	static constexpr offs_t REG_DATAIN = 0x18;   // memory-mapped compressed-data input
+	static constexpr offs_t REG_INTR_L = 0x1a;   // interrupt status, bits 7:0
+	static constexpr offs_t REG_INTR_H = 0x1b;   // interrupt status, bits 15:8
+	static constexpr offs_t REG_INTR_EN_L = 0x1c; // interrupt enable, bits 7:0
+	static constexpr offs_t REG_INTR_EN_H = 0x1d; // interrupt enable, bits 15:8
+	static constexpr offs_t REG_ATTEN_L = 0x1e;  // left output attenuation
+	static constexpr offs_t REG_ATTEN_R = 0x20;  // right output attenuation
+	static constexpr offs_t REG_AUD_ID = 0x22;   // MPEG system/packet audio stream ID
+	static constexpr offs_t REG_AUD_ID_EN = 0x24; // audio stream ID filtering enable
+	static constexpr offs_t REG_SYNC_ST = 0x26;  // synchronization status
+	static constexpr offs_t REG_SYNC_LCK = 0x28; // required additional synchronization words
+	static constexpr offs_t REG_CRC_ECM = 0x2a;  // CRC error concealment mode
+	static constexpr offs_t REG_SYNC_ECM = 0x2c; // synchronization error concealment mode
+	static constexpr offs_t REG_PLAY = 0x2e;     // decoded audio output enable
+	static constexpr offs_t REG_MUTE = 0x30;     // decoded audio mute
+	static constexpr offs_t REG_SKIP = 0x32;     // skip next audio frame
+	static constexpr offs_t REG_REPEAT = 0x34;   // repeat next audio frame
+	static constexpr offs_t REG_STR_SEL = 0x36;  // compressed input stream format
+	static constexpr offs_t REG_PCM_ORD = 0x38;  // PCM output bit order
+	static constexpr offs_t REG_LATENCY = 0x3c;  // synchronization lookahead enable
+	static constexpr offs_t REG_DRAM_EXT = 0x3e; // external input-buffer DRAM present
+	static constexpr offs_t REG_RESET = 0x40;    // decoder reset command/status
+	static constexpr offs_t REG_RESTART = 0x42;  // data-buffer flush command/status
+	static constexpr offs_t REG_PCM_FS = 0x44;   // decoded sampling frequency
+	static constexpr offs_t REG_PCM_DIV = 0x6e;  // PCM clock divider
+	static constexpr offs_t REG_DIF = 0x6f;      // 18-bit PCM justification
+	static constexpr offs_t REG_SIN_EN = 0x70;   // serial compressed-data input enable
+
+	// The on-chip input SRAM is 256 bytes; external DRAM is 256K by four bits.
+	static constexpr u32 INPUT_BUFFER_BYTES_WITHOUT_DRAM = 256;
+	static constexpr u32 INPUT_BUFFER_BYTES_WITH_DRAM = 256 * 1024 * 4 / 8;
+	// One further byte may be accepted after REQ reports full.
+	static constexpr u32 INPUT_FIFO_BYTES = INPUT_BUFFER_BYTES_WITH_DRAM + 1;
+
+	// Approximately 700 microseconds at the nominal 24 MHz oscillator frequency.
+	static constexpr u32 RESET_CYCLES_WITHOUT_DRAM = 16'800;
+	// Approximately 3.7 milliseconds at the nominal 24 MHz oscillator frequency.
+	static constexpr u32 RESET_CYCLES_WITH_DRAM = 88'800;
+
+	static constexpr u32 LEFT_CHANNEL = 0;
+	static constexpr u32 RIGHT_CHANNEL = 1;
+	static constexpr u32 OUTPUT_CHANNELS = 2;
+	static constexpr u32 INITIAL_SAMPLE_RATE = 44'100;
+	static constexpr u32 MPEG_LAYER_II_SAMPLES_PER_FRAME = 1'152;
+	static constexpr u32 MAX_MPEG1_LAYER_II_BIT_RATE = 384'000;
+	static constexpr u32 MIN_MPEG1_SAMPLE_RATE = 32'000;
+	static constexpr u32 MPEG1_LAYER_II_FRAME_SCALE = 144;
+	static constexpr u32 MPEG_FRAME_PADDING_BYTES = 1;
+	static constexpr u32 MAX_MPEG_AUDIO_FRAME_BYTES =
+		(MPEG1_LAYER_II_FRAME_SCALE * MAX_MPEG1_LAYER_II_BIT_RATE / MIN_MPEG1_SAMPLE_RATE) + MPEG_FRAME_PADDING_BYTES;
+	// Private staging storage for adapting streaming input to the frame decoder.
+	static constexpr u32 DECODER_INPUT_BYTES = 2 * MAX_MPEG_AUDIO_FRAME_BYTES;
+
 	void decoder_reset();
 	bool decode_frame();
 	void fifo_w(u8 data);
@@ -45,7 +106,19 @@ private:
 
 	sound_stream *m_stream;
 	devcb_write_line m_req_cb;
-	std::unique_ptr<decoder_state> m_decoder;
+	u8 m_registers[HOST_REGISTER_COUNT];
+	std::unique_ptr<u8[]> m_input_fifo;
+	u8 m_input[DECODER_INPUT_BYTES];
+	s16 m_pcm[MPEG_LAYER_II_SAMPLES_PER_FRAME * OUTPUT_CHANNELS];
+	std::unique_ptr<mpeg_audio> m_decoder;
+	u32 m_input_fifo_read;
+	u32 m_input_fifo_write;
+	u32 m_input_fifo_count;
+	u32 m_input_bytes;
+	u32 m_input_bit_position;
+	u32 m_pcm_position;
+	u32 m_pcm_count;
+	u32 m_pcm_channels;
 	bool m_external_dram;
 	emu_timer *m_input_timer;
 	emu_timer *m_reset_timer;

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -1,0 +1,43 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+
+#ifndef MAME_SOUND_TMS320AV110_H
+#define MAME_SOUND_TMS320AV110_H
+
+#pragma once
+
+class tms320av110_device : public device_t, public device_sound_interface
+{
+public:
+	tms320av110_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+	virtual ~tms320av110_device();
+
+	auto req() { return m_req_cb.bind(); } // active-low compressed-data request output
+
+	void reset_w(int state); // active-low RESET input
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void sound_stream_update(sound_stream &stream) override;
+
+private:
+	struct decoder_state;
+
+	void decoder_create();
+	void decoder_reset();
+	bool decode_frame();
+	void fifo_w(u8 data);
+	void update_req();
+
+	sound_stream *m_stream;
+	devcb_write_line m_req_cb;
+	std::unique_ptr<decoder_state> m_decoder;
+	bool m_reset_asserted;
+};
+
+DECLARE_DEVICE_TYPE(TMS320AV110, tms320av110_device)
+
+#endif // MAME_SOUND_TMS320AV110_H

--- a/src/devices/sound/tms320av110.h
+++ b/src/devices/sound/tms320av110.h
@@ -18,9 +18,8 @@ public:
 	auto req() { return m_req_cb.bind(); } // active-low compressed-data request output
 	void set_external_dram(bool external) { m_external_dram = external; }
 
+	void map(address_map &map) ATTR_COLD;
 	void reset_w(int state); // active-low RESET input
-	u8 read(offs_t offset);
-	void write(offs_t offset, u8 data);
 
 protected:
 	virtual void device_start() override ATTR_COLD;
@@ -31,7 +30,6 @@ protected:
 private:
 	// The host interface has seven address pins, SADDR6 through SADDR0.
 	static constexpr u32 HOST_REGISTER_COUNT = 0x80;
-	static constexpr offs_t HOST_ADDRESS_MASK = HOST_REGISTER_COUNT - 1;
 
 	// Host-interface register addresses from the data sheet.
 	static constexpr offs_t REG_BUFF_L = 0x12;   // input buffer word count, bits 7:0
@@ -94,6 +92,37 @@ private:
 
 	void decoder_reset();
 	bool decode_frame();
+	u8 buffer_low_r();
+	u8 buffer_high_r();
+	u8 external_dram_r();
+	void data_w(u8 data);
+	void reset_command_w(u8 data);
+	void restart_command_w(u8 data);
+	u8 unimplemented_r(offs_t offset);
+	void unimplemented_w(offs_t offset, u8 data);
+	void store_register(offs_t reg, u8 data, u8 mask, bool update_stream);
+	template <offs_t Register> u8 register_r();
+	void free_form_low_w(u8 data);
+	void free_form_high_w(u8 data);
+	void pcm_precision_w(u8 data);
+	void interrupt_enable_w(offs_t offset, u8 data);
+	void left_attenuation_w(u8 data);
+	void right_attenuation_w(u8 data);
+	void audio_id_w(u8 data);
+	void audio_id_enable_w(u8 data);
+	void sync_words_w(u8 data);
+	void crc_error_concealment_w(u8 data);
+	void sync_error_concealment_w(u8 data);
+	void play_w(u8 data);
+	void mute_w(u8 data);
+	void skip_w(u8 data);
+	void repeat_w(u8 data);
+	void stream_select_w(u8 data);
+	void pcm_order_w(u8 data);
+	void latency_w(u8 data);
+	void pcm_divider_w(u8 data);
+	void pcm_justification_w(u8 data);
+	void serial_input_enable_w(u8 data);
 	void fifo_w(u8 data);
 	void input_fifo_reset();
 	void start_input_timer();

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -493,7 +493,9 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	m_ymz->add_route(0, "lspeaker", 1.0);
 	m_ymz->add_route(1, "rspeaker", 1.0);
 
-	TMS320AV110(config, m_av110, 0);
+	TMS320AV110(config, m_av110, 24_MHz_XTAL);
+	// Cobra enables decoder modes that require the optional external DRAM.
+	m_av110->set_external_dram(true);
 	// AV110 REQ and MC68340 DREQ2 are both active low.
 	m_av110->req().set(m_maincpu, FUNC(m68340_cpu_device::dma_dreq2_w));
 	m_av110->add_route(0, "lspeaker", 1.0);

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -320,7 +320,7 @@ void bfm_cobra3_state::bfm_cobra3_map(address_map &map)
 	map(0x00000000, 0xffffffff).rw(FUNC(bfm_cobra3_state::mem_r), FUNC(bfm_cobra3_state::mem_w));
 	map(0x00800000, 0x009fffff).m(m_scc66470, FUNC(scc66470_device::map)).cswidth(16);
 	map(0x00a80000, 0x00a80001).w(FUNC(bfm_cobra3_state::av110_reset_strobe_w)).umask16(0x00ff);
-	map(0x00a81000, 0x00a810ff).rw(m_av110, FUNC(tms320av110_device::read), FUNC(tms320av110_device::write)).umask16(0x00ff);
+	map(0x00a81000, 0x00a810ff).m(m_av110, FUNC(tms320av110_device::map)).umask16(0x00ff);
 }
 
 void bfm_cobra3_state::ramdac_map(address_map &map)

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -4,7 +4,8 @@
 /* Bellfruit SWP (Skill With Prizes) Video hardware
     aka Cobra 3
 
-   TODO: MPEG decoding currently not implemented
+   MPEG audio decoding is preliminary.
+   TODO: MPEG video decoding is not implemented.
 */
 
 
@@ -17,11 +18,12 @@
 #include "machine/ncr5380.h"
 #include "machine/nscsi_bus.h"
 #include "machine/nvram.h"
-#include "video/ramdac.h"
 #include "machine/rescap.h"
 #include "machine/scc66470.h"
 #include "machine/watchdog.h"
+#include "sound/tms320av110.h"
 #include "sound/ymz280b.h"
+#include "video/ramdac.h"
 
 #include "screen.h"
 #include "speaker.h"
@@ -37,6 +39,7 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_cpuregion(*this, "maincpu"),
 		m_nvram(*this, "nvram"),
+		m_av110(*this, "av110"),
 		m_ymz(*this, "ymz280b"),
 		m_palette(*this, "palette"),
 		m_ramdac(*this, "ramdac"),
@@ -56,6 +59,7 @@ protected:
 	required_device<m68340_cpu_device> m_maincpu;
 	required_region_ptr<uint16_t> m_cpuregion;
 	required_device<nvram_device> m_nvram;
+	required_device<tms320av110_device> m_av110;
 	required_device<ymz280b_device> m_ymz;
 	required_device<palette_device> m_palette;
 	required_device<ramdac_device> m_ramdac;
@@ -77,6 +81,7 @@ protected:
 	virtual void machine_start() override ATTR_COLD;
 
 	void volume_control(uint8_t direction, uint8_t clock);
+	void av110_reset_strobe_w(u8 data);
 	uint16_t mem_r(offs_t offset, uint16_t mem_mask = ~0);
 	void mem_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
@@ -91,7 +96,7 @@ protected:
 
 void bfm_cobra3_state::volume_control(uint8_t direction, uint8_t clock)
 {
-	int clock_changed = m_vol_clock ^ clock;
+	uint8_t const clock_changed = m_vol_clock ^ clock;
 
 	m_vol_clock = clock;
 	if (clock_changed)
@@ -109,12 +114,21 @@ void bfm_cobra3_state::volume_control(uint8_t direction, uint8_t clock)
 					m_volume--;
 			}
 
-			float fraction = (64 - m_volume) / 64.0f;
+			float const fraction = (32 - m_volume) / 32.0f;
 
 			m_ymz->set_output_gain(0, fraction);
 			m_ymz->set_output_gain(1, fraction);
+			m_av110->set_output_gain(0, fraction);
+			m_av110->set_output_gain(1, fraction);
 		}
 	}
+}
+
+void bfm_cobra3_state::av110_reset_strobe_w(u8)
+{
+	// This decoded write pulses the AV110's active-low RESET input.
+	m_av110->reset_w(0);
+	m_av110->reset_w(1);
 }
 
 uint16_t bfm_cobra3_state::mem_r(offs_t offset, uint16_t mem_mask)
@@ -305,6 +319,8 @@ void bfm_cobra3_state::bfm_cobra3_map(address_map &map)
 {
 	map(0x00000000, 0xffffffff).rw(FUNC(bfm_cobra3_state::mem_r), FUNC(bfm_cobra3_state::mem_w));
 	map(0x00800000, 0x009fffff).m(m_scc66470, FUNC(scc66470_device::map)).cswidth(16);
+	map(0x00a80000, 0x00a80001).w(FUNC(bfm_cobra3_state::av110_reset_strobe_w)).umask16(0x00ff);
+	map(0x00a81000, 0x00a810ff).rw(m_av110, FUNC(tms320av110_device::read), FUNC(tms320av110_device::write)).umask16(0x00ff);
 }
 
 void bfm_cobra3_state::ramdac_map(address_map &map)
@@ -375,8 +391,13 @@ INPUT_PORTS_END
 void bfm_cobra3_state::machine_start()
 {
 	m_active_strobe = 0;
+	m_vol_clock = 0;
+	m_volume = 0;
 	m_mainram = make_unique_clear<uint16_t[]>((1024 * 16) / 2);
 	m_nvram->set_base(m_mainram.get(), 1024 * 16);
+
+	save_item(NAME(m_vol_clock));
+	save_item(NAME(m_volume));
 }
 
 
@@ -471,6 +492,12 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	YMZ280B(config, m_ymz, 16.9344_MHz_XTAL);
 	m_ymz->add_route(0, "lspeaker", 1.0);
 	m_ymz->add_route(1, "rspeaker", 1.0);
+
+	TMS320AV110(config, m_av110, 0);
+	// AV110 REQ and MC68340 DREQ2 are both active low.
+	m_av110->req().set(m_maincpu, FUNC(m68340_cpu_device::dma_dreq2_w));
+	m_av110->add_route(0, "lspeaker", 1.0);
+	m_av110->add_route(1, "rspeaker", 1.0);
 
 	SCC66470(config,m_scc66470,30000000);
 	m_scc66470->set_addrmap(0, &bfm_cobra3_state::scc66470_map);


### PR DESCRIPTION
## 2/5 for Telly Addicts on the Bellfruit Cobra 3

This is the second of a series of changes intended to get Telly Addicts on the Bellfruit Cobra 3 through to working.

The planned dependency order is:

1. MC68340 DMA, interrupt handling, and Cobra 3 board-level integration — merged in #15896
2. TMS320AV110 MPEG audio - **this change**
3. MPEG-1 video and STi3400 support
4. Telly Addicts controls, lamps, layout, and serial interfaces
5. Telly Addicts cash-handling hardware and meters

The complete development version can be viewed here:

https://github.com/MagikalUnicorn/mame/commits/cobra3-telly

## This change

This adds preliminary emulation of the Texas Instruments TMS320AV110 MPEG audio decoder.

The implemented subset in this change covers the functionality currently required by the Cobra 3 for Telly Addicts:

- the seven-bit host register address window;
- memory-mapped compressed-audio input;
- the 256-byte internal input buffer and optional 128 KiB external DRAM buffer;
- input-buffer level reporting and active-low REQ handshaking;
- active-low RESET input and clock-based reset completion;
- decoder restart and input-buffer flushing;
- PLAY, MUTE and left/right attenuation controls;
- synchronization and sample-frequency status;
- buffered MPEG-1 Audio Layer II input;
- mono and stereo PCM output;
- sample-rate changes taken from MPEG frame headers; and
- save-state support for the registers, compressed and decoded audio buffers, handshake state, reset state and MPEG synthesis history.

MAME's existing `mpeg_audio` implementation is used as the Layer II decoding backend:

https://github.com/mamedev/mame/blob/master/src/devices/sound/mpeg_audio.cpp

The Cobra 3 driver supplies the decoder’s 24 MHz input clock and configures the optional external DRAM used by the machine. Its host interface is mapped into the appropriate memory ranges, its active-low REQ output is connected to MC68340 DMA channel 2, and its stereo output is routed to the speakers.

I have also corrected the Cobra 3 digital volume handling to use the full 32-step range generated by the output latch. Its state is initialised and saved, and the resulting gain is applied to both the TMS320AV110 and YMZ280B outputs. The AV110’s own independent left and right attenuation controls are also honoured.

The device behaviour was implemented from the Texas Instruments TMS320AV110 data sheet, SCSS013C - see https://datasheet.datasheetarchive.com/originals/library/Datasheet-039/DSA0084950.pdf

The device remains preliminary. Functionality not exercised by the available Cobra 3 software, including interrupt generation, serial compressed-data input and several specialised stream-processing controls, remains outside the implemented scope as I cannot test it.

## Validation

Targeted release and assertion-enabled builds completed successfully.

MAME validation passed for:

- `c3_telly`
- `c3_tellyns`
- `c3_rtime`
- `c3_totp`
- `c3_ppays`

## AI assistance disclosure

I used OpenAI Codex (GPT-5) to carry out the investigations, and then do the majority of the implementation (usually around 80% of it, rising to 100% for the MPEG decoder backend), code reviews, clean-history reconstruction, and testing. I reviewed the resulting changes and test results, extensively tested myself, and shaped the code, overall approach and change structuring towards what I thought was cleanest and most MAME-like were I could see obvious issues in style or encapsulation.

For each change, with the exception of the MPEG video decoder backend, I am trying to learn exactly how it works to expand my own knowledge. It's been a very long time since I did C++, so please bear with me.

I take responsibility for the submitted changes and will disclose the extent of AI assistance separately for each subsequent submission.