### PR TITLE
chdman: fix session parsing (PR #15886)

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -902,6 +902,9 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 	std::string metadata;
 	std::error_condition err;
 	uint32_t sessionnum = 1;
+	uint32_t sessionindex = 0;
+	uint32_t lastmetaindex = 0;
+	uint32_t metaindex = 0;
 
 	/* clear structures */
 	memset(&toc, 0, sizeof(toc));
@@ -923,19 +926,23 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 		std::fill(std::begin(pgsub), std::end(pgsub), 0);
 
 		// fetch the session metadata first
-		if (!chd->read_metadata(CDROM_SESSION_METADATA_TAG, toc.numtrks, metadata))
+		if (!chd->read_metadata(CDROM_SESSION_METADATA_TAG, sessionindex, metadata, metaindex))
 		{
-			if (sscanf(metadata.c_str(), CDROM_SESSION_METADATA_FORMAT, &sessionnum) != 1)
-				return chd_file::error::INVALID_DATA;
-		}	
+			if (metaindex-lastmetaindex <= 1) // the session is updated only when the metadata is next in line
+			{
+				if (sscanf(metadata.c_str(), CDROM_SESSION_METADATA_FORMAT, &sessionnum) != 1)
+					return chd_file::error::INVALID_DATA;
+				sessionindex++;
+			}
+		}
 
 		// fetch the metadata for this track
-		if (!chd->read_metadata(CDROM_TRACK_METADATA_TAG, toc.numtrks, metadata))
+		if (!chd->read_metadata(CDROM_TRACK_METADATA_TAG, toc.numtrks, metadata, metaindex))
 		{
 			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA_FORMAT, &tracknum, type, subtype, &frames) != 4)
 				return chd_file::error::INVALID_DATA;
 		}
-		else if (!chd->read_metadata(CDROM_TRACK_METADATA2_TAG, toc.numtrks, metadata))
+		else if (!chd->read_metadata(CDROM_TRACK_METADATA2_TAG, toc.numtrks, metadata, metaindex))
 		{
 			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA2_FORMAT, &tracknum, type, subtype, &frames, &pregap, pgtype, pgsub, &postgap) != 8)
 				return chd_file::error::INVALID_DATA;
@@ -943,11 +950,11 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 		else
 		{
 			// fall through to GD-ROM detection
-			err = chd->read_metadata(GDROM_OLD_METADATA_TAG, toc.numtrks, metadata);
+			err = chd->read_metadata(GDROM_OLD_METADATA_TAG, toc.numtrks, metadata, metaindex);
 			if (!err)
 				toc.flags |= CD_FLAG_GDROMLE; // legacy GDROM track was detected
 			else
-				err = chd->read_metadata(GDROM_TRACK_METADATA_TAG, toc.numtrks, metadata);
+				err = chd->read_metadata(GDROM_TRACK_METADATA_TAG, toc.numtrks, metadata, metaindex);
 
 			if (err)
 				break;
@@ -1000,6 +1007,7 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 
 		/* set the postgap info */
 		track->postgap = postgap;
+		lastmetaindex = metaindex; 
 	}
 
 	toc.numsessions = sessionnum;
@@ -1102,7 +1110,7 @@ std::error_condition cdrom_file::write_metadata(chd_file *chd, const toc &toc)
 		if (toc.numsessions > 1 && sessionnum != toc.tracks[i].session)
 		{
 			metadata = util::string_format(CDROM_SESSION_METADATA_FORMAT, toc.tracks[i].session+1);
-			err = chd->write_metadata(CDROM_SESSION_METADATA_TAG, i, metadata);
+			err = chd->write_metadata(CDROM_SESSION_METADATA_TAG, toc.tracks[i].session, metadata);
 	
 			if (err)
 				return err;

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -107,6 +107,7 @@ enum
 // description of where a metadata entry lives within the file
 struct chd_file::metadata_entry
 {
+	uint32_t                index;			// index of the metadata
 	uint64_t                offset;         // offset within the file of the header
 	uint64_t                next;           // offset within the file of the next header
 	uint64_t                prev;           // offset within the file of the previous header
@@ -1411,11 +1412,36 @@ std::error_condition chd_file::write_bytes(uint64_t offset, const void *buffer, 
 
 std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output)
 {
+	uint32_t index = 0;
+	return read_metadata(searchtag,searchindex, output, index);
+}
+
+/**
+ * @fn  std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output)
+ *
+ * @brief   -------------------------------------------------
+ *            read_metadata - read the indexed metadata of the given type
+ *          -------------------------------------------------.
+ *
+ * @exception   CHDERR_METADATA_NOT_FOUND   Thrown when a chderr metadata not found error
+ *                                          condition occurs.
+ *
+ * @param   searchtag       The searchtag.
+ * @param   searchindex     The searchindex.
+ * @param [in,out]  output  The output.
+ * @param [in,out]  index   The index of the metadata.
+ *
+ * @return  An error condition.
+ */
+
+std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag,uint32_t searchindex,std::string &output,uint32_t &index)
+{
 	// if we didn't find it, just return
 	metadata_entry metaentry;
 	if (std::error_condition err = metadata_find(searchtag, searchindex, metaentry))
 		return err;
 
+	index = metaentry.index;
 	// read the metadata
 	try { output.assign(metaentry.length, '\0'); }
 	catch (std::bad_alloc const &) { return std::errc::not_enough_memory; }
@@ -2813,6 +2839,7 @@ std::error_condition chd_file::metadata_find(chd_metadata_tag metatag, int32_t m
 	{
 		metaentry.offset = m_metaoffset;
 		metaentry.prev = 0;
+		metaentry.index = 0;
 	}
 	else
 	{
@@ -2841,6 +2868,7 @@ std::error_condition chd_file::metadata_find(chd_metadata_tag metatag, int32_t m
 				return std::error_condition();
 
 		// no match, fetch the next link
+		metaentry.index++;
 		metaentry.prev = metaentry.offset;
 		metaentry.offset = metaentry.next;
 	}

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -1417,7 +1417,7 @@ std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_
 }
 
 /**
- * @fn  std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output)
+ * @fn  std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output, uint32_t &index)
  *
  * @brief   -------------------------------------------------
  *            read_metadata - read the indexed metadata of the given type
@@ -1434,7 +1434,7 @@ std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_
  * @return  An error condition.
  */
 
-std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag,uint32_t searchindex,std::string &output,uint32_t &index)
+std::error_condition chd_file::read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output, uint32_t &index)
 {
 	// if we didn't find it, just return
 	metadata_entry metaentry;

--- a/src/lib/util/chd.h
+++ b/src/lib/util/chd.h
@@ -346,6 +346,7 @@ public:
 
 	// metadata management
 	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output);
+	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::string &output, uint32_t &index);
 	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::vector<uint8_t> &output);
 	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, void *output, uint32_t outputlen, uint32_t &resultlen);
 	std::error_condition read_metadata(chd_metadata_tag searchtag, uint32_t searchindex, std::vector<uint8_t> &output, chd_metadata_tag &resulttag, uint8_t &resultflags);


### PR DESCRIPTION
I identified an **issue** in my previous PR (https://github.com/mamedev/mame/pull/15886).

`read_metadata` works differently than I originally thought. The individual metadata entries do not store an index; instead, the read function 'groups' the metadata by metadata tag and returns this index.

I do not want to change this core logic, but the absolute index is required to determine the order. I have therefore extended the `read_metadata` function to include the absolute meta-index.

You could also include the track in the session metadata, but I think the metadata order is sufficient.

Is this solution acceptable, or is there a better approach?