### PR TITLE
scc68070: Fix i2c Mismatch

### DIFF
--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -609,7 +609,7 @@ uint8_t scc68070_device::iack_r(offs_t offset)
 			m_uart_tx_int = false;
 			update_ipl();
 		}
-		else if (m_i2c_int && offset == ((m_picr2 >> 4) & 7))
+		else if (m_i2c_int && offset == ((m_picr1 >> 4) & 7))
 		{
 			m_i2c_int = false;
 			update_ipl();


### PR DESCRIPTION
The corrects a mismatch in the assigned bits for the i2c status. The bits in line 612 don't match line 492 where i2c level is reset. It seems to have been copying the m_uart_rx_int value due to a typo.