### PR TITLE
kn5000: emulate the TEMPO/PROGRAM data wheel

### DIFF
--- a/src/mame/layout/kn5000.lay
+++ b/src/mame/layout/kn5000.lay
@@ -1338,11 +1338,8 @@ license:CC0-1.0
 		-- Slider and knob library starts.
 		-- Can be copied as-is to other layouts.
 		-----------------------------------------------------------------------
-		-- Widgets are stored PER VIEW. A single shared list is WRONG when the same control is registered in
-		-- more than one view (e.g. a Compact view plus a single-block view): each view has its own coordinate
-		-- normalisation, so a pointer hit-test in view A against a widget's bounds registered for view B gives
-		-- false matches (symptom: clicking near one control in one view drags a slider that "lives" in another
-		-- view whose normalised bounds happen to overlap). Keying the widget list by view fixes that.
+		-- Widgets are stored per view: bounds are normalised per view, so a hit test is only
+		-- meaningful against widgets registered for the same view.
 		local view_widgets = {}   -- view (userdata) -> list of its widgets
 		local active_wl = nil     -- widget list of the view whose pointer last moved (for the frame wheel poll)
 		local pointers = {}       -- Tracks pointer state (keyed by pointer id).
@@ -1375,19 +1372,13 @@ license:CC0-1.0
 				scale     = scale })
 		end
 
-		-- An INFINITE rotary knob (e.g. the TEMPO/PROGRAM wheel). A circular drag rotates the `finger_id`
-		-- element around the knob centre and steps the attached relative encoder (an IPT_ADJUSTER the driver
-		-- diffs wrap-aware). `finger_id` is repositioned every frame via set_bounds_callback; the running
-		-- angle accumulates without limit, so the finger just keeps going round and round.
-		-- Every rotary knob, for the per-frame finger update. MUST be declared before
+		-- Every rotary knob, for the per-frame finger update.  Must be declared before
 		-- add_rotary_knob(): a Lua local is not visible to code written above it.
 		local rotary_widgets = {}
 
-		-- `drag_port_name` is written by this script; `key_port_name` is the control the KEYS and the
-		-- mouse axis drive, which the script only ever READS. They cannot be the same field: an
-		-- analog field's only Lua write path, set_value(), latches m_use_adjoverride permanently and
-		-- detaches the field from the input system, so one drag would kill the keys for the rest of
-		-- the session. An adjuster's user_value has no such side effect, and the driver sums both.
+		-- An infinite rotary knob.  A circular drag rotates `finger_id` around the knob centre and
+		-- steps the encoder.  `drag_port_name` is the adjuster this script writes; `key_port_name`
+		-- is the control the keys and mouse axis drive, which it only reads.
 		function add_rotary_knob(view, clickarea_id, finger_id, drag_port_name, key_port_name)
 			local w = {
 				clickarea = get_layout_item(view, clickarea_id),
@@ -1400,12 +1391,9 @@ license:CC0-1.0
 				notch     = 0 }    -- last encoder notch emitted
 			table.insert(widget_list(view), w)
 			table.insert(rotary_widgets, w)
-			-- The finger orbits the knob centre at the current angle (0 = 12 o'clock, clockwise positive).
-			-- item.bounds is normalised PER-AXIS (x by view width, y by view height), so a screen-circular
-			-- orbit needs the x offset scaled by the click area's normalised WIDTH and the y offset by its
-			-- normalised HEIGHT (the click area is square in view units, so these encode the pixel aspect).
-			-- Orbit radius 0.24 keeps the finger (half-size 0.148) fully inside the wheel (r 0.48) with an
-			-- internal margin; the wheel is square in view units so scale x by width, y by height.
+			-- The finger orbits the knob centre (0 = 12 o'clock, clockwise positive).  item.bounds is
+			-- normalised per axis, so the x offset scales by the click area's width and y by its height.
+			-- Orbit radius 0.24 keeps the finger (half-size 0.148) inside the wheel (r 0.48).
 			w.finger:set_bounds_callback(function()
 				local b = w.clickarea.bounds
 				local cx = (b.x0 + b.x1) / 2
@@ -1447,14 +1435,12 @@ license:CC0-1.0
 			return field
 		end
 
-		-- Step the rotary encoder: map the accumulated angle to notches and nudge the adjuster by the
-		-- notch delta (wrapping 0..100). The driver diffs the adjuster wrap-aware into [0x17] encoder steps.
+		-- Step the rotary encoder: map the accumulated angle to notches and nudge the adjuster by
+		-- the notch delta, wrapping at 101, which the driver diffs wrap-aware.
 		local ROTARY_STEPS_PER_REV = 24
 		local function rotary_emit(w)
 			local target = math.floor(w.angle * ROTARY_STEPS_PER_REV / (2 * math.pi) + 0.5)
 			if target ~= w.notch then
-				-- Writes the DRAG adjuster via user_value: the one route that does not latch the
-				-- field away from MAME's input system. The driver diffs it wrap-aware at 101.
 				local v = (w.field.user_value + (target - w.notch)) % 101
 				if v < 0 then v = v + 101 end
 				w.field.user_value = v
@@ -1462,9 +1448,8 @@ license:CC0-1.0
 			end
 		end
 
-		-- Pointer angle around a widget's knob centre (0 = 12 o'clock, clockwise positive). Per-axis
-		-- normalisation (÷ width, ÷ height) matches the finger's aspect-corrected orbit, so the finger
-		-- tracks the cursor faithfully all the way round instead of leading/lagging near the sides.
+		-- Pointer angle around a widget's knob centre (0 = 12 o'clock, clockwise positive), with the
+		-- same per-axis normalisation as the finger's orbit so the two track each other.
 		local function knob_angle(w, x, y)
 			local b = w.clickarea.bounds
 			local cx = (b.x0 + b.x1) / 2
@@ -1472,11 +1457,9 @@ license:CC0-1.0
 			return math.atan((x - cx) / (b.x1 - b.x0), (cy - y) / (b.y1 - b.y0))
 		end
 
-		-- Mouse-WHEEL editing for rotary knobs. MAME's layout pointer API does NOT deliver wheel events,
-		-- so we read the mouse device's relative Z axis directly each frame (the sandbox exposes `machine`,
-		-- hence machine.input). One detent = 120 * RELATIVE_PER_PIXEL(512) = 61440 accumulator units
-		-- (SDL osd: m_v += wheel.y * 120 * RELATIVE_PER_PIXEL). Each notch nudges the finger and the encoder
-		-- exactly like a click of a drag, but only while the cursor hovers over the wheel.
+		-- Mouse-wheel editing for rotary knobs.  The pointer API delivers no wheel event, so the
+		-- mouse device's relative Z axis is read each frame.  One detent is
+		-- 120 * RELATIVE_PER_PIXEL(512) accumulator units (SDL osd: m_v += wheel.y * 120 * RPP).
 		local WHEEL_PER_NOTCH = 120 * 512
 		local wheel_item, wheel_probed, wheel_accum = nil, false, 0
 		local function find_wheel_item()
@@ -1493,10 +1476,8 @@ license:CC0-1.0
 			end
 			return nil
 		end
-		-- The knob graphic must turn for whatever moved the wheel -- keys, mouse axis, pointer drag or
-		-- scroll wheel -- so it is driven by the summed wrap-aware DELTA of both controls rather than
-		-- by the drag gesture. Driving it from either control's absolute value would make it jump
-		-- whenever the other one moved.
+		-- The knob graphic follows the summed wrap-aware delta of both controls, so that it turns
+		-- for whatever moved the wheel: keys, mouse axis, pointer drag or scroll wheel.
 		local function wrapped_delta(cur, prev, modulus)
 			local d = cur - prev
 			if d > modulus / 2 then d = d - modulus
@@ -1550,8 +1531,8 @@ license:CC0-1.0
 			end
 		end
 
-		-- `wl` is the widget list of the view this callback was installed on (see install_slider_callbacks).
-		-- Only widgets belonging to THIS view are hit-tested, so a click never matches another view's control.
+		-- `wl` is the widget list of the view this callback was installed on, so only that view's
+		-- widgets are hit-tested.
 		local function pointer_updated(wl, type, id, dev, x, y, btn, dn, up, cnt)
 			hover_x, hover_y = x, y   -- remember where the cursor is, so the wheel poll can hit-test it
 			active_wl = wl            -- this is the view the user is interacting with
@@ -1599,8 +1580,8 @@ license:CC0-1.0
 			local pointer = pointers[id]
 			local widget = pointer.selected_wl[pointer.selected_widget]
 
-			-- Rotary knob: rotate the finger by the pointer's angular motion and step the encoder. The angle
-			-- accumulates without limit, so it can be spun round and round (24 encoder steps per revolution).
+			-- Rotary knob: rotate the finger by the pointer's angular motion and step the encoder.
+			-- The angle accumulates without limit, so the wheel can be spun round and round.
 			if widget.is_rotary then
 				local pa = knob_angle(widget, x, y)
 				local d = pa - pointer.last_pa
@@ -1665,11 +1646,8 @@ license:CC0-1.0
 		-----------------------------------------------------------------------
 		-- Slider and knob library ends.
 
-		-- KN5000 TEMPO/PROGRAM data wheel: an INFINITE rotary encoder, made draggable with the same
-		-- shared widget library, inlined because MAME layouts cannot include external files.
-		-- A circular drag (or the mouse wheel while hovering) spins the finger and steps the
-		-- ENCODER control, 24 notches per revolution. The driver turns each step into one detent
-		-- and the control-panel device puts it on the serial link as [0xD7, signed count].
+		-- KN5000 TEMPO/PROGRAM data wheel: a circular drag, or the mouse wheel while hovering,
+		-- spins the finger and steps the encoder 24 notches per revolution.
 		file:set_resolve_tags_callback(function()
 			for vname, view in pairs(file.views) do
 				if view.items["tempo_program_encoder"] ~= nil and view.items["tempo_program_encoder_finger"] ~= nil then
@@ -1679,8 +1657,7 @@ license:CC0-1.0
 				end
 			end
 		end)
-		-- The layout plugin invokes the returned table's frame() every video frame; use it to poll
-		-- the mouse wheel for the rotary wheel (the pointer API delivers no wheel event).
+		-- The layout plugin invokes the returned table's frame() every video frame.
 		return { frame = function() poll_rotary_wheels(); follow_rotary_values() end }
 	]]></script>
 </mamelayout>

--- a/src/mame/layout/kn5000.lay
+++ b/src/mame/layout/kn5000.lay
@@ -1334,4 +1334,353 @@ license:CC0-1.0
 		<bounds x="320" y="30" width="640" height="390"/>
 		<group ref="compact"><bounds x="0" y="0" width="1280" height="640"/></group>
 	</view>
+	<script><![CDATA[
+		-- Slider and knob library starts.
+		-- Can be copied as-is to other layouts.
+		-----------------------------------------------------------------------
+		-- Widgets are stored PER VIEW. A single shared list is WRONG when the same control is registered in
+		-- more than one view (e.g. a Compact view plus a single-block view): each view has its own coordinate
+		-- normalisation, so a pointer hit-test in view A against a widget's bounds registered for view B gives
+		-- false matches (symptom: clicking near one control in one view drags a slider that "lives" in another
+		-- view whose normalised bounds happen to overlap). Keying the widget list by view fixes that.
+		local view_widgets = {}   -- view (userdata) -> list of its widgets
+		local active_wl = nil     -- widget list of the view whose pointer last moved (for the frame wheel poll)
+		local pointers = {}       -- Tracks pointer state (keyed by pointer id).
+		local hover_x, hover_y = -1, -1   -- last pointer position (for wheel-over-widget hit testing)
+
+		local function widget_list(view)
+			local wl = view_widgets[view]
+			if wl == nil then wl = {}; view_widgets[view] = wl end
+			return wl
+		end
+
+		-- The knob's Y position must be animated using <animate inputtag="{port_name}">.
+		-- The click area's vertical size must exactly span the range of the
+		-- knob's movement.
+		function add_vertical_slider(view, clickarea_id, knob_id, port_name)
+			table.insert(widget_list(view), {
+				clickarea   = get_layout_item(view, clickarea_id),
+				slider_knob = get_layout_item(view, knob_id),
+				field       = get_port_field(port_name),
+				is_knob     = false })
+		end
+
+		-- A sweep between the attached field's min and max values requires
+		-- moving the pointer by `scale * clickarea.height` pixes.
+		function add_simplecounter_knob(view, clickarea_id, port_name, scale)
+			table.insert(widget_list(view), {
+				clickarea = get_layout_item(view, clickarea_id),
+				field     = get_port_field(port_name),
+				is_knob   = true,
+				scale     = scale })
+		end
+
+		-- An INFINITE rotary knob (e.g. the TEMPO/PROGRAM wheel). A circular drag rotates the `finger_id`
+		-- element around the knob centre and steps the attached relative encoder (an IPT_ADJUSTER the driver
+		-- diffs wrap-aware). `finger_id` is repositioned every frame via set_bounds_callback; the running
+		-- angle accumulates without limit, so the finger just keeps going round and round.
+		-- Every rotary knob, for the per-frame finger update. MUST be declared before
+		-- add_rotary_knob(): a Lua local is not visible to code written above it.
+		local rotary_widgets = {}
+
+		-- `drag_port_name` is written by this script; `key_port_name` is the control the KEYS and the
+		-- mouse axis drive, which the script only ever READS. They cannot be the same field: an
+		-- analog field's only Lua write path, set_value(), latches m_use_adjoverride permanently and
+		-- detaches the field from the input system, so one drag would kill the keys for the rest of
+		-- the session. An adjuster's user_value has no such side effect, and the driver sums both.
+		function add_rotary_knob(view, clickarea_id, finger_id, drag_port_name, key_port_name)
+			local w = {
+				clickarea = get_layout_item(view, clickarea_id),
+				finger    = get_layout_item(view, finger_id),
+				field     = get_port_field(drag_port_name),
+				key_field = get_port_field(key_port_name),
+				is_rotary = true,
+				angle     = 0.0,   -- running GESTURE angle (radians), unbounded: pointer input
+				display   = 0.0,   -- running DISPLAY angle: follows the value, whatever moved it
+				notch     = 0 }    -- last encoder notch emitted
+			table.insert(widget_list(view), w)
+			table.insert(rotary_widgets, w)
+			-- The finger orbits the knob centre at the current angle (0 = 12 o'clock, clockwise positive).
+			-- item.bounds is normalised PER-AXIS (x by view width, y by view height), so a screen-circular
+			-- orbit needs the x offset scaled by the click area's normalised WIDTH and the y offset by its
+			-- normalised HEIGHT (the click area is square in view units, so these encode the pixel aspect).
+			-- Orbit radius 0.24 keeps the finger (half-size 0.148) fully inside the wheel (r 0.48) with an
+			-- internal margin; the wheel is square in view units so scale x by width, y by height.
+			w.finger:set_bounds_callback(function()
+				local b = w.clickarea.bounds
+				local cx = (b.x0 + b.x1) / 2
+				local cy = (b.y0 + b.y1) / 2
+				local wd = b.x1 - b.x0
+				local ht = b.y1 - b.y0
+				local fx = cx + wd * 0.24 * math.sin(w.display)
+				local fy = cy - ht * 0.24 * math.cos(w.display)
+				local fhx = wd * 0.148
+				local fhy = ht * 0.148
+				return emu.render_bounds(fx - fhx, fy - fhy, fx + fhx, fy + fhy)
+			end)
+			return w
+		end
+
+		function get_layout_item(view, item_id)
+			local item = view.items[item_id]
+			if item == nil then
+				emu.print_error("Layout element: '" .. item_id .. "' not found.")
+			end
+			return item
+		end
+
+		function get_port_field(port_name)
+			local port = file.device:ioport(port_name)
+			if port == nil then
+				emu.print_error("Port: '" .. port_name .. "' not found.")
+				return nil
+			end
+			local field = nil
+			for k, val in pairs(port.fields) do
+				field = val
+				break
+			end
+			if field == nil then
+				emu.print_error("Port: '" .. port_name .."' does not seem to be an IPT_ADJUSTER.")
+				return nil
+			end
+			return field
+		end
+
+		-- Step the rotary encoder: map the accumulated angle to notches and nudge the adjuster by the
+		-- notch delta (wrapping 0..100). The driver diffs the adjuster wrap-aware into [0x17] encoder steps.
+		local ROTARY_STEPS_PER_REV = 24
+		local function rotary_emit(w)
+			local target = math.floor(w.angle * ROTARY_STEPS_PER_REV / (2 * math.pi) + 0.5)
+			if target ~= w.notch then
+				-- Writes the DRAG adjuster via user_value: the one route that does not latch the
+				-- field away from MAME's input system. The driver diffs it wrap-aware at 101.
+				local v = (w.field.user_value + (target - w.notch)) % 101
+				if v < 0 then v = v + 101 end
+				w.field.user_value = v
+				w.notch = target
+			end
+		end
+
+		-- Pointer angle around a widget's knob centre (0 = 12 o'clock, clockwise positive). Per-axis
+		-- normalisation (÷ width, ÷ height) matches the finger's aspect-corrected orbit, so the finger
+		-- tracks the cursor faithfully all the way round instead of leading/lagging near the sides.
+		local function knob_angle(w, x, y)
+			local b = w.clickarea.bounds
+			local cx = (b.x0 + b.x1) / 2
+			local cy = (b.y0 + b.y1) / 2
+			return math.atan((x - cx) / (b.x1 - b.x0), (cy - y) / (b.y1 - b.y0))
+		end
+
+		-- Mouse-WHEEL editing for rotary knobs. MAME's layout pointer API does NOT deliver wheel events,
+		-- so we read the mouse device's relative Z axis directly each frame (the sandbox exposes `machine`,
+		-- hence machine.input). One detent = 120 * RELATIVE_PER_PIXEL(512) = 61440 accumulator units
+		-- (SDL osd: m_v += wheel.y * 120 * RELATIVE_PER_PIXEL). Each notch nudges the finger and the encoder
+		-- exactly like a click of a drag, but only while the cursor hovers over the wheel.
+		local WHEEL_PER_NOTCH = 120 * 512
+		local wheel_item, wheel_probed, wheel_accum = nil, false, 0
+		local function find_wheel_item()
+			local input = machine.input
+			if input == nil then return nil end
+			local classes = input.device_classes
+			if classes == nil then return nil end
+			local mouse = classes["mouse"]
+			if mouse == nil then return nil end
+			for _, mdev in pairs(mouse.devices) do
+				for _, it in pairs(mdev.items) do
+					if it.token == "ZAXIS" then return it end   -- first mouse's wheel axis
+				end
+			end
+			return nil
+		end
+		-- The knob graphic must turn for whatever moved the wheel -- keys, mouse axis, pointer drag or
+		-- scroll wheel -- so it is driven by the summed wrap-aware DELTA of both controls rather than
+		-- by the drag gesture. Driving it from either control's absolute value would make it jump
+		-- whenever the other one moved.
+		local function wrapped_delta(cur, prev, modulus)
+			local d = cur - prev
+			if d > modulus / 2 then d = d - modulus
+			elseif d < -modulus / 2 then d = d + modulus end
+			return d
+		end
+
+		local function follow_rotary_values()
+			local step = 2 * math.pi / ROTARY_STEPS_PER_REV
+			for i = 1, #rotary_widgets do
+				local w = rotary_widgets[i]
+				if w.field and w.key_field then
+					local kv = w.key_field.port:read() % ROTARY_STEPS_PER_REV
+					local dv = w.field.port:read() % 101
+					if not w.synced then
+						w.key_prev, w.drag_prev, w.synced = kv, dv, true
+					else
+						local d = wrapped_delta(kv, w.key_prev, ROTARY_STEPS_PER_REV)
+								+ wrapped_delta(dv, w.drag_prev, 101)
+						w.key_prev, w.drag_prev = kv, dv
+						if d ~= 0 then w.display = w.display + d * step end
+					end
+				end
+			end
+		end
+
+		function poll_rotary_wheels()
+			if not wheel_probed then wheel_item = find_wheel_item(); wheel_probed = true end
+			if wheel_item == nil or active_wl == nil then return end
+			local dv = machine.input:code_value(wheel_item.code)
+			if dv == 0 then return end
+			-- find a rotary widget (in the ACTIVE view) under the cursor's last-known position
+			local target = nil
+			for i = 1, #active_wl do
+				if active_wl[i].is_rotary and active_wl[i].clickarea.bounds:includes(hover_x, hover_y) then
+					target = active_wl[i]; break
+				end
+			end
+			if target == nil then wheel_accum = 0; return end
+			wheel_accum = wheel_accum + dv
+			local step = 2 * math.pi / ROTARY_STEPS_PER_REV
+			while wheel_accum >= WHEEL_PER_NOTCH do
+				wheel_accum = wheel_accum - WHEEL_PER_NOTCH
+				target.angle = target.angle + step   -- scroll up: turn clockwise / increase
+				rotary_emit(target)
+			end
+			while wheel_accum <= -WHEEL_PER_NOTCH do
+				wheel_accum = wheel_accum + WHEEL_PER_NOTCH
+				target.angle = target.angle - step
+				rotary_emit(target)
+			end
+		end
+
+		-- `wl` is the widget list of the view this callback was installed on (see install_slider_callbacks).
+		-- Only widgets belonging to THIS view are hit-tested, so a click never matches another view's control.
+		local function pointer_updated(wl, type, id, dev, x, y, btn, dn, up, cnt)
+			hover_x, hover_y = x, y   -- remember where the cursor is, so the wheel poll can hit-test it
+			active_wl = wl            -- this is the view the user is interacting with
+
+			-- If a button is not pressed, reset the state of the current pointer.
+			if btn & 1 == 0 then
+				pointers[id] = nil
+				return
+			end
+
+			-- If a button was just pressed, find the affected widget, if any.
+			if dn & 1 ~= 0 then
+				for i = 1, #wl do
+					local found, relative
+					if wl[i].slider_knob and wl[i].slider_knob.bounds:includes(x, y) then
+						found = true
+						relative = true
+					elseif wl[i].clickarea.bounds:includes(x, y) then
+						found = true
+						relative = false
+					end
+					if found then
+						pointers[id] = {
+							selected_wl = wl,
+							selected_widget = i,
+							relative = relative,
+							start_y = y,
+							start_value = wl[i].field.user_value }
+						if wl[i].is_rotary then
+							pointers[id].last_pa = knob_angle(wl[i], x, y)
+						end
+						break
+					end
+				end
+			end
+
+			-- If there is no widget selected by the current pointer, we are done.
+			if pointers[id] == nil then
+				return
+			end
+
+			-- A widget is selected. Update its state based on the pointer's Y
+			-- position. It is assumed the attached IO field is an IPT_ADJUSTER.
+
+			local pointer = pointers[id]
+			local widget = pointer.selected_wl[pointer.selected_widget]
+
+			-- Rotary knob: rotate the finger by the pointer's angular motion and step the encoder. The angle
+			-- accumulates without limit, so it can be spun round and round (24 encoder steps per revolution).
+			if widget.is_rotary then
+				local pa = knob_angle(widget, x, y)
+				local d = pa - pointer.last_pa
+				if d > math.pi then d = d - 2 * math.pi elseif d < -math.pi then d = d + 2 * math.pi end
+				widget.angle = widget.angle + d
+				pointer.last_pa = pa
+				rotary_emit(widget)
+				return
+			end
+
+			local min_value = widget.field.minvalue
+			local max_value = widget.field.maxvalue
+			local value_range = max_value - min_value
+
+			local new_value
+			if widget.is_knob then
+				local step_y = value_range / (widget.scale * widget.clickarea.bounds.height)
+				new_value = pointer.start_value + (pointer.start_y - y) * step_y
+			else
+				local knob_half_height = widget.slider_knob.bounds.height / 2
+				local min_y = widget.clickarea.bounds.y0 + knob_half_height
+				local max_y = widget.clickarea.bounds.y1 - knob_half_height
+
+				if pointer.relative then
+					-- User clicked on the knob. The new value will depend on how
+					--  much the knob was dragged.
+					new_value = pointer.start_value - value_range * (y - pointer.start_y) / (max_y - min_y)
+				else
+					-- User clicked elsewhere on the slider. The new value will depend on
+					-- the absolute position of the click.
+					new_value = max_value - value_range * (y - min_y) / (max_y - min_y)
+				end
+			end
+
+			new_value = math.floor(new_value + 0.5)
+			if new_value < min_value then new_value = min_value end
+			if new_value > max_value then new_value = max_value end
+			widget.field.user_value = new_value
+		end
+
+		local function pointer_left(type, id, dev, x, y, up, cnt)
+			pointers[id] = nil
+		end
+
+		local function pointer_aborted(type, id, dev, x, y, up, cnt)
+			pointers[id] = nil
+		end
+
+		local function forget_pointers()
+			pointers = {}
+		end
+
+		function install_slider_callbacks(view)
+			local wl = widget_list(view)
+			view:set_pointer_updated_callback(function(type, id, dev, x, y, btn, dn, up, cnt)
+				pointer_updated(wl, type, id, dev, x, y, btn, dn, up, cnt)
+			end)
+			view:set_pointer_left_callback(pointer_left)
+			view:set_pointer_aborted_callback(pointer_aborted)
+			view:set_forget_pointers_callback(forget_pointers)
+		end
+		-----------------------------------------------------------------------
+		-- Slider and knob library ends.
+
+		-- KN5000 TEMPO/PROGRAM data wheel: an INFINITE rotary encoder, made draggable with the same
+		-- shared widget library, inlined because MAME layouts cannot include external files.
+		-- A circular drag (or the mouse wheel while hovering) spins the finger and steps the
+		-- ENCODER control, 24 notches per revolution. The driver turns each step into one detent
+		-- and the control-panel device puts it on the serial link as [0xD7, signed count].
+		file:set_resolve_tags_callback(function()
+			for vname, view in pairs(file.views) do
+				if view.items["tempo_program_encoder"] ~= nil and view.items["tempo_program_encoder_finger"] ~= nil then
+					add_rotary_knob(view, "tempo_program_encoder", "tempo_program_encoder_finger",
+										"ENCODER_DRAG", "ENCODER")
+					install_slider_callbacks(view)
+				end
+			end
+		end)
+		-- The layout plugin invokes the returned table's frame() every video frame; use it to poll
+		-- the mouse wheel for the rotary wheel (the pointer API delivers no wheel event).
+		return { frame = function() poll_rotary_wheels(); follow_rotary_values() end }
+	]]></script>
 </mamelayout>

--- a/src/mame/matsushita/kn5000.cpp
+++ b/src/mame/matsushita/kn5000.cpp
@@ -92,10 +92,8 @@ uint16_t mn89304_vga_device::offset()
 
 namespace {
 
-// Detents per full turn of the data wheel.  The exact number does not reach the firmware --
-// only the count of detents does -- so this is a UI granularity choice, not a hardware fact.
+// data wheel: detents per full turn, and the drag adjuster's 0..100 range plus one
 static constexpr int ENCODER_POSITIONS = 24;
-// The drag control is a plain 0..100 adjuster; its full turn is one more than its range.
 static constexpr int ENCODER_DRAG_POSITIONS = 101;
 
 class kn5000_state : public driver_device
@@ -120,7 +118,6 @@ public:
 		, m_cpanel_inta(0)
 	{ }
 
-	// One detent of the TEMPO/PROGRAM data wheel.  Public: reached by PORT_CHANGED_MEMBER.
 	DECLARE_INPUT_CHANGED_MEMBER(encoder_moved);
 
 	void kn5000(machine_config &config) ATTR_COLD;
@@ -456,13 +453,8 @@ static INPUT_PORTS_START(kn5000)
 	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("UP 1")
 	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("DOWN 2")
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("UP 2")
-	// The TEMPO/PROGRAM data wheel below the LCD.  It is an ENDLESS rotary encoder, so it is
-	// modelled as a wrapping positional control rather than an adjuster: there is no absolute
-	// position to represent, only motion.  Following src/mame/oberheim/xpander.cpp, which has
-	// the same kind of control on a synthesiser front panel.
-	//
-	// The panel MCU reports detents, so every step of this control becomes one detent handed to
-	// the control-panel device; it is that device that puts them on the serial link.
+	// TEMPO/PROGRAM data wheel below the LCD: an endless rotary encoder, so a wrapping
+	// positional control.  Each step becomes one detent for the control panel device.
 	PORT_START("ENCODER")
 	PORT_BIT(0x1f, 0x00, IPT_POSITIONAL) PORT_NAME("Tempo / Program Data Wheel")
 		PORT_POSITIONS(ENCODER_POSITIONS) PORT_WRAPS PORT_SENSITIVITY(20) PORT_KEYDELTA(1)
@@ -470,13 +462,7 @@ static INPUT_PORTS_START(kn5000)
 		PORT_FULL_TURN_COUNT(ENCODER_POSITIONS)
 		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(kn5000_state::encoder_moved), ENCODER_POSITIONS)
 
-	// The layout script drags this one in a circle. It needs to be a separate field from the
-	// control above, and specifically an IPT_ADJUSTER, because the two Lua write paths are
-	// mutually exclusive: set_value() is the only route into an analog field and it sets
-	// m_use_adjoverride permanently (ioport.cpp:3822), so the field stops reading its accumulator
-	// and the KEY BINDINGS above would go dead for the rest of the session after one drag; while
-	// user_value, which has no such side effect, is ignored on anything that is not an adjuster
-	// (ioport.cpp:1048). Detents from both are summed by the panel device.
+	// The same wheel, as an adjuster for the layout script to drag; detents from both are summed.
 	PORT_START("ENCODER_DRAG")
 	PORT_ADJUSTER(50, "Tempo / Program Data Wheel (mouse drag)")
 		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(kn5000_state::encoder_moved), ENCODER_DRAG_POSITIONS)
@@ -500,13 +486,10 @@ void kn5000_state::machine_reset()
 	m_checking_device_led_cn12 = 0;
 }
 
-// A step of the data wheel.  PORT_WRAPS means a full turn wraps the position, so a step across
-// the wrap point looks like a huge jump; recognise it and treat it as one detent, the way
-// src/mame/oberheim/xpander.cpp does for its encoders.
+// A step of the data wheel.  Both wheel controls arrive here; param is the control's full
+// turn, so that a wrap reads as one detent rather than a full-scale move backwards.
 INPUT_CHANGED_MEMBER(kn5000_state::encoder_moved)
 {
-	// Both wheel controls arrive here; the parameter is the control's full turn, so that a jump
-	// of more than half of it reads as a wrap rather than a full-scale move backwards.
 	int const modulus = int(param);
 	int delta = int(newval) - int(oldval);
 	if (delta > modulus / 2)
@@ -514,8 +497,7 @@ INPUT_CHANGED_MEMBER(kn5000_state::encoder_moved)
 	else if (delta < -modulus / 2)
 		delta += modulus;
 
-	// The magnitude is kept, not reduced to a direction: the firmware reads the reported count
-	// as an index into an acceleration curve, so a fast turn is meant to move further per detent.
+	// magnitude is kept, not reduced to a direction: the firmware uses it as an acceleration index
 	if (delta != 0)
 		m_cpanel->encoder_detent(delta);
 }

--- a/src/mame/matsushita/kn5000.cpp
+++ b/src/mame/matsushita/kn5000.cpp
@@ -92,6 +92,12 @@ uint16_t mn89304_vga_device::offset()
 
 namespace {
 
+// Detents per full turn of the data wheel.  The exact number does not reach the firmware --
+// only the count of detents does -- so this is a UI granularity choice, not a hardware fact.
+static constexpr int ENCODER_POSITIONS = 24;
+// The drag control is a plain 0..100 adjuster; its full turn is one more than its range.
+static constexpr int ENCODER_DRAG_POSITIONS = 101;
+
 class kn5000_state : public driver_device
 {
 public:
@@ -113,6 +119,9 @@ public:
 		, m_sstat(0)
 		, m_cpanel_inta(0)
 	{ }
+
+	// One detent of the TEMPO/PROGRAM data wheel.  Public: reached by PORT_CHANGED_MEMBER.
+	DECLARE_INPUT_CHANGED_MEMBER(encoder_moved);
 
 	void kn5000(machine_config &config) ATTR_COLD;
 
@@ -447,6 +456,31 @@ static INPUT_PORTS_START(kn5000)
 	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("UP 1")
 	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("DOWN 2")
 	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD ) PORT_NAME("UP 2")
+	// The TEMPO/PROGRAM data wheel below the LCD.  It is an ENDLESS rotary encoder, so it is
+	// modelled as a wrapping positional control rather than an adjuster: there is no absolute
+	// position to represent, only motion.  Following src/mame/oberheim/xpander.cpp, which has
+	// the same kind of control on a synthesiser front panel.
+	//
+	// The panel MCU reports detents, so every step of this control becomes one detent handed to
+	// the control-panel device; it is that device that puts them on the serial link.
+	PORT_START("ENCODER")
+	PORT_BIT(0x1f, 0x00, IPT_POSITIONAL) PORT_NAME("Tempo / Program Data Wheel")
+		PORT_POSITIONS(ENCODER_POSITIONS) PORT_WRAPS PORT_SENSITIVITY(20) PORT_KEYDELTA(1)
+		PORT_CODE_DEC(KEYCODE_OPENBRACE) PORT_CODE_INC(KEYCODE_CLOSEBRACE)
+		PORT_FULL_TURN_COUNT(ENCODER_POSITIONS)
+		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(kn5000_state::encoder_moved), ENCODER_POSITIONS)
+
+	// The layout script drags this one in a circle. It needs to be a separate field from the
+	// control above, and specifically an IPT_ADJUSTER, because the two Lua write paths are
+	// mutually exclusive: set_value() is the only route into an analog field and it sets
+	// m_use_adjoverride permanently (ioport.cpp:3822), so the field stops reading its accumulator
+	// and the KEY BINDINGS above would go dead for the rest of the session after one drag; while
+	// user_value, which has no such side effect, is ignored on anything that is not an adjuster
+	// (ioport.cpp:1048). Detents from both are summed by the panel device.
+	PORT_START("ENCODER_DRAG")
+	PORT_ADJUSTER(50, "Tempo / Program Data Wheel (mouse drag)")
+		PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(kn5000_state::encoder_moved), ENCODER_DRAG_POSITIONS)
+
 INPUT_PORTS_END
 
 
@@ -464,6 +498,26 @@ void kn5000_state::machine_reset()
 {
 	m_checking_device_led_cn11 = 0;
 	m_checking_device_led_cn12 = 0;
+}
+
+// A step of the data wheel.  PORT_WRAPS means a full turn wraps the position, so a step across
+// the wrap point looks like a huge jump; recognise it and treat it as one detent, the way
+// src/mame/oberheim/xpander.cpp does for its encoders.
+INPUT_CHANGED_MEMBER(kn5000_state::encoder_moved)
+{
+	// Both wheel controls arrive here; the parameter is the control's full turn, so that a jump
+	// of more than half of it reads as a wrap rather than a full-scale move backwards.
+	int const modulus = int(param);
+	int delta = int(newval) - int(oldval);
+	if (delta > modulus / 2)
+		delta -= modulus;
+	else if (delta < -modulus / 2)
+		delta += modulus;
+
+	// The magnitude is kept, not reduced to a direction: the firmware reads the reported count
+	// as an index into an acceleration curve, so a fast turn is meant to move further per detent.
+	if (delta != 0)
+		m_cpanel->encoder_detent(delta);
 }
 
 void kn5000_state::kn5000(machine_config &config)

--- a/src/mame/matsushita/kn5000_cpanel.cpp
+++ b/src/mame/matsushita/kn5000_cpanel.cpp
@@ -551,25 +551,17 @@ uint8_t kn5000_cpanel_device::read_button_segment(int segment, bool is_left_pane
 
 void kn5000_cpanel_device::encoder_detent(int delta)
 {
-	// Accumulate; the next scan reports the total.  The panel MCU counts detents between
-	// reports, so several detents arriving inside one scan period is a larger count, not
-	// several packets -- which is what makes the firmware's acceleration curve reachable.
+	// the panel MCU counts detents between reports, so the next scan reports the total
 	m_encoder_accum += delta;
 }
 
 void kn5000_cpanel_device::send_encoder_packet(int8_t detents)
 {
-	// The TEMPO/PROGRAM data wheel is an input of the LEFT panel MCU: the service manual has
-	// SW101 (ENCODER SWITCH) on the CPL board, wired to that MCU's ROTA/ROTB pins.  It reports
-	// as a two-byte frame, header then a signed count of detents since the last report.
-	//
-	// Header 0xD7 = 0xC0 | 0x17: bits 7:6 = 11 select the left panel, as send_button_packet
-	// already encodes, and 0x17 is the encoder's sub-address.  The firmware turns a header into
-	// a record index with ((header & 0xC0) >> 1) | (header & 0x1F), so 0xD7 selects record 0x19,
-	// the data wheel.
-	//
-	// Deliberately not routed through send_button_packet(), which masks the sub-address to four
-	// bits -- 0x17 does not fit.
+	// SW101 (ENCODER SWITCH) is on the CPL board, wired to the left panel MCU's ROTA/ROTB pins.
+	// Header 0xD7 = 0xC0 (left panel) | 0x17 (encoder sub-address); the firmware maps it to
+	// record index ((header & 0xc0) >> 1) | (header & 0x1f) = 0x19.  Then a signed count of
+	// detents since the last report.  send_button_packet() cannot carry this: it masks the
+	// sub-address to four bits.
 	send_byte(0xd7);
 	send_byte(uint8_t(detents));
 
@@ -925,14 +917,9 @@ TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::button_scan_callback)
 		}
 	}
 
-	// Report any data-wheel movement accumulated since the last scan.
-	//
-	// The count is NEGATED: the firmware indexes an acceleration curve with it, and that curve
-	// is monotonically decreasing, so a negative count is what raises the on-screen value.
-	//
-	// It is also CLAMPED.  The firmware computes the curve index as sext8(count + 0x10) with no
-	// bounds check, so magnitudes outside -16..+15 index off the end of a 32-entry table.  A
-	// real panel cannot produce those, and neither may this one.
+	// Report any data-wheel movement accumulated since the last scan.  The count is negated
+	// because the firmware's acceleration curve is monotonically decreasing, and clamped to
+	// -16..+15 because the curve index is sext8(count + 0x10) into a 32-entry table, unchecked.
 	if (m_encoder_accum != 0)
 	{
 		int32_t count = -m_encoder_accum;

--- a/src/mame/matsushita/kn5000_cpanel.cpp
+++ b/src/mame/matsushita/kn5000_cpanel.cpp
@@ -63,6 +63,7 @@ kn5000_cpanel_device::kn5000_cpanel_device(const machine_config &mconfig, const 
 	m_inta_cb(*this),
 	m_cpl_ports(*this, finder_base::DUMMY_TAG, 0U),
 	m_cpr_ports(*this, finder_base::DUMMY_TAG, 0U),
+	m_encoder_accum(0),
 	m_cpl_leds(*this, "cpl_led_%u", 0U),
 	m_cpr_leds(*this, "cpr_led_%u", 0U)
 {
@@ -100,6 +101,7 @@ void kn5000_cpanel_device::device_start()
 	save_item(NAME(m_self_clock_bytes_sent));
 	save_item(NAME(m_last_button_state));
 	save_item(NAME(m_pending_button_state));
+	save_item(NAME(m_encoder_accum));
 
 	// Initial state - line idle high
 	m_txd_cb(1);
@@ -547,6 +549,33 @@ uint8_t kn5000_cpanel_device::read_button_segment(int segment, bool is_left_pane
 	return (is_left_panel ? m_cpl_ports : m_cpr_ports)[segment].read_safe(0) & 0xff;
 }
 
+void kn5000_cpanel_device::encoder_detent(int delta)
+{
+	// Accumulate; the next scan reports the total.  The panel MCU counts detents between
+	// reports, so several detents arriving inside one scan period is a larger count, not
+	// several packets -- which is what makes the firmware's acceleration curve reachable.
+	m_encoder_accum += delta;
+}
+
+void kn5000_cpanel_device::send_encoder_packet(int8_t detents)
+{
+	// The TEMPO/PROGRAM data wheel is an input of the LEFT panel MCU: the service manual has
+	// SW101 (ENCODER SWITCH) on the CPL board, wired to that MCU's ROTA/ROTB pins.  It reports
+	// as a two-byte frame, header then a signed count of detents since the last report.
+	//
+	// Header 0xD7 = 0xC0 | 0x17: bits 7:6 = 11 select the left panel, as send_button_packet
+	// already encodes, and 0x17 is the encoder's sub-address.  The firmware turns a header into
+	// a record index with ((header & 0xC0) >> 1) | (header & 0x1F), so 0xD7 selects record 0x19,
+	// the data wheel.
+	//
+	// Deliberately not routed through send_button_packet(), which masks the sub-address to four
+	// bits -- 0x17 does not fit.
+	send_byte(0xd7);
+	send_byte(uint8_t(detents));
+
+	LOGMASKED(LOG_BUTTONS, "Encoder packet: %d detent(s)\n", detents);
+}
+
 void kn5000_cpanel_device::send_button_packet(int segment, bool is_left_panel)
 {
 	// Button packet header: bits 7:6 = panel (00=right, 11=left),
@@ -894,6 +923,26 @@ TIMER_CALLBACK_MEMBER(kn5000_cpanel_device::button_scan_callback)
 		{
 			m_pending_button_state[idx] = state;
 		}
+	}
+
+	// Report any data-wheel movement accumulated since the last scan.
+	//
+	// The count is NEGATED: the firmware indexes an acceleration curve with it, and that curve
+	// is monotonically decreasing, so a negative count is what raises the on-screen value.
+	//
+	// It is also CLAMPED.  The firmware computes the curve index as sext8(count + 0x10) with no
+	// bounds check, so magnitudes outside -16..+15 index off the end of a 32-entry table.  A
+	// real panel cannot produce those, and neither may this one.
+	if (m_encoder_accum != 0)
+	{
+		int32_t count = -m_encoder_accum;
+		if (count > 15)
+			count = 15;
+		else if (count < -16)
+			count = -16;
+		m_encoder_accum = 0;
+		send_encoder_packet(int8_t(count));
+		changed = true;
 	}
 
 	if (changed)

--- a/src/mame/matsushita/kn5000_cpanel.h
+++ b/src/mame/matsushita/kn5000_cpanel.h
@@ -28,6 +28,10 @@ public:
 	template <typename T> void set_cpl_port(unsigned n, T &&tag) { m_cpl_ports[n].set_tag(std::forward<T>(tag)); }
 	template <typename T> void set_cpr_port(unsigned n, T &&tag) { m_cpr_ports[n].set_tag(std::forward<T>(tag)); }
 
+	// One detent of the TEMPO/PROGRAM data wheel, +1 clockwise.  Called from the driver's
+	// input-changed handler; the detents are accumulated and reported on the next panel scan.
+	void encoder_detent(int delta);
+
 	// Configuration
 	void set_baudrate(uint16_t br);
 
@@ -60,6 +64,7 @@ private:
 	// Response generation
 	void send_sync_packet();
 	void send_button_packet(int segment, bool is_left_panel);
+	void send_encoder_packet(int8_t detents);
 	void send_all_button_states(bool is_left_panel);
 
 	// LED control
@@ -112,6 +117,7 @@ private:
 	// Input port pointers (set by main driver)
 	optional_ioport_array<11> m_cpl_ports;  // Left panel segments 0-10
 	optional_ioport_array<11> m_cpr_ports;  // Right panel segments 0-10
+	int32_t m_encoder_accum;                // data-wheel detents not yet reported
 
 	// LED outputs
 	output_finder<50> m_cpl_leds;  // Left panel LEDs (CPL_0 through CPL_49)

--- a/src/mame/matsushita/kn5000_cpanel.h
+++ b/src/mame/matsushita/kn5000_cpanel.h
@@ -28,8 +28,7 @@ public:
 	template <typename T> void set_cpl_port(unsigned n, T &&tag) { m_cpl_ports[n].set_tag(std::forward<T>(tag)); }
 	template <typename T> void set_cpr_port(unsigned n, T &&tag) { m_cpr_ports[n].set_tag(std::forward<T>(tag)); }
 
-	// One detent of the TEMPO/PROGRAM data wheel, +1 clockwise.  Called from the driver's
-	// input-changed handler; the detents are accumulated and reported on the next panel scan.
+	// one detent of the TEMPO/PROGRAM data wheel, +1 clockwise; reported on the next panel scan
 	void encoder_detent(int delta);
 
 	// Configuration


### PR DESCRIPTION
The panel reports the wheel over its serial link as [0xD7, signed detent count], which is encoded identically in all six dumped firmware revisions. The count is kept rather than reduced to a direction, because the firmware indexes an acceleration curve with it.

The wheel needs two fields: a wrapping IPT_POSITIONAL for the keys and mouse axis, and an IPT_ADJUSTER the layout script drags. They cannot be one field -- set_value() is Lua's only route into an analog field and it latches m_use_adjoverride permanently, killing the key bindings, while user_value is ignored on anything that is not an adjuster. The driver sums both wrap-aware deltas.

https://github.com/user-attachments/assets/421feed3-6506-4c07-afab-228c00283bcd


