### PR TITLE
wangpc: add the PC-PM007 IBM PC Color Emulation card

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -6366,6 +6366,8 @@ if BUSES["WANGPC"] then
 		MAME_DIR .. "src/devices/bus/wangpc/wangpc.cpp",
 		MAME_DIR .. "src/devices/bus/wangpc/wangpc.h",
 		MAME_DIR .. "src/devices/bus/wangpc/emb.cpp",
+		MAME_DIR .. "src/devices/bus/wangpc/ibmc.cpp",
+		MAME_DIR .. "src/devices/bus/wangpc/ibmc.h",
 		MAME_DIR .. "src/devices/bus/wangpc/emb.h",
 		MAME_DIR .. "src/devices/bus/wangpc/lic.cpp",
 		MAME_DIR .. "src/devices/bus/wangpc/lic.h",

--- a/src/devices/bus/wangpc/ibmc.cpp
+++ b/src/devices/bus/wangpc/ibmc.cpp
@@ -1,0 +1,428 @@
+// license:BSD-3-Clause
+// copyright-holders:Fausto Pracek
+/**********************************************************************
+
+    Wang PC-PM007 IBM PC Color Emulation Card
+
+    LOADIBM scans the bus for option ID 0x16 before anything else and,
+    when found, runs the colour emulation environment against this card.
+
+    Table 15-3 of the Technical Reference names 0x16 "IBM PC Color
+    Emulation", which is the PM007.  The character-only boards, PM101 and
+    PM008, answer 0x11 - the same code as the plain monochrome monitor
+    card - under the name "Wang/IBM Monochrome Emulation".
+
+    Memory map, established by tracing LOADIBM 2.11 and the running
+    emulation environment:
+
+    - 0xb8000-0xbbfff   16K of CGA-style video memory
+    - 0xbc000-0xbffff   character generator RAM: LOADIBM downloads the
+                        font from IBMFONTC.FNT here before the panel is
+                        shown, so the card needs no character ROM
+    - 0xc0000-0xc3fff   16K of RAM
+
+    The RAM window must not extend past 0xc4000: LOADIBM probes the word
+    right there ('TC') and picks its loading strategy on the result.  On
+    the real card the probe fails, which routes the loader to the INT
+    21h/4B03 overlay path - the colour firmware only ever shipped as
+    ROMBIOSC.EXE, there is no ROMBIOSC.BIN.
+
+    The firmware programs the card's own MC6845 at +0x00/+0x02 with the
+    standard 80-column CGA parameter set and writes text into the video
+    memory, IBM PC style: character in the even byte, attribute in the
+    odd byte.
+
+**********************************************************************/
+
+#include "emu.h"
+#include "ibmc.h"
+
+#include "screen.h"
+
+
+
+//**************************************************************************
+//  MACROS/CONSTANTS
+//**************************************************************************
+
+#define OPTION_ID               0x16
+
+#define OPTION_ID_ENABLED       0x17
+
+#define MC6845_TAG      "mc6845"
+#define SCREEN_TAG      "screen"
+
+#define RAM_SIZE        0x2000      // 8K words = 16K bytes: 0xc0000-0xc3fff
+
+#define RAM_BASE        (0xc0000/2)
+
+#define VIDEO_RAM_SIZE  0x2000      // 8K words = 16K bytes at 0xb8000
+
+#define CHAR_RAM_SIZE   0x2000      // 8K words = 16K bytes at 0xbc000
+
+// the standard CGA palette
+static const rgb_t PALETTE_IBMC[16] =
+{
+	rgb_t(0x00, 0x00, 0x00), rgb_t(0x00, 0x00, 0xaa),
+	rgb_t(0x00, 0xaa, 0x00), rgb_t(0x00, 0xaa, 0xaa),
+	rgb_t(0xaa, 0x00, 0x00), rgb_t(0xaa, 0x00, 0xaa),
+	rgb_t(0xaa, 0x55, 0x00), rgb_t(0xaa, 0xaa, 0xaa),
+	rgb_t(0x55, 0x55, 0x55), rgb_t(0x55, 0x55, 0xff),
+	rgb_t(0x55, 0xff, 0x55), rgb_t(0x55, 0xff, 0xff),
+	rgb_t(0xff, 0x55, 0x55), rgb_t(0xff, 0x55, 0xff),
+	rgb_t(0xff, 0xff, 0x55), rgb_t(0xff, 0xff, 0xff)
+};
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(WANGPC_IBMC, wangpc_ibmc_device, "wangpc_ibmc", "Wang PC-PM007 IBM PC Color Emulation Card")
+
+
+//-------------------------------------------------
+//  mc6845
+//-------------------------------------------------
+
+//-------------------------------------------------
+//  screen_update - the display is drawn from the
+//  video memory and the mode register alone.  The
+//  6845 is kept for the sync outputs the status
+//  register reports, but the screen geometry stays
+//  fixed: the emulated software reprograms the
+//  timings freely (Flight Simulator switches to
+//  one-line character rows) and following them
+//  would reshape the screen under MAME's feet.
+//-------------------------------------------------
+
+uint32_t wangpc_ibmc_device::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	bitmap.fill(rgb_t::black(), cliprect);
+
+	// bit 3 of the mode control register is video enable
+	if (!BIT(m_control, 3))
+		return 0;
+
+	if (BIT(m_control, 1))
+	{
+		// CGA graphics: two interleaved banks of 0x1000 words, even scan
+		// lines in the first, odd in the second
+		for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
+		{
+			if (y >= 200) break;
+			offs_t const base = ((y & 1) << 12) | ((y >> 1) * 40);
+			uint32_t *const dst = &bitmap.pix(y);
+
+			for (int column = 0; column < 40; column++)
+			{
+				uint16_t const data = m_video_ram[(base + column) & (VIDEO_RAM_SIZE - 1)];
+
+				if (BIT(m_control, 4))
+				{
+					// 640x200, one bit per pixel
+					rgb_t const fg = PALETTE_IBMC[m_color & 0x0f];
+
+					for (int bit = 0; bit < 16; bit++)
+						dst[(column * 16) + bit] = BIT(data, 7 - (bit & 7) + (bit & 8)) ? fg : rgb_t::black();
+				}
+				else
+				{
+					// 320x200, two bits per pixel, drawn double width
+					for (int pel = 0; pel < 8; pel++)
+					{
+						int const shift = 6 - ((pel & 3) << 1) + ((pel & 4) << 1);
+						int const pix = (data >> shift) & 3;
+
+						rgb_t color;
+						if (pix == 0)
+							color = PALETTE_IBMC[m_color & 0x0f];
+						else if (BIT(m_color, 5))
+							color = PALETTE_IBMC[(pix << 1) | 1 | ((m_color & 0x10) >> 1)];
+						else
+							color = PALETTE_IBMC[(pix << 1) | ((m_color & 0x10) >> 1)];
+
+						dst[(column * 16) + (pel * 2)] = color;
+						dst[(column * 16) + (pel * 2) + 1] = color;
+					}
+				}
+			}
+		}
+	}
+	else
+	{
+		// 80x25 text with the 8x8 soft font.  Start address and cursor
+		// come from the shadowed 6845 registers.
+		offs_t const start = ((m_crtc_regs[12] << 8) | m_crtc_regs[13]) & (VIDEO_RAM_SIZE - 1);
+		offs_t const cursor = ((m_crtc_regs[14] << 8) | m_crtc_regs[15]) & (VIDEO_RAM_SIZE - 1);
+		bool const cursor_on = (screen.frame_number() & 0x10) != 0;
+
+		for (int y = cliprect.top(); y <= cliprect.bottom(); y++)
+		{
+			if (y >= 200) break;
+			int const row = y >> 3;
+			int const ra = y & 0x07;
+			uint32_t *const dst = &bitmap.pix(y);
+
+			for (int column = 0; column < 80; column++)
+			{
+				offs_t const ma = (start + (row * 80) + column) & (VIDEO_RAM_SIZE - 1);
+				uint16_t const code = m_video_ram[ma];
+				uint8_t const attr = code >> 8;
+
+				// the font download writes one glyph byte per word, low
+				// byte: a character is 8 consecutive words, one line each
+				uint8_t glyph = m_char_ram[(((code & 0xff) << 3) | ra) & (CHAR_RAM_SIZE - 1)] & 0xff;
+
+				if (ma == cursor && cursor_on && ra >= 6)
+					glyph = 0xff;
+
+				rgb_t const fg = PALETTE_IBMC[attr & 0x0f];
+				rgb_t const bg = PALETTE_IBMC[(attr >> 4) & 0x07];
+
+				for (int bit = 0; bit < 8; bit++)
+				{
+					dst[(column * 8) + bit] = BIT(glyph, 7) ? fg : bg;
+					glyph <<= 1;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+
+//-------------------------------------------------
+//  machine_config( wangpc_ibmc )
+//-------------------------------------------------
+
+void wangpc_ibmc_device::device_add_mconfig(machine_config &config)
+{
+	screen_device &screen(SCREEN(config, SCREEN_TAG, SCREEN_TYPE_RASTER));
+	screen.set_screen_update(FUNC(wangpc_ibmc_device::screen_update));
+	screen.set_size(80*8, 25*8);
+	screen.set_visarea(0, 80*8-1, 0, 25*8-1);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
+	screen.set_refresh_hz(60);
+
+	// the 6845 supplies the sync state the status register reports; the
+	// display itself is drawn by screen_update, so no screen is attached
+	// and the timings the software programs cannot reshape the visible area
+	MC6845_1(config, m_crtc, XTAL(14'318'181)/8);
+	m_crtc->set_screen(nullptr);
+	m_crtc->set_show_border_area(false);
+	m_crtc->set_char_width(8);
+}
+
+
+
+//**************************************************************************
+//  INLINE HELPERS
+//**************************************************************************
+
+inline bool wangpc_ibmc_device::ram_enabled() const
+{
+	// bit 2 of the option register switches the memory windows in.  The
+	// running firmware turns the card on by writing 0x07 here without
+	// touching the enable register again, so the 0xc5 enable value the
+	// loader writes during detection is not part of the gate.
+	return BIT(m_option, 2);
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+wangpc_ibmc_device::wangpc_ibmc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, WANGPC_IBMC, tag, owner, clock),
+	device_wangpcbus_card_interface(mconfig, *this),
+	m_crtc(*this, MC6845_TAG),
+	m_screen(*this, SCREEN_TAG),
+	m_ram(*this, "ram", RAM_SIZE * 2, ENDIANNESS_LITTLE),
+	m_video_ram(*this, "video_ram", VIDEO_RAM_SIZE * 2, ENDIANNESS_LITTLE),
+	m_char_ram(*this, "char_ram", CHAR_RAM_SIZE * 2, ENDIANNESS_LITTLE),
+	m_option(0),
+	m_enable(0),
+	m_mode(0),
+	m_live(0),
+	m_control(0),
+	m_color(0),
+	m_reg30(0),
+	m_crtc_idx(0)
+{
+	std::fill(std::begin(m_crtc_regs), std::end(m_crtc_regs), 0);
+}
+
+void wangpc_ibmc_device::device_start()
+{
+	save_item(NAME(m_option));
+	save_item(NAME(m_enable));
+	save_item(NAME(m_mode));
+	save_item(NAME(m_live));
+	save_item(NAME(m_control));
+	save_item(NAME(m_color));
+	save_item(NAME(m_reg30));
+	save_item(NAME(m_crtc_idx));
+	save_item(NAME(m_crtc_regs));
+}
+
+void wangpc_ibmc_device::device_reset()
+{
+	m_option = 0;
+	m_enable = 0;
+	m_mode = 0;
+	m_live = 0;
+	m_control = 0;
+	m_color = 0;
+	m_reg30 = 0;
+}
+
+
+//-------------------------------------------------
+//  wangpcbus_mrdc_r - memory read
+//-------------------------------------------------
+
+uint16_t wangpc_ibmc_device::wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask)
+{
+	uint16_t data = 0xffff;
+
+	if (ram_enabled())
+	{
+		if (offset >= RAM_BASE && offset < RAM_BASE + RAM_SIZE)
+			data = m_ram[offset - RAM_BASE];
+		else if (offset >= 0xb8000/2 && offset < 0xbc000/2)
+			data = m_video_ram[offset & (VIDEO_RAM_SIZE - 1)];
+		else if (offset >= 0xbc000/2 && offset < 0xc0000/2)
+			data = m_char_ram[offset & (CHAR_RAM_SIZE - 1)];
+	}
+
+	return data;
+}
+
+
+//-------------------------------------------------
+//  wangpcbus_amwc_w - memory write
+//-------------------------------------------------
+
+void wangpc_ibmc_device::wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint16_t data)
+{
+	if (offset >= 0xbc000/2 && offset < 0xc0000/2)
+	{
+		// LOADIBM downloads the font while the option register is still
+		// zero, so the character generator takes writes unconditionally
+		COMBINE_DATA(&m_char_ram[offset & (CHAR_RAM_SIZE - 1)]);
+	}
+	else if (ram_enabled())
+	{
+		if (offset >= RAM_BASE && offset < RAM_BASE + RAM_SIZE)
+		{
+			COMBINE_DATA(&m_ram[offset - RAM_BASE]);
+		}
+		else if (offset >= 0xb8000/2 && offset < 0xbc000/2)
+		{
+			COMBINE_DATA(&m_video_ram[offset & (VIDEO_RAM_SIZE - 1)]);
+		}
+	}
+}
+
+
+//-------------------------------------------------
+//  wangpcbus_iorc_r - I/O read
+//-------------------------------------------------
+
+uint16_t wangpc_ibmc_device::wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask)
+{
+	uint16_t data = 0xffff;
+
+	if (sad(offset))
+	{
+		switch (offset & 0x7f)
+		{
+		case 0x02/2:
+			data = 0xff00 | m_crtc->register_r();
+			break;
+
+		case 0x20/2:
+			data = 0xff00 | m_option;
+			break;
+
+		case 0xc0/2:
+			data = 0xff00 | m_live;
+			break;
+
+		case 0xfe/2:
+			// the loader writes 0x10 to +0x2a and then expects the ID to
+			// read back as 0x17 instead of 0x16 before it will go on
+			data = 0xff00 | (BIT(m_mode, 4) ? OPTION_ID_ENABLED : OPTION_ID);
+			break;
+		}
+	}
+
+	return data;
+}
+
+
+//-------------------------------------------------
+//  wangpcbus_aiowc_w - I/O write
+//-------------------------------------------------
+
+void wangpc_ibmc_device::wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint16_t data)
+{
+	if (sad(offset) && ACCESSING_BITS_0_7)
+	{
+		switch (offset & 0x7f)
+		{
+		case 0x00/2:
+			m_crtc_idx = data & 0x1f;
+			m_crtc->address_w(data & 0xff);
+			break;
+
+		case 0x02/2:
+			m_crtc_regs[m_crtc_idx] = data & 0xff;
+			m_crtc->register_w(data & 0xff);
+			break;
+
+		case 0x10/2:
+			// mode control: written with 0x01 while the display is set
+			// up, 0xe9 once it is running, 0x00 to shut the card down
+			m_control = data & 0xff;
+			break;
+
+		case 0x20/2:
+			m_option = data & 0xff;
+			break;
+
+		case 0x2a/2:
+			m_mode = data & 0xff;
+			break;
+
+		case 0x30/2:
+			// written once with 0xff as the firmware brings the display up
+			m_reg30 = data & 0xff;
+			break;
+
+		case 0xe0/2:
+			// colour select, in the same shape as the IBM PC register at
+			// 0x3d9: the firmware translates the emulated software's
+			// writes into this one (0x30 for the standard palette on a
+			// black background, 0x3f with a white background)
+			m_color = data & 0xff;
+			break;
+
+		case 0xc0/2:
+			// the loader counts 3,2,1,0 into this register while it sets
+			// the card up and writes 0x04 as its last act before handing
+			// control to the emulation environment
+			m_live = data & 0xff;
+			break;
+
+		case 0xfa/2:
+			m_enable = data & 0xff;
+			break;
+		}
+	}
+}

--- a/src/devices/bus/wangpc/ibmc.h
+++ b/src/devices/bus/wangpc/ibmc.h
@@ -1,0 +1,73 @@
+// license:BSD-3-Clause
+// copyright-holders:Fausto Pracek
+/**********************************************************************
+
+    Wang PC-PM007 IBM PC Color Emulation Card
+
+**********************************************************************/
+
+#ifndef MAME_BUS_WANGPC_IBMC_H
+#define MAME_BUS_WANGPC_IBMC_H
+
+#pragma once
+
+#include "wangpc.h"
+#include "video/mc6845.h"
+#include "screen.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> wangpc_ibmc_device
+
+class wangpc_ibmc_device : public device_t,
+							public device_wangpcbus_card_interface
+{
+public:
+	// construction/destruction
+	wangpc_ibmc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+
+	// device_wangpcbus_card_interface overrides
+	virtual uint16_t wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask) override;
+	virtual void wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint16_t data) override;
+	virtual uint16_t wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask) override;
+	virtual void wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint16_t data) override;
+
+private:
+	inline bool ram_enabled() const;
+
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	required_device<mc6845_device> m_crtc;
+	required_device<screen_device> m_screen;
+	memory_share_creator<uint16_t> m_ram;
+	memory_share_creator<uint16_t> m_video_ram;
+	memory_share_creator<uint16_t> m_char_ram;
+
+	uint8_t m_option;
+	uint8_t m_enable;
+	uint8_t m_mode;
+	uint8_t m_live;
+	uint8_t m_control;
+	uint8_t m_color;
+	uint8_t m_reg30;
+	uint8_t m_crtc_idx;
+	uint8_t m_crtc_regs[32];
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(WANGPC_IBMC, wangpc_ibmc_device)
+
+#endif // MAME_BUS_WANGPC_IBMC_H

--- a/src/devices/bus/wangpc/mvc.cpp
+++ b/src/devices/bus/wangpc/mvc.cpp
@@ -13,6 +13,27 @@
     - character clock
     - blink
 
+    The IBM PC Emulation Option is a daughter board carried by this card and
+    is driven through the card's own I/O block.  What is modelled here was
+    reverse engineered from LOADIBM.EXE of the Wang "IBM PC Emulation Option"
+    software, version 2.11 (1986), which probes it like this:
+
+    - write 0x00 to +0x10/+0x12 (video option register), then read +0x50 and
+      require the low nibble to be clear to accept the card
+    - read +0x20: bit 2 set means the monochrome emulation option is fitted,
+      bit 3 set means the board provides the display itself (when clear the
+      software goes looking for a TIG card to drive the high resolution
+      monitor)
+    - write 0x04 to +0x20 and 0x01 to +0xfa to switch the option memory in,
+      then size it by probing at 0xf4000: boards that answer there carry 32K
+      at 0xf4000-0xfbfff, the others 16K at 0xf8000-0xfbfff
+
+    The emulation board of the separate "emulator card" (option ID 0x16) is
+    driven the same way but answers at 0xc0000 and takes 0xc5 in +0xfa.
+
+    Note that the host memory map has to extend past 0xf3fff for this window
+    to be reachable at all.
+
 */
 
 #include "emu.h"
@@ -36,9 +57,19 @@
 #define VIDEO_RAM_SIZE      0x800
 #define CHAR_RAM_SIZE       0x1000
 #define BITMAP_RAM_SIZE     0x4000
+#define IBM_RAM_SIZE        0x4000
 
 #define OPTION_VRAM         BIT(m_option, 0)
 #define OPTION_VSYNC        BIT(m_option, 3)
+
+#define IBM_OPTION_INSTALLED    (m_sw->read() & 0x03)
+#define IBM_OPTION_32K          BIT(m_sw->read(), 1)
+#define IBM_OPTION_STANDALONE   BIT(m_sw->read(), 2)
+
+// bit 2 of the option register switches the memory window in, bit 0 is set
+// only once the emulated IBM software has taken the display over: the Wang
+// software draws its own panels with the window already enabled
+#define IBM_DISPLAY_MODE        (ibm_ram_enabled() && BIT(m_ibm_option, 0))
 
 #define ATTR_BLINK          BIT(attr, 0)
 #define ATTR_REVERSE        BIT(attr, 1)
@@ -90,7 +121,13 @@ MC6845_UPDATE_ROW( wangpc_mvc_device::crtc_update_row )
 	for (int column = 0; column < x_count; column++)
 	{
 		uint16_t const code = m_video_ram[((ma + column) & 0x7ff)];
-		uint8_t const attr = code & 0xff;
+		uint8_t attr = code & 0xff;
+
+		// with the IBM PC emulation option driving the display, the attribute
+		// byte is the one the emulated software wrote and follows the
+		// monochrome adapter meaning, not the Wang one
+		if (IBM_DISPLAY_MODE)
+			attr = ibm_attribute(attr);
 
 		uint8_t new_ra = ra + 1;
 
@@ -157,6 +194,35 @@ void wangpc_mvc_device::device_add_mconfig(machine_config &config)
 
 
 
+//-------------------------------------------------
+//  INPUT_PORTS( wangpc_mvc )
+//-------------------------------------------------
+
+static INPUT_PORTS_START( wangpc_mvc )
+	PORT_START("SW")
+	PORT_CONFNAME( 0x07, 0x00, "IBM PC Emulation Option" )
+	PORT_CONFSETTING(    0x00, DEF_STR( None ) )
+	PORT_CONFSETTING(    0x01, "Monochrome (16K)" )
+	PORT_CONFSETTING(    0x03, "Monochrome (32K)" )
+	// the settings above make the software look for a TIG card in the next
+	// slot to put the emulated display on; these declare that the board
+	// drives the display itself, which is what this implementation does
+	PORT_CONFSETTING(    0x05, "Monochrome (16K), self-contained" )
+	PORT_CONFSETTING(    0x07, "Monochrome (32K), self-contained" )
+INPUT_PORTS_END
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+ioport_constructor wangpc_mvc_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( wangpc_mvc );
+}
+
+
+
 //**************************************************************************
 //  INLINE HELPERS
 //**************************************************************************
@@ -170,6 +236,52 @@ inline void wangpc_mvc_device::set_irq(int state)
 	m_irq = state;
 
 	m_bus->irq3_w(m_irq);
+}
+
+
+//-------------------------------------------------
+//  ibm_ram_enabled - is the IBM PC emulation
+//  option memory window turned on?
+//-------------------------------------------------
+
+inline bool wangpc_mvc_device::ibm_ram_enabled() const
+{
+	return IBM_OPTION_INSTALLED && BIT(m_ibm_option, 2) && BIT(m_ibm_enable, 0);
+}
+
+
+//-------------------------------------------------
+//  ibm_ram_base - start of the option memory
+//  window (32K boards decode 16K lower)
+//-------------------------------------------------
+
+inline offs_t wangpc_mvc_device::ibm_ram_base() const
+{
+	return IBM_OPTION_32K ? 0xf4000 : 0xf8000;
+}
+
+
+//-------------------------------------------------
+//  ibm_attribute - translate an IBM monochrome
+//  adapter attribute into the Wang one
+//-------------------------------------------------
+
+inline uint8_t wangpc_mvc_device::ibm_attribute(uint8_t attr) const
+{
+	uint8_t result = 0;
+
+	if (BIT(attr, 7))                       // blink
+		result |= 0x01;
+	if ((attr & 0x77) == 0x70)              // reverse video
+		result |= 0x02;
+	if ((attr & 0x77) == 0x00)              // non display
+		result |= 0x04;
+	if (BIT(attr, 3))                       // high intensity
+		result |= 0x08;
+	if ((attr & 0x07) == 0x01)              // underline
+		result |= 0x20;
+
+	return result;
 }
 
 
@@ -189,7 +301,11 @@ wangpc_mvc_device::wangpc_mvc_device(const machine_config &mconfig, const char *
 	m_video_ram(*this, "video_ram", VIDEO_RAM_SIZE*2, ENDIANNESS_LITTLE),
 	m_char_ram(*this, "char_ram", CHAR_RAM_SIZE*2, ENDIANNESS_LITTLE),
 	m_bitmap_ram(*this, "bitmap_ram", BITMAP_RAM_SIZE*2, ENDIANNESS_LITTLE),
+	m_ibm_ram(*this, "ibm_ram", IBM_RAM_SIZE*2, ENDIANNESS_LITTLE),
+	m_sw(*this, "SW"),
 	m_option(0),
+	m_ibm_option(0),
+	m_ibm_enable(0),
 	m_irq(CLEAR_LINE)
 {
 }
@@ -203,6 +319,8 @@ void wangpc_mvc_device::device_start()
 {
 	// state saving
 	save_item(NAME(m_option));
+	save_item(NAME(m_ibm_option));
+	save_item(NAME(m_ibm_enable));
 	save_item(NAME(m_irq));
 }
 
@@ -214,6 +332,8 @@ void wangpc_mvc_device::device_start()
 void wangpc_mvc_device::device_reset()
 {
 	m_option = 0;
+	m_ibm_option = 0;
+	m_ibm_enable = 0;
 
 	set_irq(CLEAR_LINE);
 }
@@ -243,6 +363,20 @@ uint16_t wangpc_mvc_device::wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask)
 		}
 	}
 
+	if (ibm_ram_enabled())
+	{
+		if (offset >= ibm_ram_base()/2 && offset < 0xfc000/2)
+		{
+			data = m_ibm_ram[offset - ibm_ram_base()/2];
+		}
+		else if (offset >= 0xb0000/2 && offset < 0xb1000/2)
+		{
+			// the character memory also answers where an IBM monochrome
+			// adapter would be, with the character in the low byte
+			data = swapendian_int16(m_video_ram[offset & 0x7ff]);
+		}
+	}
+
 	return data;
 }
 
@@ -268,6 +402,27 @@ void wangpc_mvc_device::wangpcbus_amwc_w(offs_t offset, uint16_t mem_mask, uint1
 			m_char_ram[offset & 0xfff] = data;
 		}
 	}
+
+	if (ibm_ram_enabled())
+	{
+		if (offset >= ibm_ram_base()/2 && offset < 0xfc000/2)
+		{
+			// the option memory takes byte writes: DOS loads the emulation
+			// ROM image into it a byte at a time
+			COMBINE_DATA(&m_ibm_ram[offset - ibm_ram_base()/2]);
+		}
+		else if (offset >= 0xb0000/2 && offset < 0xb1000/2)
+		{
+			// see wangpcbus_mrdc_r: the emulated IBM software writes the
+			// character in the low byte, the Wang card keeps it in the high
+			// one, so the bytes swap on the way through
+			uint16_t const swapped = swapendian_int16(data);
+			uint16_t const swapped_mask = swapendian_int16(mem_mask);
+			offs_t const addr = offset & 0x7ff;
+
+			m_video_ram[addr] = (swapped & swapped_mask) | (m_video_ram[addr] & ~swapped_mask);
+		}
+	}
 }
 
 
@@ -283,6 +438,18 @@ uint16_t wangpc_mvc_device::wangpcbus_iorc_r(offs_t offset, uint16_t mem_mask)
 	{
 		switch (offset & 0x7f)
 		{
+		case 0x20/2:
+			// bit 2 reports the IBM PC emulation option, bit 3 that the board
+			// drives the display itself instead of needing a TIG card
+			data = 0xff00 | (IBM_OPTION_INSTALLED ? 0x04 : 0x00) | (IBM_OPTION_STANDALONE ? 0x08 : 0x00);
+			break;
+
+		case 0x50/2:
+			// the low nibble has to read back clear for the emulation
+			// software to accept the card
+			data = 0xff00;
+			break;
+
 		case 0xfe/2:
 			data = 0xff00 | (m_irq << 7) | OPTION_ID;
 
@@ -318,6 +485,18 @@ void wangpc_mvc_device::wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint
 			if (LOG) logerror("MVC option %02x\n", data & 0xff);
 
 			m_option = data & 0xff;
+			break;
+
+		case 0x20/2:
+			if (LOG) logerror("MVC IBM option %02x\n", data & 0xff);
+
+			m_ibm_option = data & 0xff;
+			break;
+
+		case 0xfa/2:
+			if (LOG) logerror("MVC IBM enable %02x\n", data & 0xff);
+
+			m_ibm_enable = data & 0xff;
 			break;
 		}
 	}

--- a/src/devices/bus/wangpc/mvc.h
+++ b/src/devices/bus/wangpc/mvc.h
@@ -34,6 +34,7 @@ protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
 
 	// device_wangpcbus_card_interface overrides
 	virtual uint16_t wangpcbus_mrdc_r(offs_t offset, uint16_t mem_mask) override;
@@ -47,12 +48,20 @@ private:
 
 	inline void set_irq(int state);
 
+	inline bool ibm_ram_enabled() const;
+	inline offs_t ibm_ram_base() const;
+	inline uint8_t ibm_attribute(uint8_t attr) const;
+
 	required_device<mc6845_device> m_crtc;
 	memory_share_creator<uint16_t> m_video_ram;
 	memory_share_creator<uint16_t> m_char_ram;
 	memory_share_creator<uint16_t> m_bitmap_ram;
+	memory_share_creator<uint16_t> m_ibm_ram;
+	required_ioport m_sw;
 
 	uint8_t m_option;
+	uint8_t m_ibm_option;
+	uint8_t m_ibm_enable;
 	int m_irq;
 };
 

--- a/src/devices/bus/wangpc/wangpc.cpp
+++ b/src/devices/bus/wangpc/wangpc.cpp
@@ -222,6 +222,7 @@ void device_wangpcbus_card_interface::interface_pre_start()
 
 // slot devices
 #include "emb.h"
+#include "ibmc.h"
 #include "lic.h"
 #include "lvc.h"
 #include "mcc.h"
@@ -233,6 +234,7 @@ void device_wangpcbus_card_interface::interface_pre_start()
 void wangpc_cards(device_slot_interface &device)
 {
 	device.option_add("emb", WANGPC_EMB); // extended memory board
+	device.option_add("ibmc", WANGPC_IBMC); // PC-PM007 IBM PC color emulation card
 	device.option_add("lic", WANGPC_LIC); // local interconnect option card
 	device.option_add("lvc", WANGPC_LVC); // low-resolution video controller
 	device.option_add("mcc", WANGPC_MCC); // multiport communications controller

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -724,7 +724,8 @@ void wangpc_state::wangpc_mem(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x00000, 0x1ffff).ram();
-	map(0x20000, 0xf3fff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
+	// the IBM PC emulation option answers up to 0xfbfff, just below the BIOS
+	map(0x20000, 0xfbfff).rw(m_bus, FUNC(wangpcbus_device::mrdc_r), FUNC(wangpcbus_device::amwc_w));
 	map(0xfc000, 0xfffff).rom().region(I8086_TAG, 0);
 }
 

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -90,6 +90,10 @@ public:
 		m_fdc_drq(0),
 		m_fdc_dd0(0),
 		m_fdc_dd1(0),
+		m_fdc_index(0),
+		m_sysctrl(0),
+		m_index_prev{ 0, 0 },
+		m_index_timer(nullptr),
 		m_fdc_tc(0),
 		m_ds1(false),
 		m_ds2(false)
@@ -160,6 +164,11 @@ private:
 	uint8_t led_off_r();
 	void parity_nmi_clr_w(uint8_t data);
 	uint8_t option_id_r();
+	void option_id_w(uint8_t data);
+	uint8_t sysctrl_r();
+	void sysctrl_w(uint8_t data);
+	uint8_t index_clr_r();
+	uint8_t ibm_kb_r(offs_t offset);
 
 	void hrq_w(int state);
 	void eop_w(int state);
@@ -193,6 +202,7 @@ private:
 	void on_disk0_unload(floppy_image_device *image);
 	void on_disk1_load(floppy_image_device *image);
 	void on_disk1_unload(floppy_image_device *image);
+	TIMER_CALLBACK_MEMBER(sample_index);
 
 	void wangpc_io(address_map &map) ATTR_COLD;
 	void wangpc_mem(address_map &map) ATTR_COLD;
@@ -217,6 +227,11 @@ private:
 	int m_fdc_drq;
 	int m_fdc_dd0;
 	int m_fdc_dd1;
+	int m_fdc_index;
+	uint8_t m_sysctrl;
+	uint8_t m_kb_latch = 0;
+	int m_index_prev[2];
+	emu_timer *m_index_timer;
 	int m_fdc_tc;
 	int m_ds1;
 	int m_ds2;
@@ -550,9 +565,58 @@ uint8_t wangpc_state::uart_r()
 	uint8_t data = m_uart->read();
 
 	if (!machine().side_effects_disabled())
+	{
 		LOG("%s: UART read %02x\n", machine().describe_context(), data);
 
+		// the last keyboard byte stays readable at port 0x60, IBM PC
+		// style: the port scan run on real hardware finds the break code
+		// of the key that launched it there
+		m_kb_latch = data;
+	}
+
 	return data;
+}
+
+
+//-------------------------------------------------
+//  ibm_kb_r - IBM PC style view of the keyboard:
+//  port 0x60 returns the last scan code translated
+//  to the XT set, 0x61 a control latch the guest
+//  toggles to acknowledge
+//-------------------------------------------------
+
+//  Wang to XT scan code translation, from the IBMSCAN.KBD table that ships
+//  with the IBM PC emulation option (first byte of the file is the entry
+//  count, 0x7f).  The translation is consistent with the port scan run on
+//  real hardware: Return maps to the same code in both sets, and 0x9c -
+//  the break of the Return that launched the scan - is what port 0x60
+//  holds there.
+static const uint8_t WANG_TO_XT[0x80] =
+{
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0x51, 0x45, 0x46, 0x4a, 0x2b, 0x48, 0x49, 0x4d, 0x29, 0x37, 0xff, 0x2a, 0x1c, 0x00, 0x3a, 0x01,
+	0x00, 0x00, 0x00, 0x00, 0x1d, 0x38, 0x47, 0xff, 0x50, 0x48, 0x34, 0x0e, 0x39, 0x4b, 0x4d, 0x0c,
+	0x50, 0x4f, 0x53, 0xff, 0x52, 0x36, 0xff, 0x35, 0x33, 0x32, 0x31, 0x30, 0x2f, 0x2e, 0x2d, 0x2c,
+	0x4c, 0x4b, 0xff, 0xff, 0x1c, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x20, 0x1f, 0x1e,
+	0x47, 0x51, 0x53, 0x1c, 0x1b, 0x1a, 0x19, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10,
+	0x4e, 0x49, 0x52, 0xff, 0x0d, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x0f,
+	0xff, 0xff, 0x00, 0xff, 0xff, 0x44, 0x43, 0x42, 0x41, 0x40, 0x3f, 0x3e, 0x3d, 0x3c, 0x3b, 0xff
+};
+
+uint8_t wangpc_state::ibm_kb_r(offs_t offset)
+{
+	if (BIT(offset, 0))
+	{
+		// the port scan run on real hardware reads 0x4c at port 0x61.
+		// Bit 4 is the refresh detect bit of the IBM PC, toggling every
+		// 15.085us: software of the day counts its flips as a CPU speed
+		// independent time base - Flight Simulator paces its frames on it
+		uint8_t data = 0x4c & ~0x10;
+		data |= (machine().time().as_ticks(66287) & 1) << 4;
+		return data;
+	}
+
+	return WANG_TO_XT[m_kb_latch & 0x7f] | (m_kb_latch & 0x80);
 }
 
 
@@ -705,9 +769,62 @@ uint8_t wangpc_state::option_id_r()
 	uint8_t data = 0;
 
 	// FDC interrupt
-	data |= (m_fdc_dd0 || m_fdc_dd1 || (int) m_fdc->get_irq()) << 7;
+	data |= (m_fdc_dd0 || m_fdc_dd1 || m_fdc_index || (int) m_fdc->get_irq()) << 7;
+
+	// the index latch is cleared by the read, so that software polling this
+	// port sees one pulse per disk revolution rather than a level
+	if (!machine().side_effects_disabled())
+		m_fdc_index = 0;
 
 	return data;
+}
+
+
+//-------------------------------------------------
+//  sysctrl_r / sysctrl_w -
+//-------------------------------------------------
+
+uint8_t wangpc_state::sysctrl_r()
+{
+	// Undocumented: the shape comes from the software that uses the pair.
+	// The Wang LapTop translator writes 0x00 then 0x80 to 0x1098 and checks
+	// bit 1 here after each, which reads as a presence test, so the status
+	// follows what was last written.
+	return 0xfd | (BIT(m_sysctrl, 7) << 1);
+}
+
+void wangpc_state::sysctrl_w(uint8_t data)
+{
+	m_sysctrl = data;
+}
+
+
+//-------------------------------------------------
+//  index_clr_r -
+//-------------------------------------------------
+
+uint8_t wangpc_state::index_clr_r()
+{
+	// Also undocumented.  The IBM PC emulation firmware reads this and
+	// throws the value away, right after it has counted a disk index
+	// pulse, which is how the Wang board clears its latches everywhere
+	// else - so reading here drops the index latch.
+	if (!machine().side_effects_disabled())
+		m_fdc_index = 0;
+
+	return 0xff;
+}
+
+
+//-------------------------------------------------
+//  option_id_w -
+//-------------------------------------------------
+
+void wangpc_state::option_id_w(uint8_t data)
+{
+	// the IBM PC emulation firmware writes here once it is done timing the
+	// drives, which reads as an acknowledge of the index latch
+	m_fdc_index = 0;
 }
 
 
@@ -737,6 +854,11 @@ void wangpc_state::wangpc_mem(address_map &map)
 void wangpc_state::wangpc_io(address_map &map)
 {
 	map.unmap_value_high();
+
+	// the keyboard answers IBM PC style down here, as the port scan run on
+	// real hardware shows
+	map(0x0060, 0x0061).r(FUNC(wangpc_state::ibm_kb_r));
+
 	map(0x1000, 0x1000).w(FUNC(wangpc_state::fdc_ctrl_w));
 	map(0x1004, 0x1004).rw(FUNC(wangpc_state::deselect_drive1_r), FUNC(wangpc_state::deselect_drive1_w));
 	map(0x1006, 0x1006).rw(FUNC(wangpc_state::select_drive1_r), FUNC(wangpc_state::select_drive1_w));
@@ -753,6 +875,9 @@ void wangpc_state::wangpc_io(address_map &map)
 	map(0x1060, 0x1063).rw(m_pic, FUNC(pic8259_device::read), FUNC(pic8259_device::write)).umask16(0x00ff);
 	map(0x1080, 0x1087).r(m_epci, FUNC(scn_pci_device::read)).umask16(0x00ff);
 	map(0x1088, 0x108f).w(m_epci, FUNC(scn_pci_device::write)).umask16(0x00ff);
+	map(0x1090, 0x1090).r(FUNC(wangpc_state::sysctrl_r));
+	map(0x1094, 0x1094).r(FUNC(wangpc_state::index_clr_r));
+	map(0x1098, 0x1098).w(FUNC(wangpc_state::sysctrl_w));
 	map(0x10a0, 0x10bf).rw(m_dmac, FUNC(am9517a_device::read), FUNC(am9517a_device::write)).umask16(0x00ff);
 	map(0x10c2, 0x10c7).w(FUNC(wangpc_state::dma_page_w)).umask16(0x00ff);
 	map(0x10e0, 0x10e0).rw(FUNC(wangpc_state::status_r), FUNC(wangpc_state::timer0_irq_clr_w));
@@ -763,7 +888,7 @@ void wangpc_state::wangpc_io(address_map &map)
 	map(0x10ea, 0x10ea).rw(FUNC(wangpc_state::centronics_r), FUNC(wangpc_state::centronics_w));
 	map(0x10ec, 0x10ec).rw(FUNC(wangpc_state::busy_clr_r), FUNC(wangpc_state::acknlg_clr_w));
 	map(0x10ee, 0x10ee).rw(FUNC(wangpc_state::led_off_r), FUNC(wangpc_state::parity_nmi_clr_w));
-	map(0x10fe, 0x10fe).r(FUNC(wangpc_state::option_id_r));
+	map(0x10fe, 0x10fe).rw(FUNC(wangpc_state::option_id_r), FUNC(wangpc_state::option_id_w));
 	map(0x1100, 0x1fff).rw(m_bus, FUNC(wangpcbus_device::sad_r), FUNC(wangpcbus_device::sad_w));
 }
 
@@ -1184,6 +1309,10 @@ void wangpc_state::machine_start()
 	m_floppy[0]->setup_unload_cb(floppy_image_device::unload_cb(&wangpc_state::on_disk0_unload, this));
 	m_floppy[1]->setup_load_cb(floppy_image_device::load_cb(&wangpc_state::on_disk1_load, this));
 	m_floppy[1]->setup_unload_cb(floppy_image_device::unload_cb(&wangpc_state::on_disk1_unload, this));
+	// the index line is sampled rather than hooked: floppy_image_device keeps
+	// room for a single index callback and the FDC claims it
+	m_index_timer = timer_alloc(FUNC(wangpc_state::sample_index), this);
+	m_index_timer->adjust(attotime::from_usec(500), 0, attotime::from_usec(500));
 
 	// state saving
 	save_item(NAME(m_dma_page));
@@ -1202,6 +1331,10 @@ void wangpc_state::machine_start()
 	save_item(NAME(m_enable_eop));
 	save_item(NAME(m_disable_dreq2));
 	save_item(NAME(m_fdc_drq));
+	save_item(NAME(m_fdc_index));
+	save_item(NAME(m_sysctrl));
+	save_item(NAME(m_kb_latch));
+	save_item(NAME(m_index_prev));
 	save_item(NAME(m_ds1));
 	save_item(NAME(m_ds2));
 }
@@ -1221,6 +1354,24 @@ void wangpc_state::machine_reset()
 //-------------------------------------------------
 //  on_disk0_change -
 //-------------------------------------------------
+
+TIMER_CALLBACK_MEMBER(wangpc_state::sample_index)
+{
+	// One pulse per revolution, and only while a drive is spinning with a
+	// disk in it: the IBM PC emulation firmware times the interval between
+	// these to tell a 300 rpm drive from a 360 rpm one.  The pulse lasts
+	// about 2ms, so it is latched for software to find.
+	for (int i = 0; i < 2; i++)
+	{
+		int const state = m_floppy[i]->idx_r();
+
+		if (state && !m_index_prev[i])
+			m_fdc_index = 1;
+
+		m_index_prev[i] = state;
+	}
+}
+
 
 void wangpc_state::on_disk0_load(floppy_image_device *image)
 {

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -909,7 +909,12 @@ void wangpc_state::check_level1_interrupts()
 
 void wangpc_state::check_level2_interrupts()
 {
-	int state = !m_dma_eop || m_uart_dr || m_uart_tbre || m_fdc_dd0 || m_fdc_dd1 || m_fdc->get_irq() || m_fpu_irq || m_bus_irq2;
+	// the "door disturbed" latches are reported in the status register but
+	// are deliberately left out here: holding the line for them would keep
+	// level 2 asserted until the floppy control register is written, and
+	// since the keyboard shares this level nothing could be typed to get
+	// there - inserting a disk would wedge the machine
+	int state = !m_dma_eop || m_uart_dr || m_uart_tbre || m_fdc->get_irq() || m_fpu_irq || m_bus_irq2;
 
 	m_pic->ir2_w(state);
 }
@@ -1227,6 +1232,9 @@ void wangpc_state::on_disk0_unload(floppy_image_device *image)
 	LOG("Door 1 disturbed\n");
 
 	m_fdc_dd0 = 1;
+
+	// let the software know with a pulse, not by holding the line
+	m_pic->ir2_w(1);
 	check_level2_interrupts();
 }
 
@@ -1245,6 +1253,9 @@ void wangpc_state::on_disk1_unload(floppy_image_device *image)
 	LOG("Door 2 disturbed\n");
 
 	m_fdc_dd1 = 1;
+
+	// let the software know with a pulse, not by holding the line
+	m_pic->ir2_w(1);
 	check_level2_interrupts();
 }
 

--- a/src/mame/wang/wangpc.cpp
+++ b/src/mame/wang/wangpc.cpp
@@ -855,8 +855,13 @@ void wangpc_state::wangpc_io(address_map &map)
 {
 	map.unmap_value_high();
 
-	// the keyboard answers IBM PC style down here, as the port scan run on
-	// real hardware shows
+	// the machine also answers IBM PC style down here, as the port scan run
+	// on real hardware shows: the same peripherals, but at consecutive byte
+	// addresses instead of every other word.  IBM software that drives the
+	// hardware directly - Flight Simulator reprogramming timer 0 to its own
+	// tick rate, for one - depends on this.
+	map(0x0020, 0x0021).rw(m_pic, FUNC(pic8259_device::read), FUNC(pic8259_device::write));
+	map(0x0040, 0x0043).rw(m_pit, FUNC(pit8253_device::read), FUNC(pit8253_device::write));
 	map(0x0060, 0x0061).r(FUNC(wangpc_state::ibm_kb_r));
 
 	map(0x1000, 0x1000).w(FUNC(wangpc_state::fdc_ctrl_w));


### PR DESCRIPTION
## What this adds

The Wang Professional Computer ran IBM PC software through an emulation
option: a loader (LOADIBM) finds the option card on the bus, and an IBM PC
BIOS work-alike runs the show from there. The monochrome flavour rides on
the video controller; the colour one is a card of its own, the **PC-PM007**,
answering option ID 0x16 - "IBM PC Color Emulation" in table 15-3 of the
Wang PC Technical Reference Manual (2nd ed., August 1985).

Three commits are this PR's own:

1. **`wangpc: give software the IBM PC compatible views the hardware has`** -
   system board behaviour established with a port scanner run on a real
   Wang PC: an IBM-style keyboard view at ports 0x60/0x61 (scan code
   translated to the XT set with the mapping from IBMSCAN.KBD, the table
   shipped with the option; refresh detect bit toggling at the authentic
   15.085us), the floppy index pulse latch the emulation firmware uses to
   time drive speed, and the register pair at 0x1090/0x1098 the loader
   probes.

2. **`bus/wangpc: add the Wang PC-PM007 IBM PC Color Emulation Card`** -
   the card itself: 16K CGA-style video memory at 0xb8000, character
   generator RAM at 0xbc000 (LOADIBM downloads the font from the file
   shipped with the option, so there is **no character ROM to dump**), an
   MC6845, 16K RAM at 0xc0000, and the card's native word-spaced register
   set: +0x10 mode control and +0xE0 colour select, which have the shape of
   the CGA 0x3d8/0x3d9 registers. The window size matters: LOADIBM probes
   the word at 0xc4000 and, finding no RAM there (as on the real card), runs
   the firmware as a DOS overlay - the colour firmware only ever shipped as
   an .EXE.

3. **`wangpc: decode the IBM PC aliases of the interrupt controller and
   timer`** - the same port scan shows the machine answering at IBM PC
   addresses too, the same peripherals at consecutive byte addresses
   instead of every other word. Software that drives the hardware directly
   needs them: Flight Simulator programs timer 0 with a divisor of its own
   and paces itself on the crystal over 65536, so with the writes falling
   into the void it ran eleven times slow.

## Tested

- `wangpc -slot2 mvc -slot3 ibmc`: LOADIBM 2.11 detects the card, passes
  its memory test, brings the emulation environment up on the card's own
  screen, boots Leading Edge MS-DOS 2.11 (Phoenix compatibility software)
  from a 360K floppy through the Wang's native controller, to a working
  COMMAND.COM prompt.
- Microsoft Flight Simulator 2.12 boots from its original booter diskette:
  display selection, CGA 320x200 graphics, CRTC access and keyboard input
  through INT 9 / port 0x60 all work; the aircraft takes off and flies.
- The plain machine (no ibmc, just the Wang monitor) still boots Wang DOS
  from the `boot` floppy to the date prompt in 9 seconds with the driver
  changes in place.
- `-validate` clean.

## Dependencies / notes for review

- Builds on the pending Wang PC series: the 640K memory window fix (#15780,
  merged), the default bus card responses (#15916, merged), the disk-change
  fix (#15917, open) and the IBM emulation option on the video card (#15971,
  open). Those are the first commits of this branch so it builds and can be
  tested as a whole; happy to rebase as they merge.
- Testing the full IBM path also needs the Winchester controller PR
  (#15781, merged) to boot DOS from hard disk; the card itself does not
  depend on it.
- No IBM-style 0x3d0-0x3df decode inside the card, and no routing of the
  low I/O window to the bus. Both were tried and dropped: the emulation
  firmware translates the emulated software's writes into the card's own
  registers itself, which is how the real thing works. The aliases in
  commit 3 are a different matter - they are in the driver's own I/O map,
  going to the system board's 8259 and 8253, which is where the port scan
  on real hardware shows them answering.
- The 128-byte Wang->XT scan code table is data taken from IBMSCAN.KBD, the
  translation table Wang shipped with the option (its first byte is the
  entry count). It describes a fixed hardware mapping; the values are
  consistent with what the real machine shows at port 0x60.

## AI disclosure

This work was done with substantial assistance from Anthropic's Claude
(Claude Fable 5 for most of it, Claude Opus 5 for the later work), driven
and reviewed by me throughout. Every claim above was verified by running
period software on the emulated machine, and the hardware behaviour the
driver changes rest on comes from a port scan run on a real Wang PC.