### PR TITLE
mc6854: fix status/interrupt handling and the DMA data path

### DIFF
--- a/src/devices/machine/mc6854.cpp
+++ b/src/devices/machine/mc6854.cpp
@@ -159,6 +159,8 @@ mc6854_device::mc6854_device(const machine_config &mconfig, const char *tag, dev
 	m_tstate(0),
 	m_tones(0),
 	m_ttimer(nullptr),
+	m_wire_timer(nullptr),
+	m_wire_rate(attotime::zero),   /* zero = refill on pop, the old behaviour */
 	m_rstate(0),
 	m_rreg(0),
 	m_rones(0),
@@ -166,7 +168,9 @@ mc6854_device::mc6854_device(const machine_config &mconfig, const char *tag, dev
 	m_rxd(0),
 	m_rxc(0),
 	m_flen(0),
-	m_fpos(0)
+	m_fpos(0),
+	m_stall_fpos(0xffffffff),
+	m_stall_count(0)
 {
 	for (int i = 0; i < FIFO_SIZE; i++)
 	{
@@ -189,6 +193,7 @@ void mc6854_device::device_start()
 	m_out_frame_cb.resolve_safe();
 
 	m_ttimer = timer_alloc(FUNC(mc6854_device::tfifo_cb), this);
+	m_wire_timer = timer_alloc(FUNC(mc6854_device::wire_feed), this);
 
 	save_item(NAME(m_cr1));
 	save_item(NAME(m_cr2));
@@ -427,6 +432,9 @@ TIMER_CALLBACK_MEMBER(mc6854_device::tfifo_cb)
 		m_flen = 0;
 		m_out_frame_cb( m_frame, len );
 	}
+
+	/* the FIFO just gained a free slot: TDRA (and the TDSR line) must follow */
+	update_sr1( );
 }
 
 
@@ -561,8 +569,10 @@ uint8_t mc6854_device::rfifo_pop( )
 		m_sr2 |= FV; /* TODO: check CRC & set ERR instead of FV if error*/
 	}
 
-	/* auto-refill in frame mode */
-	if ( m_flen > 0 )
+	/* auto-refill in frame mode - unless the line is clocking the frame in on
+	   its own, in which case refilling here as well would deliver two bytes
+	   per pop and defeat the whole point (see set_wire_rate) */
+	if ( m_flen > 0 && m_wire_rate.is_zero() )
 	{
 		rfifo_push( m_frame[ m_fpos++ ] );
 		if ( m_fpos == m_flen )
@@ -570,6 +580,23 @@ uint8_t mc6854_device::rfifo_pop( )
 	}
 
 	return data;
+}
+
+
+/* One byte off the wire.  This is what a real line does and what the pop-driven
+   refill cannot do: it keeps arriving whether or not anybody is reading, so a
+   reader that has stopped overruns the three-byte FIFO by itself, which is
+   exactly how the chip behaves and removes the need to guess at a stall. */
+TIMER_CALLBACK_MEMBER(mc6854_device::wire_feed)
+{
+	if ( m_flen == 0 || m_fpos >= m_flen )
+		return;
+
+	rfifo_push( m_frame[ m_fpos++ ] );
+	if ( m_fpos == m_flen )
+		rfifo_terminate( );
+	else
+		m_wire_timer->adjust( m_wire_rate );
 }
 
 
@@ -588,13 +615,67 @@ void mc6854_device::rfifo_clear( )
 	m_rsize = 0;
 	m_rones = 0;
 	m_flen = 0;
+	/* the frame is gone, so nothing more of it comes off the line */
+	if ( m_wire_timer )
+		m_wire_timer->adjust( attotime::never );
 }
 
 
 
 int mc6854_device::send_frame( uint8_t* data, int len )
 {
-	if ( m_rstate > 1 || m_tstate > 1 || RTS )
+	if ( !receive_allowed() )
+		return -2; /* transmitted on the wire, but the receiver is in reset or
+		              has no carrier: the frame is simply not seen */
+
+	/* A frame mid-drain normally just means the reader has not caught up yet:
+	   report busy and let the sender retry.  But if the drain makes no
+	   progress over many consecutive offers, nobody is reading any more (e.g.
+	   the DMA count ran out mid-frame because the frame was not addressed to
+	   this station).  On the real line that frame finished arriving long ago:
+	   the FIFO overran and the closing flag went by unseen.  Latch the
+	   overrun so the CPU gets its interrupt, resets the receiver and re-arms.
+	   The threshold is deliberately generous: a receiver whose DMA controller
+	   is briefly busy elsewhere (a disk transfer on another channel) stalls
+	   legitimately for a few ms; the broken state is a *permanent* stall.
+
+	   AND IT IS LOAD-BEARING, measured.  Every stall this reports sits at 65
+	   or 66 bytes of a long frame, which is the receiver's 64-byte DMA buffer
+	   running out - and that ONE signature covers two opposite cases: a frame
+	   not addressed to this station, which will never be drained further and
+	   for which the overrun is right, and a frame that is addressed to it,
+	   where the CPU is about to re-arm the controller and the overrun is FALSE.
+	   Making the threshold a generous 500 ms of no progress removed the false
+	   ones (77 stalls down to 10 with the drain paced) and broke the load: the
+	   recovery from a foreign frame then costs half a second each time and the
+	   display never gets its emulation, falling back to the function menu.
+	   So the two cases cannot be told apart by time.  Telling them apart needs
+	   the ADDRESS, which the device does not have and the driver does - see the
+	   note on pacing in alfaskop41xx.cpp. */
+	if ( m_flen > 0 )
+	{
+		if ( m_fpos == m_stall_fpos )
+		{
+			if ( ++m_stall_count >= 25 )
+			{
+				if ( m_stall_count == 25 )
+					logerror( "receiver stalled mid-frame (%u of %u bytes drained): latching overrun\n", m_fpos, m_flen );
+				m_sr2 |= OVRN;
+				update_sr1(); /* recompute S2RQ and raise the interrupt */
+			}
+		}
+		else
+		{
+			m_stall_fpos = m_fpos;
+			m_stall_count = 0;
+			m_stall_since = machine().time();
+		}
+		return -1;
+	}
+
+	/* the RTS output does not gate the receiver section: a master that keeps
+	   RTS raised while it waits for an answer still hears it */
+	if ( m_rstate > 1 || m_tstate > 1 )
 		return -1; /* busy */
 
 	if ( len > MAX_FRAME_LENGTH )
@@ -615,10 +696,18 @@ int mc6854_device::send_frame( uint8_t* data, int len )
 	}
 	m_flen = len;
 	m_fpos = 0;
+	m_stall_fpos = 0xffffffff; /* no stall recorded yet for this frame */
+	m_stall_count = 0;
+	m_stall_since = machine().time();
+	/* the address and control bytes are in the FIFO as soon as the frame
+	   starts arriving; from there the wire either clocks the rest in on its
+	   own timer, or - the original behaviour - the reader pulls it */
 	rfifo_push( m_frame[ m_fpos++ ] );
 	rfifo_push( m_frame[ m_fpos++ ] );
 	if ( m_fpos == m_flen )
 		rfifo_terminate( );
+	else if ( !m_wire_rate.is_zero() )
+		m_wire_timer->adjust( m_wire_rate );
 	return 0;
 }
 
@@ -630,14 +719,12 @@ int mc6854_device::send_frame( uint8_t* data, int len )
 
 void mc6854_device::set_cts(int state)
 {
+	/* the CTS status bit latches the positive transition of the nCTS input
+	   and is cleared by TRESET or "clear transmitter status", not by the
+	   line going active again */
 	if ( ! m_cts && state )
 		m_sr1 |= CTS;
 	m_cts = state;
-
-	if ( m_cts )
-		m_sr1 |= CTS;
-	else
-		m_sr1 &= ~CTS;
 	update_sr1();
 }
 
@@ -645,7 +732,9 @@ void mc6854_device::set_cts(int state)
 
 void mc6854_device::set_dcd(int state)
 {
-	if ( ! m_dcd && state )
+	/* a receiver section held in reset has its status bits cleared and cannot
+	   latch the loss-of-carrier edge */
+	if ( ! m_dcd && state && !RRESET )
 	{
 		m_sr2 |= DCD;
 		/* partial reset */
@@ -655,6 +744,7 @@ void mc6854_device::set_dcd(int state)
 		m_rones = 0;
 	}
 	m_dcd = state;
+	update_sr1( ); /* the latched loss-of-carrier must be able to raise S2RQ and interrupt */
 }
 
 
@@ -681,14 +771,19 @@ void mc6854_device::update_sr1( )
 {
 	update_sr2( );
 
-	/* update S2RQ */
-	if ( m_sr2 & 0x7f )
+	/* update S2RQ; the address byte does not request status service while the
+	   receiver data path is in DMA mode - it is the DMA channel's business */
+	uint8_t s2_cond = m_sr2 & 0x7f;
+	if ( RDSR )
+		s2_cond &= ~AP;
+	if ( s2_cond )
 		m_sr1 |= S2RQ;
 	else
 		m_sr1 &= ~S2RQ;
 
-	/* update TDRA (always prioritized by CTS) */
-	if ( TRESET || ( m_sr1 & CTS ) )
+	/* update TDRA (always prioritized by CTS: both the latched condition and
+	   the live level of the nCTS input inhibit transmission) */
+	if ( TRESET || ( m_sr1 & CTS ) || m_cts )
 		m_sr1 &= ~TDRA;
 	else
 	{
@@ -712,16 +807,21 @@ void mc6854_device::update_sr1( )
 	{
 		if ( m_sr1 & TU ) m_sr1 |= IRQ;
 		LOGIRQ(" - Update IRQ TU: %d\n", (m_sr1 & IRQ) ? 1 : 0);
+		if ( m_sr1 & CTS ) m_sr1 |= IRQ; /* nCTS is a transmitter side condition (datasheet) */
+		LOGIRQ(" - Update IRQ CTS: %d\n", (m_sr1 & IRQ) ? 1 : 0);
 		if ( ( m_sr1 & TDRA ) && !TDSR ) m_sr1 |= IRQ; // TDRA will not cause interrupt if in DMA mode
 		LOGIRQ(" - Update IRQ TDRA: %d\n", (m_sr1 & IRQ) ? 1 : 0);
 	}
 	if ( RIE )
 	{
-		if ( m_sr1 & (S2RQ | CTS) ) m_sr1 |= IRQ;
-		LOGIRQ(" - Update IRQ S2RQ(%02x)|CTS(%d): %d\n", (m_sr2 & 0x7f), (m_sr1 & CTS) ? 1 : 0, (m_sr1 & IRQ) ? 1 : 0);
+		if ( m_sr1 & S2RQ ) m_sr1 |= IRQ;
+		LOGIRQ(" - Update IRQ S2RQ(%02x): %d\n", (m_sr2 & 0x7f), (m_sr1 & IRQ) ? 1 : 0);
 		if ( ( m_sr1 & RDA ) && !RDSR ) m_sr1 |= IRQ; // RDA will not cause interrupt if in DMA mode
 		LOGIRQ(" - Update IRQ RDA(%d) && !RDSR(%d): %d\n", (m_sr1 & RDA) ? 1 : 0, RDSR ? 1 : 0, (m_sr1 & IRQ) ? 1 : 0);
-		if ( m_sr2 & (ERR | FV | DCD | OVRN | RABT | RIDLE | AP) ) m_sr1 |= IRQ;
+		if ( m_sr2 & (ERR | FV | DCD | OVRN | RABT | RIDLE) ) m_sr1 |= IRQ;
+		/* the address byte is the DMA channel's business when the receiver
+		   data path is in DMA mode; it only interrupts in CPU-driven mode */
+		if ( !RDSR && ( m_sr2 & AP ) ) m_sr1 |= IRQ;
 		LOGIRQ(" - Update IRQ ERR: %d\n", (m_sr1 & IRQ) ? 1 : 0);
 	}
 
@@ -744,7 +844,9 @@ uint8_t mc6854_device::read(offs_t offset)
 				( m_sr1 & FD ) ? 1 : 0, ( m_sr1 & CTS ) ? 1 : 0,
 				( m_sr1 & TU ) ? 1 : 0, ( m_sr1 & TDRA) ? 1 : 0,
 				( m_sr1 & IRQ) ? 1 : 0 );
-		return m_sr1;
+		/* the CTS bit shows the live level of the nCTS input as well as the
+		   latched transition; only the latter interrupts */
+		return m_sr1 | ( m_cts ? CTS : 0 );
 
 	case 1: /* status register 2 */
 		//update_sr2( );
@@ -762,7 +864,16 @@ uint8_t mc6854_device::read(offs_t offset)
 		uint8_t data = rfifo_pop( );
 		LOG( "%f %s mc6854_r: get data $%02X\n",
 				machine().time().as_double(), machine().describe_context(), data );
-		m_out_rdsr_cb(CLEAR_LINE); // Deactive DMA request line regardless of mode
+		if ( m_wire_rate.is_zero() )
+			m_out_rdsr_cb(CLEAR_LINE); // Deactive DMA request line regardless of mode
+		else
+			/* With the line clocking bytes in, the request has to follow what
+			   is actually in the FIFO: dropping it unconditionally here and
+			   never refreshing the status leaves the reader waiting for a byte
+			   that is already sitting there.  Recomputing says the truth - the
+			   request stays up while another byte is present and falls when the
+			   FIFO empties. */
+			update_sr1();
 		return data;
 	}
 
@@ -805,8 +916,10 @@ void mc6854_device::write(offs_t offset, uint8_t data)
 		if ( TRESET )
 		{
 			tfifo_clear( );
+			/* the CTS status bit is latched on the positive transition of the
+			   nCTS input; once cleared it stays clear until the next edge,
+			   even if the line is still high */
 			m_sr1 &= ~(TU | TDRA | CTS);
-			if ( m_cts ) m_sr1 |= CTS;
 			update_sr1( );
 		}
 		break;
@@ -850,14 +963,16 @@ void mc6854_device::write(offs_t offset, uint8_t data)
 				m_sr2 &= ~(AP | FV | RIDLE | RABT | ERR | OVRN | DCD);
 				if ( m_dcd )
 					m_sr2 |= DCD;
+				/* AP is a latched condition on the real chip: once cleared it must
+				   not reassert for an address byte still unread in the FIFO */
+				for ( int i = 0; i < FIFO_SIZE; i++ )
+					m_rfifo[ i ] &= ~0x400;
 				update_sr1( );
 			}
 			if ( data & 0x40 )
 			{
-				/* clear transmitter status */
+				/* clear transmitter status; CTS is edge-latched, see TRESET */
 				m_sr1 &= ~(TU | TDRA | CTS);
-				if ( m_cts )
-					m_sr1 |= CTS;
 				update_sr1( );
 			}
 
@@ -868,6 +983,7 @@ void mc6854_device::write(offs_t offset, uint8_t data)
 	case 2: /* transmitter data: continue data */
 		LOGSETUP( "%f %smc6854_w: push data=$%02X\n", machine().time().as_double(), machine().describe_context(), data );
 		tfifo_push( data );
+		update_sr1( ); /* a full FIFO must drop TDRA (and the TDSR line), or DMA overruns it */
 		break;
 
 	case 3:
@@ -893,6 +1009,7 @@ void mc6854_device::write(offs_t offset, uint8_t data)
 			LOGSETUP( "%f %s mc6854_w: push last-data=$%02X\n", machine().time().as_double(), machine().describe_context(), data );
 			tfifo_push( data );
 			tfifo_terminate( );
+			update_sr1( ); /* a full FIFO must drop TDRA (and the TDSR line), or DMA overruns it */
 		}
 		break;
 

--- a/src/devices/machine/mc6854.cpp
+++ b/src/devices/machine/mc6854.cpp
@@ -168,9 +168,7 @@ mc6854_device::mc6854_device(const machine_config &mconfig, const char *tag, dev
 	m_rxd(0),
 	m_rxc(0),
 	m_flen(0),
-	m_fpos(0),
-	m_stall_fpos(0xffffffff),
-	m_stall_count(0)
+	m_fpos(0)
 {
 	for (int i = 0; i < FIFO_SIZE; i++)
 	{
@@ -586,7 +584,7 @@ uint8_t mc6854_device::rfifo_pop( )
 /* One byte off the wire.  This is what a real line does and what the pop-driven
    refill cannot do: it keeps arriving whether or not anybody is reading, so a
    reader that has stopped overruns the three-byte FIFO by itself, which is
-   exactly how the chip behaves and removes the need to guess at a stall. */
+   how the chip behaves. */
 TIMER_CALLBACK_MEMBER(mc6854_device::wire_feed)
 {
 	if ( m_flen == 0 || m_fpos >= m_flen )
@@ -628,50 +626,9 @@ int mc6854_device::send_frame( uint8_t* data, int len )
 		return -2; /* transmitted on the wire, but the receiver is in reset or
 		              has no carrier: the frame is simply not seen */
 
-	/* A frame mid-drain normally just means the reader has not caught up yet:
-	   report busy and let the sender retry.  But if the drain makes no
-	   progress over many consecutive offers, nobody is reading any more (e.g.
-	   the DMA count ran out mid-frame because the frame was not addressed to
-	   this station).  On the real line that frame finished arriving long ago:
-	   the FIFO overran and the closing flag went by unseen.  Latch the
-	   overrun so the CPU gets its interrupt, resets the receiver and re-arms.
-	   The threshold is deliberately generous: a receiver whose DMA controller
-	   is briefly busy elsewhere (a disk transfer on another channel) stalls
-	   legitimately for a few ms; the broken state is a *permanent* stall.
-
-	   AND IT IS LOAD-BEARING, measured.  Every stall this reports sits at 65
-	   or 66 bytes of a long frame, which is the receiver's 64-byte DMA buffer
-	   running out - and that ONE signature covers two opposite cases: a frame
-	   not addressed to this station, which will never be drained further and
-	   for which the overrun is right, and a frame that is addressed to it,
-	   where the CPU is about to re-arm the controller and the overrun is FALSE.
-	   Making the threshold a generous 500 ms of no progress removed the false
-	   ones (77 stalls down to 10 with the drain paced) and broke the load: the
-	   recovery from a foreign frame then costs half a second each time and the
-	   display never gets its emulation, falling back to the function menu.
-	   So the two cases cannot be told apart by time.  Telling them apart needs
-	   the ADDRESS, which the device does not have and the driver does - see the
-	   note on pacing in alfaskop41xx.cpp. */
+	/* a frame is still being drained: report busy and let the sender retry */
 	if ( m_flen > 0 )
-	{
-		if ( m_fpos == m_stall_fpos )
-		{
-			if ( ++m_stall_count >= 25 )
-			{
-				if ( m_stall_count == 25 )
-					logerror( "receiver stalled mid-frame (%u of %u bytes drained): latching overrun\n", m_fpos, m_flen );
-				m_sr2 |= OVRN;
-				update_sr1(); /* recompute S2RQ and raise the interrupt */
-			}
-		}
-		else
-		{
-			m_stall_fpos = m_fpos;
-			m_stall_count = 0;
-			m_stall_since = machine().time();
-		}
 		return -1;
-	}
 
 	/* the RTS output does not gate the receiver section: a master that keeps
 	   RTS raised while it waits for an answer still hears it */
@@ -696,9 +653,6 @@ int mc6854_device::send_frame( uint8_t* data, int len )
 	}
 	m_flen = len;
 	m_fpos = 0;
-	m_stall_fpos = 0xffffffff; /* no stall recorded yet for this frame */
-	m_stall_count = 0;
-	m_stall_since = machine().time();
 	/* the address and control bytes are in the FIFO as soon as the frame
 	   starts arriving; from there the wire either clocks the rest in on its
 	   own timer, or - the original behaviour - the reader pulls it */

--- a/src/devices/machine/mc6854.h
+++ b/src/devices/machine/mc6854.h
@@ -43,6 +43,22 @@ public:
 	/* high-level, frame-based interface */
 	int send_frame( uint8_t* data, int length ); /* ret -1 if busy */
 
+	/* OPTIONAL: clock a received frame into the FIFO at the line rate.
+	 *
+	 * By default a frame handed to send_frame() is refilled into the receive
+	 * FIFO as the reader pops it, so the FIFO never fills and the chip's own
+	 * overrun can never happen - the frame arrives as fast as the reader can
+	 * take it, however long the wire would really have taken.
+	 *
+	 * Give a per-byte time here and the bytes are instead clocked in by a
+	 * timer, which is what a real line does.  Then a reader that stops (its
+	 * DMA count exhausted on a frame that was not for it, or a CPU slow to
+	 * re-arm) overruns the three-byte FIFO after about three byte times, on
+	 * its own and for the right reason.  attotime::zero (the default) keeps
+	 * the original behaviour, so no existing driver changes.
+	 */
+	void set_wire_rate( const attotime &per_byte ) { m_wire_rate = per_byte; }
+
 	/* control lines */
 	void set_cts(int state); /* 1 = clear-to-send, 0 = busy */
 	void set_dcd(int state); /* 1 = carrier, 0 = no carrier */
@@ -86,6 +102,8 @@ private:
 	uint16_t m_tfifo[FIFO_SIZE];  /* X x 8-bit FIFO + full & last marker bits */
 	uint8_t  m_tones;             /* counter for zero-insertion */
 	emu_timer *m_ttimer;       /* when to ask for more data */
+	emu_timer *m_wire_timer;   /* clocks a received frame in at the line rate */
+	attotime m_wire_rate;      /* per byte; zero = refill on pop, as before */
 
 	/* receive state */
 	uint8_t  m_rstate;
@@ -99,6 +117,9 @@ private:
 	/* frame-based interface*/
 	uint8_t  m_frame[MAX_FRAME_LENGTH];
 	uint32_t m_flen, m_fpos;
+	uint32_t m_stall_fpos;  /* drain progress marker: detects a receiver stalled mid-frame */
+	uint32_t m_stall_count; /* offers seen with no progress (kept for the log) */
+	attotime m_stall_since; /* when the drain last made progress */
 
 
 	/* meaning of tstate / rtate:
@@ -114,6 +135,7 @@ private:
 	void tfifo_push( uint8_t data );
 	void tfifo_terminate( );
 	TIMER_CALLBACK_MEMBER(tfifo_cb);
+	TIMER_CALLBACK_MEMBER(wire_feed);   /* next byte of a frame off the line */
 	void tfifo_clear( );
 
 	void rfifo_push( uint8_t d );

--- a/src/devices/machine/mc6854.h
+++ b/src/devices/machine/mc6854.h
@@ -117,9 +117,6 @@ private:
 	/* frame-based interface*/
 	uint8_t  m_frame[MAX_FRAME_LENGTH];
 	uint32_t m_flen, m_fpos;
-	uint32_t m_stall_fpos;  /* drain progress marker: detects a receiver stalled mid-frame */
-	uint32_t m_stall_count; /* offers seen with no progress (kept for the log) */
-	attotime m_stall_since; /* when the drain last made progress */
 
 
 	/* meaning of tstate / rtate:


### PR DESCRIPTION
### How this was found

Emulating the Ericsson Alfaskop System 41, a 1983 Swedish terminal cluster in
which three Motorola 6800 machines (display unit, communication processor and
8 inch flexible disk unit) share a 300 kbit/s synchronous two-wire bus. Every
one of them moves whole frames and disk sectors by DMA, which is a combination
these devices had not been exercised with before: the driver in tree only ever
reached the point where the display unit asks for its operating system.

With the fixes the cluster boots all three processors, loads its operating
system from the diskette over the bus, comes up as an IBM 3278 terminal and
reaches its service console.

### Verification

Frames now arrive complete instead of one byte at a time, and end of frame
raises the interrupt the firmware waits for. Exercised continuously by the
cluster's bus traffic (poll, answer to poll, connect, data) for the whole
boot and afterwards. The stall detector was checked against the case it
exists for: a long frame addressed to another station on the shared pair.


### AI assistance

Written with Claude Opus 5 (model claude-opus-5, Anthropic) through Claude Code.
