### PR TITLE
Refactor color calculation in kingdrby.cpp

### DIFF
--- a/src/mame/tatsumi/kingdrby.cpp
+++ b/src/mame/tatsumi/kingdrby.cpp
@@ -913,9 +913,10 @@ void kingdrby_state::kingdrby_palette(palette_device &palette) const
 	{
 		int bit0, bit1, bit2;
 
-		bit0 = BIT(color_prom[0], 1);
-		bit1 = BIT(color_prom[0], 0);
-		int const b = 0x52 * bit0 + 0xad * bit1;
+		bit0 = 0;
+		bit1 = BIT(color_prom[0], 1);
+		bit2 = BIT(color_prom[0], 0);
+		int const b = 0x21 * bit0 + 0x47 * bit1 + 0x97 * bit2;
 
 		bit0 = BIT(color_prom[0], 4);
 		bit1 = BIT(color_prom[0], 3);
@@ -946,9 +947,10 @@ void kingdrby_state::kingdrbb_palette(palette_device &palette) const
 	{
 		int bit0, bit1, bit2;
 
-		bit0 = BIT(prom[i], 1);
-		bit1 = BIT(prom[i], 0);
-		int const b = 0x52 * bit0 + 0xad * bit1;
+		bit0 = 0;
+		bit1 = BIT(prom[i], 1);
+		bit2 = BIT(prom[i], 0);
+		int const b = 0x21 * bit0 + 0x47 * bit1 + 0x97 * bit2;
 
 		bit0 = BIT(prom[i], 4);
 		bit1 = BIT(prom[i], 3);


### PR DESCRIPTION
sorry!
While both color schemes have their respective shortcomings, there is no doubt that the revised scheme—featuring the lawn, small trees, betting background, and character colors—best reflects the original creator's vision.
<img width="2559" height="952" alt="a" src="https://github.com/user-attachments/assets/d75f3db9-9078-4e6f-8d6c-e57f716a6847" />
