### PR TITLE
osd/modules/debugger/debuggdbstub.cpp: answer qOffsets so symbol files load unrelocated

### DIFF
--- a/src/osd/modules/debugger/debuggdbstub.cpp
+++ b/src/osd/modules/debugger/debuggdbstub.cpp
@@ -1330,8 +1330,13 @@ debug_gdbstub::cmd_reply debug_gdbstub::handle_q(const char *buf)
 	if ( name == "Supported" )
 	{
 		std::string reply = string_format("PacketSize=%x", MAX_PACKET_SIZE);
-		reply += ";qXfer:features:read+";
+		reply += ";qXfer:features:read+;qOffsets+";
 		send_reply(reply);
+		return REPLY_NONE;
+	}
+	else if ( name == "Offsets" )
+	{
+		send_reply("Text=0;Data=0;Bss=0");
 		return REPLY_NONE;
 	}
 	else if ( name == "Xfer" )


### PR DESCRIPTION
GDB asks for the section offsets of the running target when a symbol file is loaded; without an answer it applies its default relocation and symbol addresses stop matching the emulated address space.  The CPU address space is not relocated, so reply with all-zero offsets: a symbol file linked at its runtime addresses and loaded with "file"/"add-symbol-file" is used as-is.

assisted: GLM-5.1

Example (Z80, symbol file linked at its runtime addresses):

    (gdb) file boot.elf
    (gdb) target remote 127.0.0.1:12000
    0x00000000 in ?? ()
    (gdb) break boot_continue
    Breakpoint 1 at 0x69