### PR TITLE
scc68070: Add UART output

### DIFF
--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -1358,8 +1358,8 @@ void scc68070_device::ucsr_w(uint8_t data)
 
 	static const uint32_t s_baud_divisors[8] = { 65536, 32768, 16384, 4096, 2048, 1024, 512, 256 };
 
-	attotime rx_rate = attotime::from_ticks(s_baud_divisors[(data >> 4) & 7] * 10, 49152000);
-	attotime tx_rate = attotime::from_ticks(s_baud_divisors[data & 7] * 10, 49152000);
+	attotime rx_rate = attotime::from_ticks(s_baud_divisors[(data >> 4) & 7] * 10, 4915200);
+	attotime tx_rate = attotime::from_ticks(s_baud_divisors[data & 7] * 10, 4915200);
 	m_uart.rx_timer->adjust(rx_rate, 0, rx_rate);
 	m_uart.tx_timer->adjust(tx_rate, 0, tx_rate);
 }

--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -40,7 +40,7 @@ TODO:
 
 #include "logmacro.h"
 
-#define ENABLE_UART_PRINTING (0)
+static constexpr XTAL XCKI_CLOCK = 4.9152_MHz_XTAL;
 
 //**************************************************************************
 // Register defines
@@ -240,11 +240,13 @@ void scc68070_device::cpu_space_map(address_map &map)
 
 scc68070_device::scc68070_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: scc68070_base_device(mconfig, tag, owner, clock, SCC68070, address_map_constructor(FUNC(scc68070_device::internal_map), this))
+	, device_serial_interface(mconfig, *this)
 	, m_iack2_callback(*this, autovector(2))
 	, m_iack4_callback(*this, autovector(4))
 	, m_iack5_callback(*this, autovector(5))
 	, m_iack7_callback(*this, autovector(7))
 	, m_uart_tx_callback(*this)
+	, m_txd_cb(*this)
 	, m_uart_rtsn_callback(*this)
 	, m_i2c_scl_callback(*this)
 	, m_i2c_sdaw_callback(*this)
@@ -307,12 +309,9 @@ void scc68070_device::device_start()
 	save_item(NAME(m_uart.clock_select));
 	save_item(NAME(m_uart.command_register));
 	save_item(NAME(m_uart.receive_holding_register));
-	save_item(NAME(m_uart.receive_pointer));
-	save_item(NAME(m_uart.receive_buffer));
 	save_item(NAME(m_uart.transmit_holding_register));
-	save_item(NAME(m_uart.transmit_pointer));
-	save_item(NAME(m_uart.transmit_buffer));
 	save_item(NAME(m_uart.transmit_ctsn));
+	save_item(NAME(m_uart.transmit_break));
 
 	save_item(NAME(m_timers.timer_status_register));
 	save_item(NAME(m_timers.timer_control_register));
@@ -340,12 +339,6 @@ void scc68070_device::device_start()
 
 	m_timers.timer0_timer = timer_alloc(FUNC(scc68070_device::timer0_callback), this);
 	m_timers.timer0_timer->adjust(attotime::never);
-
-	m_uart.rx_timer = timer_alloc(FUNC(scc68070_device::rx_callback), this);
-	m_uart.rx_timer->adjust(attotime::never);
-
-	m_uart.tx_timer = timer_alloc(FUNC(scc68070_device::tx_callback), this);
-	m_uart.tx_timer->adjust(attotime::never);
 
 	m_i2c.timer = timer_alloc(FUNC(scc68070_device::i2c_callback), this);
 	m_i2c.timer->adjust(attotime::never);
@@ -380,14 +373,18 @@ void scc68070_device::reset_peripheral_state()
 	m_i2c.clocks = 0;
 
 	m_uart.mode_register = 0;
-	m_uart.status_register = USR_TXRDY;
+	m_uart.status_register = USR_TXRDY | USR_TXEMT;
 	m_uart.clock_select = 0;
 	m_uart.command_register = 0;
 	m_uart.transmit_holding_register = 0;
 	m_uart.receive_holding_register = 0;
-	m_uart.receive_pointer = -1;
-	m_uart.transmit_pointer = -1;
 	m_uart.transmit_ctsn = true;
+	m_uart.transmit_break = false;
+	receive_register_reset();
+	transmit_register_reset();
+	m_txd_cb(1);
+	recalc_framing();
+	recalc_baud();
 
 	m_timers.timer_status_register = 0;
 	m_timers.timer_control_register = 0;
@@ -419,8 +416,6 @@ void scc68070_device::reset_peripheral_state()
 		m_mmu.desc[index].base = 0;
 	}
 
-	m_uart.rx_timer->adjust(attotime::never);
-	m_uart.tx_timer->adjust(attotime::never);
 	m_i2c.timer->adjust(attotime::never);
 
 	set_timer_callback(0);
@@ -625,118 +620,107 @@ TIMER_CALLBACK_MEMBER(scc68070_device::timer0_callback)
 void scc68070_device::uart_ctsn(int state)
 {
 	m_uart.transmit_ctsn = state ? true : false;
+	if (started())
+		check_for_tx_start();
+}
+
+void scc68070_device::recalc_baud()
+{
+	static const uint32_t s_divisors[8] = { 65536, 32768, 16384, 4096, 2048, 1024, 512, 256 };
+
+	const uint8_t cls = m_uart.clock_select;
+	const uint32_t source = BIT(cls, 7) ? XCKI_CLOCK.value() : (clock() / 4);
+
+	set_rcv_rate(source, s_divisors[(cls >> 4) & 7]);
+	set_tra_rate(source, s_divisors[cls & 7]);
+}
+
+void scc68070_device::recalc_framing()
+{
+	const uint8_t umr = m_uart.mode_register;
+	const int data_bits = BIT(umr, 0) ? 8 : 7;
+	const parity_t parity = BIT(umr, 3) ? (BIT(umr, 2) ? PARITY_EVEN : PARITY_ODD) : PARITY_NONE;
+	const stop_bits_t stop_bits = BIT(umr, 1) ? STOP_BITS_2 : STOP_BITS_1;
+
+	set_data_frame(1, data_bits, parity, stop_bits);
+}
+
+void scc68070_device::check_for_tx_start()
+{
+	if (((m_uart.command_register >> 2) & 3) != 1)
+		return;
+
+	if (m_uart.transmit_ctsn && (m_uart.mode_register & UMR_TXC))
+		return;
+
+	if (m_uart.transmit_break)
+		return;
+
+	const bool not_ready = m_uart.status_register & USR_TXRDY;
+	const bool shifter_busy = !is_transmit_register_empty();
+	if (not_ready || shifter_busy)
+		return;
+
+	LOGMASKED(LOG_MORE_UART, "check_for_tx_start: Transmitting %02x\n", m_uart.transmit_holding_register);
+	transmit_register_setup(m_uart.transmit_holding_register);
+	m_uart_tx_callback(m_uart.transmit_holding_register); // Temporary due to tap
+	m_uart.status_register &= ~USR_TXEMT;
+	m_uart.status_register |= USR_TXRDY;
+	m_uart_tx_int = true;
+	update_ipl();
+}
+
+void scc68070_device::tra_callback()
+{
+	m_txd_cb(m_uart.transmit_break ? 0 : transmit_register_get_data_bit());
+}
+
+void scc68070_device::tra_complete()
+{
+	m_uart.status_register |= USR_TXEMT;
+	check_for_tx_start();
+}
+
+void scc68070_device::rcv_complete()
+{
+	receive_register_extract();
+
+	if ((m_uart.command_register & 3) != 1)
+		return;
+
+	if (is_receive_framing_error())
+		m_uart.status_register |= USR_FE;
+	if (is_receive_parity_error())
+		m_uart.status_register |= USR_PE;
+
+	if (m_uart.status_register & USR_RXRDY)
+	{
+		LOGMASKED(LOG_UART, "rcv_complete: receiver overrun\n");
+		m_uart.status_register |= USR_OE;
+		return;
+	}
+
+	m_uart.receive_holding_register = get_received_char();
+	LOGMASKED(LOG_UART, "rcv_complete: Received %02x\n", m_uart.receive_holding_register);
+
+	m_uart.status_register |= USR_RXRDY;
+	m_uart_rx_int = true;
+	update_ipl();
 }
 
 void scc68070_device::uart_rx(uint8_t data)
 {
-	if (m_uart.receive_pointer >= int16_t(std::size(m_uart.receive_buffer) - 1))
+	if (m_uart.status_register & USR_RXRDY)
 	{
 		LOGMASKED(LOG_UART, "%s: uart_rx: receiver overrun, discarding %02x\n", machine().describe_context(), data);
 		m_uart.status_register |= USR_OE;
 		return;
 	}
-	m_uart.receive_pointer++;
-	m_uart.receive_buffer[m_uart.receive_pointer] = data;
-}
 
-void scc68070_device::uart_tx(uint8_t data)
-{
-	if(ENABLE_UART_PRINTING)
-	{
-		// Static variable does not survive load state.
-		static std::string s_line;
-		if (data == '\r' || data == '\n')
-		{
-			if (!s_line.empty())
-			{
-				logerror("UART: %s\n", s_line);
-				s_line.clear();
-			}
-		}
-		else
-		{
-			s_line += char(data);
-		}
-	}
-
-	if (m_uart.transmit_pointer >= int16_t(std::size(m_uart.transmit_buffer) - 1))
-	{
-		LOGMASKED(LOG_UART, "%s: uart_tx: transmit buffer full, discarding %02x\n", machine().describe_context(), data);
-		return;
-	}
-	m_uart.transmit_pointer++;
-	m_uart.transmit_buffer[m_uart.transmit_pointer] = data;
-	m_uart.status_register &= ~USR_TXEMT;
-}
-
-TIMER_CALLBACK_MEMBER(scc68070_device::rx_callback)
-{
-	if ((m_uart.command_register & 3) == 1)
-	{
-		if (m_uart.receive_pointer >= 0)
-		{
-			m_uart.status_register |= USR_RXRDY;
-		}
-		else
-		{
-			m_uart.status_register &= ~USR_RXRDY;
-		}
-
-		m_uart.receive_holding_register = m_uart.receive_buffer[0];
-
-		if (m_uart.receive_pointer > -1)
-		{
-			LOGMASKED(LOG_UART, "scc68070_rx_callback: Receiving %02x\n", m_uart.receive_holding_register);
-
-			m_uart_rx_int = true;
-			update_ipl();
-
-			m_uart.status_register |= USR_RXRDY;
-		}
-		else
-		{
-			m_uart.status_register &= ~USR_RXRDY;
-		}
-	}
-	else
-	{
-		m_uart.status_register &= ~USR_RXRDY;
-	}
-}
-
-TIMER_CALLBACK_MEMBER(scc68070_device::tx_callback)
-{
-	if (((m_uart.command_register >> 2) & 3) != 1)
-	{
-		return;
-	}
-
-	if (m_uart.transmit_pointer > -1)
-	{
-		if (m_uart.transmit_ctsn && BIT(m_uart.mode_register, 4))
-		{
-			return;
-		}
-
-		m_uart.transmit_holding_register = m_uart.transmit_buffer[0];
-		m_uart_tx_callback(m_uart.transmit_holding_register);
-
-		LOGMASKED(LOG_MORE_UART, "tx_callback: Transmitting %02x\n", m_uart.transmit_holding_register);
-		for(int index = 0; index < m_uart.transmit_pointer; index++)
-		{
-			m_uart.transmit_buffer[index] = m_uart.transmit_buffer[index+1];
-		}
-		m_uart.transmit_pointer--;
-
-		m_uart.status_register |= USR_TXRDY;
-		m_uart_tx_int = true;
-		update_ipl();
-	}
-
-	if (m_uart.transmit_pointer < 0)
-	{
-		m_uart.status_register |= USR_TXEMT | USR_TXRDY;
-	}
+	m_uart.receive_holding_register = data;
+	m_uart.status_register |= USR_RXRDY;
+	m_uart_rx_int = true;
+	update_ipl();
 }
 
 uint8_t scc68070_device::lir_r()
@@ -1330,6 +1314,7 @@ void scc68070_device::umr_w(uint8_t data)
 {
 	LOGMASKED(LOG_MORE_UART, "%s: UART Mode Register Write: %02x\n", machine().describe_context(), data);
 	m_uart.mode_register = data;
+	recalc_framing();
 }
 
 uint8_t scc68070_device::usr_r()
@@ -1340,7 +1325,7 @@ uint8_t scc68070_device::usr_r()
 		m_uart.status_register |= (1 << 1);
 		LOGMASKED(LOG_MORE_UART, "%s: UART Status Register Read: %02x\n", machine().describe_context(), m_uart.status_register);
 	}
-	return m_uart.status_register | 0x08; // hack for magicard
+	return m_uart.status_register;
 }
 
 uint8_t scc68070_device::ucsr_r()
@@ -1356,12 +1341,7 @@ void scc68070_device::ucsr_w(uint8_t data)
 	LOGMASKED(LOG_UART, "%s: UART Clock Select Write: %02x\n", machine().describe_context(), data);
 	m_uart.clock_select = data;
 
-	static const uint32_t s_baud_divisors[8] = { 65536, 32768, 16384, 4096, 2048, 1024, 512, 256 };
-
-	attotime rx_rate = attotime::from_ticks(s_baud_divisors[(data >> 4) & 7] * 10, 4915200);
-	attotime tx_rate = attotime::from_ticks(s_baud_divisors[data & 7] * 10, 4915200);
-	m_uart.rx_timer->adjust(rx_rate, 0, rx_rate);
-	m_uart.tx_timer->adjust(tx_rate, 0, tx_rate);
+	recalc_baud();
 }
 
 uint8_t scc68070_device::ucr_r()
@@ -1375,35 +1355,55 @@ uint8_t scc68070_device::ucr_r()
 void scc68070_device::ucr_w(uint8_t data)
 {
 	LOGMASKED(LOG_MORE_UART, "%s: UART Command Register Write: %02x\n", machine().describe_context(), data);
+	const bool was_enabled = (m_uart.command_register & 3) == 1;
 	m_uart.command_register = data;
-	const uint8_t misc_command = (data & 0x70) >> 4;
+	if (!was_enabled && (data & 3) == 1)
+		receive_register_reset();
+
+	const uint8_t misc_command = (data & 0xf0) >> 4;
 	switch (misc_command)
 	{
 	case 0x2: // Reset receiver
 		LOGMASKED(LOG_MORE_UART, "%s: Reset receiver\n", machine().describe_context());
-		m_uart.receive_pointer = -1;
-		m_uart.command_register &= 0xf0;
+		receive_register_reset();
+		m_uart.status_register &= ~USR_RXRDY;
+		m_uart.command_register &= 0xfc;
 		m_uart.receive_holding_register = 0x00;
+		m_uart_rx_int = false;
+		update_ipl();
 		break;
 	case 0x3: // Reset transmitter
 		LOGMASKED(LOG_MORE_UART, "%s: Reset transmitter\n", machine().describe_context());
-		m_uart.transmit_pointer = -1;
+		transmit_register_reset();
 		m_uart.status_register |= USR_TXEMT | USR_TXRDY;
-		m_uart.command_register &= 0xf0;
+		m_uart.command_register &= 0xf3;
 		m_uart.transmit_holding_register = 0x00;
+		m_uart_tx_int = false;
+		update_ipl();
 		break;
 	case 0x4: // Reset error status
 		LOGMASKED(LOG_MORE_UART, "%s: Reset error status\n", machine().describe_context());
-		m_uart.status_register &= ~(USR_RB | USR_FE | USR_PE | USR_OE); // Clear error bits in USR
-		m_uart.command_register &= 0xf0;
+		m_uart.status_register &= ~(USR_RB | USR_FE | USR_PE | USR_OE);
 		break;
 	case 0x6: // Start break
-		LOGMASKED(LOG_MORE_UART, "%s: Start break (not yet implemented)\n", machine().describe_context());
+		LOGMASKED(LOG_MORE_UART, "%s: Start break\n", machine().describe_context());
+		if (!m_uart.transmit_break)
+		{
+			m_uart.transmit_break = true;
+			m_txd_cb(0);
+		}
 		break;
 	case 0x7: // Stop break
-		LOGMASKED(LOG_MORE_UART, "%s: Stop break (not yet implemented)\n", machine().describe_context());
+		LOGMASKED(LOG_MORE_UART, "%s: Stop break\n", machine().describe_context());
+		if (m_uart.transmit_break)
+		{
+			m_uart.transmit_break = false;
+			m_txd_cb(1);
+		}
 		break;
 	}
+
+	check_for_tx_start();
 }
 
 uint8_t scc68070_device::uth_r()
@@ -1417,9 +1417,9 @@ uint8_t scc68070_device::uth_r()
 void scc68070_device::uth_w(uint8_t data)
 {
 	LOGMASKED(LOG_MORE_UART, "%s: UART Transmit Holding Register Write: %02x ('%c')\n", machine().describe_context(), data, (data >= 0x20 && data < 0x7f) ? data : ' ');
-	uart_tx(data);
 	m_uart.transmit_holding_register = data;
-	m_uart.status_register &= ~USR_TXRDY;
+	m_uart.status_register &= ~(USR_TXRDY | USR_TXEMT);
+	check_for_tx_start();
 }
 
 uint8_t scc68070_device::urh_r()
@@ -1435,15 +1435,7 @@ uint8_t scc68070_device::urh_r()
 			update_ipl();
 		}
 
-		m_uart.receive_holding_register = m_uart.receive_buffer[0];
-		if (m_uart.receive_pointer >= 0)
-		{
-			for(int index = 0; index < m_uart.receive_pointer; index++)
-			{
-				m_uart.receive_buffer[index] = m_uart.receive_buffer[index + 1];
-			}
-			m_uart.receive_pointer--;
-		}
+		m_uart.status_register &= ~USR_RXRDY;
 	}
 	return m_uart.receive_holding_register;
 }

--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -1307,13 +1307,13 @@ uint8_t scc68070_device::umr_r()
 	// UART mode register: 80002011
 	if (!machine().side_effects_disabled())
 		LOGMASKED(LOG_MORE_UART, "%s: UART Mode Register Read: %02x\n", machine().describe_context(), m_uart.mode_register);
-	return m_uart.mode_register | 0x20;
+	return m_uart.mode_register;
 }
 
 void scc68070_device::umr_w(uint8_t data)
 {
 	LOGMASKED(LOG_MORE_UART, "%s: UART Mode Register Write: %02x\n", machine().describe_context(), data);
-	m_uart.mode_register = data;
+	m_uart.mode_register = data & 0xdf;
 	recalc_framing();
 }
 

--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -641,6 +641,24 @@ void scc68070_device::uart_rx(uint8_t data)
 
 void scc68070_device::uart_tx(uint8_t data)
 {
+	if(ENABLE_UART_PRINTING)
+	{
+		// Static variable does not survive load state.
+		static std::string s_line;
+		if (data == '\r' || data == '\n')
+		{
+			if (!s_line.empty())
+			{
+				logerror("UART: %s\n", s_line);
+				s_line.clear();
+			}
+		}
+		else
+		{
+			s_line += char(data);
+		}
+	}
+
 	if (m_uart.transmit_pointer >= int16_t(std::size(m_uart.transmit_buffer) - 1))
 	{
 		LOGMASKED(LOG_UART, "%s: uart_tx: transmit buffer full, discarding %02x\n", machine().describe_context(), data);
@@ -1809,10 +1827,3 @@ void scc68070_device::mmu_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		break;
 	}
 }
-
-#if ENABLE_UART_PRINTING
-uint16_t scc68070_device::uart_loopback_enable()
-{
-	return 0x1234;
-}
-#endif

--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -1561,6 +1561,7 @@ uint16_t scc68070_device::dma_r(offs_t offset, uint16_t mem_mask)
 		}
 		return (m_dma.channel[offset / 32].sequence_control << 8) | m_dma.channel[offset / 32].channel_control;
 	case 0x0a/2:
+	case 0x4a/2:
 		if (!machine().side_effects_disabled())
 			LOGMASKED(LOG_DMA, "%s: DMA(%d) Memory Transfer Counter Read: %04x & %04x\n", machine().describe_context(), offset / 32, m_dma.channel[offset / 32].transfer_counter, mem_mask);
 		return m_dma.channel[offset / 32].transfer_counter;
@@ -1643,6 +1644,7 @@ void scc68070_device::dma_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		}
 		break;
 	case 0x0a/2:
+	case 0x4a/2:
 		LOGMASKED(LOG_DMA, "%s: DMA(%d) Memory Transfer Counter Write: %04x & %04x\n", machine().describe_context(), offset / 32, data, mem_mask);
 		COMBINE_DATA(&m_dma.channel[offset / 32].transfer_counter);
 		break;

--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -1321,10 +1321,7 @@ uint8_t scc68070_device::usr_r()
 {
 	// UART status register: 80002013
 	if (!machine().side_effects_disabled())
-	{
-		m_uart.status_register |= (1 << 1);
 		LOGMASKED(LOG_MORE_UART, "%s: UART Status Register Read: %02x\n", machine().describe_context(), m_uart.status_register);
-	}
 	return m_uart.status_register;
 }
 

--- a/src/devices/machine/scc68070.h
+++ b/src/devices/machine/scc68070.h
@@ -17,7 +17,7 @@ STATUS:
 
 TODO:
 
-- Proper handling of the 68070's internal devices (UART, DMA, Timers, etc.)
+- Proper handling of the 68070's internal devices (DMA, Timers, etc.)
 
 *******************************************************************************/
 
@@ -27,6 +27,7 @@ TODO:
 #pragma once
 
 #include "cpu/m68000/scc68070.h"
+#include "diserial.h"
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -43,7 +44,7 @@ enum scc68070_ocr_bits
 
 // ======================> scc68070_device
 
-class scc68070_device : public scc68070_base_device
+class scc68070_device : public scc68070_base_device, public device_serial_interface
 {
 public:
 	scc68070_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -53,6 +54,7 @@ public:
 	auto iack5_callback() { return m_iack5_callback.bind(); }
 	auto iack7_callback() { return m_iack7_callback.bind(); }
 	auto uart_tx_callback() { return m_uart_tx_callback.bind(); }
+	auto out_txd_cb() { return m_txd_cb.bind(); }
 	auto uart_rtsn_callback() { return m_uart_rtsn_callback.bind(); }
 	auto i2c_scl_w() { return m_i2c_scl_callback.bind(); }
 	auto i2c_sda_w() { return m_i2c_sdaw_callback.bind(); }
@@ -68,8 +70,6 @@ public:
 	void write_scl(int state);
 
 	TIMER_CALLBACK_MEMBER(timer0_callback);
-	TIMER_CALLBACK_MEMBER(rx_callback);
-	TIMER_CALLBACK_MEMBER(tx_callback);
 	TIMER_CALLBACK_MEMBER(i2c_callback);
 
 	// external callbacks
@@ -117,14 +117,8 @@ public:
 		uint8_t reserved5;
 		uint8_t receive_holding_register;
 
-		int16_t receive_pointer;
-		uint8_t receive_buffer[32768];
-		emu_timer* rx_timer;
-
-		int16_t transmit_pointer;
-		uint8_t transmit_buffer[32768];
-		emu_timer* tx_timer;
 		bool transmit_ctsn;
+		bool transmit_break;
 	};
 
 	struct timer_regs_t
@@ -195,6 +189,11 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 	virtual void device_config_complete() override;
 
+	// device_serial_interface implementation
+	virtual void tra_callback() override;
+	virtual void tra_complete() override;
+	virtual void rcv_complete() override;
+
 	// device_execute_interface implementation
 	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 2 - 1) / 2; }
 	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return (cycles * 2); }
@@ -257,10 +256,9 @@ private:
 	uint16_t mmu_r(offs_t offset, uint16_t mem_mask);
 	void mmu_w(offs_t offset, uint16_t data, uint16_t mem_mask);
 
-	void uart_rx_check();
-	void uart_tx_check();
-	void uart_tx(uint8_t data);
-	void uart_do_tx();
+	void recalc_framing();
+	void recalc_baud();
+	void check_for_tx_start();
 	void set_timer_callback(int channel);
 
 	// callbacks
@@ -269,6 +267,7 @@ private:
 	devcb_read8 m_iack5_callback;
 	devcb_read8 m_iack7_callback;
 	devcb_write8 m_uart_tx_callback;
+	devcb_write_line m_txd_cb;
 	devcb_write_line m_uart_rtsn_callback;
 	devcb_write_line m_i2c_scl_callback;
 	devcb_write_line m_i2c_sdaw_callback;

--- a/src/mame/layout/cdi.lay
+++ b/src/mame/layout/cdi.lay
@@ -3,37 +3,50 @@
 license:CC0-1.0
 -->
 <mamelayout version="2">
-	<view name="Main Screen Standard (4:3)">
-		<screen index="0">
-			<bounds left="0" top="0" right="4" bottom="3" />
-		</screen>
-	</view>
+	<element name="pcb_digit" defstate="0">
+		<led7seg><color red="0.9" green="0.25" blue="0.1" /></led7seg>
+	</element>
+	<element name="pcb_bezel">
+		<rect><color red="0.05" green="0.05" blue="0.06" /></rect>
+	</element>
+	<element name="pcb_button" defstate="0">
+		<rect state="0"><color red="0.26" green="0.26" blue="0.28" /></rect>
+		<rect state="1"><color red="0.80" green="0.72" blue="0.20" /></rect>
+	</element>
+	<element name="pcb_yes"><text string="YES"><color red="0.1" green="0.1" blue="0.1" /></text></element>
+	<element name="pcb_test"><text string="TEST"><color red="0.1" green="0.1" blue="0.1" /></text></element>
+	<element name="pcb_no"><text string="NO"><color red="0.1" green="0.1" blue="0.1" /></text></element>
 
-	<view name="LCD Standard (15:3)">
-		<screen index="1">
-			<bounds left="0" top="0" right="15" bottom="3" />
-		</screen>
-	</view>
-
-	<view name="Main Screen Pixel Aspect (~scr0nativexaspect~:~scr0nativeyaspect~)">
-		<screen index="0">
-			<bounds left="0" top="0" right="~scr0width~" bottom="~scr0height~" />
-		</screen>
-	</view>
-
-	<view name="LCD Pixel Aspect (~scr1nativexaspect~:~scr1nativeyaspect~)">
-		<screen index="1">
-			<bounds left="0" top="0" right="~scr1width~" bottom="~scr1height~" />
-		</screen>
-	</view>
+	<!-- The service PCB fills the space left of the front panel LCD on the top row. Its
+	     digits read 0 and its buttons do nothing when no PCB is plugged in. -->
+	<group name="service_pcb">
+		<bounds x="0" y="0" width="140" height="22" />
+		<element ref="pcb_bezel"><bounds x="0" y="0" width="140" height="22" /></element>
+		<repeat count="8">
+			<param name="digitno" start="0" increment="1" />
+			<param name="digitx" start="4" increment="16" />
+			<element ref="pcb_digit" name="digit~digitno~">
+				<bounds x="~digitx~" y="1" width="14" height="11" />
+			</element>
+		</repeat>
+		<repeat count="3">
+			<param name="btnx" start="8" increment="43" />
+			<param name="btnmask" start="0x01" lshift="1" />
+			<element ref="pcb_button" inputtag=":serial:cdipcb:BUTTONS" inputmask="~btnmask~">
+				<bounds x="~btnx~" y="13" width="38" height="8" />
+			</element>
+		</repeat>
+		<element ref="pcb_yes"><bounds x="8" y="14" width="38" height="6" /></element>
+		<element ref="pcb_test"><bounds x="51" y="14" width="38" height="6" /></element>
+		<element ref="pcb_no"><bounds x="94" y="14" width="38" height="6" /></element>
+	</group>
 
 	<view name="Main Screen + LCD">
-		<screen index="1">
-			<bounds x="0" y="0" width="192" height="22" />
-		</screen>
-		<screen index="0">
-			<bounds x="0" y="22" width="384" height="288" />
-		</screen>
+		<screen index="1"><bounds x="0" y="0" width="192" height="22" /></screen>
+		<collection name="Service PCB" visible="no">
+			<group ref="service_pcb"><bounds x="244" y="0" width="140" height="22" /></group>
+		</collection>
+		<screen index="0"><bounds x="0" y="22" width="384" height="288" /></screen>
 	</view>
 
 </mamelayout>

--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -76,27 +76,28 @@ TODO:
 #define VERBOSE         (0)
 #include "logmacro.h"
 
-#define ENABLE_UART_PRINTING (0)
-
 /*************************
 *      Memory maps       *
 *************************/
-
-void cdi_state::cdimono1_mem(address_map &map)
+void cdi_state::cdi_common_mem(address_map &map)
 {
 	map(0x000000, 0xffffff).rw(FUNC(cdi_state::bus_error_r), FUNC(cdi_state::bus_error_w));
 	map(0x000000, 0x07ffff).rw(FUNC(cdi_state::plane_r<0>), FUNC(cdi_state::plane_w<0>)).share("plane0");
 	map(0x200000, 0x27ffff).rw(FUNC(cdi_state::plane_r<1>), FUNC(cdi_state::plane_w<1>)).share("plane1");
-	map(0x300000, 0x303bff).rw(m_cdic, FUNC(cdicdic_device::ram_r), FUNC(cdicdic_device::ram_w));
-#if ENABLE_UART_PRINTING
-	map(0x301400, 0x301403).r(m_maincpu, FUNC(scc68070_device::uart_loopback_enable));
-#endif
-	map(0x303c00, 0x303fff).rw(m_cdic, FUNC(cdicdic_device::regs_r), FUNC(cdicdic_device::regs_w));
-	map(0x310000, 0x317fff).rw(m_slave_hle, FUNC(cdislave_hle_device::slave_r), FUNC(cdislave_hle_device::slave_w));
-	map(0x318000, 0x31ffff).noprw();
 	map(0x320000, 0x323fff).rw("mk48t08", FUNC(timekeeper_device::read), FUNC(timekeeper_device::write)).umask16(0xff00);    /* nvram (only low bytes used) */
 	map(0x400000, 0x47ffff).r(FUNC(cdi_state::main_rom_r));
 	map(0x4fffe0, 0x4fffff).m(m_mcd212, FUNC(mcd212_device::map));
+}
+
+void cdi_state::cdimono1_mem(address_map &map)
+{
+	cdi_common_mem(map);
+	map(0x300000, 0x303bff).rw(m_cdic, FUNC(cdicdic_device::ram_r), FUNC(cdicdic_device::ram_w));
+
+	map(0x303c00, 0x303fff).rw(m_cdic, FUNC(cdicdic_device::regs_r), FUNC(cdicdic_device::regs_w));
+	map(0x310000, 0x317fff).rw(m_slave_hle, FUNC(cdislave_hle_device::slave_r), FUNC(cdislave_hle_device::slave_w));
+	map(0x318000, 0x31ffff).noprw();
+
 	map(0x500000, 0x57ffff).ram();
 	map(0xd00000, 0xdfffff).ram(); // DVC RAM block 1
 	map(0xe00000, 0xe7ffff).rw(FUNC(cdi_state::dvc_r), FUNC(cdi_state::dvc_w));
@@ -105,14 +106,7 @@ void cdi_state::cdimono1_mem(address_map &map)
 
 void cdi_state::cdimono2_mem(address_map &map)
 {
-	map(0x000000, 0x07ffff).rw(FUNC(cdi_state::plane_r<0>), FUNC(cdi_state::plane_w<0>)).share("plane0");
-	map(0x200000, 0x27ffff).rw(FUNC(cdi_state::plane_r<1>), FUNC(cdi_state::plane_w<1>)).share("plane1");
-#if ENABLE_UART_PRINTING
-	map(0x301400, 0x301403).r(m_maincpu, FUNC(scc68070_device::uart_loopback_enable));
-#endif
-	map(0x320000, 0x323fff).rw("mk48t08", FUNC(timekeeper_device::read), FUNC(timekeeper_device::write)).umask16(0xff00);    /* nvram (only low bytes used) */
-	map(0x400000, 0x47ffff).r(FUNC(cdi_state::main_rom_r));
-	map(0x4fffe0, 0x4fffff).m(m_mcd212, FUNC(mcd212_device::map));
+	cdi_common_mem(map);
 }
 
 void cdi_state::cdi910_mem(address_map &map)
@@ -120,9 +114,7 @@ void cdi_state::cdi910_mem(address_map &map)
 	map(0x000000, 0x07ffff).ram().share("plane0");
 	map(0x180000, 0x1fffff).rom().region("maincpu", 0); // boot vectors point here
 	map(0x200000, 0x27ffff).ram().share("plane1");
-#if ENABLE_UART_PRINTING
-	map(0x301400, 0x301403).r(m_maincpu, FUNC(scc68070_device::uart_loopback_enable));
-#endif
+
 	map(0x320000, 0x323fff).rw("mk48t08", FUNC(timekeeper_device::read), FUNC(timekeeper_device::write)).umask16(0xff00);    /* nvram (only low bytes used) */
 	map(0x4fffe0, 0x4fffff).m(m_mcd212, FUNC(mcd212_device::map));
 	map(0x500000, 0xffffff).noprw();

--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -62,6 +62,8 @@ TODO:
 
 #include "cdrom.h"
 
+#include "cdipcb.h"
+
 #include "cdi.lh"
 
 // TODO: NTSC system clock is 30.2098 MHz; additional 4.9152 MHz XTAL provided for UART
@@ -75,6 +77,12 @@ TODO:
 
 #define VERBOSE         (0)
 #include "logmacro.h"
+
+// What can be plugged into the serial connector on the back.
+static void cdi_serial_devices(device_slot_interface &device)
+{
+	device.option_add("cdipcb", CDI_SERVICE_PCB);
+}
 
 /*************************
 *      Memory maps       *
@@ -138,10 +146,10 @@ static INPUT_PORTS_START( cdi )
 	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_BUTTON3) PORT_CODE(MOUSECODE_BUTTON3) PORT_NAME("Button 3")
 	PORT_BIT(0xf8, IP_ACTIVE_HIGH, IPT_UNUSED)
 
-	PORT_START("TESTPLUG")
-	PORT_CONFNAME( 0x01, 0x00, "Test plug" )
-	PORT_CONFSETTING(    0x00, DEF_STR( Off ) )
-	PORT_CONFSETTING(    0x01, DEF_STR( On ) )
+	PORT_START("SERVICE")
+	PORT_CONFNAME( 0x01, 0x00, "Service mode" )
+	PORT_CONFSETTING(    0x00, DEF_STR( None ) )
+	PORT_CONFSETTING(    0x01, "Test plug (service shell)" )
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( cdimono2 )
@@ -378,6 +386,15 @@ void cdi_state::cdimono1_base(machine_config &config)
 {
 	SCC68070(config, m_maincpu, CLOCK_A);
 	m_maincpu->set_addrmap(AS_PROGRAM, &cdi_state::cdimono1_mem);
+
+
+	// The serial connector on the back, carrying the 68070's UART.
+	RS232_PORT(config, m_serial_port, cdi_serial_devices, nullptr);
+	m_maincpu->out_txd_cb().set(m_serial_port, FUNC(rs232_port_device::write_txd));
+	m_maincpu->uart_rtsn_callback().set(m_serial_port, FUNC(rs232_port_device::write_rts));
+	m_serial_port->rxd_handler().set(m_maincpu, FUNC(scc68070_device::rx_w));
+	m_serial_port->cts_handler().set(m_maincpu, FUNC(scc68070_device::uart_ctsn));
+
 	m_maincpu->iack4_callback().set(m_cdic, FUNC(cdicdic_device::intack_r));
 
 	MCD212(config, m_mcd212, CLOCK_A, m_plane_ram[0], m_plane_ram[1]);
@@ -522,7 +539,7 @@ void cdi_state::cdimono1(machine_config &config)
 	m_slave_hle->read_mousex().set_ioport("MOUSEX");
 	m_slave_hle->read_mousey().set_ioport("MOUSEY");
 	m_slave_hle->read_mousebtn().set_ioport("MOUSEBTN");
-	m_slave_hle->testplug_callback().set_ioport("TESTPLUG");
+	m_slave_hle->testplug_callback().set_ioport("SERVICE").bit(0);
 
 	SOFTWARE_LIST(config, "cd_list").set_original("cdi").set_filter("!DVC");
 	SOFTWARE_LIST(config, "photocd_list").set_compatible("photo_cd");

--- a/src/mame/philips/cdi.h
+++ b/src/mame/philips/cdi.h
@@ -64,6 +64,7 @@ protected:
 	uint32_t screen_update_cdimono1_lcd(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	virtual void machine_reset() override ATTR_COLD;
 
+	void cdi_common_mem(address_map &map) ATTR_COLD;
 	void cdimono1_mem(address_map &map) ATTR_COLD;
 
 	void cdi910_mem(address_map &map) ATTR_COLD;

--- a/src/mame/philips/cdi.h
+++ b/src/mame/philips/cdi.h
@@ -13,6 +13,7 @@
 #include "cpu/mcs51/i8051.h"
 #include "cpu/m6805/m68hc05.h"
 #include "diserial.h"
+#include "bus/rs232/rs232.h"
 #include "screen.h"
 
 /*----------- driver state -----------*/
@@ -33,6 +34,7 @@ public:
 		, m_cdrom(*this, "cdrom")
 		, m_mcd212(*this, "mcd212")
 		, m_dmadac(*this, "dac%u", 1U)
+		, m_serial_port(*this, "serial")
 	{ }
 
 	void cdimono1_base(machine_config &config);
@@ -60,6 +62,8 @@ protected:
 	required_device<mcd212_device> m_mcd212;
 
 	required_device_array<dmadac_sound_device, 2> m_dmadac;
+
+	optional_device<rs232_port_device> m_serial_port;
 
 	uint32_t screen_update_cdimono1_lcd(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	virtual void machine_reset() override ATTR_COLD;

--- a/src/mame/philips/cdipcb.cpp
+++ b/src/mame/philips/cdipcb.cpp
@@ -1,0 +1,161 @@
+// license:BSD-3-Clause
+// copyright-holders:Vincent Halver
+
+#include "emu.h"
+#include "cdipcb.h"
+
+#define LOG_CHARS   (1U << 1)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+constexpr uint8_t ACK = 0x06;
+
+
+DEFINE_DEVICE_TYPE(CDI_SERVICE_PCB, cdi_service_pcb_device, "cdipcb", "CD-i Service PCB")
+
+cdi_service_pcb_device::cdi_service_pcb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, CDI_SERVICE_PCB, tag, owner, clock)
+	, device_serial_interface(mconfig, *this)
+	, device_rs232_port_interface(mconfig, *this)
+	, m_digits(*this, "digit%u", 0U)
+{
+}
+
+static INPUT_PORTS_START( cdipcb )
+	PORT_START("BUTTONS")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_NAME("Yes") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(cdi_service_pcb_device::button_changed), 'Y')
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_NAME("Test") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(cdi_service_pcb_device::button_changed), 'B')
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_BUTTON3 ) PORT_NAME("No") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(cdi_service_pcb_device::button_changed), 'N')
+	PORT_BIT( 0xf8, IP_ACTIVE_HIGH, IPT_UNUSED )
+INPUT_PORTS_END
+
+ioport_constructor cdi_service_pcb_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( cdipcb );
+}
+
+INPUT_CHANGED_MEMBER(cdi_service_pcb_device::button_changed)
+{
+	if (newval)
+		send_char(uint8_t(param));
+}
+
+void cdi_service_pcb_device::device_start()
+{
+	std::fill(std::begin(m_display), std::end(m_display), ' ');
+
+	save_item(NAME(m_answered));
+	save_item(NAME(m_cursor));
+	save_item(NAME(m_display));
+}
+
+void cdi_service_pcb_device::device_reset()
+{
+	set_data_frame(1, 8, PARITY_NONE, STOP_BITS_1);
+	set_rcv_rate(9600);
+	set_tra_rate(9600);
+
+	receive_register_reset();
+	transmit_register_reset();
+	output_rxd(1);
+
+	m_answered = false;
+
+	std::fill(std::begin(m_display), std::end(m_display), ' ');
+	m_cursor = 0;
+	refresh_display();
+
+	transmit_register_setup(ACK);
+}
+
+void cdi_service_pcb_device::tra_callback()
+{
+	output_rxd(transmit_register_get_data_bit());
+}
+
+void cdi_service_pcb_device::tra_complete()
+{
+	// ACK announces until the player responds.
+	if (!m_answered)
+		transmit_register_setup(ACK);
+}
+
+void cdi_service_pcb_device::rcv_complete()
+{
+	receive_register_extract();
+
+	// Wait for a real output character.
+	const uint8_t data = get_received_char();
+	if (data >= 0x20 && data < 0x7f)
+		m_answered = true;
+
+	put_char(data);
+}
+
+void cdi_service_pcb_device::put_char(uint8_t data)
+{
+	LOGMASKED(LOG_CHARS, "put_char: %02x\n", data);
+
+	switch (data)
+	{
+	case 0x08: // Backspace
+		if (m_cursor)
+			m_cursor--;
+		break;
+
+	case 0x0d: // Carriage return
+		m_cursor = 0;
+		break;
+
+	case 0x0a: // Line feed
+		std::fill(std::begin(m_display), std::end(m_display), ' ');
+		m_cursor = 0;
+		break;
+
+	default:
+		if (data < 0x20 || data >= 0x7f)
+			break;
+		if (m_cursor < 8)
+		{
+			m_display[m_cursor] = data;
+			m_cursor++;
+		}
+		else
+		{
+			std::copy(std::begin(m_display) + 1, std::end(m_display), std::begin(m_display));
+			m_display[7] = data;
+		}
+		break;
+	}
+
+	refresh_display();
+}
+
+void cdi_service_pcb_device::send_char(uint8_t data)
+{
+	if (is_transmit_register_empty())
+		transmit_register_setup(data);
+}
+
+void cdi_service_pcb_device::refresh_display()
+{
+	// Seven segment bits, for 0x20 to 0x5f. Space, [0-9], [A-Z].
+	static constexpr uint8_t s_ascii_to_segments[0x40] =
+	{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x39, 0x0f, 0x00, 0x00, 0x00, 0x40, 0x80, 0x00,
+		0x3f, 0x06, 0x5b, 0x4f, 0x66, 0x6d, 0x7d, 0x07,
+		0x7f, 0x6f, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00,
+		0x00, 0x77, 0x7c, 0x39, 0x5e, 0x79, 0x71, 0x3d,
+		0x76, 0x06, 0x1e, 0x00, 0x38, 0x00, 0x37, 0x3f,
+		0x73, 0x67, 0x50, 0x6d, 0x78, 0x3e, 0x1c, 0x00,
+		0x00, 0x6e, 0x5b, 0x39, 0x00, 0x0f, 0x00, 0x08
+	};
+
+	for (int i = 0; i < 8; i++)
+	{
+		const uint8_t c = m_display[i];
+		m_digits[i] = (c >= 0x20 && c < 0x60) ? s_ascii_to_segments[c - 0x20] : 0x00;
+	}
+}

--- a/src/mame/philips/cdipcb.h
+++ b/src/mame/philips/cdipcb.h
@@ -1,0 +1,55 @@
+// license:BSD-3-Clause
+// copyright-holders:Vincent Halver
+/******************************************************************************
+
+    CD-i PCB Test Device described in the 220 Service Manual.
+
+    The service PCB has a seven segment display and three buttons.
+
+*******************************************************************************/
+
+#ifndef MAME_PHILIPS_CDIPCB_H
+#define MAME_PHILIPS_CDIPCB_H
+
+#pragma once
+
+#include "bus/rs232/rs232.h"
+#include "diserial.h"
+
+class cdi_service_pcb_device : public device_t,
+	public device_serial_interface,
+	public device_rs232_port_interface
+{
+public:
+	cdi_service_pcb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	DECLARE_INPUT_CHANGED_MEMBER(button_changed);
+
+protected:
+	// device_rs232_port_interface implementation
+	virtual void input_txd(int state) override { device_serial_interface::rx_w(state); }
+
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+
+	// device_serial_interface implementation
+	virtual void tra_callback() override;
+	virtual void tra_complete() override;
+	virtual void rcv_complete() override;
+
+private:
+	void put_char(uint8_t data);
+	void send_char(uint8_t data);
+	void refresh_display();
+
+	output_finder<8> m_digits;
+
+	bool m_answered;
+	uint8_t m_cursor;
+	uint8_t m_display[8];
+};
+
+DECLARE_DEVICE_TYPE(CDI_SERVICE_PCB, cdi_service_pcb_device)
+
+#endif // MAME_PHILIPS_CDIPCB_H


### PR DESCRIPTION
This is towards enabling the hidden RL1.1 PCB UART test in the cdimono1. Currently there is no where to see the output of the PCB test, since the UART mechanism is only partially implemented. This change allows the output to go to error.log

This also properly defines the loopback enablement function, which otherwise doesn't compile when enabling UART printing.

