### PR TITLE
apple/macpdm: add the Power Macintosh 7100 and 8100, add all speedbumped variants, fix bugs

### DIFF
--- a/src/devices/cpu/powerpc/ppcfe.cpp
+++ b/src/devices/cpu/powerpc/ppcfe.cpp
@@ -322,6 +322,9 @@ bool ppc_device::frontend::describe(opcode_desc &desc, const opcode_desc *prev, 
 			{
 				desc.set_ctr_used();
 				desc.set_ctr_modified();
+				// branch folding
+				if ((G_BO(op) & 0x10) && (!prev || !prev->ctr_modified()) && (is_601_class() || is_603_class()))
+					desc.cycles = 0;
 			}
 			if (op & M_LK)
 				desc.set_lr_modified();

--- a/src/devices/cpu/powerpc/ppcfe.h
+++ b/src/devices/cpu/powerpc/ppcfe.h
@@ -63,6 +63,8 @@ public:
 	void set_fpscr_used(unsigned n)         { regin.set(REG_BIT_FPSCR0 + n); }
 	void set_fpscr_modified(unsigned n)     { regout.set(REG_BIT_FPSCR0 + n); }
 
+	bool ctr_modified() const               { return regout[REG_BIT_CTR]; }
+
 	uint32_t cr_modified() const            { return regmask_field<64, 32>(regout); }
 	uint8_t cr_modified(unsigned n) const   { return reg_cr(regout, n); }
 	uint32_t cr_required() const            { return regmask_field<64, 32>(regreq); }

--- a/src/devices/machine/ncr53c90.cpp
+++ b/src/devices/machine/ncr53c90.cpp
@@ -201,6 +201,7 @@ ncr53cf94_device::ncr53cf94_device(const machine_config &mconfig, device_type ty
 	, config4(0)
 	, family_id(0x04)
 	, revision_level(0x02)
+	, tcount_hi2_loaded(false)
 {
 }
 
@@ -1409,8 +1410,10 @@ void ncr53c94_device::check_drq()
 void ncr53cf94_device::device_start()
 {
 	save_item(NAME(config4));
+	save_item(NAME(tcount_hi2_loaded));
 
 	config4 = 0;
+	tcount_hi2_loaded = false;
 
 	ncr53c94_device::device_start();
 }
@@ -1419,6 +1422,8 @@ void ncr53cf94_device::device_reset()
 {
 	config4 = 0;
 
+	tcount_hi2_loaded = false;
+
 	ncr53c94_device::device_reset();
 }
 
@@ -1426,14 +1431,15 @@ void ncr53cf94_device::load_tcounter()
 {
 	ncr53c94_device::load_tcounter();
 
-	// ID may be read by executing DMA NOP command twice, first with the features bit clear and then with it set
-	if ((config2 & S2FE) == 0)
-		tcount = (1 << 23) | (family_id << 19) | (revision_level << 16) | (tcount & 0xffff);
+	// A DMA NOP with the features enable bit set, if register 0x0E hasn't been
+	// written since reset, fills register 0x0E with the chip ID.
+	if (!tcount_hi2_loaded && (config2 & ENF) && ((command[0] & 0x7f) == CM_NOP))
+		tcounter = (1 << 23) | (family_id << 19) | (revision_level << 16) | (tcounter & 0xffff);
 }
 
 void ncr53cf94_device::conf2_w(uint8_t data)
 {
-	tcounter_mask = (data & S2FE) ? 0xffffff : 0xffff;
+	tcounter_mask = (data & ENF) ? 0xffffff : 0xffff;
 	config2 = data;
 }
 
@@ -1446,5 +1452,6 @@ uint8_t ncr53cf94_device::tcounter_hi2_r()
 void ncr53cf94_device::tcount_hi2_w(uint8_t data)
 {
 	tcount = (tcount & ~uint32_t(0xff0000)) | (uint32_t(data) << 16);
+	tcount_hi2_loaded = true;
 	LOG("tcount_hi2_w %02x (%s)\n", data, machine().describe_context());
 }

--- a/src/devices/machine/ncr53c90.h
+++ b/src/devices/machine/ncr53c90.h
@@ -359,6 +359,12 @@ public:
 protected:
 	ncr53cf94_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
+	// 53cf94 has additional features attached to bit 6 of config2
+	enum conf2_mask : u8
+	{
+		ENF = 0x40, // features enable
+	};
+
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 
@@ -368,6 +374,7 @@ private:
 	u8 config4;
 	u8 family_id;
 	u8 revision_level;
+	bool tcount_hi2_loaded;
 };
 
 class ncr53cf96_device : public ncr53cf94_device

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -103,6 +103,7 @@ private:
 	floppy_image_device *m_cur_floppy = nullptr;
 
 	uint32_t m_model_id = 0;
+	uint8_t m_simm_sockets = 2;
 	uint64_t m_hmc_reg = 0, m_hmc_buffer = 0;
 	uint8_t m_hmc_bit = 0;
 
@@ -229,6 +230,8 @@ private:
 	void hmc_w(offs_t offset, uint8_t data);
 
 	void ram_size();
+	void ram_size_6100();
+	void ram_size_7100_8100();
 
 	uint32_t id_r(offs_t offset, uint32_t mem_mask);
 
@@ -780,13 +783,72 @@ void macpdm_state::hmc_w(offs_t offset, uint8_t data)
     PDM uses a variant on the V8/Sonora style memory controller.
     - Motherboard RAM can be 4 or 8 MiB
     - The hardware officially limits SIMMs to 2, 8, or 32 MiB, and SIMMs must be installed in pairs
-    - In reality, 128 MiB SIMMs will also work.
+    - In reality, 128 MiB SIMMs will also work on the 6100.
     - 6100 has only 2 SIMM slots, so valid sizes are 8MiB (no SIMMs), 12MiB (2 MiB SIMM x2),
       24MiB (8 MiB SIMM x2), 72MiB (32 MiB SIMM x2), and 264MiB (128 MiB SIMM x2)
-    - 7100 has 4 SIMM slots, allowing RAM up to 520MiB (128 MiB SIMM x4)
+    - 7100 has 4 SIMM slots, but not 520MiB (128 MiB SIMM x4) as one might expect: the
+      7100 and 8100 decode each socket into its own 64 MiB window, so a SIMM larger than
+      that would overlap the socket above it, and the ROM only probes 32 MiB of each
+      window anyway.
     - 8100 has 8 SIMM slots, which add valid sizes up to 264 MiB (32 MiB SIMM x8)
 */
-void macpdm_state::ram_size(){
+void macpdm_state::ram_size()
+{
+	if (m_simm_sockets > 2)
+		ram_size_7100_8100();
+	else
+		ram_size_6100();
+}
+
+void macpdm_state::ram_size_7100_8100()
+{
+	static constexpr u32 SOCKET_BASE   = 0x01000000;
+	static constexpr u32 SOCKET_STRIDE = 0x04000000;
+	static constexpr u32 SOCKET_MAX    = 32*1024*1024;
+
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+	const u32 total_ram = m_ram->size();
+	const u32 mb_ram_size = 8*1024*1024;
+	const u32 simm_total = total_ram - mb_ram_size;
+
+	space.unmap_readwrite(0x00000000, 0x3fffffff);
+
+	u8 *const mb_ram = (u8 *)m_ram->pointer();
+	space.install_ram(0x00000000, mb_ram_size - 1, 0, (void *)mb_ram);
+
+	if (!simm_total)
+	{
+		LOGMASKED(LOG_MEMORY_SIZING, "Total RAM: %08x, motherboard RAM: %08x, no SIMMs\n", total_ram, mb_ram_size);
+		return;
+	}
+
+	u32 sockets = 2;
+	while ((sockets < m_simm_sockets) && ((simm_total / sockets) > SOCKET_MAX))
+		sockets *= 2;
+
+	u32 simm_size = simm_total / sockets;
+
+	if (simm_size > SOCKET_STRIDE)
+	{
+		LOGMASKED(LOG_MEMORY_SIZING, "SIMM size %08x exceeds the %08x socket window, clamping\n", simm_size, SOCKET_STRIDE);
+		simm_size = SOCKET_STRIDE;
+	}
+
+	LOGMASKED(LOG_MEMORY_SIZING, "Total RAM: %08x, motherboard RAM: %08x, SIMM size: %08x x%d\n", total_ram, mb_ram_size, simm_size, sockets);
+
+	u8 *simm = mb_ram + mb_ram_size;
+	for (u32 i = 0; i < sockets; i++)
+	{
+		const u32 base = SOCKET_BASE + (i * SOCKET_STRIDE);
+		LOGMASKED(LOG_MEMORY_SIZING, "SIMM %d at %08x - %08x\n", i, base, base + simm_size - 1);
+		space.install_ram(base, base + simm_size - 1, 0, (void *)simm);
+
+		simm += simm_size;
+	}
+}
+
+void macpdm_state::ram_size_6100()
+{
 	static const uint32_t sizes[4] = { 128*1024*1024, 2*1024*1024, 8*1024*1024, 32*1024*1024 };
 	const u8 config = (m_hmc_reg >> 29) & 3;        // 0 = 128MiB, 1 = 2MiB, 2 = 8MiB, 3 = 32MiB
 	address_space &space = m_maincpu->space(AS_PROGRAM);
@@ -1594,7 +1656,6 @@ void macpdm_state::pdm_base(machine_config &config)
 
 	RAM(config, m_ram);
 	m_ram->set_default_size("8M");
-	m_ram->set_extra_options("16M,24M,40M,72M,136M");
 
 	nubus_device &nubus(NUBUS(config, "nubus"));
 	nubus.set_space(m_maincpu, AS_PROGRAM);
@@ -1627,6 +1688,10 @@ void macpdm_state::pmac6100(machine_config &config)
 
 	m_model_id = 0xa55a3010;
 
+	// 2 SIMM sockets, supporting up to 128 MiB per SIMM
+	m_simm_sockets = 2;
+	m_ram->set_extra_options("12M,16M,24M,40M,72M,136M,264M");
+
 	// 6100 with the NuBus adapter has one slot, slot $E
 	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
 }
@@ -1645,6 +1710,10 @@ void macpdm_state::pmac7100(machine_config &config)
 	m_maincpu->set_clock(66'000'000);
 
 	m_model_id = 0xa55a3012;
+
+	// 4 SIMM sockets, supporting up to 32 MiB per SIMM
+	m_simm_sockets = 4;
+	m_ram->set_extra_options("12M,16M,24M,40M,72M,136M");
 
 	NUBUS_SLOT(config, "nbc", "nubus", powermac_nubus_cards, nullptr);
 	NUBUS_SLOT(config, "nbd", "nubus", powermac_nubus_cards, nullptr);
@@ -1666,6 +1735,10 @@ void macpdm_state::pmac8100(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &macpdm_state::pdm_8100map);
 
 	m_model_id = 0xa55a3013;
+
+	// 8 SIMM sockets, supporting up to 32 MiB per SIMM
+	m_simm_sockets = 8;
+	m_ram->set_extra_options("12M,16M,24M,40M,72M,136M,264M");
 
 	// On the 8100 the hard drive is connected to the fast SCSI bus instead
 	subdevice<nscsi_connector>("scsi:0")->set_default_option(nullptr);

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -59,6 +59,12 @@ static constexpr u8 SCCDMA_RELOAD               = 0x40;
 static constexpr u8 SCCDMA_IRQ                  = 0x80;
 static constexpr u8 SCCDMA_WRITE_MASK           = (SCCDMA_RELOAD|SCCDMA_PAUSE|SCCDMA_IRQENABLE|SCCDMA_CONTINUE|SCCDMA_RUN);
 
+// Triggers used to release the CPU when a 53C9x raises DRQ again during a
+// pseudo-DMA transfer, plus the maximum time we're willing to wait for it.
+static constexpr int TRIGGER_SCSI_A_DRQ         = 1000;
+static constexpr int TRIGGER_SCSI_B_DRQ         = 1001;
+static constexpr int SCSI_DRQ_TIMEOUT_US        = 100;
+
 class macpdm_state : public driver_device
 {
 public:
@@ -126,6 +132,9 @@ private:
 
 	bool m_dma_scsi_a_in_step = false, m_dma_scsi_b_in_step = false;
 	bool m_dma_floppy_in_step = false, m_floppy_drq = false;
+
+	emu_timer *m_scsi_a_drq_timeout_timer = nullptr;
+	emu_timer *m_scsi_b_drq_timeout_timer = nullptr;
 
 	void pdm_map(address_map &map) ATTR_COLD;
 	void pdm_8100map(address_map &map) ATTR_COLD;
@@ -207,6 +216,14 @@ private:
 	void scsi_a_w(offs_t offset, uint8_t data);
 	uint8_t scsi_b_r(offs_t offset);
 	void scsi_b_w(offs_t offset, uint8_t data);
+
+	uint16_t scsi_a_pdma_r();
+	void scsi_a_pdma_w(uint16_t data);
+	uint16_t scsi_b_pdma_r();
+	void scsi_b_pdma_w(uint16_t data);
+	void scsi_pdma_wait(uint8_t drq_mask, int trigger, emu_timer *timeout_timer);
+	TIMER_CALLBACK_MEMBER(scsi_a_drq_timeout);
+	TIMER_CALLBACK_MEMBER(scsi_b_drq_timeout);
 
 	uint8_t hmc_r(offs_t offset);
 	void hmc_w(offs_t offset, uint8_t data);
@@ -296,6 +313,9 @@ macpdm_state::macpdm_state(const machine_config &mconfig, device_type type, cons
 void macpdm_state::driver_init()
 {
 	m_maincpu->space().install_ram(0, m_ram->mask(), 0, m_ram->pointer());
+
+	m_scsi_a_drq_timeout_timer = timer_alloc(FUNC(macpdm_state::scsi_a_drq_timeout), this);
+	m_scsi_b_drq_timeout_timer = timer_alloc(FUNC(macpdm_state::scsi_b_drq_timeout), this);
 
 	save_item(NAME(m_hmc_reg));
 	save_item(NAME(m_hmc_buffer));
@@ -655,6 +675,51 @@ void macpdm_state::scsi_b_w(offs_t offset, uint8_t data)
 	m_ncr53cf96->write(offset >> 4, data);
 }
 
+void macpdm_state::scsi_pdma_wait(uint8_t drq_mask, int trigger, emu_timer *timeout_timer)
+{
+	if (machine().side_effects_disabled() || (m_via2_ifr & drq_mask))
+		return;
+
+	m_maincpu->spin_until_trigger(trigger);
+	timeout_timer->adjust(attotime::from_usec(SCSI_DRQ_TIMEOUT_US));
+}
+
+uint16_t macpdm_state::scsi_a_pdma_r()
+{
+	const uint16_t data = m_ncr53c94->dma16_swap_r();
+	scsi_pdma_wait(0x01, TRIGGER_SCSI_A_DRQ, m_scsi_a_drq_timeout_timer);
+	return data;
+}
+
+void macpdm_state::scsi_a_pdma_w(uint16_t data)
+{
+	m_ncr53c94->dma16_swap_w(data);
+	scsi_pdma_wait(0x01, TRIGGER_SCSI_A_DRQ, m_scsi_a_drq_timeout_timer);
+}
+
+uint16_t macpdm_state::scsi_b_pdma_r()
+{
+	const uint16_t data = m_ncr53cf96->dma16_swap_r();
+	scsi_pdma_wait(0x04, TRIGGER_SCSI_B_DRQ, m_scsi_b_drq_timeout_timer);
+	return data;
+}
+
+void macpdm_state::scsi_b_pdma_w(uint16_t data)
+{
+	m_ncr53cf96->dma16_swap_w(data);
+	scsi_pdma_wait(0x04, TRIGGER_SCSI_B_DRQ, m_scsi_b_drq_timeout_timer);
+}
+
+TIMER_CALLBACK_MEMBER(macpdm_state::scsi_a_drq_timeout)
+{
+	machine().scheduler().trigger(TRIGGER_SCSI_A_DRQ);
+}
+
+TIMER_CALLBACK_MEMBER(macpdm_state::scsi_b_drq_timeout)
+{
+	machine().scheduler().trigger(TRIGGER_SCSI_B_DRQ);
+}
+
 uint8_t macpdm_state::hmc_r(offs_t offset)
 {
 	const uint8_t rv = (m_hmc_reg >> m_hmc_bit) & 1;
@@ -1008,6 +1073,8 @@ void macpdm_state::scsi_a_irq(int state)
 void macpdm_state::scsi_a_drq(int state)
 {
 	via2_irq_main_set(0x01, state);
+	if (state)
+		machine().scheduler().trigger(TRIGGER_SCSI_A_DRQ);
 	if ((m_dma_scsi_a_ctrl & 0x02) && (m_via2_ifr & 0x01) && !m_dma_scsi_a_in_step)
 		dma_scsi_a_step();
 }
@@ -1020,6 +1087,8 @@ void macpdm_state::scsi_b_irq(int state)
 void macpdm_state::scsi_b_drq(int state)
 {
 	via2_irq_main_set(0x04, state);
+	if (state)
+		machine().scheduler().trigger(TRIGGER_SCSI_B_DRQ);
 	if ((m_dma_scsi_b_ctrl & 0x02) && (m_via2_ifr & 0x04) && !m_dma_scsi_b_in_step)
 		dma_scsi_b_step();
 }
@@ -1384,7 +1453,7 @@ void macpdm_state::pdm_map(address_map &map)
 	// 50f08000 = ethernet ID PROM
 	// 50f0a000 = MACE ethernet controller
 	map(0x50f10000, 0x50f100ff).rw(FUNC(macpdm_state::scsi_a_r), FUNC(macpdm_state::scsi_a_w));
-	map(0x50f10100, 0x50f10101).rw(m_ncr53c94, FUNC(ncr53c94_device::dma16_swap_r), FUNC(ncr53c94_device::dma16_swap_w));
+	map(0x50f10100, 0x50f10101).rw(FUNC(macpdm_state::scsi_a_pdma_r), FUNC(macpdm_state::scsi_a_pdma_w));
 	map(0x50f14000, 0x50f1401f).rw(m_awacs, FUNC(awacs_device::read), FUNC(awacs_device::write));
 	map(0x50f16000, 0x50f16000).rw(FUNC(macpdm_state::fdc_r), FUNC(macpdm_state::fdc_w)).select(0x1e00);
 
@@ -1436,7 +1505,7 @@ void macpdm_state::pdm_8100map(address_map &map)
 	pdm_map(map);
 
 	map(0x50f11000, 0x50f110ff).rw(FUNC(macpdm_state::scsi_b_r), FUNC(macpdm_state::scsi_b_w));
-	map(0x50f11100, 0x50f11101).rw(m_ncr53cf96, FUNC(ncr53cf96_device::dma16_swap_r), FUNC(ncr53cf96_device::dma16_swap_w));
+	map(0x50f11100, 0x50f11101).rw(FUNC(macpdm_state::scsi_b_pdma_r), FUNC(macpdm_state::scsi_b_pdma_w));
 }
 
 void macpdm_state::pdm_base(machine_config &config)

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -77,8 +77,10 @@ private:
 	required_device<adb_bus_device> m_adbbus;
 	required_device<ram_device> m_ram;
 	required_device<z80scc_device> m_scc;
-	required_device<nscsi_bus_device> m_scsibus;
+	required_device<nscsi_bus_device> m_scsibus_a;
 	required_device<ncr53c94_device> m_ncr53c94;
+	optional_device<nscsi_bus_device> m_scsibus_b; // 8100 only
+	optional_device<ncr53cf96_device> m_ncr53cf96; // 8100 only
 	required_device<swim3_device> m_fdc;
 	required_device_array<floppy_connector, 2> m_floppy;
 	required_device<mac_video_sonora_device> m_video;
@@ -95,7 +97,8 @@ private:
 
 	uint8_t m_via2_ier = 0, m_via2_ifr = 0, m_via2_sier = 0, m_via2_sifr = 0;
 
-	uint64_t m_dma_scsi_buffer = 0;
+	uint64_t m_dma_scsi_a_buffer = 0;
+	uint64_t m_dma_scsi_b_buffer = 0;
 
 	uint32_t m_dma_badr = 0, m_dma_floppy_adr = 0;
 	uint16_t m_dma_floppy_byte_count = 0, m_dma_floppy_offset = 0;
@@ -106,12 +109,14 @@ private:
 	uint32_t m_dma_scsi_a_cur_offset = 0, m_dma_scsi_b_cur_offset = 0;
 
 	uint8_t m_dma_scsi_a_ctrl = 0, m_dma_scsi_b_ctrl = 0, m_dma_floppy_ctrl = 0;
-	uint8_t m_dma_scsi_buffer_word_count = 0;
+	uint8_t m_dma_scsi_a_buffer_word_count = 0;
+	uint8_t m_dma_scsi_b_buffer_word_count = 0;
 
 	uint8_t m_dma_scc_txa_ctrl = 0, m_dma_scc_rxa_ctrl = 0, m_dma_scc_txb_ctrl = 0, m_dma_scc_rxb_ctrl = 0;
 	uint8_t m_dma_enet_rx_ctrl = 0, m_dma_enet_tx_ctrl = 0;
 
-	bool m_dma_scsi_a_in_step = false, m_dma_floppy_in_step = false, m_floppy_drq = false;
+	bool m_dma_scsi_a_in_step = false, m_dma_scsi_b_in_step = false;
+	bool m_dma_floppy_in_step = false, m_floppy_drq = false;
 
 	void pdm_map(address_map &map) ATTR_COLD;
 
@@ -141,7 +146,8 @@ private:
 	void txb_err_irq(int state);
 	void rxb_err_irq(int state);
 
-	void scsi_err_irq(int state);
+	void scsi_a_err_irq(int state);
+	void scsi_b_err_irq(int state);
 	void sndo_err_irq(int state);
 	void sndi_err_irq(int state);
 
@@ -153,8 +159,10 @@ private:
 	void fdc_irq(int state);
 	void fdc_drq(int state);
 	void recalc_dma_irqs();
-	void scsi_irq(int state);
-	void scsi_drq(int state);
+	void scsi_a_irq(int state);
+	void scsi_a_drq(int state);
+	void scsi_b_irq(int state);
+	void scsi_b_drq(int state);
 
 	void phases_w(uint8_t phases);
 	void sel35_w(int sel35);
@@ -185,8 +193,10 @@ private:
 	uint8_t fdc_r(offs_t offset);
 	void fdc_w(offs_t offset, uint8_t data);
 
-	uint8_t scsi_r(offs_t offset);
-	void scsi_w(offs_t offset, uint8_t data);
+	uint8_t scsi_a_r(offs_t offset);
+	void scsi_a_w(offs_t offset, uint8_t data);
+	uint8_t scsi_b_r(offs_t offset);
+	void scsi_b_w(offs_t offset, uint8_t data);
 
 	uint8_t hmc_r(offs_t offset);
 	void hmc_w(offs_t offset, uint8_t data);
@@ -211,6 +221,7 @@ private:
 	void dma_berr_flag_w(offs_t, uint16_t data, uint16_t mem_mask);
 
 	void dma_scsi_a_step();
+	void dma_scsi_b_step();
 	uint32_t dma_scsi_a_base_adr_r();
 	void dma_scsi_a_base_adr_w(offs_t, uint32_t data, uint32_t mem_mask);
 	uint32_t dma_scsi_b_base_adr_r();
@@ -259,8 +270,10 @@ macpdm_state::macpdm_state(const machine_config &mconfig, device_type type, cons
 	m_adbbus(*this, "adb"),
 	m_ram(*this, RAM_TAG),
 	m_scc(*this, "scc"),
-	m_scsibus(*this, "scsi"),
+	m_scsibus_a(*this, "scsi"),
 	m_ncr53c94(*this, "ncr53c94"),
+	m_scsibus_b(*this, "fastscsi"),
+	m_ncr53cf96(*this, "ncr53cf96"),
 	m_fdc(*this, "fdc"),
 	m_floppy(*this, "fdc:%d", 0U),
 	m_video(*this, "video"),
@@ -292,9 +305,12 @@ void macpdm_state::driver_init()
 	save_item(NAME(m_dma_badr));
 	save_item(NAME(m_dma_berr_en));
 	save_item(NAME(m_dma_berr_flag));
-	save_item(NAME(m_dma_scsi_buffer));
-	save_item(NAME(m_dma_scsi_buffer_word_count));
+	save_item(NAME(m_dma_scsi_a_buffer));
+	save_item(NAME(m_dma_scsi_b_buffer));
+	save_item(NAME(m_dma_scsi_a_buffer_word_count));
+	save_item(NAME(m_dma_scsi_b_buffer_word_count));
 	save_item(NAME(m_dma_scsi_a_in_step));
+	save_item(NAME(m_dma_scsi_b_in_step));
 	save_item(NAME(m_dma_scsi_a_base_adr));
 	save_item(NAME(m_dma_scsi_b_base_adr));
 	save_item(NAME(m_dma_scsi_a_ctrl));
@@ -332,9 +348,12 @@ void macpdm_state::driver_reset()
 	m_dma_badr = 0;
 	m_dma_berr_en = 0;
 	m_dma_berr_flag = 0;
-	m_dma_scsi_buffer = 0;
-	m_dma_scsi_buffer_word_count = 0;
+	m_dma_scsi_a_buffer = 0;
+	m_dma_scsi_b_buffer = 0;
+	m_dma_scsi_a_buffer_word_count = 0;
+	m_dma_scsi_b_buffer_word_count = 0;
 	m_dma_scsi_a_in_step = false;
+	m_dma_scsi_b_in_step = false;
 	m_dma_scsi_a_base_adr = 0;
 	m_dma_scsi_b_base_adr = 0;
 	m_dma_scsi_a_ctrl = 0;
@@ -543,16 +562,18 @@ uint8_t macpdm_state::via2_ier_r()
 void macpdm_state::via2_ier_w(uint8_t data)
 {
 	if (data & 0x80)
-		m_via2_ier |= data & 0x3b;
+		m_via2_ier |= data & 0x7f;
 	else
 		m_via2_ier &= ~data;
 
-	LOGMASKED(LOG_VIA2, "via2 ier %s %s %s %s\n",
+	LOGMASKED(LOG_VIA2, "via2 ier %s %s %s %s %s %s %s\n",
+			 m_via2_ier & 0x40 ? "scsi_b" : "-",
 			 m_via2_ier & 0x20 ? "fdc" : "-",
 			 m_via2_ier & 0x10 ? "sound" : "-",
-			 m_via2_ier & 0x08 ? "scsi" : "-",
+			 m_via2_ier & 0x08 ? "scsi_a" : "-",
+			 m_via2_ier & 0x04 ? "scsidrq_b" : "-",
 			 m_via2_ier & 0x02 ? "slot" : "-",
-			 m_via2_ier & 0x01 ? "scsidrq" : "-");
+			 m_via2_ier & 0x01 ? "scsidrq_a" : "-");
 
 	irq_main_set(0x02, (m_via2_ifr & m_via2_ier) != 0);
 }
@@ -608,14 +629,24 @@ void macpdm_state::fdc_w(offs_t offset, uint8_t data)
 	m_fdc->write(offset >> 9, data);
 }
 
-uint8_t macpdm_state::scsi_r(offs_t offset)
+uint8_t macpdm_state::scsi_a_r(offs_t offset)
 {
 	return m_ncr53c94->read(offset >> 4);
 }
 
-void macpdm_state::scsi_w(offs_t offset, uint8_t data)
+void macpdm_state::scsi_a_w(offs_t offset, uint8_t data)
 {
 	m_ncr53c94->write(offset >> 4, data);
+}
+
+uint8_t macpdm_state::scsi_b_r(offs_t offset)
+{
+	return m_ncr53cf96->read(offset >> 4);
+}
+
+void macpdm_state::scsi_b_w(offs_t offset, uint8_t data)
+{
+	m_ncr53cf96->write(offset >> 4, data);
 }
 
 uint8_t macpdm_state::hmc_r(offs_t offset)
@@ -897,14 +928,14 @@ void macpdm_state::dma_scsi_a_step()
 	{
 		while (m_via2_ifr & 0x01)
 		{
-			if (m_dma_scsi_buffer_word_count == 0)
+			if (m_dma_scsi_a_buffer_word_count == 0)
 			{
-				m_dma_scsi_buffer_word_count = 4;
-				m_dma_scsi_buffer = m_maincpu->space().read_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset);
+				m_dma_scsi_a_buffer_word_count = 4;
+				m_dma_scsi_a_buffer = m_maincpu->space().read_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset);
 				m_dma_scsi_a_cur_offset += 8;
 			}
-			m_dma_scsi_buffer_word_count--;
-			m_ncr53c94->dma16_swap_w(m_dma_scsi_buffer >> (16*m_dma_scsi_buffer_word_count));
+			m_dma_scsi_a_buffer_word_count--;
+			m_ncr53c94->dma16_swap_w(m_dma_scsi_a_buffer >> (16*m_dma_scsi_a_buffer_word_count));
 		}
 	}
 	else
@@ -912,12 +943,12 @@ void macpdm_state::dma_scsi_a_step()
 		while (m_via2_ifr & 0x01)
 		{
 			uint16_t w = m_ncr53c94->dma16_swap_r();
-			m_dma_scsi_buffer = (m_dma_scsi_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_buffer_word_count));
-			m_dma_scsi_buffer_word_count++;
-			if(m_dma_scsi_buffer_word_count == 4)
+			m_dma_scsi_a_buffer = (m_dma_scsi_a_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_a_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_a_buffer_word_count));
+			m_dma_scsi_a_buffer_word_count++;
+			if (m_dma_scsi_a_buffer_word_count == 4)
 			{
-				m_dma_scsi_buffer_word_count = 0;
-				m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_buffer);
+				m_dma_scsi_a_buffer_word_count = 0;
+				m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_a_buffer);
 				m_dma_scsi_a_cur_offset += 8;
 			}
 		}
@@ -926,16 +957,65 @@ void macpdm_state::dma_scsi_a_step()
 	m_dma_scsi_a_in_step = false;
 }
 
-void macpdm_state::scsi_irq(int state)
+void macpdm_state::dma_scsi_b_step()
+{
+	m_dma_scsi_b_in_step = true;
+
+	if (m_dma_scsi_b_ctrl & 0x40)
+	{
+		while (m_via2_ifr & 0x04)
+		{
+			if (m_dma_scsi_b_buffer_word_count == 0)
+			{
+				m_dma_scsi_b_buffer_word_count = 4;
+				m_dma_scsi_b_buffer = m_maincpu->space().read_qword(m_dma_scsi_b_base_adr + m_dma_scsi_b_cur_offset);
+				m_dma_scsi_b_cur_offset += 8;
+			}
+			m_dma_scsi_b_buffer_word_count--;
+			m_ncr53cf96->dma16_swap_w(m_dma_scsi_b_buffer >> (16*m_dma_scsi_b_buffer_word_count));
+		}
+	}
+	else
+	{
+		while (m_via2_ifr & 0x04)
+		{
+			uint16_t w = m_ncr53cf96->dma16_swap_r();
+			m_dma_scsi_b_buffer = (m_dma_scsi_b_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_b_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_b_buffer_word_count));
+			m_dma_scsi_b_buffer_word_count++;
+			if (m_dma_scsi_b_buffer_word_count == 4)
+			{
+				m_dma_scsi_b_buffer_word_count = 0;
+				m_maincpu->space().write_qword(m_dma_scsi_b_base_adr + m_dma_scsi_b_cur_offset, m_dma_scsi_b_buffer);
+				m_dma_scsi_b_cur_offset += 8;
+			}
+		}
+	}
+
+	m_dma_scsi_b_in_step = false;
+}
+
+void macpdm_state::scsi_a_irq(int state)
 {
 	via2_irq_main_set(0x08, state);
 }
 
-void macpdm_state::scsi_drq(int state)
+void macpdm_state::scsi_a_drq(int state)
 {
 	via2_irq_main_set(0x01, state);
 	if ((m_dma_scsi_a_ctrl & 0x02) && (m_via2_ifr & 0x01) && !m_dma_scsi_a_in_step)
 		dma_scsi_a_step();
+}
+
+void macpdm_state::scsi_b_irq(int state)
+{
+	via2_irq_main_set(0x40, state);
+}
+
+void macpdm_state::scsi_b_drq(int state)
+{
+	via2_irq_main_set(0x04, state);
+	if ((m_dma_scsi_b_ctrl & 0x02) && (m_via2_ifr & 0x04) && !m_dma_scsi_b_in_step)
+		dma_scsi_b_step();
 }
 
 uint32_t macpdm_state::dma_scsi_a_base_adr_r()
@@ -948,7 +1028,7 @@ void macpdm_state::dma_scsi_a_base_adr_w(offs_t, uint32_t data, uint32_t mem_mas
 	COMBINE_DATA(&m_dma_scsi_a_base_adr);
 	m_dma_scsi_a_base_adr &= ~7;
 	m_dma_scsi_a_cur_offset = 0;
-	m_dma_scsi_buffer_word_count = 0;
+	m_dma_scsi_a_buffer_word_count = 0;
 	LOGMASKED(LOG_DMA, "dma_scsi_a_base_adr_w %08x\n", m_dma_scsi_a_base_adr);
 }
 
@@ -962,6 +1042,7 @@ void macpdm_state::dma_scsi_b_base_adr_w(offs_t, uint32_t data, uint32_t mem_mas
 	COMBINE_DATA(&m_dma_scsi_b_base_adr);
 	m_dma_scsi_b_base_adr &= ~7;
 	m_dma_scsi_b_cur_offset = 0;
+	m_dma_scsi_b_buffer_word_count = 0;
 	LOGMASKED(LOG_DMA, "dma_scsi_b_base_adr_w %08x\n", m_dma_scsi_b_base_adr);
 }
 
@@ -978,26 +1059,26 @@ void macpdm_state::dma_scsi_a_ctrl_w(uint8_t data)
 	{
 		m_dma_scsi_a_ctrl &= 0x40;
 		m_dma_scsi_a_cur_offset = 0;
-		m_dma_scsi_buffer_word_count = 0;
+		m_dma_scsi_a_buffer_word_count = 0;
 	}
 	if (data & 0x10)
 	{
 		while (m_via2_ifr & 0x01)
 		{
 			uint16_t w = m_ncr53c94->dma16_swap_r();
-			m_dma_scsi_buffer = (m_dma_scsi_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_buffer_word_count));
-			m_dma_scsi_buffer_word_count++;
-			if (m_dma_scsi_buffer_word_count == 4)
+			m_dma_scsi_a_buffer = (m_dma_scsi_a_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_a_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_a_buffer_word_count));
+			m_dma_scsi_a_buffer_word_count++;
+			if (m_dma_scsi_a_buffer_word_count == 4)
 			{
-				m_dma_scsi_buffer_word_count = 0;
-				m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_buffer);
+				m_dma_scsi_a_buffer_word_count = 0;
+				m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_a_buffer);
 				m_dma_scsi_a_cur_offset += 8;
 			}
 		}
-		if (m_dma_scsi_buffer_word_count)
+		if (m_dma_scsi_a_buffer_word_count)
 		{
-			m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_buffer);
-			m_dma_scsi_buffer_word_count = 0;
+			m_maincpu->space().write_qword(m_dma_scsi_a_base_adr + m_dma_scsi_a_cur_offset, m_dma_scsi_a_buffer);
+			m_dma_scsi_a_buffer_word_count = 0;
 		}
 	}
 
@@ -1014,13 +1095,42 @@ uint8_t macpdm_state::dma_scsi_b_ctrl_r()
 
 void macpdm_state::dma_scsi_b_ctrl_w(uint8_t data)
 {
-	// Channel B is not actually connected to anything
-	m_dma_scsi_b_ctrl = data & 0x42;
+	// Channel B is only used on the 8100 for the fast SCSI controller
+	m_dma_scsi_b_ctrl = data & 0x4e;
 	if (data & 1)
 	{
 		m_dma_scsi_b_ctrl &= 0x40;
 		m_dma_scsi_b_cur_offset = 0;
+		m_dma_scsi_b_buffer_word_count = 0;
 	}
+
+	if (m_ncr53cf96)
+	{
+		if (data & 0x10)
+		{
+			while (m_via2_ifr & 0x04)
+			{
+				uint16_t w = m_ncr53cf96->dma16_swap_r();
+				m_dma_scsi_b_buffer = (m_dma_scsi_b_buffer & ~(u64(0xffff) << (48 - 16*m_dma_scsi_b_buffer_word_count))) | (u64(w) << (48 - 16*m_dma_scsi_b_buffer_word_count));
+				m_dma_scsi_b_buffer_word_count++;
+				if (m_dma_scsi_b_buffer_word_count == 4)
+				{
+					m_dma_scsi_b_buffer_word_count = 0;
+					m_maincpu->space().write_qword(m_dma_scsi_b_base_adr + m_dma_scsi_b_cur_offset, m_dma_scsi_b_buffer);
+					m_dma_scsi_b_cur_offset += 8;
+				}
+			}
+			if (m_dma_scsi_b_buffer_word_count)
+			{
+				m_maincpu->space().write_qword(m_dma_scsi_b_base_adr + m_dma_scsi_b_cur_offset, m_dma_scsi_b_buffer);
+				m_dma_scsi_b_buffer_word_count = 0;
+			}
+		}
+
+		if ((m_dma_scsi_b_ctrl & 0x02) && (m_via2_ifr & 0x04) && !m_dma_scsi_b_in_step)
+			dma_scsi_b_step();
+	}
+
 	LOGMASKED(LOG_DMA,
 		"dma_scsi_b_ctrl_w %02x\n", m_dma_scsi_b_ctrl);
 }
@@ -1267,7 +1377,7 @@ void macpdm_state::pdm_map(address_map &map)
 	map(0x50f04000, 0x50f04007).rw(m_scc, FUNC(z80scc_device::dc_ab_r), FUNC(z80scc_device::dc_ab_w)).umask64(0xff00ff00ff00ff00);
 	// 50f08000 = ethernet ID PROM
 	// 50f0a000 = MACE ethernet controller
-	map(0x50f10000, 0x50f100ff).rw(FUNC(macpdm_state::scsi_r), FUNC(macpdm_state::scsi_w));
+	map(0x50f10000, 0x50f100ff).rw(FUNC(macpdm_state::scsi_a_r), FUNC(macpdm_state::scsi_a_w));
 	map(0x50f10100, 0x50f10101).rw(m_ncr53c94, FUNC(ncr53c94_device::dma16_swap_r), FUNC(ncr53c94_device::dma16_swap_w));
 	// 50f11000 = 53CF94 on 8100
 	map(0x50f14000, 0x50f1401f).rw(m_awacs, FUNC(awacs_device::read), FUNC(awacs_device::write));
@@ -1337,7 +1447,7 @@ void macpdm_state::pmac6100(machine_config &config)
 	m_awacs->add_route(0, "speaker", 1.0, 0);
 	m_awacs->add_route(1, "speaker", 1.0, 1);
 
-	NSCSI_BUS(config, m_scsibus);
+	NSCSI_BUS(config, m_scsibus_a);
 	NSCSI_CONNECTOR(config, "scsi:0", default_scsi_devices, "harddisk");
 	NSCSI_CONNECTOR(config, "scsi:1", default_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsi:2", default_scsi_devices, nullptr);
@@ -1352,10 +1462,10 @@ void macpdm_state::pmac6100(machine_config &config)
 	NSCSI_CONNECTOR(config, "scsi:6", default_scsi_devices, nullptr);
 
 	NCR53C94(config, m_ncr53c94, ENET_CLOCK/2);
-	m_scsibus->set_external_device(7, m_ncr53c94);
+	m_scsibus_a->set_external_device(7, m_ncr53c94);
 	m_ncr53c94->set_busmd(ncr53c94_device::BUSMD_3);
-	m_ncr53c94->drq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_drq));
-	m_ncr53c94->irq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_irq));
+	m_ncr53c94->drq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_a_drq));
+	m_ncr53c94->irq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_a_irq));
 
 	SOFTWARE_LIST(config, "flop_mac35_orig").set_original("mac_flop_orig");
 	SOFTWARE_LIST(config, "flop_mac35_clean").set_original("mac_flop_clcracked");

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -66,8 +66,12 @@ public:
 
 	void pdm_base(machine_config &config) ATTR_COLD;
 	void pmac6100(machine_config &config) ATTR_COLD;
+	void pmac6100_66(machine_config &config) ATTR_COLD;
 	void pmac7100(machine_config &config) ATTR_COLD;
+	void pmac7100_80(machine_config &config) ATTR_COLD;
 	void pmac8100(machine_config &config) ATTR_COLD;
+	void pmac8100_100(machine_config &config) ATTR_COLD;
+	void pmac8100_110(machine_config &config) ATTR_COLD;
 
 	void driver_init() ATTR_COLD;
 
@@ -1558,6 +1562,13 @@ void macpdm_state::pmac6100(machine_config &config)
 	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
 }
 
+void macpdm_state::pmac6100_66(machine_config &config)
+{
+	pmac6100(config);
+
+	m_maincpu->set_clock(66'000'000);
+}
+
 void macpdm_state::pmac7100(machine_config &config)
 {
 	pdm_base(config);
@@ -1569,6 +1580,13 @@ void macpdm_state::pmac7100(machine_config &config)
 	NUBUS_SLOT(config, "nbc", "nubus", powermac_nubus_cards, nullptr);
 	NUBUS_SLOT(config, "nbd", "nubus", powermac_nubus_cards, nullptr);
 	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
+}
+
+void macpdm_state::pmac7100_80(machine_config &config)
+{
+	pmac7100(config);
+
+	m_maincpu->set_clock(80'000'000);
 }
 
 void macpdm_state::pmac8100(machine_config &config)
@@ -1603,6 +1621,20 @@ void macpdm_state::pmac8100(machine_config &config)
 	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
 }
 
+void macpdm_state::pmac8100_100(machine_config &config)
+{
+	pmac8100(config);
+
+	m_maincpu->set_clock(100'000'000);
+}
+
+void macpdm_state::pmac8100_110(machine_config &config)
+{
+	pmac8100(config);
+
+	m_maincpu->set_clock(110'000'000);
+}
+
 static INPUT_PORTS_START( macpdm )
 INPUT_PORTS_END
 
@@ -1611,12 +1643,26 @@ ROM_START( pmac6100 )
 	ROM_LOAD( "9feb69b3.rom", 0x000000, 0x400000, CRC(a43fadbc) SHA1(6fac1c4e920a077c077b03902fef9199d5e8f2c3) )
 ROM_END
 
+ROM_START( pmac6100_66 )
+	ROM_REGION64_BE(0x400000, "bootrom", 0)
+	ROM_LOAD( "9b7a3aad.rom", 0x000000, 0x400000, CRC(22ef0260) SHA1(ec58cdb4b7fe3282b2fb76bf9a39f1ec9c9635d7) )
+ROM_END
+
 #define rom_pmac7100 rom_pmac6100
 #define rom_pmac8100 rom_pmac6100
+
+#define rom_pmac7100_80 rom_pmac6100_66
+#define rom_pmac8100_100 rom_pmac6100_66
+#define rom_pmac8100_110 rom_pmac6100_66
 
 } // anonymous namespace
 
 
-COMP( 1994, pmac6100,  0,        0, pmac6100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 6100/60",  MACHINE_SUPPORTS_SAVE )
-COMP( 1994, pmac7100,  0,        0, pmac7100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 7100/66",  MACHINE_SUPPORTS_SAVE )
-COMP( 1994, pmac8100,  0,        0, pmac8100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 8100/80",  MACHINE_SUPPORTS_SAVE )
+//    YEAR  NAME          PARENT    COMPAT  MACHINE        INPUT   CLASS         INIT         COMPANY           FULLNAME                    FLAGS
+COMP( 1994, pmac6100,     0,        0,      pmac6100,      macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 6100/60",  MACHINE_SUPPORTS_SAVE )
+COMP( 1995, pmac6100_66,  pmac6100, 0,      pmac6100_66,   macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 6100/66",  MACHINE_SUPPORTS_SAVE )
+COMP( 1994, pmac7100,     0,        0,      pmac7100,      macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 7100/66",  MACHINE_SUPPORTS_SAVE )
+COMP( 1995, pmac7100_80,  pmac7100, 0,      pmac7100_80,   macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 7100/80",  MACHINE_SUPPORTS_SAVE )
+COMP( 1994, pmac8100,     0,        0,      pmac8100,      macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 8100/80",  MACHINE_SUPPORTS_SAVE )
+COMP( 1995, pmac8100_100, pmac8100, 0,      pmac8100_100,  macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 8100/100", MACHINE_SUPPORTS_SAVE )
+COMP( 1994, pmac8100_110, pmac8100, 0,      pmac8100_110,  macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 8100/110", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -167,6 +167,7 @@ private:
 	void via1_out_b(uint8_t data);
 	TIMER_DEVICE_CALLBACK_MEMBER(via1_60_15_timer);
 	void via1_out_cb2(int state);
+	void via_sync();
 
 	void cuda_reset_w(int state);
 
@@ -488,6 +489,28 @@ void macpdm_state::via1_out_cb2(int state)
 	m_cuda->set_via_data(state & 1);
 }
 
+void macpdm_state::via_sync()
+{
+	// The via runs at 783.36KHz while the main cpu runs at 15MHz or
+	// more, so we need to sync the access with the via clock.  Plus
+	// the whole access takes half a (via) cycle and ends when synced
+	// with the main cpu again.
+
+	// Get the main cpu time
+	const u64 cycle = m_maincpu->total_cycles();
+
+	// Get the number of the cycle the via is in at that time
+	const u64 via_cycle = cycle * m_via1->clock() / m_maincpu->clock();
+
+	// The access is going to start at via_cycle+1 and end at
+	// via_cycle+1.5, compute what that means in maincpu cycles (the
+	// +1 rounds up, since the clocks are too different to ever be
+	// synced).
+	const u64 main_cycle = (via_cycle * 2 + 3) * m_maincpu->clock() / (2 * m_via1->clock()) + 1;
+
+	// Finally adjust the main cpu icount as needed.
+	m_maincpu->adjust_icount(-int(main_cycle - cycle));
+}
 
 void macpdm_state::cuda_reset_w(int state)
 {
@@ -498,11 +521,16 @@ void macpdm_state::cuda_reset_w(int state)
 
 uint8_t macpdm_state::via1_r(offs_t offset)
 {
+	if (!machine().side_effects_disabled())
+		via_sync();
+
 	return m_via1->read(offset >> 9);
 }
 
 void macpdm_state::via1_w(offs_t offset, uint8_t data)
 {
+	via_sync();
+
 	m_via1->write(offset >> 9, data);
 }
 

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -62,7 +62,10 @@ class macpdm_state : public driver_device
 public:
 	macpdm_state(const machine_config &mconfig, device_type type, const char *tag);
 
+	void pdm_base(machine_config &config) ATTR_COLD;
 	void pmac6100(machine_config &config) ATTR_COLD;
+	void pmac7100(machine_config &config) ATTR_COLD;
+	void pmac8100(machine_config &config) ATTR_COLD;
 
 	void driver_init() ATTR_COLD;
 
@@ -119,6 +122,7 @@ private:
 	bool m_dma_floppy_in_step = false, m_floppy_drq = false;
 
 	void pdm_map(address_map &map) ATTR_COLD;
+	void pdm_8100map(address_map &map) ATTR_COLD;
 
 	void nmi_irq(int state);
 	void dma_irq(int state);
@@ -286,10 +290,6 @@ macpdm_state::macpdm_state(const machine_config &mconfig, device_type type, cons
 void macpdm_state::driver_init()
 {
 	m_maincpu->space().install_ram(0, m_ram->mask(), 0, m_ram->pointer());
-
-	m_model_id = 0xa55a3010;
-	// 7100 = a55a3012
-	// 8100 = a55a3013
 
 	save_item(NAME(m_hmc_reg));
 	save_item(NAME(m_hmc_buffer));
@@ -1379,7 +1379,6 @@ void macpdm_state::pdm_map(address_map &map)
 	// 50f0a000 = MACE ethernet controller
 	map(0x50f10000, 0x50f100ff).rw(FUNC(macpdm_state::scsi_a_r), FUNC(macpdm_state::scsi_a_w));
 	map(0x50f10100, 0x50f10101).rw(m_ncr53c94, FUNC(ncr53c94_device::dma16_swap_r), FUNC(ncr53c94_device::dma16_swap_w));
-	// 50f11000 = 53CF94 on 8100
 	map(0x50f14000, 0x50f1401f).rw(m_awacs, FUNC(awacs_device::read), FUNC(awacs_device::write));
 	map(0x50f16000, 0x50f16000).rw(FUNC(macpdm_state::fdc_r), FUNC(macpdm_state::fdc_w)).select(0x1e00);
 
@@ -1426,7 +1425,15 @@ void macpdm_state::pdm_map(address_map &map)
 	map(0xffc00000, 0xffffffff).rom().region("bootrom", 0);
 }
 
-void macpdm_state::pmac6100(machine_config &config)
+void macpdm_state::pdm_8100map(address_map &map)
+{
+	pdm_map(map);
+
+	map(0x50f11000, 0x50f110ff).rw(FUNC(macpdm_state::scsi_b_r), FUNC(macpdm_state::scsi_b_w));
+	map(0x50f11100, 0x50f11101).rw(m_ncr53cf96, FUNC(ncr53cf96_device::dma16_swap_r), FUNC(ncr53cf96_device::dma16_swap_w));
+}
+
+void macpdm_state::pdm_base(machine_config &config)
 {
 	PPC601(config, m_maincpu, 60'000'000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &macpdm_state::pdm_map);
@@ -1520,9 +1527,6 @@ void macpdm_state::pmac6100(machine_config &config)
 	nubus.out_irqd_callback().set(FUNC(macpdm_state::slot1_irq_w));
 	nubus.out_irqe_callback().set(FUNC(macpdm_state::slot2_irq_w));
 
-	// 6100 with the NuBus adapter has one slot, slot $E
-	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
-
 	ADB_BUS(config, m_adbbus);
 	ADB_CONNECTOR(config, "adb:0", adb_devices, "hle_keyboard");
 	ADB_CONNECTOR(config, "adb:1", adb_devices, "hle_mouse");
@@ -1542,6 +1546,61 @@ void macpdm_state::pmac6100(machine_config &config)
 	TIMER(config, "beat_60_15").configure_periodic(FUNC(macpdm_state::via1_60_15_timer), attotime::from_double(1/60.15));
 }
 
+void macpdm_state::pmac6100(machine_config &config)
+{
+	pdm_base(config);
+
+	m_model_id = 0xa55a3010;
+
+	// 6100 with the NuBus adapter has one slot, slot $E
+	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
+}
+
+void macpdm_state::pmac7100(machine_config &config)
+{
+	pdm_base(config);
+
+	m_maincpu->set_clock(66'000'000);
+
+	m_model_id = 0xa55a3012;
+
+	NUBUS_SLOT(config, "nbc", "nubus", powermac_nubus_cards, nullptr);
+	NUBUS_SLOT(config, "nbd", "nubus", powermac_nubus_cards, nullptr);
+	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
+}
+
+void macpdm_state::pmac8100(machine_config &config)
+{
+	pdm_base(config);
+
+	m_maincpu->set_clock(80'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &macpdm_state::pdm_8100map);
+
+	m_model_id = 0xa55a3013;
+
+	// On the 8100 the hard drive is connected to the fast SCSI bus instead
+	subdevice<nscsi_connector>("scsi:0")->set_default_option(nullptr);
+
+	NSCSI_BUS(config, m_scsibus_b);
+	NSCSI_CONNECTOR(config, "fastscsi:0", default_scsi_devices, "harddisk");
+	NSCSI_CONNECTOR(config, "fastscsi:1", default_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "fastscsi:2", default_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "fastscsi:3", default_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "fastscsi:4", default_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "fastscsi:5", default_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "fastscsi:6", default_scsi_devices, nullptr);
+
+	NCR53CF96(config, m_ncr53cf96, ENET_CLOCK);
+	m_scsibus_b->set_external_device(7, m_ncr53cf96);
+	m_ncr53cf96->set_busmd(ncr53cf96_device::BUSMD_3);
+	m_ncr53cf96->drq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_b_drq));
+	m_ncr53cf96->irq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_b_irq));
+
+	NUBUS_SLOT(config, "nbc", "nubus", powermac_nubus_cards, nullptr);
+	NUBUS_SLOT(config, "nbd", "nubus", powermac_nubus_cards, nullptr);
+	NUBUS_SLOT(config, "nbe", "nubus", powermac_nubus_cards, nullptr);
+}
+
 static INPUT_PORTS_START( macpdm )
 INPUT_PORTS_END
 
@@ -1550,7 +1609,12 @@ ROM_START( pmac6100 )
 	ROM_LOAD( "9feb69b3.rom", 0x000000, 0x400000, CRC(a43fadbc) SHA1(6fac1c4e920a077c077b03902fef9199d5e8f2c3) )
 ROM_END
 
+#define rom_pmac7100 rom_pmac6100
+#define rom_pmac8100 rom_pmac6100
+
 } // anonymous namespace
 
 
 COMP( 1994, pmac6100,  0,        0, pmac6100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 6100/60",  MACHINE_SUPPORTS_SAVE )
+COMP( 1994, pmac7100,  0,        0, pmac7100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 7100/66",  MACHINE_SUPPORTS_SAVE )
+COMP( 1994, pmac8100,  0,        0, pmac8100, macpdm, macpdm_state, driver_init, "Apple Computer", "Power Macintosh 8100/80",  MACHINE_SUPPORTS_SAVE )

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -43,6 +43,8 @@ namespace {
 static constexpr auto IO_CLOCK = 31.3344_MHz_XTAL;
 static constexpr auto ENET_CLOCK = 20_MHz_XTAL;
 static constexpr auto SOUND_CLOCK = 45.1584_MHz_XTAL;
+static constexpr auto SCSI_CLOCK = ENET_CLOCK;
+static constexpr auto SCSI_FAST_CLOCK = 40_MHz_XTAL;
 
 static constexpr u8 DMA2_IRQ_SND_IN             = 0x01;
 static constexpr u8 DMA2_IRQ_SND_OUT            = 0x02;
@@ -1468,7 +1470,7 @@ void macpdm_state::pdm_base(machine_config &config)
 	NSCSI_CONNECTOR(config, "scsi:5", default_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "scsi:6", default_scsi_devices, nullptr);
 
-	NCR53C94(config, m_ncr53c94, ENET_CLOCK/2);
+	NCR53C94(config, m_ncr53c94, SCSI_CLOCK);
 	m_scsibus_a->set_external_device(7, m_ncr53c94);
 	m_ncr53c94->set_busmd(ncr53c94_device::BUSMD_3);
 	m_ncr53c94->drq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_a_drq));
@@ -1590,7 +1592,7 @@ void macpdm_state::pmac8100(machine_config &config)
 	NSCSI_CONNECTOR(config, "fastscsi:5", default_scsi_devices, nullptr);
 	NSCSI_CONNECTOR(config, "fastscsi:6", default_scsi_devices, nullptr);
 
-	NCR53CF96(config, m_ncr53cf96, ENET_CLOCK);
+	NCR53CF96(config, m_ncr53cf96, SCSI_FAST_CLOCK);
 	m_scsibus_b->set_external_device(7, m_ncr53cf96);
 	m_ncr53cf96->set_busmd(ncr53cf96_device::BUSMD_3);
 	m_ncr53cf96->drq_handler_cb().set(DEVICE_SELF, FUNC(macpdm_state::scsi_b_drq));

--- a/src/mame/apple/macpdm.cpp
+++ b/src/mame/apple/macpdm.cpp
@@ -933,7 +933,7 @@ void macpdm_state::dma_scsi_b_base_adr_w(offs_t, uint32_t data, uint32_t mem_mas
 {
 	COMBINE_DATA(&m_dma_scsi_b_base_adr);
 	m_dma_scsi_b_base_adr &= ~7;
-	m_dma_scsi_a_cur_offset = 0;
+	m_dma_scsi_b_cur_offset = 0;
 	LOGMASKED(LOG_DMA, "dma_scsi_b_base_adr_w %08x\n", m_dma_scsi_b_base_adr);
 }
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -1360,8 +1360,12 @@ maclc550
 
 @source:apple/macpdm.cpp
 pmac6100
+pmac6100_66
 pmac7100
+pmac7100_80
 pmac8100
+pmac8100_100
+pmac8100_110
 
 @source:apple/macprtb.cpp
 macpb100

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -1360,6 +1360,8 @@ maclc550
 
 @source:apple/macpdm.cpp
 pmac6100
+pmac7100
+pmac8100
 
 @source:apple/macprtb.cpp
 macpb100


### PR DESCRIPTION
**AI disclosure:** I used Claude Opus 5 for debugging, testing, and writing code. I performed extensive testing by hand, verified claims in datasheets with my own eyes, and cleaned up the code and comments by hand. I likely wouldn't have been able to discover the PowerPC and SCSI controller problems on my own without Claude's help.

**Summary**

The ultimate purpose of this change is to add support for the Power Macintosh 7100 and 8100, but I ended up fixing a few things on the 6100 as well as some bugs in a couple of emulated devices.

**Bug fixes outside of macpdm**

- A particular type of PowerPC branch folding wasn't being handled (with `bdnz` and `bdz` instructions), which caused the ROM to miscalculate the CPU clock by a factor of 8/9. This is especially important because it's how the Mac ROM differentiates between the speeds of different variants such as the 6100/60 and 6100/66. I verified on real 6100/60 hardware that a real PowerPC 601 folds the branch.
- The NCR53CF94 was looking at the wrong bit for "features enable" which affected 24-bit vs. 16-bit transfer counters and the chip revision readback algorithm. The Mac thought it was in 16-bit mode and the chip thought it was in 24-bit mode, which caused transfer errors if a value of 0 was written for the transfer count. 0 means 64 KB in 16-bit mode and 16 MB in 24-bit mode.

**Changes in macpdm**

- Add the 6100/66 speed-bumped variant and all variants of the 7100 and 8100: `pmac6100_66`, `pmac7100`, `pmac7100_80`, `pmac8100`, `pmac8100_100`, and `pmac8100_110`. (The 1994 date on the 110 variant is not a mistake; Wikipedia says it came out before the others)
- Add the second internal fast SCSI controller (NCR53CF96) for the 8100, and hook the hard drive up to it by default just like real hardware. Fix a small existing copy/paste error on SCSI-B too.
- Implement VIA synchronization like most of the other Macs have. The lack of synchronization caused corruption during communication with the Cuda which led to the 7100 and 8100 hanging during boot, and probably wasn't good for the 6100 either.
- Adjust the SCSI clocks -- the 8100/100 was particularly picky about this for some reason and refused to boot without this fix.
- Throttle the SCSI pseudo-DMA -- this was required in order for the newer ROM used in the speedbumped variants to successfully boot. Without this fix, the newer ROM reads a partition map that is interspersed with 0xFF padding bytes.
- Add a couple of missing RAM size options on the 6100 that the comments mentioned.

**Requirements**

The speedbumped models use a new ROM (`9b7a3aad.rom`) which is already widely available out there.

**Tests performed**

- I compiled a full build of MAME with `make REGENIE=1 -j 16`.
- I tested installing Windows NT 4.0 on `mmr4000le` to validate that I didn't break it with the NCR53CF94 changes.
- I tested `bujutsu` and `optiger` and they didn't seem to behave any different with the PowerPC branch folding change.

**How to run**

`pmac7100` and `pmac8100` should boot anything that was already capable of booting `pmac6100`. The Power Mac 6100/7100/8100 System 7.1.2 install CD will give you an OS install that shows the Mac model by name in the About this Macintosh window: 6100/60, 7100/66, or 8100/80.

The speed-bumped variants won't boot with System 7.1.2 because the new ROM requires a newer Mac OS version. There is a 6100/7100/8100 System 7.5 install CD that gives you an OS install with display names for all the speedbumped variants in About this Macintosh: 6100/66, 7100/80, 8100/100, and 8100/110.

Example command: `./mame pmac8100 -harddisk1 Test.hda -cdrom1 ~/Downloads/Power\ Macintosh\ CD.toast -ram 16M`