### PR TITLE
bus/wangpc: add the IBM PC Emulation Option to the video card

### DIFF
--- a/src/devices/bus/wangpc/mvc.cpp
+++ b/src/devices/bus/wangpc/mvc.cpp
@@ -13,6 +13,27 @@
     - character clock
     - blink
 
+    The IBM PC Emulation Option is a daughter board carried by this card and
+    is driven through the card's own I/O block.  What is modelled here was
+    reverse engineered from LOADIBM.EXE of the Wang "IBM PC Emulation Option"
+    software, version 2.11 (1986), which probes it like this:
+
+    - write 0x00 to +0x10/+0x12 (video option register), then read +0x50 and
+      require the low nibble to be clear to accept the card
+    - read +0x20: bit 2 set means the monochrome emulation option is fitted,
+      bit 3 set means the board provides the display itself (when clear the
+      software goes looking for a TIG card to drive the high resolution
+      monitor)
+    - write 0x04 to +0x20 and 0x01 to +0xfa to switch the option memory in,
+      then size it by probing at 0xf4000: boards that answer there carry 32K
+      at 0xf4000-0xfbfff, the others 16K at 0xf8000-0xfbfff
+
+    The emulation board of the separate "emulator card" (option ID 0x16) is
+    driven the same way but answers at 0xc0000 and takes 0xc5 in +0xfa.
+
+    Note that the host memory map has to extend past 0xf3fff for this window
+    to be reachable at all.
+
 */
 
 #include "emu.h"
@@ -36,9 +57,19 @@
 #define VIDEO_RAM_SIZE      0x800
 #define CHAR_RAM_SIZE       0x1000
 #define BITMAP_RAM_SIZE     0x4000
+#define IBM_RAM_SIZE        0x4000
 
 #define OPTION_VRAM         BIT(m_option, 0)
 #define OPTION_VSYNC        BIT(m_option, 3)
+
+#define IBM_OPTION_INSTALLED    (m_sw->read() & 0x03)
+#define IBM_OPTION_32K          BIT(m_sw->read(), 1)
+#define IBM_OPTION_STANDALONE   BIT(m_sw->read(), 2)
+
+// bit 2 of the option register switches the memory window in, bit 0 is set
+// only once the emulated IBM software has taken the display over: the Wang
+// software draws its own panels with the window already enabled
+#define IBM_DISPLAY_MODE        (ibm_ram_enabled() && BIT(m_ibm_option, 0))
 
 #define ATTR_BLINK          BIT(attr, 0)
 #define ATTR_REVERSE        BIT(attr, 1)
@@ -90,7 +121,13 @@ MC6845_UPDATE_ROW( wangpc_mvc_device::crtc_update_row )
 	for (int column = 0; column < x_count; column++)
 	{
 		uint16_t const code = m_video_ram[((ma + column) & 0x7ff)];
-		uint8_t const attr = code & 0xff;
+		uint8_t attr = code & 0xff;
+
+		// with the IBM PC emulation option driving the display, the attribute
+		// byte is the one the emulated software wrote and follows the
+		// monochrome adapter meaning, not the Wang one
+		if (IBM_DISPLAY_MODE)
+			attr = ibm_attribute(attr);
 
 		uint8_t new_ra = ra + 1;
 
@@ -157,6 +194,35 @@ void wangpc_mvc_device::device_add_mconfig(machine_config &config)
 
 
 
+//-------------------------------------------------
+//  INPUT_PORTS( wangpc_mvc )
+//-------------------------------------------------
+
+static INPUT_PORTS_START( wangpc_mvc )
+	PORT_START("SW")
+	PORT_CONFNAME( 0x07, 0x00, "IBM PC Emulation Option" )
+	PORT_CONFSETTING(    0x00, DEF_STR( None ) )
+	PORT_CONFSETTING(    0x01, "Monochrome (16K)" )
+	PORT_CONFSETTING(    0x03, "Monochrome (32K)" )
+	// the settings above make the software look for a TIG card in the next
+	// slot to put the emulated display on; these declare that the board
+	// drives the display itself, which is what this implementation does
+	PORT_CONFSETTING(    0x05, "Monochrome (16K), self-contained" )
+	PORT_CONFSETTING(    0x07, "Monochrome (32K), self-contained" )
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor wangpc_mvc_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( wangpc_mvc );
+}
+
+
+
 //**************************************************************************
 //  INLINE HELPERS
 //**************************************************************************
@@ -170,6 +236,52 @@ inline void wangpc_mvc_device::set_irq(int state)
 	m_irq = state;
 
 	m_bus->irq3_w(m_irq);
+}
+
+
+//-------------------------------------------------
+//  ibm_ram_enabled - is the IBM PC emulation
+//  option memory window turned on?
+//-------------------------------------------------
+
+inline bool wangpc_mvc_device::ibm_ram_enabled() const
+{
+	return IBM_OPTION_INSTALLED && BIT(m_ibm_option, 2) && BIT(m_ibm_enable, 0);
+}
+
+
+//-------------------------------------------------
+//  ibm_ram_base - start of the option memory
+//  window (32K boards decode 16K lower)
+//-------------------------------------------------
+
+inline offs_t wangpc_mvc_device::ibm_ram_base() const
+{
+	return IBM_OPTION_32K ? 0xf4000 : 0xf8000;
+}
+
+
+//-------------------------------------------------
+//  ibm_attribute - translate an IBM monochrome
+//  adapter attribute into the Wang one
+//-------------------------------------------------
+
+inline uint8_t wangpc_mvc_device::ibm_attribute(uint8_t attr) const
+{
+	uint8_t result = 0;
+
+	if (BIT(attr, 7))                       // blink
+		result |= 0x01;
+	if ((attr & 0x77) == 0x70)              // reverse video
+		result |= 0x02;
+	if ((attr & 0x77) == 0x00)              // non display
+		result |= 0x04;
+	if (BIT(attr, 3))                       // high intensity
+		result |= 0x08;
+	if ((attr & 0x07) == 0x01)              // underline
+		result |= 0x20;
+
+	return result;
 }
 
 
@@ -189,7 +301,11 @@ wangpc_mvc_device::wangpc_mvc_device(const machine_config &mconfig, const char *
 	m_video_ram(*this, "video_ram", VIDEO_RAM_SIZE*2, ENDIANNESS_LITTLE),
 	m_char_ram(*this, "char_ram", CHAR_RAM_SIZE*2, ENDIANNESS_LITTLE),
 	m_bitmap_ram(*this, "bitmap_ram", BITMAP_RAM_SIZE*2, ENDIANNESS_LITTLE),
+	m_ibm_ram(*this, "ibm_ram", IBM_RAM_SIZE*2, ENDIANNESS_LITTLE),
+	m_sw(*this, "SW"),
 	m_option(0),
+	m_ibm_option(0),
+	m_ibm_enable(0),
 	m_irq(CLEAR_LINE)
 {
 }
@@ -203,6 +319,8 @@ void wangpc_mvc_device::device_start()
 {
 	// state saving
 	save_item(NAME(m_option));
+	save_item(NAME(m_ibm_option));
+	save_item(NAME(m_ibm_enable));
 	save_item(NAME(m_irq));
 }
 
@@ -214,6 +332,8 @@ void wangpc_mvc_device::device_start()
 void wangpc_mvc_device::device_reset()
 {
 	m_option = 0;
+	m_ibm_option = 0;
+	m_ibm_enable = 0;
 
 	set_irq(CLEAR_LINE);
 }
@@ -243,6 +363,20 @@ uint16_t wangpc_mvc_device::wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask)
 		}
 	}
 
+	if (ibm_ram_enabled())
+	{
+		if (offset >= ibm_ram_base()/2 && offset < 0xfc000/2)
+		{
+			data = m_ibm_ram[offset - ibm_ram_base()/2];
+		}
+		else if (offset >= 0xb0000/2 && offset < 0xb1000/2)
+		{
+			// the character memory also answers where an IBM monochrome
+			// adapter would be, with the character in the low byte
+			data = swapendian_int16(m_video_ram[offset & 0x7ff]);
+		}
+	}
+
 	return data;
 }
 
@@ -268,6 +402,27 @@ void wangpc_mvc_device::wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint1
 			m_char_ram[offset & 0xfff] = data;
 		}
 	}
+
+	if (ibm_ram_enabled())
+	{
+		if (offset >= ibm_ram_base()/2 && offset < 0xfc000/2)
+		{
+			// the option memory takes byte writes: DOS loads the emulation
+			// ROM image into it a byte at a time
+			COMBINE_DATA(&m_ibm_ram[offset - ibm_ram_base()/2]);
+		}
+		else if (offset >= 0xb0000/2 && offset < 0xb1000/2)
+		{
+			// see wangpcbus_mrdc_r: the emulated IBM software writes the
+			// character in the low byte, the Wang card keeps it in the high
+			// one, so the bytes swap on the way through
+			uint16_t const swapped = swapendian_int16(data);
+			uint16_t const swapped_mask = swapendian_int16(mem_mask);
+			offs_t const addr = offset & 0x7ff;
+
+			m_video_ram[addr] = (swapped & swapped_mask) | (m_video_ram[addr] & ~swapped_mask);
+		}
+	}
 }
 
 
@@ -283,6 +438,18 @@ uint16_t wangpc_mvc_device::wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask)
 	{
 		switch (offset & 0x7f)
 		{
+		case 0x20/2:
+			// bit 2 reports the IBM PC emulation option, bit 3 that the board
+			// drives the display itself instead of needing a TIG card
+			data = 0xff00 | (IBM_OPTION_INSTALLED ? 0x04 : 0x00) | (IBM_OPTION_STANDALONE ? 0x08 : 0x00);
+			break;
+
+		case 0x50/2:
+			// the low nibble has to read back clear for the emulation
+			// software to accept the card
+			data = 0xff00;
+			break;
+
 		case 0xfe/2:
 			data = 0xff00 | (m_irq << 7) | OPTION_ID;
 
@@ -318,6 +485,18 @@ void wangpc_mvc_device::wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint
 			if (LOG) logerror("MVC option %02x\n", data & 0xff);
 
 			m_option = data & 0xff;
+			break;
+
+		case 0x20/2:
+			if (LOG) logerror("MVC IBM option %02x\n", data & 0xff);
+
+			m_ibm_option = data & 0xff;
+			break;
+
+		case 0xfa/2:
+			if (LOG) logerror("MVC IBM enable %02x\n", data & 0xff);
+
+			m_ibm_enable = data & 0xff;
 			break;
 		}
 	}

--- a/src/devices/bus/wangpc/mvc.h
+++ b/src/devices/bus/wangpc/mvc.h
@@ -34,6 +34,7 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
 
 	// device_wangpcbus_card_interface overrides
 	virtual uint16_t wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask) override;
@@ -47,12 +48,20 @@ private:
 
 	inline void set_irq(int state);
 
+	inline bool ibm_ram_enabled() const;
+	inline offs_t ibm_ram_base() const;
+	inline uint8_t ibm_attribute(uint8_t attr) const;
+
 	required_device<mc6845_device> m_crtc;
 	memory_share_creator<uint16_t> m_video_ram;
 	memory_share_creator<uint16_t> m_char_ram;
 	memory_share_creator<uint16_t> m_bitmap_ram;
+	memory_share_creator<uint16_t> m_ibm_ram;
+	required_ioport m_sw;
 
 	uint8_t m_option;
+	uint8_t m_ibm_option;
+	uint8_t m_ibm_enable;
 	int m_irq;
 };
 

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -724,7 +724,8 @@ void wangpc_state::wangpc_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x00000, 0x1ffff).ram();
-	map(0x20000, 0xf3fff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
+	// the IBM PC emulation option answers up to 0xfbfff, just below the BIOS
+	map(0x20000, 0xfbfff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
 	map(0xfc000, 0xfffff).rom().region(I8086_TAG, 0);
 }
 


### PR DESCRIPTION
The Wang PC ran IBM PC software through an emulation option: a loader,
LOADIBM, finds the option and hands control to an IBM PC BIOS work-alike.
The monochrome flavour of the option rides on the medium-resolution video
card, and this implements it: the option's 32K/16K memory window, the
enable registers the loader writes, and the translation from IBM
monochrome adapter attributes to the Wang ones so the emulated display
comes out right on the Wang monitor.

## Tested

- LOADIBM 2.11 detects the option, brings the emulation environment up on
  the video card's own screen, boots Leading Edge MS-DOS 2.11 to a working
  COMMAND.COM prompt.
- `-validate` clean.

## AI disclosure

This work was done with substantial assistance from Anthropic's Claude,
driven and reviewed by me throughout. Every claim above was verified by
running period software on the emulated machine.