### PR TITLE
machine/z80scc, machine/z8536: fixes for interrupt-driven serial on a Z8000 daisy chain

### DIFF
--- a/src/devices/machine/z80scc.cpp
+++ b/src/devices/machine/z80scc.cpp
@@ -2508,6 +2508,12 @@ void z80scc_channel::data_write(uint8_t data)
 
 	check_dma_request();
 
+	/* A character has just been loaded into the transmit buffer, so a preceding
+	   "Reset Tx Int Pending" command no longer applies: that command only suppresses
+	   transmit interrupts "until after the next character has been loaded into the
+	   transmit buffer". */
+	m_tx_int_disarm = 0;
+
 	/* Transmitter enabled?  */
 	if (m_wr5 & WR5_TX_ENABLE)
 	{

--- a/src/devices/machine/z8536.cpp
+++ b/src/devices/machine/z8536.cpp
@@ -1021,6 +1021,7 @@ void cio_base_device::device_start()
 	m_timer->adjust(attotime::from_hz(clock() / 2), 0, attotime::from_hz(clock() / 2));
 
 	save_item(NAME(m_irq));
+	save_item(NAME(m_ius_level));
 	save_item(NAME(m_register));
 	save_item(NAME(m_input));
 	save_item(NAME(m_output));

--- a/src/devices/machine/z8536.cpp
+++ b/src/devices/machine/z8536.cpp
@@ -247,10 +247,14 @@ void cio_base_device::check_interrupt()
 		state = ASSERT_LINE;
 	}
 
-	if (m_irq != state)
+	// The under-service level gates everything further down the daisy chain, so a
+	// change there has to be published even when our own request line does not move.
+	if (m_irq != state || m_ius_level != ius_level)
 	{
-		LOG("%s CIO Interrupt: %u\n", machine().describe_context(), state);
+		if (m_irq != state)
+			LOG("%s CIO Interrupt: %u\n", machine().describe_context(), state);
 		m_irq = state;
+		m_ius_level = ius_level;
 		m_write_irq(state);
 	}
 }
@@ -971,7 +975,7 @@ cio_base_device::cio_base_device(const machine_config &mconfig, device_type type
 	m_write_pb(*this),
 	m_read_pc(*this, 0),
 	m_write_pc(*this),
-	m_irq(CLEAR_LINE)
+	m_irq(CLEAR_LINE), m_ius_level(-1)
 {
 }
 

--- a/src/devices/machine/z8536.h
+++ b/src/devices/machine/z8536.h
@@ -411,6 +411,7 @@ protected:
 
 	// interrupt state
 	int m_irq;
+	int m_ius_level;    // interrupt under service level, gates the daisy chain
 
 	// register state
 	u8 m_register[48];


### PR DESCRIPTION
Two device fixes found while getting the Zilog System 8000 (`s8000s2`) to run ZEUS 3.21
off an emulated disk. With both applied the machine reaches its shell and the serial
console keeps up at full speed; without them the console falls silent after a few
characters, and it looks intermittent because it depends on timing.

### machine/z80scc.cpp: re-arm the transmit interrupt when a character is loaded

`m_tx_int_disarm` belongs to the "Reset Tx Int Pending" command (WR0 = 101), which
suppresses transmit interrupts *"until after the next character has been loaded into
the transmit buffer"*. The flag was only cleared at the end of the following
`tra_complete()`, so the transmit-buffer-empty interrupt raised for that very character
was swallowed. A driver that writes the next character from its interrupt handler
therefore stopped after one byte, whenever a write happened to land while the shift
register was still busy.

The ZEUS tty driver does exactly that: its handler ends with `WR0 = 0x28` when it has
nothing more to send, and relies on the next character re-arming the interrupt.

### machine/z8536.cpp: publish changes of the interrupt under service level

While one of its sources has IUS set, the CIO returns `Z80_DAISY_IEO`, which blocks
every device further down the daisy chain. The interrupt callback was only invoked when
the CIO's own request line changed, so when software cleared IUS nothing told the chain
that the devices behind it were eligible again, and their pending interrupts were never
serviced.

On the System 8000 the CIO is the clock and sits ahead of the SCC, so the SCC was
serviced 17 times per run instead of 268.

### Testing

Both were measured on `s8000s2` by toggling each fix on and off separately: with either
one missing the console stalls, with both present five consecutive boots reach the shell
and answer commands. The changes were developed and tested on 0.289 and rebased here;
the surrounding code is unchanged in the touched hunks.
