### PR TITLE
mc6846: CP2 latches an interrupt edge only when it is an input

### DIFF
--- a/src/devices/machine/mc6846.cpp
+++ b/src/devices/machine/mc6846.cpp
@@ -506,7 +506,9 @@ void mc6846_device::set_input_cp2(int data)
 		return;
 	m_cp2 = data;
 	LOG( "%f: mc6846 input CP2 set to %i\n", machine().time().as_double(), data );
-	if (m_pcr & 0x20)
+	/* PCR bit 5 = 0 selects CP2 as an interrupt INPUT (bit 5 = 1 makes it an
+	   output); the edge flag can only latch in input mode */
+	if (!(m_pcr & 0x20))
 	{
 		if (( data &&  (m_pcr & 0x10)) || (!data && !(m_pcr & 0x10)))
 		{


### PR DESCRIPTION
### How this was found

Emulating the Ericsson Alfaskop System 41, a 1983 Swedish terminal cluster in
which three Motorola 6800 machines (display unit, communication processor and
8 inch flexible disk unit) share a 300 kbit/s synchronous two-wire bus. Every
one of them moves whole frames and disk sectors by DMA, which is a combination
these devices had not been exercised with before: the driver in tree only ever
reached the point where the display unit asks for its operating system.

With the fixes the cluster boots all three processors, loads its operating
system from the diskette over the bus, comes up as an IBM 3278 terminal and
reaches its service console.

### Verification

One line. The keyboard unit of this system is a 6802 plus a 6846 and takes
its serial start-bit edge on CP2; with the test inverted the edge was never
latched.