### PR TITLE
scc68070: Cleanup Reset

### DIFF
--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -355,10 +355,9 @@ void scc68070_device::device_start()
 //  device_reset - device-specific reset
 //-------------------------------------------------
 
-void scc68070_device::device_reset()
-{
-	scc68070_base_device::device_reset();
 
+void scc68070_device::reset_peripheral_state()
+{
 	m_lir = 0;
 
 	m_picr1 = 0;
@@ -420,11 +419,19 @@ void scc68070_device::device_reset()
 		m_mmu.desc[index].base = 0;
 	}
 
-	update_ipl();
-
 	m_uart.rx_timer->adjust(attotime::never);
 	m_uart.tx_timer->adjust(attotime::never);
+	m_i2c.timer->adjust(attotime::never);
+
 	set_timer_callback(0);
+	update_ipl();
+}
+
+void scc68070_device::device_reset()
+{
+	scc68070_base_device::device_reset();
+
+	reset_peripheral_state();
 }
 
 
@@ -439,43 +446,7 @@ void scc68070_device::device_config_complete()
 void scc68070_device::reset_peripherals(int state)
 {
 	if (state)
-	{
-		m_lir = 0;
-
-		m_picr1 = 0;
-		m_picr2 = 0;
-		m_timer_int = false;
-		m_i2c_int = false;
-		m_uart_rx_int = false;
-		m_uart_tx_int = false;
-
-		m_i2c.status_register = ISR_PIN;
-		m_i2c.control_register = 0;
-		m_i2c.clock_control_register = 0;
-		m_i2c.scl_out_state = true;
-		m_i2c.scl_in_state = true;
-		m_i2c.sda_out_state = true;
-		m_i2c.state = I2C_IDLE;
-		m_i2c.clock_change_state = I2C_SCL_IDLE;
-		m_i2c.clocks = 0;
-		m_uart.command_register = 0;
-		m_uart.receive_pointer = -1;
-		m_uart.transmit_pointer = -1;
-
-		m_uart.mode_register = 0;
-		m_uart.status_register = USR_TXRDY;
-		m_uart.clock_select = 0;
-
-		m_timers.timer_status_register = 0;
-		m_timers.timer_control_register = 0;
-
-		m_uart.rx_timer->adjust(attotime::never);
-		m_uart.tx_timer->adjust(attotime::never);
-		m_timers.timer0_timer->adjust(attotime::never);
-		m_i2c.timer->adjust(attotime::never);
-
-		update_ipl();
-	}
+		reset_peripheral_state();
 }
 
 void scc68070_device::update_ipl()

--- a/src/devices/machine/scc68070.h
+++ b/src/devices/machine/scc68070.h
@@ -203,6 +203,7 @@ private:
 	void internal_map(address_map &map) ATTR_COLD;
 	void cpu_space_map(address_map &map) ATTR_COLD;
 
+	void reset_peripheral_state() ATTR_COLD;
 	void reset_peripherals(int state);
 
 	void update_ipl();

--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -105,8 +105,8 @@ void cdi_state::cdimono1_mem(address_map &map)
 
 void cdi_state::cdimono2_mem(address_map &map)
 {
-	map(0x000000, 0x07ffff).ram().share("plane0");
-	map(0x200000, 0x27ffff).ram().share("plane1");
+	map(0x000000, 0x07ffff).rw(FUNC(cdi_state::plane_r<0>), FUNC(cdi_state::plane_w<0>)).share("plane0");
+	map(0x200000, 0x27ffff).rw(FUNC(cdi_state::plane_r<1>), FUNC(cdi_state::plane_w<1>)).share("plane1");
 #if ENABLE_UART_PRINTING
 	map(0x301400, 0x301403).r(m_maincpu, FUNC(scc68070_device::uart_loopback_enable));
 #endif


### PR DESCRIPTION
The reset function has duplicated code and is slightly out of sync. This merge corrects a few mismatches. This likely impacts no games.

Also adds RAM time to the cdimono2.