### PR TITLE
scc68070: Fix UART Status

### DIFF
--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -658,12 +658,23 @@ void scc68070_device::uart_ctsn(int state)
 
 void scc68070_device::uart_rx(uint8_t data)
 {
+	if (m_uart.receive_pointer >= int16_t(std::size(m_uart.receive_buffer) - 1))
+	{
+		LOGMASKED(LOG_UART, "%s: uart_rx: receiver overrun, discarding %02x\n", machine().describe_context(), data);
+		m_uart.status_register |= USR_OE;
+		return;
+	}
 	m_uart.receive_pointer++;
 	m_uart.receive_buffer[m_uart.receive_pointer] = data;
 }
 
 void scc68070_device::uart_tx(uint8_t data)
 {
+	if (m_uart.transmit_pointer >= int16_t(std::size(m_uart.transmit_buffer) - 1))
+	{
+		LOGMASKED(LOG_UART, "%s: uart_tx: transmit buffer full, discarding %02x\n", machine().describe_context(), data);
+		return;
+	}
 	m_uart.transmit_pointer++;
 	m_uart.transmit_buffer[m_uart.transmit_pointer] = data;
 	m_uart.status_register &= ~USR_TXEMT;
@@ -706,35 +717,36 @@ TIMER_CALLBACK_MEMBER(scc68070_device::rx_callback)
 
 TIMER_CALLBACK_MEMBER(scc68070_device::tx_callback)
 {
-	if (((m_uart.command_register >> 2) & 3) == 1)
+	if (((m_uart.command_register >> 2) & 3) != 1)
 	{
-		m_uart.status_register |= USR_TXRDY;
+		return;
+	}
 
+	if (m_uart.transmit_pointer > -1)
+	{
+		if (m_uart.transmit_ctsn && BIT(m_uart.mode_register, 4))
+		{
+			return;
+		}
+
+		m_uart.transmit_holding_register = m_uart.transmit_buffer[0];
+		m_uart_tx_callback(m_uart.transmit_holding_register);
+
+		LOGMASKED(LOG_MORE_UART, "tx_callback: Transmitting %02x\n", m_uart.transmit_holding_register);
+		for(int index = 0; index < m_uart.transmit_pointer; index++)
+		{
+			m_uart.transmit_buffer[index] = m_uart.transmit_buffer[index+1];
+		}
+		m_uart.transmit_pointer--;
+
+		m_uart.status_register |= USR_TXRDY;
 		m_uart_tx_int = true;
 		update_ipl();
+	}
 
-		if (m_uart.transmit_pointer > -1)
-		{
-			if (m_uart.transmit_ctsn && BIT(m_uart.mode_register, 4))
-			{
-				return;
-			}
-
-			m_uart.transmit_holding_register = m_uart.transmit_buffer[0];
-			m_uart_tx_callback(m_uart.transmit_holding_register);
-
-			LOGMASKED(LOG_MORE_UART, "tx_callback: Transmitting %02x\n", m_uart.transmit_holding_register);
-			for(int index = 0; index < m_uart.transmit_pointer; index++)
-			{
-				m_uart.transmit_buffer[index] = m_uart.transmit_buffer[index+1];
-			}
-			m_uart.transmit_pointer--;
-		}
-
-		if (m_uart.transmit_pointer < 0)
-		{
-			m_uart.status_register |= USR_TXEMT;
-		}
+	if (m_uart.transmit_pointer < 0)
+	{
+		m_uart.status_register |= USR_TXEMT | USR_TXRDY;
 	}
 }
 
@@ -1387,13 +1399,13 @@ void scc68070_device::ucr_w(uint8_t data)
 	case 0x3: // Reset transmitter
 		LOGMASKED(LOG_MORE_UART, "%s: Reset transmitter\n", machine().describe_context());
 		m_uart.transmit_pointer = -1;
-		m_uart.status_register |= USR_TXEMT;
+		m_uart.status_register |= USR_TXEMT | USR_TXRDY;
 		m_uart.command_register &= 0xf0;
 		m_uart.transmit_holding_register = 0x00;
 		break;
 	case 0x4: // Reset error status
 		LOGMASKED(LOG_MORE_UART, "%s: Reset error status\n", machine().describe_context());
-		m_uart.status_register &= 0x87; // Clear error bits in USR
+		m_uart.status_register &= ~(USR_RB | USR_FE | USR_PE | USR_OE); // Clear error bits in USR
 		m_uart.command_register &= 0xf0;
 		break;
 	case 0x6: // Start break
@@ -1418,6 +1430,7 @@ void scc68070_device::uth_w(uint8_t data)
 	LOGMASKED(LOG_MORE_UART, "%s: UART Transmit Holding Register Write: %02x ('%c')\n", machine().describe_context(), data, (data >= 0x20 && data < 0x7f) ? data : ' ');
 	uart_tx(data);
 	m_uart.transmit_holding_register = data;
+	m_uart.status_register &= ~USR_TXRDY;
 }
 
 uint8_t scc68070_device::urh_r()


### PR DESCRIPTION
This change fixes several issues in the UART for this device. This has the effect of resolving some errors in the CD-i bios tests.

Previously, UART would flag as Ready on every callback. Now it won't identify as ready while a transmission is currently queued.

It would also preserve the Break flag on reset. This change correctly resets the Break flag.

Finally, this unsets Ready when transmitting a write.

Citation: https://frank.pocnet.net/other/sos/Philips_68070.pdf page 49 (53 of the PDF)