### PR TITLE
util/cdrom.cpp: Support CD+G Discs

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -718,6 +718,11 @@ void cdrom_file::get_info_from_type_string(const char *typestring, uint32_t *trk
 		*trktype = CD_TRACK_AUDIO;
 		*datasize = 2352;
 	}
+	else if (!strcmp(typestring, "CDG"))
+	{
+		*trktype = CD_TRACK_AUDIO;
+		*datasize = 2352;
+	}
 }
 
 /*-------------------------------------------------
@@ -2594,6 +2599,8 @@ std::error_condition cdrom_file::parse_cue(std::string_view tocfname, toc &outto
 					osd_printf_verbose("trk %d: fname %s offset %d\n", trknum, outinfo.track[trknum].fname, outinfo.track[trknum].offset);
 				}
 			}
+			
+			const bool is_cdg = !strcmp(token, "CDG");
 
 			convert_type_string_to_track_info(token, &outtoc.tracks[trknum]);
 			if (outtoc.tracks[trknum].datasize == 0)
@@ -2607,6 +2614,13 @@ std::error_condition cdrom_file::parse_cue(std::string_view tocfname, toc &outto
 			TOKENIZE
 
 			convert_subtype_string_to_track_info(token, &outtoc.tracks[trknum]);
+
+			if (is_cdg)
+			{
+				/* CD+G format has no unique subcode. */
+				outtoc.tracks[trknum].subtype = CD_SUB_RAW;
+				outtoc.tracks[trknum].subsize = 96;
+			}
 		}
 		else if (!strcmp(token, "INDEX"))
 		{
@@ -3138,6 +3152,8 @@ std::error_condition cdrom_file::parse_toc(std::string_view tocfname, toc &outto
 			outtoc.tracks[trknum].pgsub = CD_SUB_NONE;
 			outtoc.tracks[trknum].padframes = 0;
 
+			const bool is_cdg = !strcmp(token, "CDG");
+			
 			convert_type_string_to_track_info(token, &outtoc.tracks[trknum]);
 			if (outtoc.tracks[trknum].datasize == 0)
 			{
@@ -3150,6 +3166,13 @@ std::error_condition cdrom_file::parse_toc(std::string_view tocfname, toc &outto
 			TOKENIZE
 
 			convert_subtype_string_to_track_info(token, &outtoc.tracks[trknum]);
+
+			if (is_cdg)
+			{
+				/* CD+G format has no unique subcode. */
+				outtoc.tracks[trknum].subtype = CD_SUB_RAW;
+				outtoc.tracks[trknum].subsize = 96;
+			}
 		}
 		else if (!strcmp(token, "START"))
 		{


### PR DESCRIPTION
Without this change, CD+G discs when played in the CD-i audio player will sound like "crackling" because it actually has 96 additional bytes. With this change, CD+G discs will play correctly.

CD+G is a type of disc which features graphics that are streamed along with the audio. On many CD players, this data is simply ignored. The Philips CD-i's built in audio player allows this data to be visualized. This was a short lived feature often used for karaoke style animations and visualizations of album art to go along with the music. Here is an example from `Fleetwood Mac - Behind the Mask`.

Note: Testing this feature is not yet possible in MAME upstream. This screenshot is from my local revision, using the M68HC05 SPI/SCI which is still undergoing feedback and revision.

<img width="1223" height="985" alt="image" src="https://github.com/user-attachments/assets/06a51930-971c-43c8-8532-22a42b1046c7" />
