### PR TITLE
CD-i: Add Test Plug to activate new Menu

### DIFF
--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -145,6 +145,11 @@ static INPUT_PORTS_START( cdi )
 	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_BUTTON2) PORT_CODE(MOUSECODE_BUTTON2) PORT_NAME("Button 2")
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3) PORT_CODE(MOUSECODE_BUTTON3) PORT_NAME("Button 3")
 	PORT_BIT(0xf8, IP_ACTIVE_HIGH, IPT_UNUSED)
+
+	PORT_START("TESTPLUG")
+	PORT_CONFNAME( 0x01, 0x00, "Test plug" )
+	PORT_CONFSETTING(    0x00, DEF_STR( Off ) )
+	PORT_CONFSETTING(    0x01, DEF_STR( On ) )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( cdimono2 )
@@ -525,6 +530,7 @@ void cdi_state::cdimono1(machine_config &config)
 	m_slave_hle->read_mousex().set_ioport("MOUSEX");
 	m_slave_hle->read_mousey().set_ioport("MOUSEY");
 	m_slave_hle->read_mousebtn().set_ioport("MOUSEBTN");
+	m_slave_hle->testplug_callback().set_ioport("TESTPLUG");
 
 	SOFTWARE_LIST(config, "cd_list").set_original("cdi").set_filter("!DVC");
 	SOFTWARE_LIST(config, "photocd_list").set_compatible("photo_cd");

--- a/src/mame/philips/cdislavehle.cpp
+++ b/src/mame/philips/cdislavehle.cpp
@@ -325,7 +325,7 @@ void cdislave_hle_device::slave_w(offs_t offset, uint16_t data)
 					case 0xf4: // Request Test Plug Status
 						LOGMASKED(LOG_COMMANDS | LOG_WRITES, "slave_w: Channel %d: Request Test Plug Status (0xf4)\n", offset);
 						m_in_index = 0;
-						prepare_readback(attotime::from_hz(10000), 2, 2, 0xf4, 0, 0, 0, 0xf4);
+						prepare_readback(attotime::from_hz(10000), 2, 2, 0xf4, m_testplug_cb() ? 1 : 0, 0, 0, 0xf4);
 						break;
 					case 0xf6: // Request NTSC/PAL Status
 						LOGMASKED(LOG_COMMANDS | LOG_WRITES, "slave_w: Channel %d: Request NTSC/PAL Status (0xf6)\n", offset);
@@ -370,6 +370,7 @@ cdislave_hle_device::cdislave_hle_device(const machine_config &mconfig, const ch
 	, m_read_mousebtn(*this, 0x00)
 	, m_dmadac(*this, ":dac%u", 1U)
 	, m_atten_w(*this)
+	, m_testplug_cb(*this, 0)
 {
 }
 

--- a/src/mame/philips/cdislavehle.h
+++ b/src/mame/philips/cdislavehle.h
@@ -39,6 +39,7 @@ public:
 	auto read_mousey() { return m_read_mousey.bind(); }
 	auto read_mousebtn() { return m_read_mousebtn.bind(); }
 	auto atten_callback() { return m_atten_w.bind(); }
+	auto testplug_callback() { return m_testplug_cb.bind(); }
 
 	uint8_t* get_lcd_state() { return m_lcd_state; }
 
@@ -66,6 +67,7 @@ private:
 
 	required_device_array<dmadac_sound_device, 2> m_dmadac;
 	devcb_write32 m_atten_w;
+	devcb_read_line m_testplug_cb;
 
 	struct channel_state
 	{


### PR DESCRIPTION
Allows booting the console with the Test Plug set. This opens a unique test menu.

The menu needs https://github.com/mamedev/mame/pull/15790 in order to test using the mouse.

To test, use Tab > Machine Config > Set the test flag > Reset the machine

This will boot into this test menu instead of the normal bios.

<img width="1232" height="1025" alt="image" src="https://github.com/user-attachments/assets/d1b1019b-52ba-4ee6-ba16-27d72ca9736b" />
