### PR TITLE
wangpc: don't wedge the machine when a floppy is inserted

### DIFF
--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -908,7 +908,12 @@ void wangpc_state::check_level1_interrupts()
 
 void wangpc_state::check_level2_interrupts()
 {
-	int state = !m_dma_eop || m_uart_dr || m_uart_tbre || m_fdc_dd0 || m_fdc_dd1 || m_fdc->get_irq() || m_fpu_irq || m_bus_irq2;
+	// the "door disturbed" latches are reported in the status register but
+	// are deliberately left out here: holding the line for them would keep
+	// level 2 asserted until the floppy control register is written, and
+	// since the keyboard shares this level nothing could be typed to get
+	// there - inserting a disk would wedge the machine
+	int state = !m_dma_eop || m_uart_dr || m_uart_tbre || m_fdc->get_irq() || m_fpu_irq || m_bus_irq2;
 
 	m_pic->ir2_w(state);
 }
@@ -1226,6 +1231,9 @@ void wangpc_state::on_disk0_unload(floppy_image_device *image)
 	LOG("Door 1 disturbed\n");
 
 	m_fdc_dd0 = 1;
+
+	// let the software know with a pulse, not by holding the line
+	m_pic->ir2_w(1);
 	check_level2_interrupts();
 }
 
@@ -1244,6 +1252,9 @@ void wangpc_state::on_disk1_unload(floppy_image_device *image)
 	LOG("Door 2 disturbed\n");
 
 	m_fdc_dd1 = 1;
+
+	// let the software know with a pulse, not by holding the line
+	m_pic->ir2_w(1);
 	check_level2_interrupts();
 }
 


### PR DESCRIPTION
Inserting or removing a floppy sets the "door disturbed" latch for that drive, and check_level2_interrupts() had it hold IR2 of the interrupt controller. The latch is only cleared by writing the floppy control register, which the BIOS does while running a disk command - so the line stayed asserted, and since the keyboard shares level 2 (it comes in through the UART data ready) no further edge could get through and the machine stopped accepting input. Changing a disk left the emulated machine unusable until reset, which the real one plainly was not.

The latches still show up in the status register, so software continues to notice that a disk was swapped: MS-DOS reports "Not ready error reading drive B" on the first access after the change and reads the new disk when the operation is retried, which is what it should do.

Testing: with a disk inserted at the DOS prompt through the file manager, the machine keeps taking keystrokes, and DIR B: answers correctly after a retry. Booting and reading disks mounted at start-up are unaffected.

## AI disclosure

This work was done with substantial assistance from Anthropic's Claude, driven and reviewed by me throughout.