### PR TITLE
bus/wangpc: fix default card responses on the read buses

### DIFF
--- a/src/devices/bus/wangpc/wangpc.h
+++ b/src/devices/bus/wangpc/wangpc.h
@@ -152,11 +152,13 @@ class device_wangpcbus_card_interface : public device_interface
 
 public:
 	// memory access
-	virtual uint16_t wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask) { return 0; }
+	// the bus ANDs all card responses, so cards that do not respond must
+	// return 0xffff to leave the data lines released
+	virtual uint16_t wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask) { return 0xffff; }
 	virtual void wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint16_t data) { }
 
 	// I/O access
-	virtual uint16_t wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask) { return 0; }
+	virtual uint16_t wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask) { return 0xffff; }
 	virtual void wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint16_t data) { }
 	bool sad(offs_t offset) const { return (offset & 0xf80) == (0x800 | (m_sid << 7)); }
 


### PR DESCRIPTION
The Wang PC bus ANDs the responses of all installed cards, so a card that does not decode an address has to leave the data lines released. The default implementations in `device_wangpcbus_card_interface` returned 0 instead, which meant any card without a memory or I/O read handler forced every read on that bus to zero.

With a Text/Image/Graphics controller installed - it has no memory presence of its own - this made the extended memory board test in the power-up diagnostic fail, leaving the machine with 128K of RAM.

One-line change to each default; no other card is affected, since every card that does respond overrides them.

## AI disclosure

This work was done with substantial assistance from Anthropic's Claude, driven and reviewed by me throughout.