### PR TITLE
bus/wangpc: implement the Text/Image/Graphics controller

### DIFF
--- a/src/devices/bus/wangpc/tig.cpp
+++ b/src/devices/bus/wangpc/tig.cpp
@@ -1,18 +1,40 @@
 // license:BSD-3-Clause
-// copyright-holders:Curt Coder
+// copyright-holders:Curt Coder, Fausto Pracek
 /**********************************************************************
 
     Wang PC Text/Image/Graphics controller emulation
 
+    The card carries two uPD7220 GDCs sharing one 800x600 monochrome
+    screen: GDC0 draws the text plane out of its own frame and font
+    memory, GDC1 draws a 1bpp graphics plane on top of it.
+
+    Text plane (GDC0 address space):
+
+    - 0x0000-0x0fff frame memory, one word per character cell: the
+      character code is in the low byte and the attributes are in the
+      high byte.  Only 4K words are fitted and the address is decoded
+      incompletely, so the buffer repeats every 0x1000 words: the BIOS
+      relies on that, scrolling by walking SAD one row at a time and
+      letting it wrap around from 0x0ff0 back to 0x0040
+    - 0x4000-0x7fff font memory, 32 words per character indexed by
+      code << 5, one word per scan line with the leftmost dot in bit 9;
+      the alternate font lives at +0x2000
+
+    The cell is 10 dots wide and the display list programs 24 scan
+    lines per row, so the visible text screen is 800x600.
+
+    I/O map (relative to the card's slot address):
+
+    - 0x00-0x1e attribute registers
+    - 0x20/0x22 GDC0 (text)
+    - 0x24/0x26 GDC1 (graphics)
+    - 0x28      underscore scan line
+    - 0x2a      option register: bit 0 selects which GDC the DMA
+                channel talks to, bits 1-3 pick the bus DREQ line,
+                bit 4 selects the option ID reported at 0xfe
+    - 0xfc      reset
+
 **********************************************************************/
-
-/*
-
-    TODO:
-
-    - all
-
-*/
 
 #include "emu.h"
 #include "tig.h"
@@ -25,7 +47,7 @@
 //  MACROS/CONSTANTS
 //**************************************************************************
 
-#define LOG 1
+#define LOG 0
 
 #define OPTION_ID_0         0x13
 #define OPTION_ID_1         0x17
@@ -86,12 +108,59 @@ const tiny_rom_entry *wangpc_tig_device::device_rom_region() const
 void wangpc_tig_device::upd7220_0_map(address_map &map)
 {
 	map.global_mask(0x7fff);
-	map(0x0000, 0x0fff).mirror(0x1000).ram(); // frame buffer
-	map(0x4000, 0x7fff).ram(); // font memory
+	map(0x0000, 0x0fff).mirror(0x3000).ram().share("frame_ram"); // frame buffer
+	map(0x4000, 0x7fff).ram().share("font_ram"); // font memory
 }
 
 UPD7220_DRAW_TEXT_LINE_MEMBER( wangpc_tig_device::hgdc_draw_text )
 {
+	for (int column = 0; column < pitch; column++)
+	{
+		uint16_t const code = m_frame_ram[(addr + column) & 0x0fff];
+		uint8_t const chr = code & 0xff;
+		uint16_t const data = code; // attribute bits live in the high byte
+
+		for (int sy = 0; sy < lr; sy++)
+		{
+			// the font stores 32 rows per character; the cell displays
+			// 24 of them, sub/superscript shift the window
+			uint8_t row = sy;
+
+			if (ATTR_SUPERSCRIPT)
+				row = sy + 6;
+			else if (ATTR_SUBSCRIPT)
+				row = (sy >= 6) ? sy - 6 : 0;
+
+			offs_t faddr = (ATTR_ALT_FONT ? 0x2000 : 0) | (chr << 5) | (row & 0x1f);
+			uint16_t dots = m_font_ram[faddr & 0x3fff];
+
+			bool const cursor = (cursor_on && (addr + column) == cursor_addr);
+
+			if (cursor || (ATTR_UNDERSCORE && sy == (m_underline & 0x1f)))
+				dots = 0x3ff;
+
+			if (ATTR_BLANK)
+				dots = 0;
+
+			if (ATTR_REVERSE)
+				dots ^= 0x3ff;
+
+			// the GDC can be programmed with more rows than the bitmap
+			// holds (e.g. during a 25/35-line mode switch): clip
+			if (y + sy >= 0 && y + sy < bitmap.height())
+			{
+				for (int bit = 0; bit < 10; bit++)
+				{
+					int const x = (column * 10) + bit;
+					if (x >= bitmap.width())
+						break;
+					int const color = BIT(dots, 9 - bit) ? (ATTR_BOLD ? 2 : 1) : 0;
+
+					bitmap.pix(y + sy, x) = m_palette->pen(color);
+				}
+			}
+		}
+	}
 }
 
 
@@ -102,11 +171,28 @@ UPD7220_DRAW_TEXT_LINE_MEMBER( wangpc_tig_device::hgdc_draw_text )
 void wangpc_tig_device::upd7220_1_map(address_map &map)
 {
 	map.global_mask(0xffff);
-	map(0x0000, 0xffff).ram(); // graphics memory
+	map(0x0000, 0xffff).ram().share("gfx_ram"); // graphics memory
 }
 
 UPD7220_DISPLAY_PIXELS_MEMBER( wangpc_tig_device::hgdc_display_pixels )
 {
+	// 1 bpp graphics layer, drawn over the text layer: only set pixels
+	// are written so the text underneath stays visible
+	if (y < 0 || y >= bitmap.height())
+		return;
+
+	uint16_t const data = m_gfx_ram[address & 0xffff];
+
+	for (int i = 0; i < 16; i++)
+	{
+		int const px = x + i;
+
+		if (px >= bitmap.width())
+			break;
+
+		if (BIT(data, i))
+			bitmap.pix(y, px) = m_palette->pen(1);
+	}
 }
 
 
@@ -118,8 +204,8 @@ void wangpc_tig_device::device_add_mconfig(machine_config &config)
 {
 	screen_device &screen(SCREEN(config, SCREEN_TAG).set_color(rgb_t::green()));
 	screen.set_screen_update(FUNC(wangpc_tig_device::screen_update));
-	screen.set_size(80*10, 25*12);
-	screen.set_visarea(0, 80*10-1, 0, 25*12-1);
+	screen.set_size(80*10, 25*24);
+	screen.set_visarea(0, 80*10-1, 0, 25*24-1);
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500));
 	screen.set_refresh_hz(60);
 
@@ -129,11 +215,14 @@ void wangpc_tig_device::device_add_mconfig(machine_config &config)
 	m_hgdc0->set_addrmap(0, &wangpc_tig_device::upd7220_0_map);
 	m_hgdc0->set_draw_text(FUNC(wangpc_tig_device::hgdc_draw_text));
 	m_hgdc0->set_screen(SCREEN_TAG);
+	m_hgdc0->set_char_dots(10); // the character cell is 10 dots wide
+	m_hgdc0->drq_wr_callback().set(FUNC(wangpc_tig_device::gdc0_drq_w));
 
 	UPD7220(config, m_hgdc1, XTAL(52'832'000)/28);
 	m_hgdc1->set_addrmap(0, &wangpc_tig_device::upd7220_1_map);
 	m_hgdc1->set_display_pixels(FUNC(wangpc_tig_device::hgdc_display_pixels));
 	m_hgdc1->set_screen(SCREEN_TAG);
+	m_hgdc1->drq_wr_callback().set(FUNC(wangpc_tig_device::gdc1_drq_w));
 }
 
 
@@ -150,9 +239,41 @@ wangpc_tig_device::wangpc_tig_device(const machine_config &mconfig, const char *
 	device_wangpcbus_card_interface(mconfig, *this),
 	m_hgdc0(*this, UPD7720_0_TAG),
 	m_hgdc1(*this, UPD7720_1_TAG),
+	m_frame_ram(*this, "frame_ram"),
+	m_font_ram(*this, "font_ram"),
+	m_gfx_ram(*this, "gfx_ram"),
 	m_option(0), m_underline(0),
+	m_gdc0_drq(0), m_gdc1_drq(0),
 	m_palette(*this, "palette")
 {
+}
+
+
+//-------------------------------------------------
+//  DRQ routing - the option register selects which
+//  GDC drives the DMA channel and which bus DREQ
+//  line carries the request
+//-------------------------------------------------
+
+void wangpc_tig_device::gdc0_drq_w(int state)
+{
+	m_gdc0_drq = state;
+	update_drq();
+}
+
+void wangpc_tig_device::gdc1_drq_w(int state)
+{
+	m_gdc1_drq = state;
+	update_drq();
+}
+
+void wangpc_tig_device::update_drq()
+{
+	int const state = DMA_GRAPHICS ? m_gdc1_drq : m_gdc0_drq;
+
+	if (DMA_DREQ1) m_bus->drq1_w(state);
+	if (DMA_DREQ2) m_bus->drq2_w(state);
+	if (DMA_DREQ3) m_bus->drq3_w(state);
 }
 
 
@@ -166,6 +287,8 @@ void wangpc_tig_device::device_start()
 	save_item(NAME(m_option));
 	save_item(NAME(m_attr));
 	save_item(NAME(m_underline));
+	save_item(NAME(m_gdc0_drq));
+	save_item(NAME(m_gdc1_drq));
 }
 
 
@@ -236,9 +359,9 @@ void wangpc_tig_device::wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint
 		{
 		case 0x00/2: case 0x02/2: case 0x04/2: case 0x06/2: case 0x08/2: case 0x0a/2: case 0x0c/2: case 0x0e/2:
 		case 0x10/2: case 0x12/2: case 0x14/2: case 0x16/2: case 0x18/2: case 0x1a/2: case 0x1c/2: case 0x1e/2:
-			if (LOG) logerror("TIG attribute %u: %02x\n", offset, data & 0xff);
+			if (LOG) logerror("TIG attribute %u: %02x\n", offset & 0x0f, data & 0xff);
 
-			m_attr[offset] = data & 0xff;
+			m_attr[offset & 0x0f] = data & 0xff;
 			break;
 
 		case 0x20/2:
@@ -260,7 +383,13 @@ void wangpc_tig_device::wangpcbus_aiowc_w(offs_t offset, uint16_t mem_mask, uint
 		case 0x2a/2:
 			if (LOG) logerror("TIG option %02x\n", data & 0xff);
 
+			// release the DREQ lines of the old routing before switching
+			if (DMA_DREQ1) m_bus->drq1_w(0);
+			if (DMA_DREQ2) m_bus->drq2_w(0);
+			if (DMA_DREQ3) m_bus->drq3_w(0);
+
 			m_option = data & 0xff;
+			update_drq();
 			break;
 
 		case 0xfc/2:

--- a/src/devices/bus/wangpc/tig.h
+++ b/src/devices/bus/wangpc/tig.h
@@ -50,16 +50,25 @@ private:
 	UPD7220_DRAW_TEXT_LINE_MEMBER( hgdc_draw_text );
 	UPD7220_DISPLAY_PIXELS_MEMBER( hgdc_display_pixels );
 
+	void gdc0_drq_w(int state);
+	void gdc1_drq_w(int state);
+	void update_drq();
+
 	void upd7220_0_map(address_map &map) ATTR_COLD;
 	void upd7220_1_map(address_map &map) ATTR_COLD;
 
 	// internal state
 	required_device<upd7220_device> m_hgdc0;
 	required_device<upd7220_device> m_hgdc1;
+	required_shared_ptr<uint16_t> m_frame_ram;
+	required_shared_ptr<uint16_t> m_font_ram;
+	required_shared_ptr<uint16_t> m_gfx_ram;
 
 	uint8_t m_option;
 	uint8_t m_attr[16];
 	uint8_t m_underline;
+	int m_gdc0_drq;
+	int m_gdc1_drq;
 	required_device<palette_device> m_palette;
 };
 

--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -365,7 +365,7 @@ inline void upd7220_device::update_vsync_timer(int state)
 
 inline void upd7220_device::update_hsync_timer(int state)
 {
-	const int horiz_mult = (m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_GRAPHICS ? 16 : 8;
+	const int horiz_mult = (m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_GRAPHICS ? 16 : m_char_dots;
 	int y = screen().vpos();
 
 	int next_x = state ? m_hs * horiz_mult : 0;
@@ -408,7 +408,7 @@ inline void upd7220_device::recompute_parameters()
 	// microbx2 wants horizontal multiplier of x16
 	// pc9801:diremono sets up m_mode to be specifically in character mode, wanting x8 here
 	// TODO: verify compis uhrg video & high reso Hyper 98
-	const int horiz_mult = (m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_GRAPHICS ? 16 : 8;
+	const int horiz_mult = (m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_GRAPHICS ? 16 : m_char_dots;
 	const int vert_mult = (m_mode & UPD7220_MODE_INTERLACE_MASK) == UPD7220_MODE_INTERLACE_ON ? 2 : 1;
 
 	int horiz_pix_total = (m_hs + m_hbp + m_hfp + m_aw) * horiz_mult;
@@ -688,6 +688,7 @@ upd7220_device::upd7220_device(const machine_config &mconfig, device_type type, 
 	m_lr(1),
 	m_disp(0),
 	m_gchr(0),
+	m_char_dots(8),
 	m_bitmap_mod(0),
 	m_space_config("videoram", ENDIANNESS_LITTLE, 16, 18, -1, address_map_constructor(FUNC(upd7220_device::upd7220_vram), this))
 {

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -72,6 +72,10 @@ public:
 	template <typename... T> void set_display_pixels(T &&... args) { m_display_cb.set(std::forward<T>(args)...); }
 	template <typename... T> void set_draw_text(T &&... args) { m_draw_text_cb.set(std::forward<T>(args)...); }
 
+	// dots per character clock in character mode, for boards whose
+	// character cell is not 8 dots wide (e.g. the Wang PC TIG uses 10)
+	void set_char_dots(int dots) { m_char_dots = dots; }
+
 	auto drq_wr_callback() { return m_write_drq.bind(); }
 	auto hsync_wr_callback() { return m_write_hsync.bind(); }
 	auto vsync_wr_callback() { return m_write_vsync.bind(); }
@@ -201,6 +205,8 @@ private:
 
 	int m_disp;                       // display zoom factor
 	int m_gchr;                       // zoom factor for graphics character writing and area filling
+
+	int m_char_dots;                  // dots per character clock in character mode
 
 	uint8_t m_bitmap_mod;
 


### PR DESCRIPTION
The TIG card (previously a skeleton marked "TODO: all") carries two
uPD7220 GDCs sharing one 800x600 monochrome screen: GDC0 draws the text
plane out of its own frame and font memory, GDC1 draws a 1bpp graphics
plane on top of it.

What the hardware does, as reconstructed from the Wang BIOS and the PIC
application software (documented in the header comment of tig.cpp):

- 4K words of frame memory, one word per character cell, character code
  in the low byte and attributes in the high byte; the address is
  decoded incompletely so the buffer repeats every 0x1000 words, which
  is what the BIOS relies on when it scrolls by walking SAD forward one
  row at a time and letting it wrap from 0x0ff0 back to 0x0040
- font memory at 0x4000-0x7fff, 32 words per character indexed by
  code << 5, one word per scan line with the leftmost dot in bit 9,
  alternate font at +0x2000
- attributes: alternate font, underscore, blink, reverse, blank, bold,
  subscript, superscript; the underscore scan line comes from the
  register at +0x28
- the option register at +0x2a selects which GDC the DMA channel talks
  to, which bus DREQ line carries the request, and which option ID is
  reported at +0xfe

The card's character cell is 10 dots wide, which the uPD7220 device
could not express: `recompute_parameters()` assumes 8 dots per character
clock in character mode, so the screen it configured was 640 rather than
800 pixels wide and the rightmost two columns of text were cut off. This
adds a `set_char_dots()` configuration to `upd7220_device` (default 8, so
no other driver is affected) and the TIG sets it to 10.

## Tested

- The Wang BIOS brings the TIG up on its own (option 00, 16 attributes,
  clears the buffer through the GDC) and renders full 80-column text
  with no clipping.
- The Wang Professional Image Computer (PIC) application software runs
  on top of the driver: its image viewer decodes and displays a scanned
  image on the graphics plane over the text menus.
- `-validate` clean.

## Dependencies

Builds on #15916 (default bus card responses), needed because the TIG has
no memory-mapped presence of its own and relied on the old zero-fill
default before that fix.

## AI disclosure

This work was done with substantial assistance from Anthropic's Claude
(Claude Opus 5 for the final implementation), driven and reviewed by me
throughout. The register-level behaviour was reconstructed by
cross-referencing the Wang BIOS disassembly against known-good output
from period PIC application software running on the emulated machine.