### PR TITLE
sound/ymf271: rewrite the YMF271 (OPX) core

### DIFF
--- a/src/devices/sound/ymf271.cpp
+++ b/src/devices/sound/ymf271.cpp
@@ -1,1311 +1,491 @@
 // license:BSD-3-Clause
-// copyright-holders:Olivier Galibert, R. Belmont, hap
+// copyright-holders:superctr
 /*
-    Yamaha YMF271-F "OPX" emulator v0.1
-    By R. Belmont.
-    Based in part on YMF278B emulator by R. Belmont and O. Galibert.
-    12June04 update by Toshiaki Nijiura
-    Copyright R. Belmont.
+    Yamaha YMF271-F "OPX" emulator
 
-    TODO:
-    - A/L bit (alternate loop)
-    - EN and EXT Out bits
-    - Src B and Src NOTE bits
-    - statusreg Busy flag
-    - PFM (FM using external PCM waveform)
-    - detune (should be same as on other Yamaha chips)
-    - Acc On bit (some sound effects in viprp1?). The documentation says
-      "determines if slot output is accumulated(1), or output directly(0)"
-    - Is memory handling 100% correct? At the moment, seibuspi.cpp is the only
-      hardware currently emulated that uses external handlers.
-    - *16 multiplier for timer B is free-running like other yamaha FM chips?
+    Written from the datasheet and the application manual.  Where the
+    documents leave the behaviour open, the model follows recordings of real
+    hardware (no chip was available for direct probing).
+
+    Architecture (from the datasheet / application manual):
+      - 48 slots in 12 groups of 4; slot n = 12*bank + group, where bank is the
+        register bank (S1..S4) and the slot number is also the order in which the
+        chip evaluates operators inside one 44.1 kHz sample period.
+      - Every slot runs the same operator pipeline (PG -> oscillator -> EG -> OP).
+        The oscillator reads one of 7 internal waveforms (log-sin derived) or, for
+        the 12 slots of groups 0/4/8 only (n % 4 == 0), external PCM data.
+      - The per-group sync register selects how the 4 slots are connected
+        (4op / 2x2op / 3op+PCM / 4xPCM), which slots receive broadcast writes,
+        and which slot(s) act as key-on slot.
+
+    Model:
+      - Register model with sync broadcast, F-number latch, status / End flags,
+        timers, external memory window.
+      - OPM/OPZ-style log-sin/exp operator
+      - Per-slot LFO: clock-divider rate table 2-6-2, saw / square / triangle,
+        PMS depth fnum*k/1024 (table 2-6-3), AMS 63/126/252 units, phase reset
+        at key-on; AM starts at full attenuation for every waveform (OPM convention).
+      - AccOn = the slot output is accumulated in a saturating 14-bit sum, so
+        any sustained tone rails into a full-level square that flips at the
+        operator's zero crossings ("distorted" basses and drums).
+      - External PCM: FM PG with the implicit fnum bit 11, Fs divider, 8-bit and
+        packed 12-bit words, linear interpolation, looping, End flags, external
+        key code (manual 2-9), envelope multiply, same pan as FM.
+
+    Open points (need to be verified on real HW):
+      - Waveforms 1-6 unverified on HW recordings and based on guesswork.
+      - Key code: octave = Block for blocks 0..7, assumed to clamp at 0 for negative
+        blocks (the manual's formula wraps to the top rows instead).
+      - wave 7 on slots other than 0,4,..,44 assumed to be silent.
+
+    Not implemented (decoded, unused by the available VGMs):
+      - PFM (utility 0x0n bit 7)
+      - PCM alternate loop (A/L), probably bidirectional loop but no games use it.
+      - Timer A register split (0x10 high 8 / 0x11 low 2 bits) and the
+        external-memory write address increment follow the previous core.
 */
 
 #include "emu.h"
 #include "ymf271.h"
 
-#include <algorithm>
+#include <cmath>
 #include <numbers>
 
-#define STD_CLOCK       (16934400)
 
-#define MAXOUT          (+32767)
-#define MINOUT          (-32768)
+// ------------------------------------------------------------------------
+// constants and tables
+// ------------------------------------------------------------------------
 
-#define SIN_BITS        10
-#define SIN_LEN         (1<<SIN_BITS)
-#define SIN_MASK        (SIN_LEN-1)
+namespace {
 
-#define LFO_LENGTH      256
-#define LFO_SHIFT       8
-#define PLFO_MAX        (+1.0)
-#define PLFO_MIN        (-1.0)
-#define ALFO_MAX        (+65536)
-#define ALFO_MIN        (0)
+// register address low nibble -> group (FM banks, utility) / slot (PCM bank).
+// Nibbles 3/7/B/F are invalid.
+const int8_t fm_tab[16]  = { 0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1 };
+const int8_t pcm_tab[16] = { 0, 4, 8, -1, 12, 16, 20, -1, 24, 28, 32, -1, 36, 40, 44, -1 };
 
-#define ENV_ATTACK      0
-#define ENV_DECAY1      1
-#define ENV_DECAY2      2
-#define ENV_RELEASE     3
-
-#define OP_INPUT_FEEDBACK   -1
-#define OP_INPUT_NONE       -2
-
-#define ENV_VOLUME_SHIFT    16
-
-#define INF     -1.0
-
-static const double ARTime[64] =
+// sync modes (utility reg 0x0n bits 1:0)
+enum
 {
-	INF,        INF,        INF,        INF,        6188.12,    4980.68,    4144.76,    3541.04,
-	3094.06,    2490.34,    2072.38,    1770.52,    1547.03,    1245.17,    1036.19,    885.26,
-	773.51,     622.59,     518.10,     441.63,     386.76,     311.29,     259.05,     221.32,
-	193.38,     155.65,     129.52,     110.66,     96.69,      77.82,      64.76,      55.33,
-	48.34,      38.91,      32.38,      27.66,      24.17,      19.46,      16.19,      13.83,
-	12.09,      9.73,       8.10,       6.92,       6.04,       4.86,       4.05,       3.46,
-	3.02,       2.47,       2.14,       1.88,       1.70,       1.38,       1.16,       1.02,
-	0.88,       0.70,       0.57,       0.48,       0.43,       0.43,       0.43,       0.07
+	SYNC_4OP = 0,       // S1-S2-S3-S4, key-on slot S1
+	SYNC_2X2OP = 1,     // S1-S3 and S2-S4, key-on slots S1, S2
+	SYNC_3OP_PCM = 2,   // S1-S2-S3 FM + S4 PCM, key-on slots S1,S4
+	SYNC_PCM = 3        // 4 independent slots
 };
 
-static const double DCTime[64] =
+enum
 {
-	INF,        INF,        INF,        INF,        93599.64,   74837.91,   62392.02,   53475.56,
-	46799.82,   37418.96,   31196.01,   26737.78,   23399.91,   18709.48,   15598.00,   13368.89,
-	11699.95,   9354.74,    7799.00,    6684.44,    5849.98,    4677.37,    3899.50,    3342.22,
-	2924.99,    2338.68,    1949.75,    1671.11,    1462.49,    1169.34,    974.88,     835.56,
-	731.25,     584.67,     487.44,     417.78,     365.62,     292.34,     243.72,     208.89,
-	182.81,     146.17,     121.86,     104.44,     91.41,      73.08,      60.93,      52.22,
-	45.69,      36.55,      33.85,      26.09,      22.83,      18.28,      15.22,      13.03,
-	11.41,      9.12,       7.60,       6.51,       5.69,       5.69,       5.69,       5.69
+	EG_ATTACK = 0,
+	EG_DECAY1,
+	EG_DECAY2,
+	EG_RELEASE,
+	EG_OFF
 };
 
-/* Notes about the LFO Frequency Table below:
+// Wave 6: the MUL-scaled modulation input wraps at 2^W6_BITS (0 = continuous).
+constexpr int W6_BITS = 9;
 
-    There are 2 known errors in the LFO table listed in the original manual.
-
-    Both 201 & 202 are listed as 3.74490.  202 has been computed/corrected to 3.91513
-    232 was listed as 13.35547 but has been replaced with the correct value of 14.35547.
-
-  Corrections are computed values based on formulas by Olivier Galibert & Nicola Salmoria listed below:
-
-LFO period seems easy to compute:
-
-Olivier Galibert's version                       Nicola Salmoria's version
-
-int lfo_period(int entry)             or         int calc_lfo_period(int entry)
-{                                                {
-  int ma, ex;                                      entry = 256 - entry;
-  entry = 256-entry;
-  ma = entry & 15;                                 if (entry < 16)
-                                                   {
-  ex = entry >> 4;                                    return (entry & 0x0f) << 7;
-  if(ex)                                           }
-    return (ma | 16) << (ex+6);                    else
-  else                                             {
-    return ma << 7;                                   int shift = 6 + (entry >> 4);
-}                                                     return (0x10 + (entry & 0x0f)) << shift;
-                                                   }
-lfo_freq = 44100 / lfo_period                    }
-
-*/
-
-static const double LFO_frequency_table[256] =
+// EG increment patterns (ymfm/OPM): nibble k of entry r = increment for
+// EG sub-step k at rate r.
+const uint32_t eg_inc[64] =
 {
-	0.00066,    0.00068,    0.00070,    0.00073,    0.00075,    0.00078,    0.00081,    0.00084,
-	0.00088,    0.00091,    0.00096,    0.00100,    0.00105,    0.00111,    0.00117,    0.00124,
-	0.00131,    0.00136,    0.00140,    0.00145,    0.00150,    0.00156,    0.00162,    0.00168,
-	0.00175,    0.00183,    0.00191,    0.00200,    0.00210,    0.00221,    0.00234,    0.00247,
-	0.00263,    0.00271,    0.00280,    0.00290,    0.00300,    0.00312,    0.00324,    0.00336,
-	0.00350,    0.00366,    0.00382,    0.00401,    0.00421,    0.00443,    0.00467,    0.00495,
-	0.00526,    0.00543,    0.00561,    0.00580,    0.00601,    0.00623,    0.00647,    0.00673,
-	0.00701,    0.00731,    0.00765,    0.00801,    0.00841,    0.00885,    0.00935,    0.00990,
-	0.01051,    0.01085,    0.01122,    0.01160,    0.01202,    0.01246,    0.01294,    0.01346,
-	0.01402,    0.01463,    0.01529,    0.01602,    0.01682,    0.01771,    0.01869,    0.01979,
-	0.02103,    0.02171,    0.02243,    0.02320,    0.02403,    0.02492,    0.02588,    0.02692,
-	0.02804,    0.02926,    0.03059,    0.03204,    0.03365,    0.03542,    0.03738,    0.03958,
-	0.04206,    0.04341,    0.04486,    0.04641,    0.04807,    0.04985,    0.05176,    0.05383,
-	0.05608,    0.05851,    0.06117,    0.06409,    0.06729,    0.07083,    0.07477,    0.07917,
-	0.08411,    0.08683,    0.08972,    0.09282,    0.09613,    0.09969,    0.10353,    0.10767,
-	0.11215,    0.11703,    0.12235,    0.12817,    0.13458,    0.14167,    0.14954,    0.15833,
-	0.16823,    0.17365,    0.17944,    0.18563,    0.19226,    0.19938,    0.20705,    0.21533,
-	0.22430,    0.23406,    0.24470,    0.25635,    0.26917,    0.28333,    0.29907,    0.31666,
-	0.33646,    0.34731,    0.35889,    0.37126,    0.38452,    0.39876,    0.41410,    0.43066,
-	0.44861,    0.46811,    0.48939,    0.51270,    0.53833,    0.56666,    0.59814,    0.63333,
-	0.67291,    0.69462,    0.71777,    0.74252,    0.76904,    0.79753,    0.82820,    0.86133,
-	0.89722,    0.93623,    0.97878,    1.02539,    1.07666,    1.13333,    1.19629,    1.26666,
-	1.34583,    1.38924,    1.43555,    1.48505,    1.53809,    1.59509,    1.65640,    1.72266,
-	1.79443,    1.87245,    1.95756,    2.05078,    2.15332,    2.26665,    2.39258,    2.53332,
-	2.69165,    2.77848,    2.87109,    2.97010,    3.07617,    3.19010,    3.31280,    3.44531,
-	3.58887,    3.74490,    3.91513,    4.10156,    4.30664,    4.53331,    4.78516,    5.06664,
-	5.38330,    5.55696,    5.74219,    5.94019,    6.15234,    6.38021,    6.62560,    6.89062,
-	7.17773,    7.48981,    7.83026,    8.20312,    8.61328,    9.06661,    9.57031,    10.13327,
-	10.76660,   11.11391,   11.48438,   11.88039,   12.30469,   12.76042,   13.25120,   13.78125,
-	14.35547,   14.97962,   15.66051,   16.40625,   17.22656,   18.13322,   19.14062,   20.26654,
-	21.53320,   22.96875,   24.60938,   26.50240,   28.71094,   31.32102,   34.45312,   38.28125,
-	43.06641,   49.21875,   57.42188,   68.90625,   86.13281,   114.84375,  172.26562,  344.53125
+	0x00000000, 0x00000000, 0x10101010, 0x10101010,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x10101010, 0x10111010, 0x11101110, 0x11111110,
+	0x11111111, 0x21112111, 0x21212121, 0x22212221,
+	0x22222222, 0x42224222, 0x42424242, 0x44424442,
+	0x44444444, 0x84448444, 0x84848484, 0x88848884,
+	0x88888888, 0x88888888, 0x88888888, 0x88888888
 };
 
-static const int RKS_Table[32][8] =
+// Rate key scaling (manual table 2-6-7), [keycode][KS]
+const uint8_t rks_tab[32][8] =
 {
-	{  0,  0,  0,  0,  0,  2,  4,  8 },
-	{  0,  0,  0,  0,  1,  3,  5,  9 },
-	{  0,  0,  0,  1,  2,  4,  6, 10 },
-	{  0,  0,  0,  1,  3,  5,  7, 11 },
-	{  0,  0,  1,  2,  4,  6,  8, 12 },
-	{  0,  0,  1,  2,  5,  7,  9, 13 },
-	{  0,  0,  1,  3,  6,  8, 10, 14 },
-	{  0,  0,  1,  3,  7,  9, 11, 15 },
-	{  0,  1,  2,  4,  8, 10, 12, 16 },
-	{  0,  1,  2,  4,  9, 11, 13, 17 },
-	{  0,  1,  2,  5, 10, 12, 14, 18 },
-	{  0,  1,  2,  5, 11, 13, 15, 19 },
-	{  0,  1,  3,  6, 12, 14, 16, 20 },
-	{  0,  1,  3,  6, 13, 15, 17, 21 },
-	{  0,  1,  3,  7, 14, 16, 18, 22 },
-	{  0,  1,  3,  7, 15, 17, 19, 23 },
-	{  0,  2,  4,  8, 16, 18, 20, 24 },
-	{  0,  2,  4,  8, 17, 19, 21, 25 },
-	{  0,  2,  4,  9, 18, 20, 22, 26 },
-	{  0,  2,  4,  9, 19, 21, 23, 27 },
-	{  0,  2,  5, 10, 20, 22, 24, 28 },
-	{  0,  2,  5, 10, 21, 23, 25, 29 },
-	{  0,  2,  5, 11, 22, 24, 26, 30 },
-	{  0,  2,  5, 11, 23, 25, 27, 31 },
-	{  0,  3,  6, 12, 24, 26, 28, 31 },
-	{  0,  3,  6, 12, 25, 27, 29, 31 },
-	{  0,  3,  6, 13, 26, 28, 30, 31 },
-	{  0,  3,  6, 13, 27, 29, 31, 31 },
-	{  0,  3,  7, 14, 28, 30, 31, 31 },
-	{  0,  3,  7, 14, 29, 31, 31, 31 },
-	{  0,  3,  7, 15, 30, 31, 31, 31 },
-	{  0,  3,  7, 15, 31, 31, 31, 31 },
+	{  0,  0,  0,  0,  0,  2,  4,  8 }, {  0,  0,  0,  0,  1,  3,  5,  9 },
+	{  0,  0,  0,  1,  2,  4,  6, 10 }, {  0,  0,  0,  1,  3,  5,  7, 11 },
+	{  0,  0,  1,  2,  4,  6,  8, 12 }, {  0,  0,  1,  2,  5,  7,  9, 13 },
+	{  0,  0,  1,  3,  6,  8, 10, 14 }, {  0,  0,  1,  3,  7,  9, 11, 15 },
+	{  0,  1,  2,  4,  8, 10, 12, 16 }, {  0,  1,  2,  4,  9, 11, 13, 17 },
+	{  0,  1,  2,  5, 10, 12, 14, 18 }, {  0,  1,  2,  5, 11, 13, 15, 19 },
+	{  0,  1,  3,  6, 12, 14, 16, 20 }, {  0,  1,  3,  6, 13, 15, 17, 21 },
+	{  0,  1,  3,  7, 14, 16, 18, 22 }, {  0,  1,  3,  7, 15, 17, 19, 23 },
+	{  0,  2,  4,  8, 16, 18, 20, 24 }, {  0,  2,  4,  8, 17, 19, 21, 25 },
+	{  0,  2,  4,  9, 18, 20, 22, 26 }, {  0,  2,  4,  9, 19, 21, 23, 27 },
+	{  0,  2,  5, 10, 20, 22, 24, 28 }, {  0,  2,  5, 10, 21, 23, 25, 29 },
+	{  0,  2,  5, 11, 22, 24, 26, 30 }, {  0,  2,  5, 11, 23, 25, 27, 31 },
+	{  0,  3,  6, 12, 24, 26, 28, 31 }, {  0,  3,  6, 12, 25, 27, 29, 31 },
+	{  0,  3,  6, 13, 26, 28, 30, 31 }, {  0,  3,  6, 13, 27, 29, 31, 31 },
+	{  0,  3,  7, 14, 28, 30, 31, 31 }, {  0,  3,  7, 14, 29, 31, 31, 31 },
+	{  0,  3,  7, 15, 30, 31, 31, 31 }, {  0,  3,  7, 15, 31, 31, 31, 31 }
 };
 
-static const double multiple_table[16] = { 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-
-static const double pow_table[16] = { 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 0.5, 1, 2, 4, 8, 16, 32, 64 };
-
-static const double fs_frequency[4] = { 1.0/1.0, 1.0/2.0, 1.0/4.0, 1.0/8.0 };
-
-static const double channel_attenuation_table[16] =
+// Detune, [keycode][DT&3], in units of fs/2^20 Hz (= 1 LSB of a 20-bit phase
+// increment).  This is the OPM DT1 table; the manual's table 2-6-5 (cents
+// column) is exactly this table at fs = 44.1 kHz.
+const uint8_t detune_tab[32][4] =
 {
-	0.0, 2.5, 6.0, 8.5, 12.0, 14.5, 18.1, 20.6, 24.1, 26.6, 30.1, 32.6, 36.1, 96.1, 96.1, 96.1
+	{ 0, 0, 1, 2 }, { 0, 0, 1, 2 }, { 0, 0, 1, 2 }, { 0, 0, 1, 2 },
+	{ 0, 1, 2, 2 }, { 0, 1, 2, 3 }, { 0, 1, 2, 3 }, { 0, 1, 2, 3 },
+	{ 0, 1, 2, 4 }, { 0, 1, 3, 4 }, { 0, 1, 3, 4 }, { 0, 1, 3, 5 },
+	{ 0, 2, 4, 5 }, { 0, 2, 4, 6 }, { 0, 2, 4, 6 }, { 0, 2, 5, 7 },
+	{ 0, 2, 5, 8 }, { 0, 3, 6, 8 }, { 0, 3, 6, 9 }, { 0, 3, 7, 10 },
+	{ 0, 4, 8, 11 }, { 0, 4, 8, 12 }, { 0, 4, 9, 13 }, { 0, 5, 10, 14 },
+	{ 0, 5, 11, 16 }, { 0, 6, 12, 17 }, { 0, 6, 13, 19 }, { 0, 7, 14, 20 },
+	{ 0, 8, 16, 22 }, { 0, 8, 16, 22 }, { 0, 8, 16, 22 }, { 0, 8, 16, 22 }
 };
 
-static const int modulation_level[8] = { 16, 8, 4, 2, 1, 32, 64, 128 };
+// Modulation level (FB register of a modulated slot), manual values:
+// 0 = 16 pi, 1 = 8 pi, 2 = 4 pi, 3 = 2 pi, 4 = pi, 5 = 32 pi, 6 = 64 pi, 7 = 128 pi.
+// Applied as (14-bit modulator sum * table) >> 8 on the 10-bit phase: level 0
+// = 8192 * 128 / 256 = 4096 phase units = 4 cycles = +/-8 pi peak, i.e. half
+// the manual's figure (read as the peak-to-peak swing) and exactly OPM's
+// fixed depth.
+const uint16_t modlevel[8] = { 128, 64, 32, 16, 8, 256, 512, 1024 };
 
-// feedback_level * 16
-static const int feedback_level[8] = { 0, 1, 2, 4, 8, 16, 32, 64 };
+// LFO PM depth (manual table 2-6-3): max deviation = fnum * k / 1024,
+// k = 0, 2, 3, 4, 6, 12, 24, 48 (3.4 .. 79.3 cents).
+const uint8_t pms_k[8] = { 0, 2, 3, 4, 6, 12, 24, 48 };
 
-// slot mapping assists
-static const int fm_tab[16] = { 0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1 };
-static const int pcm_tab[16] = { 0, 4, 8, -1, 12, 16, 20, -1, 24, 28, 32, -1, 36, 40, 44, -1 };
+} // anonymous namespace
 
-
-/*****************************************************************************/
-
-void ymf271_device::calculate_step(YMF271Slot *slot)
+// Algorithm connection tables.  For each operator position of the voice:
+// mods = bitmask of positions whose output modulates it; car = bitmask of
+// carrier positions; fbsrc = position whose output is fed back into position
+// 0 (0 = self, 2 = the S3 loop of algorithms 1/5/7/11).  Positions: 4op
+// S1,S2,S3,S4 = 0..3; 2op head,tail = 0,1; 3op S1,S2,S3 = 0..2.
+static const ymf271_device::opx_alg alg4[16] =
 {
-	double st;
+	{ { 0, 0x4, 0x1, 0x2 }, 0x8, 0 },   // 0: S1>S3>S2>S4
+	{ { 0, 0x4, 0x1, 0x2 }, 0x8, 2 },   // 1: same, fb loop S1>S3
+	{ { 0, 0x5, 0x0, 0x2 }, 0x8, 0 },   // 2: (S1+S3)>S2>S4
+	{ { 0, 0x4, 0x0, 0x3 }, 0x8, 0 },   // 3: (S1 + S3>S2)>S4
+	{ { 0, 0x0, 0x1, 0x6 }, 0x8, 0 },   // 4: (S1>S3 + S2)>S4
+	{ { 0, 0x0, 0x1, 0x6 }, 0x8, 2 },   // 5: same, fb loop S1>S3
+	{ { 0, 0x0, 0x1, 0x2 }, 0xC, 0 },   // 6: S1>S3, S2>S4
+	{ { 0, 0x0, 0x1, 0x2 }, 0xC, 2 },   // 7: same, fb loop S1>S3
+	{ { 0, 0x4, 0x0, 0x2 }, 0x9, 0 },   // 8: S1, S3>S2>S4
+	{ { 0, 0x0, 0x0, 0x6 }, 0x9, 0 },   // 9: S1, (S3+S2)>S4
+	{ { 0, 0x0, 0x1, 0x0 }, 0xE, 0 },   // 10: S1>S3, S2, S4
+	{ { 0, 0x0, 0x1, 0x0 }, 0xE, 2 },   // 11: same, fb loop S1>S3
+	{ { 0, 0x1, 0x1, 0x1 }, 0xE, 0 },   // 12: S1>(S2,S3,S4)
+	{ { 0, 0x4, 0x0, 0x0 }, 0xB, 0 },   // 13: S1, S3>S2, S4
+	{ { 0, 0x0, 0x1, 0x2 }, 0xD, 0 },   // 14: S1, S1>S3, S2>S4
+	{ { 0, 0x0, 0x0, 0x0 }, 0xF, 0 }    // 15: all carriers
+};
 
-	if (slot->waveform == 7)
+static const ymf271_device::opx_alg alg2[4] =
+{
+	{ { 0, 0x1, 0, 0 }, 0x2, 0 },   // 0: A>B
+	{ { 0, 0x1, 0, 0 }, 0x2, 1 },   // 1: A>B, fb loop
+	{ { 0, 0x0, 0, 0 }, 0x3, 0 },   // 2: A, B
+	{ { 0, 0x1, 0, 0 }, 0x3, 0 }    // 3: A, A>B
+};
+
+static const ymf271_device::opx_alg alg3[8] =
+{
+	{ { 0, 0x4, 0x1, 0 }, 0x2, 0 }, // 0: S1>S3>S2
+	{ { 0, 0x4, 0x1, 0 }, 0x2, 2 }, // 1: same, fb loop
+	{ { 0, 0x5, 0x0, 0 }, 0x2, 0 }, // 2: (S1+S3)>S2
+	{ { 0, 0x4, 0x0, 0 }, 0x3, 0 }, // 3: S1, S3>S2
+	{ { 0, 0x0, 0x1, 0 }, 0x6, 0 }, // 4: S1>S3, S2
+	{ { 0, 0x0, 0x1, 0 }, 0x6, 2 }, // 5: same, fb loop
+	{ { 0, 0x0, 0x0, 0 }, 0x7, 0 }, // 6: S1, S2, S3
+	{ { 0, 0x0, 0x1, 0 }, 0x7, 0 }  // 7: S1, S1>S3, S2
+};
+
+static const ymf271_device::opx_alg alg_single = { { 0, 0, 0, 0 }, 0x1, 0 };
+
+
+// ------------------------------------------------------------------------
+// helpers
+// ------------------------------------------------------------------------
+
+// Is slot (bank, group) a key-on slot under the group's sync mode?
+bool ymf271_device::is_keyon_slot(int bank, int group) const
+{
+	switch (m_groups[group].sync)
 	{
-		// external waveform (PCM)
-		st = (double)(2 * (slot->fns | 2048)) * pow_table[slot->block] * fs_frequency[slot->fs];
-		st = st * multiple_table[slot->multiple];
+	case SYNC_4OP:      return bank == 0;
+	case SYNC_2X2OP:    return bank == 0 || bank == 1;
+	case SYNC_3OP_PCM:  return bank == 0 || bank == 3;
+	default:            return true;
+	}
+}
 
-		// LFO phase modulation
-		st *= slot->lfo_phasemod;
+// Fill 'slots' with the slot numbers that form the voice keyed by (bank, group).
+// Returns the count (0 if not a key-on slot).
+int ymf271_device::voice_slots(int bank, int group, int *slots) const
+{
+	switch (m_groups[group].sync)
+	{
+	case SYNC_4OP:
+		if (bank != 0) return 0;
+		slots[0] = group; slots[1] = group + 12; slots[2] = group + 24; slots[3] = group + 36;
+		return 4;
+	case SYNC_2X2OP:
+		if (bank == 0) { slots[0] = group; slots[1] = group + 24; return 2; }
+		if (bank == 1) { slots[0] = group + 12; slots[1] = group + 36; return 2; }
+		return 0;
+	case SYNC_3OP_PCM:
+		if (bank == 0) { slots[0] = group; slots[1] = group + 12; slots[2] = group + 24; return 3; }
+		if (bank == 3) { slots[0] = group + 36; return 1; }
+		return 0;
+	default:
+		slots[0] = 12 * bank + group;
+		return 1;
+	}
+}
 
-		st /= (double)(524288/65536); // pre-multiply with 65536
 
-		slot->step = (uint32_t)st;
+// ------------------------------------------------------------------------
+// key on / off
+// ------------------------------------------------------------------------
+
+// Key code (manual 2-9): 5 bits, octave = the *bottom 3 bits* of Block (so the
+// negative blocks wrap to the top octaves) + N4N3 from the F-number.
+// internal waveform: KC = 4 Block + N4N3, fnum thresholds 0x780/0x900/0xA80;
+// external waveform: KC = (4 SrcB + SrcNote) + (4 Block + N4N3), 11-bit fnum
+// thresholds 0x100/0x300/0x500 (table 2-9-3); the 5-bit sum wraps, which gives
+// the arithmetically right result for negative blocks.
+void ymf271_device::update_keycode(opx_slot &s, int slotnum)
+{
+	int n43, kc;
+
+	if (s.wave == 7 && (slotnum & 3) == 0)
+	{
+		uint16_t fn = s.fnum & 0x7FF;
+		if (fn < 0x100)      n43 = 0;
+		else if (fn < 0x300) n43 = 1;
+		else if (fn < 0x500) n43 = 2;
+		else                 n43 = 3;
+		kc = s.pcm_srcb * 4 + s.pcm_srcnote + (s.block & 7) * 4 + n43;
 	}
 	else
 	{
-		// internal waveform (FM)
-		st = (double)(2 * slot->fns) * pow_table[slot->block];
-		st = st * multiple_table[slot->multiple] * (double)(SIN_LEN);
-
-		// LFO phase modulation
-		st *= slot->lfo_phasemod;
-
-		st /= (double)(536870912/65536); // pre-multiply with 65536
-
-		slot->step = (uint32_t)st;
+		if (s.fnum < 0x780)      n43 = 0;
+		else if (s.fnum < 0x900) n43 = 1;
+		else if (s.fnum < 0xA80) n43 = 2;
+		else                     n43 = 3;
+		// negative blocks: the manual's 4*Block would wrap to octave 7, but
+		// a recorded bass at block -1 (DT 7 / DT 2 on a 1:3 operator pair)
+		// stays phase-locked within ~0.5 %, i.e. the detune of the lowest
+		// key codes -- so the octave clamps at 0.
+		kc = ((s.block_s < 0) ? 0 : (s.block & 7) * 4) + n43;
 	}
+	s.keycode = uint8_t(kc & 31);
 }
 
-inline bool ymf271_device::check_envelope_end(YMF271Slot *slot)
+int ymf271_device::eg_rate(int rate2, int rks)
 {
-	if (slot->volume <= 0)
-	{
-		slot->active = 0;
-		slot->volume = 0;
-		return true;
-	}
-	return false;
+	// rate2 = 2*AR/D1R/D2R or 4*RR; rate 0 stays 0 (infinite)
+	if (rate2 == 0)
+		return 0;
+	rate2 += rks;
+	return (rate2 > 63) ? 63 : rate2;
 }
 
-// calculate status end disable/enable (Desert War shots relies on this)
-inline void ymf271_device::calculate_status_end(int slotnum, bool state)
+void ymf271_device::slot_keyon(int slotnum)
 {
-	// guess: don't enable/disable if slot isn't a multiple of 4
-	if (slotnum & 3)
-		return;
+	opx_slot &s = m_slots[slotnum];
 
-	/*
-	bit scheme is kinda twisted
-	status1 Busy  End36 End24 End12 End0  ----  TimB  TimA
-	status2 End44 End32 End20 End8  End40 End28 End16 End4
-	*/
-	uint8_t subbit = slotnum / 12;
-	uint8_t bankbit = ((slotnum % 12) >> 2);
-
-	if (state == false)
-		m_end_status &= ~(1 << (subbit + bankbit * 4));
-	else
-		m_end_status |= (1 << (subbit + bankbit * 4));
-
+	s.eg_state = EG_ATTACK;
+	s.phase = 0;
+	// The attenuation continues from its current value (OPM); a maximum
+	// attack rate jumps straight to 0 dB (table 2-6-8: rate 63 = 0.07 ms).
+	if (eg_rate(s.ar * 2, rks_tab[s.keycode][s.ks]) >= 63)
+		s.eg_att = 0;
+	s.lfo_cnt = 0;
+	s.lfo_pos = 0;
+	s.pcm_pos = 0;
+	s.pcm_frac = 0;
+	s.pcm_ended = 0;
+	s.acc = 0;
+	if ((slotnum & 3) == 0)
+		m_end_status &= ~(1 << (slotnum >> 2));
 }
 
-void ymf271_device::update_envelope(YMF271Slot *slot)
+void ymf271_device::slot_keyoff(int slotnum)
 {
-	switch (slot->env_state)
-	{
-		case ENV_ATTACK:
-		{
-			slot->volume += slot->env_attack_step;
+	opx_slot &s = m_slots[slotnum];
 
-			if (slot->volume >= (255 << ENV_VOLUME_SHIFT))
-			{
-				slot->volume = (255 << ENV_VOLUME_SHIFT);
-				slot->env_state = ENV_DECAY1;
-			}
-			break;
-		}
-
-		case ENV_DECAY1:
-		{
-			int decay_level = 255 - (slot->decay1lvl << 4);
-			slot->volume -= slot->env_decay1_step;
-
-			if (!check_envelope_end(slot) && (slot->volume >> ENV_VOLUME_SHIFT) <= decay_level)
-			{
-				slot->env_state = ENV_DECAY2;
-			}
-			break;
-		}
-
-		case ENV_DECAY2:
-		{
-			slot->volume -= slot->env_decay2_step;
-			check_envelope_end(slot);
-			break;
-		}
-
-		case ENV_RELEASE:
-		{
-			slot->volume -= slot->env_release_step;
-			check_envelope_end(slot);
-			break;
-		}
-	}
+	if (s.eg_state != EG_OFF)
+		s.eg_state = EG_RELEASE;
 }
 
-inline int ymf271_device::get_keyscaled_rate(int rate, int keycode, int keyscale)
+
+// ------------------------------------------------------------------------
+// register writes
+// ------------------------------------------------------------------------
+
+// write one decoded function register to one slot
+void ymf271_device::write_slot_reg(int slotnum, int reg, uint8_t data)
 {
-	int newrate = rate + RKS_Table[keycode][keyscale];
+	opx_slot &s = m_slots[slotnum];
 
-	if (newrate > 63)
+	switch (reg)
 	{
-		newrate = 63;
-	}
-	if (newrate < 0)
-	{
-		newrate = 0;
-	}
-	return newrate;
-}
-
-inline int ymf271_device::get_internal_keycode(int block, int fns)
-{
-	int n43;
-	if (fns < 0x780)
-	{
-		n43 = 0;
-	}
-	else if (fns < 0x900)
-	{
-		n43 = 1;
-	}
-	else if (fns < 0xa80)
-	{
-		n43 = 2;
-	}
-	else
-	{
-		n43 = 3;
-	}
-
-	return ((block & 7) * 4) + n43;
-}
-
-inline int ymf271_device::get_external_keycode(int block, int fns)
-{
-	int n43;
-	if (fns < 0x100)
-	{
-		n43 = 0;
-	}
-	else if (fns < 0x300)
-	{
-		n43 = 1;
-	}
-	else if (fns < 0x500)
-	{
-		n43 = 2;
-	}
-	else
-	{
-		n43 = 3;
-	}
-
-	return ((block & 7) * 4) + n43;
-}
-
-void ymf271_device::init_envelope(YMF271Slot *slot)
-{
-	int keycode, rate;
-	int decay_level = 255 - (slot->decay1lvl << 4);
-
-	if (slot->waveform != 7)
-	{
-		keycode = get_internal_keycode(slot->block, slot->fns);
-	}
-	else
-	{
-		keycode = get_external_keycode(slot->block, slot->fns & 0x7ff);
-		/* keycode = (keycode + slot->srcb * 4 + slot->srcnote) / 2; */ // not sure
-	}
-
-	// init attack state
-	rate = get_keyscaled_rate(slot->ar * 2, keycode, slot->keyscale);
-	slot->env_attack_step = (rate < 4) ? 0 : (int)(((double)(255-0) / m_lut_ar[rate]) * 65536.0);
-
-	// init decay1 state
-	rate = get_keyscaled_rate(slot->decay1rate * 2, keycode, slot->keyscale);
-	slot->env_decay1_step = (rate < 4) ? 0 : (int)(((double)(255-decay_level) / m_lut_dc[rate]) * 65536.0);
-
-	// init decay2 state
-	rate = get_keyscaled_rate(slot->decay2rate * 2, keycode, slot->keyscale);
-	slot->env_decay2_step = (rate < 4) ? 0 : (int)(((double)(255-0) / m_lut_dc[rate]) * 65536.0);
-
-	// init release state
-	rate = get_keyscaled_rate(slot->relrate * 4, keycode, slot->keyscale);
-	slot->env_release_step = (rate < 4) ? 0 : (int)(((double)(255-0) / m_lut_dc[rate]) * 65536.0);
-
-	slot->volume = (255-160) << ENV_VOLUME_SHIFT; // -60db
-	slot->env_state = ENV_ATTACK;
-}
-
-void ymf271_device::init_lfo(YMF271Slot *slot)
-{
-	slot->lfo_phase = 0;
-	slot->lfo_amplitude = 0;
-	slot->lfo_phasemod = 0;
-
-	slot->lfo_step = (int)((((double)LFO_LENGTH * m_lut_lfo[slot->lfoFreq]) / 44100.0) * 256.0);
-}
-
-void ymf271_device::update_lfo(YMF271Slot *slot)
-{
-	slot->lfo_phase += slot->lfo_step;
-
-	slot->lfo_amplitude = m_lut_alfo[slot->lfowave][(slot->lfo_phase >> LFO_SHIFT) & (LFO_LENGTH-1)];
-	slot->lfo_phasemod = m_lut_plfo[slot->lfowave][slot->pms].get()[(slot->lfo_phase >> LFO_SHIFT) & (LFO_LENGTH-1)];
-
-	calculate_step(slot);
-}
-
-int64_t ymf271_device::calculate_slot_volume(YMF271Slot *slot)
-{
-	int64_t volume;
-	int64_t env_volume;
-	int64_t lfo_volume = 65536;
-
-	switch (slot->ams)
-	{
-		case 0: lfo_volume = 65536; break;  // 0dB
-		case 1: lfo_volume = 65536 - ((slot->lfo_amplitude * 33124) >> 16); break;  // 5.90625dB
-		case 2: lfo_volume = 65536 - ((slot->lfo_amplitude * 16742) >> 16); break;  // 11.8125dB
-		case 3: lfo_volume = 65536 - ((slot->lfo_amplitude * 4277) >> 16); break;   // 23.625dB
-	}
-
-	env_volume = (m_lut_env_volume[255 - (slot->volume >> ENV_VOLUME_SHIFT)] * lfo_volume) >> 16;
-
-	volume = (env_volume * m_lut_total_level[slot->tl]) >> 16;
-
-	return volume;
-}
-
-void ymf271_device::update_pcm(int slotnum, int32_t *mixp, int length)
-{
-	int i;
-	int64_t final_volume;
-	int16_t sample;
-	int64_t ch0_vol, ch1_vol, ch2_vol, ch3_vol;
-
-	YMF271Slot *slot = &m_slots[slotnum];
-
-	if (!slot->active)
-	{
-		return;
-	}
-
-	if (slot->waveform != 7)
-	{
-		fatalerror("Waveform %d in update_pcm!!!\n", slot->waveform);
-	}
-
-	for (i = 0; i < length; i++)
-	{
-		// loop
-		if ((slot->stepptr>>16) > slot->endaddr)
-		{
-			slot->stepptr = slot->stepptr - ((uint64_t)slot->endaddr<<16) + ((uint64_t)slot->loopaddr<<16);
-			calculate_status_end(slotnum,true);
-			if ((slot->stepptr>>16) > slot->endaddr)
-			{
-				// overflow
-				slot->stepptr &= 0xffff;
-				slot->stepptr |= ((uint64_t)slot->loopaddr<<16);
-				if ((slot->stepptr>>16) > slot->endaddr)
-				{
-					// still overflow? (triggers in rdft2, rarely)
-					slot->stepptr &= 0xffff;
-					slot->stepptr |= ((uint64_t)slot->endaddr<<16);
-				}
-			}
-		}
-
-		if (slot->bits == 8)
-		{
-			// 8bit
-			sample = read_byte(slot->startaddr + (slot->stepptr>>16))<<8;
-		}
+	case 0x0:
+		s.ext_en = (data >> 7) & 1;
+		s.ext_out = (data >> 3) & 0xF;
+		s.kon = data & 1;
+		// Every KON=1 write (re)triggers the slot: P-47 Aces writes KON=1 onto
+		// already keyed slots for note repeats, so edge-triggering would drop notes.
+		if (data & 1)
+			slot_keyon(slotnum);
 		else
-		{
-			// 12bit
-			if (slot->stepptr & 0x10000)
-				sample = read_byte(slot->startaddr + (slot->stepptr>>17)*3 + 2)<<8 | ((read_byte(slot->startaddr + (slot->stepptr>>17)*3 + 1) << 4) & 0xf0);
-			else
-				sample = read_byte(slot->startaddr + (slot->stepptr>>17)*3)<<8 | (read_byte(slot->startaddr + (slot->stepptr>>17)*3 + 1) & 0xf0);
-		}
-
-		update_envelope(slot);
-		update_lfo(slot);
-
-		final_volume = calculate_slot_volume(slot);
-
-		ch0_vol = (final_volume * m_lut_attenuation[slot->ch0_level]) >> 16;
-		ch1_vol = (final_volume * m_lut_attenuation[slot->ch1_level]) >> 16;
-		ch2_vol = (final_volume * m_lut_attenuation[slot->ch2_level]) >> 16;
-		ch3_vol = (final_volume * m_lut_attenuation[slot->ch3_level]) >> 16;
-
-		if (ch0_vol > 65536) ch0_vol = 65536;
-		if (ch1_vol > 65536) ch1_vol = 65536;
-		if (ch2_vol > 65536) ch2_vol = 65536;
-		if (ch3_vol > 65536) ch3_vol = 65536;
-
-		*mixp++ += (sample * ch0_vol) >> 16;
-		*mixp++ += (sample * ch1_vol) >> 16;
-		*mixp++ += (sample * ch2_vol) >> 16;
-		*mixp++ += (sample * ch3_vol) >> 16;
-
-		// go to next step
-		slot->stepptr += slot->step;
+			slot_keyoff(slotnum);
+		break;
+	case 0x1:
+		s.lfo_freq = data;
+		break;
+	case 0x2:
+		s.lfo_wave = data & 3;
+		s.pms = (data >> 3) & 7;
+		s.ams = (data >> 6) & 3;
+		break;
+	case 0x3:
+		s.mul = data & 0xF;
+		s.dt = (data >> 4) & 7;
+		break;
+	case 0x4:
+		s.tl = data & 0x7F;
+		break;
+	case 0x5:
+		s.ar = data & 0x1F;
+		s.ks = (data >> 5) & 7;
+		break;
+	case 0x6:
+		s.d1r = data & 0x1F;
+		break;
+	case 0x7:
+		s.d2r = data & 0x1F;
+		break;
+	case 0x8:
+		s.rr = data & 0xF;
+		s.d1l = (data >> 4) & 0xF;
+		break;
+	case 0x9:
+		// F-number low: commits the latched Block / F-number high nibble
+		// (manual: Block and F-Number2 must be written before F-Number1)
+		s.fnum = ((s.fnum_latch & 0x0F) << 8) | data;
+		s.block = s.fnum_latch >> 4;
+		s.block_s = int8_t((s.block ^ 8) - 8);
+		update_keycode(s, slotnum);
+		break;
+	case 0xA:
+		s.fnum_latch = data;
+		break;
+	case 0xB:
+		s.wave = data & 7;
+		s.fb = (data >> 4) & 7;
+		s.accon = (data >> 7) & 1;
+		update_keycode(s, slotnum);
+		break;
+	case 0xC:
+		s.alg = data & 0xF;
+		m_groups[slotnum % 12].dirty = 1;
+		break;
+	case 0xD:
+		s.ch_level[0] = data >> 4;
+		s.ch_level[1] = data & 0xF;
+		break;
+	case 0xE:
+		s.ch_level[2] = data >> 4;
+		s.ch_level[3] = data & 0xF;
+		break;
+	default:
+		break;
 	}
 }
 
-// calculates the output of one FM operator
-int64_t ymf271_device::calculate_op(int slotnum, int64_t inp)
+// FM function register write: bank 0..3 (S1..S4), address = reg<<4 | group nibble
+void ymf271_device::write_fm(int bank, uint8_t address, uint8_t data)
 {
-	YMF271Slot *slot = &m_slots[slotnum];
-	int64_t env, slot_output, slot_input = 0;
+	int group = fm_tab[address & 0xF];
+	int reg = address >> 4;
+	bool broadcast;
 
-	update_envelope(slot);
-	update_lfo(slot);
-	env = calculate_slot_volume(slot);
-
-	if (inp == OP_INPUT_FEEDBACK)
+	if (group < 0)
 	{
-		// from own feedback
-		slot_input = (slot->feedback_modulation0 + slot->feedback_modulation1) / 2;
-		slot->feedback_modulation0 = slot->feedback_modulation1;
-	}
-	else if (inp != OP_INPUT_NONE)
-	{
-		// from previous slot output
-		slot_input = ((inp << (SIN_BITS-2)) * modulation_level[slot->feedback]);
-	}
-
-	slot_output = m_lut_waves[slot->waveform][((slot->stepptr + slot_input) >> 16) & SIN_MASK];
-	slot_output = (slot_output * env) >> 16;
-	slot->stepptr += slot->step;
-
-	return slot_output;
-}
-
-void ymf271_device::set_feedback(int slotnum, int64_t inp)
-{
-	YMF271Slot *slot = &m_slots[slotnum];
-	slot->feedback_modulation1 = (((inp << (SIN_BITS-2)) * feedback_level[slot->feedback]) / 16);
-}
-
-//-------------------------------------------------
-//  sound_stream_update - handle a stream update
-//-------------------------------------------------
-
-void ymf271_device::sound_stream_update(sound_stream &stream)
-{
-	int32_t *mixp;
-
-	std::fill_n(m_mix_buffer.begin(), stream.samples() * 4, 0);
-
-	for (int j = 0; j < 12; j++)
-	{
-		YMF271Group *slot_group = &m_groups[j];
-		mixp = &m_mix_buffer[0];
-
-		if (slot_group->pfm && slot_group->sync != 3)
-		{
-			popmessage("ymf271 PFM, contact MAMEdev");
-			logerror("ymf271 Group %d: PFM, Sync = %d, Waveform Slot1 = %d, Slot2 = %d, Slot3 = %d, Slot4 = %d\n",
-				j, slot_group->sync, m_slots[j+0].waveform, m_slots[j+12].waveform, m_slots[j+24].waveform, m_slots[j+36].waveform);
-		}
-
-		switch (slot_group->sync)
-		{
-			// 4 operator FM
-			case 0:
-			{
-				int slot1 = j + (0*12);
-				int slot2 = j + (1*12);
-				int slot3 = j + (2*12);
-				int slot4 = j + (3*12);
-				mixp = &m_mix_buffer[0];
-
-				if (m_slots[slot1].active)
-				{
-					for (int i = 0; i < stream.samples(); i++)
-					{
-						int64_t output1 = 0, output2 = 0, output3 = 0, output4 = 0;
-						int64_t phase_mod1, phase_mod2, phase_mod3;
-						switch (m_slots[slot1].algorithm)
-						{
-							// <--------|
-							// +--[S1]--|--+--[S3]--+--[S2]--+--[S4]-->
-							case 0:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								phase_mod2 = calculate_op(slot2, phase_mod3);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							// <-----------------|
-							// +--[S1]--+--[S3]--|--+--[S2]--+--[S4]-->
-							case 1:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								phase_mod2 = calculate_op(slot2, phase_mod3);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							// <--------|
-							// +--[S1]--|
-							//          |
-							//  --[S3]--+--[S2]--+--[S4]-->
-							case 2:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								phase_mod2 = calculate_op(slot2, (phase_mod1 + phase_mod3) / 1);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							//          <--------|
-							//          +--[S1]--|
-							//                   |
-							//  --[S3]--+--[S2]--+--[S4]-->
-							case 3:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								phase_mod2 = calculate_op(slot2, phase_mod3);
-								output4 = calculate_op(slot4, (phase_mod1 + phase_mod2) / 1);
-								break;
-
-							//              --[S2]--|
-							// <--------|           |
-							// +--[S1]--|--+--[S3]--+--[S4]-->
-							case 4:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, (phase_mod3 + phase_mod2) / 1);
-								break;
-
-							//           --[S2]-----|
-							// <-----------------|  |
-							// +--[S1]--+--[S3]--|--+--[S4]-->
-							case 5:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, (phase_mod3 + phase_mod2) / 1);
-								break;
-
-							//  --[S2]-----+--[S4]--|
-							//                      |
-							// <--------|           |
-							// +--[S1]--|--+--[S3]--+-->
-							case 6:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output3 = calculate_op(slot3, phase_mod1);
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							//  --[S2]--+--[S4]-----|
-							//                      |
-							// <-----------------|  |
-							// +--[S1]--+--[S3]--|--+-->
-							case 7:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								output3 = phase_mod3;
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							//  --[S3]--+--[S2]--+--[S4]--|
-							//                            |
-							// <--------|                 |
-							// +--[S1]--|-----------------+-->
-							case 8:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								phase_mod2 = calculate_op(slot2, phase_mod3);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							//          <--------|
-							//          +--[S1]--|
-							//                   |
-							//  --[S3]--|        |
-							//  --[S2]--+--[S4]--+-->
-							case 9:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, (phase_mod3 + phase_mod2) / 1);
-								break;
-
-							//              --[S4]--|
-							//              --[S2]--|
-							// <--------|           |
-							// +--[S1]--|--+--[S3]--+-->
-							case 10:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output3 = calculate_op(slot3, phase_mod1);
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, OP_INPUT_NONE);
-								break;
-
-							//           --[S4]-----|
-							//           --[S2]-----|
-							// <-----------------|  |
-							// +--[S1]--+--[S3]--|--+-->
-							case 11:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								output3 = phase_mod3;
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, OP_INPUT_NONE);
-								break;
-
-							//             |--+--[S4]--|
-							// <--------|  |--+--[S3]--|
-							// +--[S1]--|--|--+--[S2]--+-->
-							case 12:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output3 = calculate_op(slot3, phase_mod1);
-								output2 = calculate_op(slot2, phase_mod1);
-								output4 = calculate_op(slot4, phase_mod1);
-								break;
-
-							//  --[S3]--+--[S2]--|
-							//                   |
-							//  --[S4]-----------|
-							// <--------|        |
-							// +--[S1]--|--------+-->
-							case 13:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								output2 = calculate_op(slot2, phase_mod3);
-								output4 = calculate_op(slot4, OP_INPUT_NONE);
-								break;
-
-							//  --[S2]-----+--[S4]--|
-							//                      |
-							// <--------|  +--[S3]--|
-							// +--[S1]--|--|--------+-->
-							case 14:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								output3 = calculate_op(slot3, phase_mod1);
-								phase_mod2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, phase_mod2);
-								break;
-
-							//  --[S4]-----|
-							//  --[S2]-----|
-							//  --[S3]-----|
-							// <--------|  |
-							// +--[S1]--|--+-->
-							case 15:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								output3 = calculate_op(slot3, OP_INPUT_NONE);
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								output4 = calculate_op(slot4, OP_INPUT_NONE);
-								break;
-						}
-
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch0_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch0_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch0_level]) +
-									(output4 * m_lut_attenuation[m_slots[slot4].ch0_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch1_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch1_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch1_level]) +
-									(output4 * m_lut_attenuation[m_slots[slot4].ch1_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch2_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch2_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch2_level]) +
-									(output4 * m_lut_attenuation[m_slots[slot4].ch2_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch3_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch3_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch3_level]) +
-									(output4 * m_lut_attenuation[m_slots[slot4].ch3_level])) >> 16;
-					}
-				}
-				break;
-			}
-
-			// 2x 2 operator FM
-			case 1:
-			{
-				for (int op = 0; op < 2; op++)
-				{
-					int slot1 = j + ((op + 0) * 12);
-					int slot3 = j + ((op + 2) * 12);
-
-					mixp = &m_mix_buffer[0];
-					if (m_slots[slot1].active)
-					{
-						for (int i = 0; i < stream.samples(); i++)
-						{
-							int64_t output1 = 0, output3 = 0;
-							int64_t phase_mod1, phase_mod3;
-							switch (m_slots[slot1].algorithm & 3)
-							{
-								// <--------|
-								// +--[S1]--|--+--[S3]-->
-								case 0:
-									phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-									set_feedback(slot1, phase_mod1);
-									output3 = calculate_op(slot3, phase_mod1);
-									break;
-
-								// <-----------------|
-								// +--[S1]--+--[S3]--|-->
-								case 1:
-									phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-									phase_mod3 = calculate_op(slot3, phase_mod1);
-									set_feedback(slot1, phase_mod3);
-									output3 = phase_mod3;
-									break;
-
-								//  --[S3]-----|
-								// <--------|  |
-								// +--[S1]--|--+-->
-								case 2:
-									phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-									set_feedback(slot1, phase_mod1);
-									output1 = phase_mod1;
-									output3 = calculate_op(slot3, OP_INPUT_NONE);
-									break;
-								//
-								// <--------|  +--[S3]--|
-								// +--[S1]--|--|--------+-->
-								case 3:
-									phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-									set_feedback(slot1, phase_mod1);
-									output1 = phase_mod1;
-									output3 = calculate_op(slot3, phase_mod1);
-									break;
-							}
-
-							*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch0_level]) +
-										(output3 * m_lut_attenuation[m_slots[slot3].ch0_level])) >> 16;
-							*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch1_level]) +
-										(output3 * m_lut_attenuation[m_slots[slot3].ch1_level])) >> 16;
-							*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch2_level]) +
-										(output3 * m_lut_attenuation[m_slots[slot3].ch2_level])) >> 16;
-							*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch3_level]) +
-										(output3 * m_lut_attenuation[m_slots[slot3].ch3_level])) >> 16;
-						}
-					}
-				}
-				break;
-			}
-
-			// 3 operator FM + PCM
-			case 2:
-			{
-				int slot1 = j + (0*12);
-				int slot2 = j + (1*12);
-				int slot3 = j + (2*12);
-				mixp = &m_mix_buffer[0];
-
-				if (m_slots[slot1].active)
-				{
-					for (int i = 0; i < stream.samples(); i++)
-					{
-						int64_t output1 = 0, output2 = 0, output3 = 0;
-						int64_t phase_mod1, phase_mod3;
-						switch (m_slots[slot1].algorithm & 7)
-						{
-							// <--------|
-							// +--[S1]--|--+--[S3]--+--[S2]-->
-							case 0:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								output2 = calculate_op(slot2, phase_mod3);
-								break;
-
-							// <-----------------|
-							// +--[S1]--+--[S3]--|--+--[S2]-->
-							case 1:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								output2 = calculate_op(slot2, phase_mod3);
-								break;
-
-							//  --[S3]-----|
-							// <--------|  |
-							// +--[S1]--|--+--[S2]-->
-							case 2:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								output2 = calculate_op(slot2, (phase_mod1 + phase_mod3) / 1);
-								break;
-
-							//  --[S3]--+--[S2]--|
-							// <--------|        |
-							// +--[S1]--|--------+-->
-							case 3:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								phase_mod3 = calculate_op(slot3, OP_INPUT_NONE);
-								output2 = calculate_op(slot2, phase_mod3);
-								break;
-
-							//              --[S2]--|
-							// <--------|           |
-							// +--[S1]--|--+--[S3]--+-->
-							case 4:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output3 = calculate_op(slot3, phase_mod1);
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								break;
-
-							//              --[S2]--|
-							// <-----------------|  |
-							// +--[S1]--+--[S3]--|--+-->
-							case 5:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								phase_mod3 = calculate_op(slot3, phase_mod1);
-								set_feedback(slot1, phase_mod3);
-								output3 = phase_mod3;
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								break;
-
-							//  --[S2]-----|
-							//  --[S3]-----|
-							// <--------|  |
-							// +--[S1]--|--+-->
-							case 6:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								output3 = calculate_op(slot3, OP_INPUT_NONE);
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								break;
-
-							//              --[S2]--|
-							// <--------|  +--[S3]--|
-							// +--[S1]--|--|--------+-->
-							case 7:
-								phase_mod1 = calculate_op(slot1, OP_INPUT_FEEDBACK);
-								set_feedback(slot1, phase_mod1);
-								output1 = phase_mod1;
-								output3 = calculate_op(slot3, phase_mod1);
-								output2 = calculate_op(slot2, OP_INPUT_NONE);
-								break;
-						}
-
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch0_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch0_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch0_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch1_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch1_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch1_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch2_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch2_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch2_level])) >> 16;
-						*mixp++ += ((output1 * m_lut_attenuation[m_slots[slot1].ch3_level]) +
-									(output2 * m_lut_attenuation[m_slots[slot2].ch3_level]) +
-									(output3 * m_lut_attenuation[m_slots[slot3].ch3_level])) >> 16;
-					}
-				}
-
-				mixp = &m_mix_buffer[0];
-				update_pcm(j + (3*12), mixp, stream.samples());
-				break;
-			}
-
-			// PCM
-			case 3:
-			{
-				update_pcm(j + (0*12), mixp, stream.samples());
-				update_pcm(j + (1*12), mixp, stream.samples());
-				update_pcm(j + (2*12), mixp, stream.samples());
-				update_pcm(j + (3*12), mixp, stream.samples());
-				break;
-			}
-		}
-	}
-
-	mixp = &m_mix_buffer[0];
-	for (int i = 0; i < stream.samples(); i++)
-	{
-		stream.put_int(0, i, *mixp++, 32768 << 2);
-		stream.put_int(1, i, *mixp++, 32768 << 2);
-		stream.put_int(2, i, *mixp++, 32768 << 2);
-		stream.put_int(3, i, *mixp++, 32768 << 2);
-	}
-}
-
-void ymf271_device::write_register(int slotnum, int reg, uint8_t data)
-{
-	YMF271Slot *slot = &m_slots[slotnum];
-
-	switch (reg)
-	{
-		case 0x0:
-			slot->ext_en = (data & 0x80) ? 1 : 0;
-			slot->ext_out = (data >> 3) & 0xf;
-
-			if (data & 1)
-			{
-				// key on
-				slot->step = 0;
-				slot->stepptr = 0;
-
-				slot->active = 1;
-
-				calculate_step(slot);
-				calculate_status_end(slotnum,false);
-				init_envelope(slot);
-				init_lfo(slot);
-				slot->feedback_modulation0 = 0;
-				slot->feedback_modulation1 = 0;
-			}
-			else
-			{
-				if (slot->active)
-				{
-					//calculate_status_end(slotnum,true); status changes if keyoff? verify this from real hardware.
-					slot->env_state = ENV_RELEASE;
-				}
-			}
-			break;
-
-		case 0x1:
-			slot->lfoFreq = data;
-			break;
-
-		case 0x2:
-			slot->lfowave = data & 3;
-			slot->pms = (data >> 3) & 0x7;
-			slot->ams = (data >> 6) & 0x3;
-			break;
-
-		case 0x3:
-			slot->multiple = data & 0xf;
-			slot->detune = (data >> 4) & 0x7;
-			break;
-
-		case 0x4:
-			slot->tl = data & 0x7f;
-			break;
-
-		case 0x5:
-			slot->ar = data & 0x1f;
-			slot->keyscale = (data >> 5) & 0x7;
-			break;
-
-		case 0x6:
-			slot->decay1rate = data & 0x1f;
-			break;
-
-		case 0x7:
-			slot->decay2rate = data & 0x1f;
-			break;
-
-		case 0x8:
-			slot->relrate = data & 0xf;
-			slot->decay1lvl = (data >> 4) & 0xf;
-			break;
-
-		case 0x9:
-			// write frequency and block here
-			slot->fns = (slot->fns_hi << 8 & 0x0f00) | data;
-			slot->block = slot->fns_hi >> 4 & 0xf;
-			break;
-
-		case 0xa:
-			slot->fns_hi = data;
-			break;
-
-		case 0xb:
-			slot->waveform = data & 0x7;
-			slot->feedback = (data >> 4) & 0x7;
-			slot->accon = (data & 0x80) ? 1 : 0;
-			break;
-
-		case 0xc:
-			slot->algorithm = data & 0xf;
-			break;
-
-		case 0xd:
-			slot->ch0_level = data >> 4;
-			slot->ch1_level = data & 0xf;
-			break;
-
-		case 0xe:
-			slot->ch2_level = data >> 4;
-			slot->ch3_level = data & 0xf;
-			break;
-
-		default:
-			break;
-	}
-}
-
-void ymf271_device::ymf271_write_fm(int bank, uint8_t address, uint8_t data)
-{
-	int groupnum = fm_tab[address & 0xf];
-	if (groupnum == -1)
-	{
-		logerror("ymf271_write_fm invalid group %02X %02X\n", address, data);
+		logerror("write to invalid FM group nibble %02X (bank %d, data %02X)\n", address, bank, data);
 		return;
 	}
 
-	int reg = (address >> 4) & 0xf;
-
-	// check if the register is a synchronized register
-	int sync_reg = 0;
+	// Registers managed by the key-on sync mode: EN/EXT out/KON, F-Number,
+	// Block, Algorithm, CH0-CH3 level.  Written to the key-on slot they are
+	// copied to all slots of the voice.
 	switch (reg)
 	{
-		case 0:
-		case 9:
-		case 10:
-		case 12:
-		case 13:
-		case 14:
-			sync_reg = 1;
-			break;
-
-		default:
-			break;
+	case 0x0: case 0x9: case 0xA: case 0xC: case 0xD: case 0xE:
+		broadcast = true;
+		break;
+	default:
+		broadcast = false;
+		break;
 	}
 
-	// check if the slot is key on slot for synchronizing
-	int sync_mode = 0;
-	switch (m_groups[groupnum].sync)
+	if (broadcast && is_keyon_slot(bank, group) && m_groups[group].sync != SYNC_PCM)
 	{
-		// 4 slot mode
-		case 0:
-			if (bank == 0)
-				sync_mode = 1;
-			break;
-
-		// 2x 2 slot mode
-		case 1:
-			if (bank == 0 || bank == 1)
-				sync_mode = 1;
-			break;
-
-		// 3 slot + 1 slot mode
-		case 2:
-			if (bank == 0)
-				sync_mode = 1;
-			break;
-
-		default:
-			break;
-	}
-
-	// key-on slot & synced register
-	if (sync_mode && sync_reg)
-	{
-		switch (m_groups[groupnum].sync)
-		{
-			// 4 slot mode
-			case 0:
-				write_register((12 * 0) + groupnum, reg, data);
-				write_register((12 * 1) + groupnum, reg, data);
-				write_register((12 * 2) + groupnum, reg, data);
-				write_register((12 * 3) + groupnum, reg, data);
-				break;
-
-			// 2x 2 slot mode
-			case 1:
-				if (bank == 0)
-				{
-					// Slot 1 - Slot 3
-					write_register((12 * 0) + groupnum, reg, data);
-					write_register((12 * 2) + groupnum, reg, data);
-				}
-				else
-				{
-					// Slot 2 - Slot 4
-					write_register((12 * 1) + groupnum, reg, data);
-					write_register((12 * 3) + groupnum, reg, data);
-				}
-				break;
-
-			// 3 slot + 1 slot mode (1 slot is handled normally)
-			case 2:
-				write_register((12 * 0) + groupnum, reg, data);
-				write_register((12 * 1) + groupnum, reg, data);
-				write_register((12 * 2) + groupnum, reg, data);
-				break;
-		}
+		int slots[4];
+		int n = voice_slots(bank, group, slots);
+		for (int i = 0; i < n; i++)
+			write_slot_reg(slots[i], reg, data);
 	}
 	else
 	{
-		// write register normally
-		write_register((12 * bank) + groupnum, reg, data);
+		write_slot_reg(12 * bank + group, reg, data);
 	}
 }
 
-void ymf271_device::ymf271_write_pcm(uint8_t address, uint8_t data)
+// PCM attribute register write (bank 5)
+void ymf271_device::write_pcm(uint8_t address, uint8_t data)
 {
-	int slotnum = pcm_tab[address & 0xf];
-	if (slotnum == -1)
+	int slotnum = pcm_tab[address & 0xF];
+
+	if (slotnum < 0)
 	{
-		logerror("ymf271_write_pcm invalid slot %02X %02X\n", address, data);
+		logerror("write to invalid PCM slot nibble %02X (data %02X)\n", address, data);
 		return;
 	}
-	YMF271Slot *slot = &m_slots[slotnum];
+	opx_slot &s = m_slots[slotnum];
 
-	switch (address >> 4 & 0xf)
+	switch (address >> 4)
 	{
-		case 0x0:
-			slot->startaddr &= ~0xff;
-			slot->startaddr |= data;
-			break;
-
-		case 0x1:
-			slot->startaddr &= ~0xff00;
-			slot->startaddr |= data<<8;
-			break;
-
-		case 0x2:
-			slot->startaddr &= ~0xff0000;
-			slot->startaddr |= (data & 0x7f)<<16;
-			slot->altloop = (data & 0x80) ? 1 : 0;
-			if (slot->altloop)
-				popmessage("ymf271 A/L, contact MAMEdev");
-			break;
-
-		case 0x3:
-			slot->endaddr &= ~0xff;
-			slot->endaddr |= data;
-			break;
-
-		case 0x4:
-			slot->endaddr &= ~0xff00;
-			slot->endaddr |= data<<8;
-			break;
-
-		case 0x5:
-			slot->endaddr &= ~0xff0000;
-			slot->endaddr |= (data & 0x7f)<<16;
-			break;
-
-		case 0x6:
-			slot->loopaddr &= ~0xff;
-			slot->loopaddr |= data;
-			break;
-
-		case 0x7:
-			slot->loopaddr &= ~0xff00;
-			slot->loopaddr |= data<<8;
-			break;
-
-		case 0x8:
-			slot->loopaddr &= ~0xff0000;
-			slot->loopaddr |= (data & 0x7f)<<16;
-			break;
-
-		case 0x9:
-			slot->fs = data & 0x3;
-			slot->bits = (data & 0x4) ? 12 : 8;
-			slot->srcnote = (data >> 3) & 0x3;
-			slot->srcb = (data >> 5) & 0x7;
-			break;
-
-		default:
-			break;
+	case 0x0: s.pcm_start = (s.pcm_start & 0xFFFF00) | data; break;
+	case 0x1: s.pcm_start = (s.pcm_start & 0xFF00FF) | (data << 8); break;
+	case 0x2:
+		s.pcm_start = (s.pcm_start & 0x00FFFF) | ((data & 0x7F) << 16);
+		s.pcm_altloop = data >> 7;
+		break;
+	case 0x3: s.pcm_end = (s.pcm_end & 0xFFFF00) | data; break;
+	case 0x4: s.pcm_end = (s.pcm_end & 0xFF00FF) | (data << 8); break;
+	case 0x5: s.pcm_end = (s.pcm_end & 0x00FFFF) | ((data & 0x7F) << 16); break;
+	case 0x6: s.pcm_loop = (s.pcm_loop & 0xFFFF00) | data; break;
+	case 0x7: s.pcm_loop = (s.pcm_loop & 0xFF00FF) | (data << 8); break;
+	case 0x8: s.pcm_loop = (s.pcm_loop & 0x00FFFF) | ((data & 0x7F) << 16); break;
+	case 0x9:
+		s.pcm_fs = data & 3;
+		s.pcm_12bit = (data >> 2) & 1;
+		s.pcm_srcnote = (data >> 3) & 3;
+		s.pcm_srcb = (data >> 5) & 7;
+		update_keycode(s, slotnum);
+		break;
+	default:
+		break;
 	}
+}
+
+void ymf271_device::update_irq()
+{
+	m_irq_handler(m_irqstate ? 1 : 0);
 }
 
 TIMER_CALLBACK_MEMBER(ymf271_device::timer_a_expired)
@@ -1313,10 +493,10 @@ TIMER_CALLBACK_MEMBER(ymf271_device::timer_a_expired)
 	m_status |= 1;
 
 	// assert IRQ
-	if (m_enable & 4)
+	if (m_timer_ctrl & 4)
 	{
 		m_irqstate |= 1;
-		m_irq_handler(1);
+		update_irq();
 	}
 
 	// reload timer
@@ -1328,118 +508,92 @@ TIMER_CALLBACK_MEMBER(ymf271_device::timer_b_expired)
 	m_status |= 2;
 
 	// assert IRQ
-	if (m_enable & 8)
+	if (m_timer_ctrl & 8)
 	{
 		m_irqstate |= 2;
-		m_irq_handler(1);
+		update_irq();
 	}
 
 	// reload timer
 	m_timB->adjust(clocks_to_attotime(384 * 16 * (256 - m_timerB)), 0);
 }
 
-void ymf271_device::ymf271_write_timer(uint8_t address, uint8_t data)
+// utility register write (bank 6): sync, timers, external memory access, test
+void ymf271_device::write_util(uint8_t address, uint8_t data)
 {
-	if ((address & 0xf0) == 0)
+	if ((address & 0xF0) == 0x00)
 	{
-		int groupnum = fm_tab[address & 0xf];
-		if (groupnum == -1)
+		int group = fm_tab[address & 0xF];
+		if (group < 0)
 		{
-			logerror("ymf271_write_timer invalid group %02X %02X\n", address, data);
+			logerror("write to invalid sync group nibble %02X (data %02X)\n", address, data);
 			return;
 		}
-		YMF271Group *group = &m_groups[groupnum];
-
-		group->sync = data & 0x3;
-		group->pfm = data >> 7;
+		m_groups[group].sync = data & 3;
+		m_groups[group].pfm = data >> 7;
+		m_groups[group].dirty = 1;
+		return;
 	}
-	else
+
+	switch (address)
 	{
-		switch (address)
+	case 0x10:  // Timer A: the manual says 0x10 = low 8 bits, 0x11 = top 2 bits;
+	            // seibuspi shows it behaves like other Yamaha chips:
+	            // 0x10 = high 8 bits, 0x11 = low 2 bits.
+		m_timerA = (m_timerA & 0x003) | (data << 2);
+		break;
+	case 0x11:
+		m_timerA = (m_timerA & 0x3FC) | (data & 0x03);
+		break;
+	case 0x12:
+		m_timerB = data;
+		break;
+	case 0x13:
+		// bit0/1 load A/B, bit2/3 enable IRQ A/B, bit4/5 reset flag A/B.
+		// A timer is (re)loaded on the rising edge of its load bit; clearing
+		// the bit does not stop a running timer (only the IRQ is gated).
+		if (~m_timer_ctrl & data & 1)
+			m_timA->adjust(clocks_to_attotime(384 * (1024 - m_timerA)), 0);
+		if (~m_timer_ctrl & data & 2)
+			m_timB->adjust(clocks_to_attotime(384 * 16 * (256 - m_timerB)), 0);
+		if (data & 0x10)
 		{
-			case 0x10:
-				m_timerA = (m_timerA & 0x003) | (data << 2); // High 8 bit of Timer A period
-				break;
-
-			case 0x11:
-				// Timer A is 10 bit, split high 8 bit and low 2 bit like other Yamaha FM chips
-				// unlike Yamaha's documentation; it says 0x11 writes timer A upper 2 bits.
-				m_timerA = (m_timerA & 0x3fc) | (data & 0x03); // Low 2 bit of Timer A period
-				break;
-
-			case 0x12:
-				m_timerB = data;
-				break;
-
-			case 0x13:
-				// timer A load
-				if (~m_enable & data & 1)
-				{
-					attotime period = clocks_to_attotime(384 * (1024 - m_timerA));
-					m_timA->adjust((data & 1) ? period : attotime::never, 0);
-				}
-
-				// timer B load
-				if (~m_enable & data & 2)
-				{
-					attotime period = clocks_to_attotime(384 * 16 * (256 - m_timerB));
-					m_timB->adjust((data & 2) ? period : attotime::never, 0);
-				}
-
-				// timer A reset
-				if (data & 0x10)
-				{
-					m_irqstate &= ~1;
-					m_status &= ~1;
-
-					if (~m_irqstate & 2)
-						m_irq_handler(0);
-				}
-
-				// timer B reset
-				if (data & 0x20)
-				{
-					m_irqstate &= ~2;
-					m_status &= ~2;
-
-					if (~m_irqstate & 1)
-						m_irq_handler(0);
-				}
-
-				m_enable = data;
-				break;
-
-			case 0x14:
-				m_ext_address &= ~0xff;
-				m_ext_address |= data;
-				break;
-
-			case 0x15:
-				m_ext_address &= ~0xff00;
-				m_ext_address |= data << 8;
-				break;
-
-			case 0x16:
-				m_ext_address &= ~0xff0000;
-				m_ext_address |= (data & 0x7f) << 16;
-				m_ext_rw = (data & 0x80) ? 1 : 0;
-				break;
-
-			case 0x17:
-				m_ext_address = (m_ext_address + 1) & 0x7fffff;
-				if (!m_ext_rw)
-					space(0).write_byte(m_ext_address, data);
-				break;
-
-			case 0x20:
-			case 0x21:
-			case 0x22:
-				// test
-				break;
-
-			default:
-				break;
+			m_status &= ~0x01;
+			m_irqstate &= ~0x01;
 		}
+		if (data & 0x20)
+		{
+			m_status &= ~0x02;
+			m_irqstate &= ~0x02;
+		}
+		m_timer_ctrl = data;
+		update_irq();
+		break;
+	case 0x14:
+		m_ext_address = (m_ext_address & 0xFFFF00) | data;
+		break;
+	case 0x15:
+		m_ext_address = (m_ext_address & 0xFF00FF) | (data << 8);
+		break;
+	case 0x16:
+		m_ext_address = (m_ext_address & 0x00FFFF) | ((data & 0x7F) << 16);
+		m_ext_rw = data >> 7;
+		// prime the read latch for the read-direction window
+		if (m_ext_rw)
+			m_ext_readlatch = read_byte(m_ext_address);
+		break;
+	case 0x17:
+		// write to external memory (SRAM); the address is incremented before
+		// the write (previous core's reading; the documents do not say)
+		m_ext_address = (m_ext_address + 1) & 0x7FFFFF;
+		if (!m_ext_rw)
+			space(0).write_byte(m_ext_address, data);
+		break;
+	case 0x20: case 0x21: case 0x22:
+		// test registers
+		break;
+	default:
+		break;
 	}
 }
 
@@ -1447,52 +601,26 @@ void ymf271_device::write(offs_t offset, u8 data)
 {
 	m_stream->update();
 
-	offset &= 0xf;
+	offset &= 0xF;
 	m_regs_main[offset] = data;
 
 	switch (offset)
 	{
-		case 0x0:
-		case 0x2:
-		case 0x4:
-		case 0x6:
-		case 0x8:
-		case 0xc:
-			// address regs
-			break;
-
-		case 0x1:
-			ymf271_write_fm(0, m_regs_main[0x0], data);
-			break;
-
-		case 0x3:
-			ymf271_write_fm(1, m_regs_main[0x2], data);
-			break;
-
-		case 0x5:
-			ymf271_write_fm(2, m_regs_main[0x4], data);
-			break;
-
-		case 0x7:
-			ymf271_write_fm(3, m_regs_main[0x6], data);
-			break;
-
-		case 0x9:
-			ymf271_write_pcm(m_regs_main[0x8], data);
-			break;
-
-		case 0xd:
-			ymf271_write_timer(m_regs_main[0xc], data);
-			break;
-
-		default:
-			break;
+	case 0x1: write_fm(0, m_regs_main[0x0], data); break;
+	case 0x3: write_fm(1, m_regs_main[0x2], data); break;
+	case 0x5: write_fm(2, m_regs_main[0x4], data); break;
+	case 0x7: write_fm(3, m_regs_main[0x6], data); break;
+	case 0x9: write_pcm(m_regs_main[0x8], data); break;
+	case 0xD: write_util(m_regs_main[0xC], data); break;
+	default:
+		// even offsets: address latches; 0xB/0xF: unused banks
+		break;
 	}
 }
 
 u8 ymf271_device::read(offs_t offset)
 {
-	offset &= 0xf;
+	offset &= 0xF;
 
 	// update stream before reading status registers
 	if (offset <= 1)
@@ -1500,227 +628,651 @@ u8 ymf271_device::read(offs_t offset)
 
 	switch (offset)
 	{
-		case 0x0:
-			return m_status | ((m_end_status & 0xf) << 3);
-
-		case 0x1:
-			// statusreg 2
-			return m_end_status >> 4;
-
-		case 0x2:
+	case 0x0:
+		// d0 TiA, d1 TiB, d2 0, d3 End0, d4 End12, d5 End24, d6 End36, d7 Busy
+		// end_status bit i = PCM slot 4*i: slots 0,12,24,36 = bits 0,3,6,9.
+		// The End flags are cleared by reading them (Brave Blade copies the
+		// status registers to RAM every ~100 us and frees a PCM channel when
+		// its End bit is seen; a sticky flag would kill the next note started
+		// on that slot from the stale copy).
+		{
+			uint8_t ret = (m_status & 0x83) | (BIT(m_end_status, 0) << 3) | (BIT(m_end_status, 3) << 4)
+			     | (BIT(m_end_status, 6) << 5) | (BIT(m_end_status, 9) << 6);
+			if (!machine().side_effects_disabled())
+				m_end_status &= ~0x0249;
+			return ret;
+		}
+	case 0x1:
+		// d0 End4, d1 End16, d2 End28, d3 End40, d4 End8, d5 End20, d6 End32, d7 End44
+		// end_status bit i belongs to slot 4*i: slots 4,16,28,40 = bits 1,4,7,10;
+		// slots 8,20,32,44 = bits 2,5,8,11
+		{
+			uint16_t e = m_end_status;
+			uint8_t ret = ((e >> 1) & 1) | (((e >> 4) & 1) << 1) | (((e >> 7) & 1) << 2) | (((e >> 10) & 1) << 3)
+			     | (((e >> 2) & 1) << 4) | (((e >> 5) & 1) << 5) | (((e >> 8) & 1) << 6) | (((e >> 11) & 1) << 7);
+			if (!machine().side_effects_disabled())
+				m_end_status &= ~0x0DB6;
+			return ret;
+		}
+	case 0x2:
 		{
 			if (!m_ext_rw)
-				return 0xff;
-
+				return 0xFF;
 			uint8_t ret = m_ext_readlatch;
 			if (!machine().side_effects_disabled())
 			{
-				m_ext_address = (m_ext_address + 1) & 0x7fffff;
+				m_ext_address = (m_ext_address + 1) & 0x7FFFFF;
 				m_ext_readlatch = read_byte(m_ext_address);
 			}
 			return ret;
 		}
-
-		default:
-			break;
+	default:
+		break;
 	}
-
-	return 0xff;
+	return 0xFF;
 }
+
+
+// ------------------------------------------------------------------------
+// synthesis
+// ------------------------------------------------------------------------
 
 void ymf271_device::init_tables()
 {
-	for (int i = 0; i < 8; i++)
-		m_lut_waves[i] = std::make_unique<int16_t[]>(SIN_LEN);
-
-	for (int i = 0; i < 4*8; i++)
-		m_lut_plfo[i>>3][i&7] = std::make_unique<double[]>(LFO_LENGTH);
-
-	for (int i = 0; i < 4; i++)
-		m_lut_alfo[i] = std::make_unique<int[]>(LFO_LENGTH);
-
-	for (int i = 0; i < SIN_LEN; i++)
-	{
-		double m = sin( ((i*2)+1) * std::numbers::pi / SIN_LEN );
-		double m2 = sin( ((i*4)+1) * std::numbers::pi / SIN_LEN );
-
-		// Waveform 0: sin(wt)    (0 <= wt <= 2PI)
-		m_lut_waves[0][i] = (int16_t)(m * MAXOUT);
-
-		// Waveform 1: sin?(wt)   (0 <= wt <= PI)     -sin?(wt)  (PI <= wt <= 2PI)
-		m_lut_waves[1][i] = (i < (SIN_LEN/2)) ? (int16_t)((m * m) * MAXOUT) : (int16_t)((m * m) * MINOUT);
-
-		// Waveform 2: sin(wt)    (0 <= wt <= PI)     -sin(wt)   (PI <= wt <= 2PI)
-		m_lut_waves[2][i] = (i < (SIN_LEN/2)) ? (int16_t)(m * MAXOUT) : (int16_t)(-m * MAXOUT);
-
-		// Waveform 3: sin(wt)    (0 <= wt <= PI)     0
-		m_lut_waves[3][i] = (i < (SIN_LEN/2)) ? (int16_t)(m * MAXOUT) : 0;
-
-		// Waveform 4: sin(2wt)   (0 <= wt <= PI)     0
-		m_lut_waves[4][i] = (i < (SIN_LEN/2)) ? (int16_t)(m2 * MAXOUT) : 0;
-
-		// Waveform 5: |sin(2wt)| (0 <= wt <= PI)     0
-		m_lut_waves[5][i] = (i < (SIN_LEN/2)) ? (int16_t)(fabs(m2) * MAXOUT) : 0;
-
-		// Waveform 6:     1      (0 <= wt <= 2PI)
-		m_lut_waves[6][i] = (int16_t)(1 * MAXOUT);
-
-		m_lut_waves[7][i] = 0;
-	}
-
-	for (int i = 0; i < LFO_LENGTH; i++)
-	{
-		int tri_wave;
-		double ftri_wave, fsaw_wave;
-		double plfo[4];
-
-		// LFO phase modulation
-		plfo[0] = 0;
-
-		fsaw_wave = ((i % (LFO_LENGTH/2)) * PLFO_MAX) / (double)((LFO_LENGTH/2)-1);
-		plfo[1] = (i < (LFO_LENGTH/2)) ? fsaw_wave : fsaw_wave - PLFO_MAX;
-
-		plfo[2] = (i < (LFO_LENGTH/2)) ? PLFO_MAX : PLFO_MIN;
-
-		ftri_wave = ((i % (LFO_LENGTH/4)) * PLFO_MAX) / (double)(LFO_LENGTH/4);
-		switch (i / (LFO_LENGTH/4))
-		{
-			case 0: plfo[3] = ftri_wave; break;
-			case 1: plfo[3] = PLFO_MAX - ftri_wave; break;
-			case 2: plfo[3] = 0 - ftri_wave; break;
-			case 3: plfo[3] = 0 - (PLFO_MAX - ftri_wave); break;
-			default: plfo[3] = 0; assert(0); break;
-		}
-
-		for (int j = 0; j < 4; j++)
-		{
-			m_lut_plfo[j][0].get()[i] = pow(2.0, 0.0);
-			m_lut_plfo[j][1].get()[i] = pow(2.0, (3.378 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][2].get()[i] = pow(2.0, (5.0646 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][3].get()[i] = pow(2.0, (6.7495 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][4].get()[i] = pow(2.0, (10.1143 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][5].get()[i] = pow(2.0, (20.1699 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][6].get()[i] = pow(2.0, (40.1076 * plfo[j]) / 1200.0);
-			m_lut_plfo[j][7].get()[i] = pow(2.0, (79.307 * plfo[j]) / 1200.0);
-		}
-
-		// LFO amplitude modulation
-		m_lut_alfo[0][i] = 0;
-
-		m_lut_alfo[1][i] = ALFO_MAX - ((i * ALFO_MAX) / LFO_LENGTH);
-
-		m_lut_alfo[2][i] = (i < (LFO_LENGTH/2)) ? ALFO_MAX : ALFO_MIN;
-
-		tri_wave = ((i % (LFO_LENGTH/2)) * ALFO_MAX) / (LFO_LENGTH/2);
-		m_lut_alfo[3][i] = (i < (LFO_LENGTH/2)) ? ALFO_MAX-tri_wave : tri_wave;
-	}
-
 	for (int i = 0; i < 256; i++)
 	{
-		m_lut_env_volume[i] = (int)(65536.0 / pow(10.0, ((double)i / (256.0 / 96.0)) / 20.0));
-	}
-
-	for (int i = 0; i < 16; i++)
-	{
-		m_lut_attenuation[i] = (int)(65536.0 / pow(10.0, channel_attenuation_table[i] / 20.0));
-	}
-	for (int i = 0; i < 128; i++)
-	{
-		double db = 0.75 * (double)i;
-		m_lut_total_level[i] = (int)(65536.0 / pow(10.0, db / 20.0));
+		m_logsin[i] = uint16_t(floor(-log(sin((i + 0.5) * std::numbers::pi / 512.0)) / log(2.0) * 256.0 + 0.5));
+		m_exp[i] = uint16_t(floor(pow(2.0, -(i + 1) / 256.0) * 2048.0 + 0.5));
 	}
 }
 
-void ymf271_device::calculate_clock_correction()
+// apply one algorithm table to a list of slots
+void ymf271_device::connect(const opx_alg &alg, const int *slots, int n)
 {
-	// timing may use a non-standard XTAL
-	double clock_correction = (clock() != 0) ? (double)(STD_CLOCK) / (double)clock() : 0.0;
-	for (int i = 0; i < 256; i++)
+	for (int p = 0; p < n; p++)
 	{
-		m_lut_lfo[i] = LFO_frequency_table[i] * clock_correction;
-	}
-
-	for (int i = 0; i < 64; i++)
-	{
-		// attack rate in number of samples
-		m_lut_ar[i] = (ARTime[i] * clock_correction * 44100.0) / 1000.0;
-	}
-	for (int i = 0; i < 64; i++)
-	{
-		// decay/release rate in number of samples
-		m_lut_dc[i] = (DCTime[i] * clock_correction * 44100.0) / 1000.0;
+		opx_slot &s = m_slots[slots[p]];
+		s.c_nmod = 0;
+		for (int q = 0; q < n; q++)
+			if (alg.mods[p] & (1 << q))
+				s.c_mod[s.c_nmod++] = uint8_t(slots[q]);
+		s.c_carrier = (alg.car >> p) & 1;
+		// the head slot takes the feedback input; its history is written by
+		// position fbsrc (itself, or S3 for the loop algorithms)
+		s.c_fbhead = (p == 0);
+		s.c_fbtarget = (p == alg.fbsrc) ? int8_t(slots[0]) : -1;
 	}
 }
+
+void ymf271_device::rebuild_group(int g)
+{
+	int slots[4];
+
+	m_groups[g].dirty = 0;
+	switch (m_groups[g].sync)
+	{
+	case SYNC_4OP:
+		slots[0] = g; slots[1] = g + 12; slots[2] = g + 24; slots[3] = g + 36;
+		connect(alg4[m_slots[g].alg & 15], slots, 4);
+		break;
+	case SYNC_2X2OP:
+		slots[0] = g; slots[1] = g + 24;
+		connect(alg2[m_slots[g].alg & 3], slots, 2);
+		slots[0] = g + 12; slots[1] = g + 36;
+		connect(alg2[m_slots[g + 12].alg & 3], slots, 2);
+		break;
+	case SYNC_3OP_PCM:
+		slots[0] = g; slots[1] = g + 12; slots[2] = g + 24;
+		connect(alg3[m_slots[g].alg & 7], slots, 3);
+		slots[0] = g + 36;
+		connect(alg_single, slots, 1);
+		break;
+	default:
+		slots[0] = g;      connect(alg_single, slots, 1);
+		slots[0] = g + 12; connect(alg_single, slots, 1);
+		slots[0] = g + 24; connect(alg_single, slots, 1);
+		slots[0] = g + 36; connect(alg_single, slots, 1);
+		break;
+	}
+}
+
+// one EG clock (fs/2) for one slot
+void ymf271_device::eg_tick(opx_slot &s)
+{
+	int rks, rate, shift, idx, inc;
+
+	if (s.eg_state == EG_OFF)
+		return;
+
+	// state transitions checked first (OPM)
+	if (s.eg_state == EG_ATTACK && s.eg_att <= 0)
+	{
+		s.eg_att = 0;
+		s.eg_state = EG_DECAY1;
+	}
+	if (s.eg_state == EG_DECAY1)
+	{
+		int d1l = (s.d1l == 15) ? (31 << 5) : (s.d1l << 5);
+		if (s.eg_att >= d1l)
+			s.eg_state = EG_DECAY2;
+	}
+
+	rks = rks_tab[s.keycode][s.ks];
+	switch (s.eg_state)
+	{
+	case EG_ATTACK:  rate = eg_rate(s.ar * 2, rks); break;
+	case EG_DECAY1:  rate = eg_rate(s.d1r * 2, rks); break;
+	case EG_DECAY2:  rate = eg_rate(s.d2r * 2, rks); break;
+	default:         rate = eg_rate(s.rr * 4, rks); break;
+	}
+
+	if (rate < 48)
+	{
+		shift = 11 - (rate >> 2);
+		if (m_eg_cnt & ((1 << shift) - 1))
+			return;
+		idx = (m_eg_cnt >> shift) & 7;
+	}
+	else
+	{
+		idx = m_eg_cnt & 7;
+	}
+	inc = (eg_inc[rate] >> (idx * 4)) & 15;
+	if (inc == 0)
+		return;
+
+	if (s.eg_state == EG_ATTACK)
+	{
+		s.eg_att += ((~s.eg_att) * inc) >> 4;
+		if (s.eg_att <= 0)
+		{
+			s.eg_att = 0;
+			s.eg_state = EG_DECAY1;
+		}
+	}
+	else
+	{
+		s.eg_att += inc;
+		if (s.eg_att >= 0x3FF)
+		{
+			s.eg_att = 0x3FF;
+			if (s.eg_state == EG_RELEASE)
+				s.eg_state = EG_OFF;
+		}
+	}
+}
+
+// LFO clock divider (manual table 2-6-2): the LFO advances one of 128 steps
+// every K samples, K = (32 - (n & 15)) << (14 - (n >> 4)) for n < 240 and
+// K = 16 - (n & 15) for n >= 240  ->  f = fs / 128 / K (0.00066 .. 344.5 Hz).
+uint32_t ymf271_device::lfo_period(uint8_t n)
+{
+	if (n >= 240)
+		return 16 - (n & 15);
+	return (32 - (n & 15)) << (14 - (n >> 4));
+}
+
+// advance the LFO of one slot by one sample
+void ymf271_device::lfo_tick(opx_slot &s)
+{
+	if (s.lfo_wave == 0)
+		return;
+	if (++s.lfo_cnt >= lfo_period(s.lfo_freq))
+	{
+		s.lfo_cnt = 0;
+		s.lfo_pos = (s.lfo_pos + 1) & 127;
+	}
+}
+
+// bipolar LFO value for PM, -128..127 (wave 1 saw, 2 square, 3 triangle),
+// all starting at 0 at key-on and rising first
+int32_t ymf271_device::lfo_pm(const opx_slot &s)
+{
+	int32_t p = s.lfo_pos;
+	switch (s.lfo_wave)
+	{
+	case 1: return ((p + 64) & 127) * 2 - 128;          // saw: 0 -> +126, -128 -> -2
+	case 2: return (p < 64) ? 127 : -128;               // square
+	case 3: // triangle: 0 -> +124 -> 0 -> -128 -> -4
+		if (p < 32) return p * 4;
+		if (p < 96) return 128 - (p - 32) * 4;
+		return (p - 96) * 4 - 128;
+	default: return 0;
+	}
+}
+
+// unipolar LFO value for AM (attenuation), 0..127.  Every waveform starts
+// at full attenuation at key-on and the saw / triangle come down from there
+// (the OPM/OPZ convention, ymfm's reading of the manual figures)
+int32_t ymf271_device::lfo_am(const opx_slot &s)
+{
+	int32_t p = s.lfo_pos;
+	switch (s.lfo_wave)
+	{
+	case 1: return 127 - p;                                         // saw: 127 -> 0
+	case 2: return (p < 64) ? 127 : 0;                              // square: attenuated half first
+	case 3: return (p < 64) ? (127 - p * 2) : (p - 64) * 2 + 1;     // triangle 127 -> 1 -> 127
+	default: return 0;
+	}
+}
+
+// phase increment per sample, 2^32 = one cycle:
+// f = 2 * fnum * 2^(block-7) * MUL * fs / 2^15  ->  inc = fnum << (block + 11) * MUL,
+// detune added in units of fs/2^20 (= 1 << 12 here) before the multiplier (OPM)
+uint32_t ymf271_device::phase_inc(const opx_slot &s, int32_t lfo_pm)
+{
+	int64_t inc;
+	int sh = s.block_s + 11;    // 3..18
+	int dt;
+	int64_t fnum = s.fnum << 7; // fnum with 7 fraction bits for the LFO
+
+	// LFO PM: fnum * (1 + k * lfo / (1024 * 128))
+	if (lfo_pm != 0)
+		fnum += (int64_t(s.fnum) * pms_k[s.pms] * lfo_pm) >> 10;
+	inc = (fnum << sh) >> 7;
+	dt = detune_tab[s.keycode][s.dt & 3] << 12;
+	if (s.dt & 4)
+		inc -= dt;
+	else
+		inc += dt;
+	if (inc < 0)
+		inc = 0;
+	if (s.mul == 0)
+		inc >>= 1;
+	else
+		inc *= s.mul;
+	// the accumulator wraps like OPM's: increments above fs/2 alias (the
+	// hi-hat carriers of the Seibu titles are fed by such a modulator)
+	return uint32_t(inc);
+}
+
+// ---- external PCM waveform (wave 7 on slots 0,4,..,44) ----
+// Step in source samples per frame (16-bit fraction):
+//   (fnum | 0x800) / 2048 * 2^block * MUL * {1, 1/2, 1/4, 1/8}[Fs]
+// i.e. the same PG as FM with the implicit F-number bit 11 (block 0 /
+// fnum 0 / MUL 1 plays a 44.1 kHz sample at its original rate), detune and
+// LFO PM applied like FM.  Positions run over [0, End): when the position
+// reaches End it wraps back by End-Loop (a looped sample's period is then
+// exactly End-Loop words), so word End is only read as the interpolation
+// partner of End-1 -- which is why the manual requires Words >= End+1.
+// Samples are 8-bit or packed 12-bit (3 bytes per 2 words, see pcm_word) and
+// linearly interpolated ("the waveform data is interpolated and the EG value
+// multiplied").
+uint32_t ymf271_device::pcm_step(const opx_slot &s, int32_t lfo_pm)
+{
+	int64_t inc;
+	int64_t fnum = ((s.fnum & 0x7FF) | 0x800) << 7;  // 7 fraction bits for the LFO
+	int dt;
+
+	if (lfo_pm != 0)
+		fnum += (int64_t((s.fnum & 0x7FF) | 0x800) * pms_k[s.pms] * lfo_pm) >> 10;
+	// fnum(q7) * 2^(block-11) * 65536 = fnum(q7) << (block + 5) >> 7
+	inc = (fnum << 16) >> (18 - s.block_s);
+	dt = detune_tab[s.keycode][s.dt & 3] << 6;  // FM units (1 << 12) / 2^6
+	if (s.dt & 4)
+		inc -= dt;
+	else
+		inc += dt;
+	if (inc < 0)
+		inc = 0;
+	if (s.mul == 0)
+		inc >>= 1;
+	else
+		inc *= s.mul;
+	inc >>= s.pcm_fs;
+	return uint32_t(inc);
+}
+
+// 12-bit sample word at index pos of slot s (8-bit data = upper byte)
+int32_t ymf271_device::pcm_word(const opx_slot &s, uint32_t pos)
+{
+	int32_t v;
+
+	if (!s.pcm_12bit)
+	{
+		v = int8_t(read_byte((s.pcm_start + pos) & 0x7FFFFF)) << 4;
+	}
+	else
+	{
+		// 3 bytes per 2 words: b0 = word0 bits 11..4, b1 = word1 bits 3..0 (high
+		// nibble) : word0 bits 3..0 (low nibble), b2 = word1 bits 11..4.
+		// (Checked on the Bloody Roar 2 / Beastorizer sample data: this order
+		// makes the smooth samples as much smoother than the 8-bit-only decode
+		// as true LSBs should, the swapped order makes them rougher than
+		// dropping the nibble.)
+		uint32_t addr = (s.pcm_start + (pos >> 1) * 3) & 0x7FFFFF;
+		if (pos & 1)
+			v = (read_byte(addr + 2) << 4) | (read_byte(addr + 1) >> 4);
+		else
+			v = (read_byte(addr) << 4) | (read_byte(addr + 1) & 0x0F);
+		v = int32_t((v & 0xFFF) ^ 0x800) - 0x800;
+	}
+	return v;
+}
+
+// interpolated 14-bit sample at the current position, then advance
+int32_t ymf271_device::pcm_sample(opx_slot &s, int slotnum, int32_t lfo_pm)
+{
+	int32_t a = pcm_word(s, s.pcm_pos);
+	int32_t b = pcm_word(s, s.pcm_pos + 1);
+	int32_t frac = int32_t(s.pcm_frac >> 8);   // 8-bit interpolation weight
+	int32_t out = (a * (256 - frac) + b * frac) >> 6;  // 12 bit -> 14 bit
+	uint32_t step = pcm_step(s, lfo_pm);
+
+	s.pcm_frac += step;
+	s.pcm_pos += s.pcm_frac >> 16;
+	s.pcm_frac &= 0xFFFF;
+	if (s.pcm_pos >= s.pcm_end)
+	{
+		if (s.pcm_end > s.pcm_loop)
+		{
+			uint32_t len = s.pcm_end - s.pcm_loop;
+			s.pcm_pos = s.pcm_loop + (s.pcm_pos - s.pcm_end) % len;
+		}
+		else
+			s.pcm_pos = s.pcm_loop;   // degenerate loop: hold
+		// The End flag is raised once per key-on, when the read address first
+		// passes the end address.  Drivers play one-shot samples as a short
+		// loop of silence at the end (loop = end - 2) and free the channel from
+		// a copy of the status register: re-raising End on every pass of that
+		// loop kills a note re-triggered on the same slot between the copy
+		// and the free pass (Bloody Roar 2 / Brave Blade lose drum hits).
+		if (!s.pcm_ended)
+		{
+			s.pcm_ended = 1;
+			m_end_status |= 1 << (slotnum >> 2);
+		}
+	}
+	return out;
+}
+
+// multiply a 14-bit sample by the envelope (10-bit attenuation, 64 = 6 dB)
+int32_t ymf271_device::env_mul(int32_t v, uint32_t env) const
+{
+	return (v * int32_t(m_exp[(env & 63) << 2])) >> (11 + (env >> 6));
+}
+
+// operator: 10-bit phase, waveform, 10-bit total attenuation -> 14-bit output
+int32_t ymf271_device::op(uint32_t phase, int wave, uint32_t env) const
+{
+	uint32_t p = phase & 1023;
+	uint32_t idx, att, neg;
+	int32_t out;
+
+	idx = p & 255;
+	if (p & 256)
+		idx ^= 255;
+	neg = 0;
+	switch (wave)
+	{
+	case 0: // sine
+		att = m_logsin[idx];
+		neg = p & 512;
+		break;
+	case 1: // +/-sin^2 (manual plot): twice the log-sin attenuation, sign from
+	        // phase bit 9 -- as ymfm's OPZ wave 1
+		att = m_logsin[idx] << 1;
+		neg = p & 512;
+		break;
+	case 2: // |sin|
+		att = m_logsin[idx];
+		break;
+	case 3: // half sine
+		if (p & 512)
+			return 0;
+		att = m_logsin[idx];
+		break;
+	case 4: // sin(2wt) on the first half
+	case 5: // |sin(2wt)| on the first half
+		if (p & 512)
+			return 0;
+		idx = (p << 1) & 255;
+		if (p & 128)
+			idx ^= 255;
+		att = m_logsin[idx];
+		if (wave == 4)
+			neg = p & 256;
+		break;
+	default:    // 6: linear waveform, 7: external PCM -- both handled in sound_stream_update
+		return 0;
+	}
+
+	att += env << 2;
+	if (att >= 4096)
+		return 0;
+	out = (m_exp[att & 255] << 2) >> (att >> 8);
+	return neg ? -out : out;
+}
+
+// channel level table: x(1 or 0.75) >> (L>>1), L >= 13 mute
+int32_t ymf271_device::pan(int32_t v, uint8_t level)
+{
+	if (level >= 13)
+		return 0;
+	if (level & 1)
+		v = (v * 3) >> 2;
+	return v >> (level >> 1);
+}
+
+void ymf271_device::sound_stream_update(sound_stream &stream)
+{
+	for (int i = 0; i < stream.samples(); i++)
+	{
+		int32_t acc[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+		for (int g = 0; g < NUM_GROUPS; g++)
+			if (m_groups[g].dirty)
+				rebuild_group(g);
+
+		// EG runs at fs/2
+		const bool eg_clock = m_eg_phase;
+		m_eg_phase ^= 1;
+		if (eg_clock)
+			m_eg_cnt++;
+
+		// slots in hardware order: modulators with a lower slot number are
+		// taken from the current frame, higher-numbered ones from the previous
+		for (int n = 0; n < NUM_SLOTS; n++)
+		{
+			opx_slot &s = m_slots[n];
+			int32_t mod, out;
+			uint32_t env;
+
+			if (eg_clock)
+				eg_tick(s);
+			lfo_tick(s);
+
+			if (s.eg_state == EG_OFF)
+			{
+				s.out = 0;
+				s.acc = 0;
+				continue;
+			}
+
+			// modulation input, in 10-bit phase units
+			if (s.c_fbhead)
+			{
+				// OPM feedback law on the average of the last two outputs; the
+				// S3->S1 loop of algorithms 1/5/7/11 follows the same law
+				int fb = s.fb & 7;
+				mod = fb ? ((s.fb_hist[0] + s.fb_hist[1]) >> (10 - fb)) : 0;
+			}
+			else
+			{
+				int32_t sum = 0;
+				for (int k = 0; k < s.c_nmod; k++)
+					sum += m_slots[s.c_mod[k]].out;
+				mod = (sum * modlevel[s.fb]) >> 8;
+			}
+
+			env = uint32_t(s.eg_att) + (uint32_t(s.tl) << 3);
+			if (s.ams && s.lfo_wave)
+			{
+				// AMS max 63 / 126 / 252 units of 0.09375 dB
+				int32_t am = lfo_am(s);
+				env += (s.ams == 1) ? (am >> 1) : (s.ams == 2) ? am : (am << 1);
+			}
+			if (env > 0x3FF)
+				env = 0x3FF;
+
+			const int32_t pm = (s.pms && s.lfo_wave) ? lfo_pm(s) : 0;
+
+			if (s.wave == 7)
+			{
+				// external PCM data: only the slots of groups 0/4/8 can fetch it;
+				// a wave-7 select elsewhere produces silence here
+				out = ((n & 3) == 0) ? env_mul(pcm_sample(s, n, pm), env) : 0;
+			}
+			else if (s.wave == 6)
+			{
+				// "linear waveform table": assumed that output does not depend on the
+				// phase; it is (1 + modulation input) * envelope, i.e. a DC level
+				// when unmodulated (drum pitch sweeps use it as a modulator) and
+				// the modulation input passed through when modulated (hi-hat
+				// carriers emit their modulator directly).  The modulation input
+				// is scaled by MUL (0 = 1/2) like a phase increment and wraps at
+				// 2^W6_BITS; full scale = one wrap.  The wrap size sets the
+				// passed-through modulator's noise floor and the level of the
+				// PG-rate line in it.  The manual only states "1" (D.C.) for
+				// this waveform; the phase does not enter.
+				int32_t mm = s.mul ? mod * int32_t(s.mul) : (mod >> 1);
+				int32_t lin;
+				if (W6_BITS)
+					lin = 8192 + ((1 + (mm & ((1 << W6_BITS) - 1))) << (13 - W6_BITS));
+				else
+					lin = 8168 + (mm << 4);
+				out = env_mul(lin, env);
+				s.phase += phase_inc(s, pm);   // the PG keeps running
+			}
+			else
+			{
+				out = op((s.phase >> 22) + mod, s.wave, env);
+				s.phase += phase_inc(s, pm);
+			}
+			if (s.accon)
+			{
+				// "Acc On": the slot output is accumulated instead of output
+				// directly -- modelled as a running sum that saturates at the
+				// 14-bit operator range.  Any sustained tone rails the sum, so
+				// the slot turns into a full-level square-like signal that
+				// flips at the operator's zero crossings ("distorted" basses
+				// and drums); the sum is cleared at key-on and when the EG
+				// reaches off.  Applies to modulators as well.
+				s.acc += out;
+				if (s.acc > 8191) s.acc = 8191;
+				else if (s.acc < -8192) s.acc = -8192;
+				out = s.acc;
+			}
+			s.out = out;
+
+			if (s.c_fbtarget >= 0)
+			{
+				opx_slot &t = m_slots[s.c_fbtarget];
+				t.fb_hist[1] = t.fb_hist[0];
+				t.fb_hist[0] = out;
+			}
+
+			if (s.c_carrier)
+			{
+				acc[0] += pan(out, s.ch_level[0]);
+				acc[1] += pan(out, s.ch_level[1]);
+				acc[2] += pan(out, s.ch_level[2]);
+				acc[3] += pan(out, s.ch_level[3]);
+				// extended channels CH4-CH7 (EXT1 = CH4/5, EXT2 = CH6/7):
+				// EN enables them, EXT Out is a bitmask of the channels the
+				// voice is sent to, at full level (no attenuation register)
+				if (s.ext_en)
+				{
+					if (s.ext_out & 1) acc[4] += out;
+					if (s.ext_out & 2) acc[5] += out;
+					if (s.ext_out & 4) acc[6] += out;
+					if (s.ext_out & 8) acc[7] += out;
+				}
+			}
+		}
+
+		// one carrier at full level = 14-bit +/-8192 = -12 dB FS
+		for (int ch = 0; ch < 8; ch++)
+			stream.put_int(ch, i, acc[ch], 32768);
+	}
+}
+
+
+// ------------------------------------------------------------------------
+// device lifecycle
+// ------------------------------------------------------------------------
 
 void ymf271_device::init_state()
 {
+	save_item(STRUCT_MEMBER(m_slots, kon));
 	save_item(STRUCT_MEMBER(m_slots, ext_en));
 	save_item(STRUCT_MEMBER(m_slots, ext_out));
-	save_item(STRUCT_MEMBER(m_slots, lfoFreq));
-	save_item(STRUCT_MEMBER(m_slots, pms));
+	save_item(STRUCT_MEMBER(m_slots, lfo_freq));
 	save_item(STRUCT_MEMBER(m_slots, ams));
-	save_item(STRUCT_MEMBER(m_slots, detune));
-	save_item(STRUCT_MEMBER(m_slots, multiple));
+	save_item(STRUCT_MEMBER(m_slots, pms));
+	save_item(STRUCT_MEMBER(m_slots, lfo_wave));
+	save_item(STRUCT_MEMBER(m_slots, dt));
+	save_item(STRUCT_MEMBER(m_slots, mul));
 	save_item(STRUCT_MEMBER(m_slots, tl));
-	save_item(STRUCT_MEMBER(m_slots, keyscale));
+	save_item(STRUCT_MEMBER(m_slots, ks));
 	save_item(STRUCT_MEMBER(m_slots, ar));
-	save_item(STRUCT_MEMBER(m_slots, decay1rate));
-	save_item(STRUCT_MEMBER(m_slots, decay2rate));
-	save_item(STRUCT_MEMBER(m_slots, decay1lvl));
-	save_item(STRUCT_MEMBER(m_slots, relrate));
+	save_item(STRUCT_MEMBER(m_slots, d1r));
+	save_item(STRUCT_MEMBER(m_slots, d2r));
+	save_item(STRUCT_MEMBER(m_slots, d1l));
+	save_item(STRUCT_MEMBER(m_slots, rr));
+	save_item(STRUCT_MEMBER(m_slots, fnum));
 	save_item(STRUCT_MEMBER(m_slots, block));
-	save_item(STRUCT_MEMBER(m_slots, fns_hi));
-	save_item(STRUCT_MEMBER(m_slots, fns));
-	save_item(STRUCT_MEMBER(m_slots, feedback));
-	save_item(STRUCT_MEMBER(m_slots, waveform));
+	save_item(STRUCT_MEMBER(m_slots, fnum_latch));
 	save_item(STRUCT_MEMBER(m_slots, accon));
-	save_item(STRUCT_MEMBER(m_slots, algorithm));
-	save_item(STRUCT_MEMBER(m_slots, ch0_level));
-	save_item(STRUCT_MEMBER(m_slots, ch1_level));
-	save_item(STRUCT_MEMBER(m_slots, ch2_level));
-	save_item(STRUCT_MEMBER(m_slots, ch3_level));
-	save_item(STRUCT_MEMBER(m_slots, startaddr));
-	save_item(STRUCT_MEMBER(m_slots, loopaddr));
-	save_item(STRUCT_MEMBER(m_slots, endaddr));
-	save_item(STRUCT_MEMBER(m_slots, altloop));
-	save_item(STRUCT_MEMBER(m_slots, fs));
-	save_item(STRUCT_MEMBER(m_slots, srcnote));
-	save_item(STRUCT_MEMBER(m_slots, srcb));
-	save_item(STRUCT_MEMBER(m_slots, step));
-	save_item(STRUCT_MEMBER(m_slots, stepptr));
-	save_item(STRUCT_MEMBER(m_slots, active));
-	save_item(STRUCT_MEMBER(m_slots, bits));
-	save_item(STRUCT_MEMBER(m_slots, volume));
-	save_item(STRUCT_MEMBER(m_slots, env_state));
-	save_item(STRUCT_MEMBER(m_slots, env_attack_step));
-	save_item(STRUCT_MEMBER(m_slots, env_decay1_step));
-	save_item(STRUCT_MEMBER(m_slots, env_decay2_step));
-	save_item(STRUCT_MEMBER(m_slots, env_release_step));
-	save_item(STRUCT_MEMBER(m_slots, feedback_modulation0));
-	save_item(STRUCT_MEMBER(m_slots, feedback_modulation1));
-	save_item(STRUCT_MEMBER(m_slots, lfo_phase));
-	save_item(STRUCT_MEMBER(m_slots, lfo_step));
-	save_item(STRUCT_MEMBER(m_slots, lfo_amplitude));
+	save_item(STRUCT_MEMBER(m_slots, fb));
+	save_item(STRUCT_MEMBER(m_slots, wave));
+	save_item(STRUCT_MEMBER(m_slots, alg));
+	save_item(STRUCT_MEMBER(m_slots, ch_level));
+	save_item(STRUCT_MEMBER(m_slots, pcm_start));
+	save_item(STRUCT_MEMBER(m_slots, pcm_end));
+	save_item(STRUCT_MEMBER(m_slots, pcm_loop));
+	save_item(STRUCT_MEMBER(m_slots, pcm_altloop));
+	save_item(STRUCT_MEMBER(m_slots, pcm_fs));
+	save_item(STRUCT_MEMBER(m_slots, pcm_12bit));
+	save_item(STRUCT_MEMBER(m_slots, pcm_srcnote));
+	save_item(STRUCT_MEMBER(m_slots, pcm_srcb));
+	save_item(STRUCT_MEMBER(m_slots, block_s));
+	save_item(STRUCT_MEMBER(m_slots, keycode));
+	save_item(STRUCT_MEMBER(m_slots, eg_state));
+	save_item(STRUCT_MEMBER(m_slots, eg_att));
+	save_item(STRUCT_MEMBER(m_slots, phase));
+	save_item(STRUCT_MEMBER(m_slots, out));
+	save_item(STRUCT_MEMBER(m_slots, acc));
+	save_item(STRUCT_MEMBER(m_slots, fb_hist));
+	save_item(STRUCT_MEMBER(m_slots, lfo_cnt));
+	save_item(STRUCT_MEMBER(m_slots, lfo_pos));
+	save_item(STRUCT_MEMBER(m_slots, pcm_pos));
+	save_item(STRUCT_MEMBER(m_slots, pcm_frac));
+	save_item(STRUCT_MEMBER(m_slots, pcm_ended));
+	save_item(STRUCT_MEMBER(m_slots, c_nmod));
+	save_item(STRUCT_MEMBER(m_slots, c_mod));
+	save_item(STRUCT_MEMBER(m_slots, c_fbhead));
+	save_item(STRUCT_MEMBER(m_slots, c_fbtarget));
+	save_item(STRUCT_MEMBER(m_slots, c_carrier));
 
 	save_item(STRUCT_MEMBER(m_groups, sync));
 	save_item(STRUCT_MEMBER(m_groups, pfm));
+	save_item(STRUCT_MEMBER(m_groups, dirty));
 
 	save_item(NAME(m_regs_main));
 	save_item(NAME(m_timerA));
 	save_item(NAME(m_timerB));
-	save_item(NAME(m_irqstate));
+	save_item(NAME(m_timer_ctrl));
 	save_item(NAME(m_status));
 	save_item(NAME(m_end_status));
-	save_item(NAME(m_enable));
+	save_item(NAME(m_irqstate));
 	save_item(NAME(m_ext_address));
 	save_item(NAME(m_ext_rw));
 	save_item(NAME(m_ext_readlatch));
+	save_item(NAME(m_eg_cnt));
+	save_item(NAME(m_eg_phase));
 	save_item(NAME(m_master_clock));
 }
-
-//-------------------------------------------------
-//  device_start - device-specific startup
-//-------------------------------------------------
 
 void ymf271_device::device_start()
 {
@@ -1731,37 +1283,46 @@ void ymf271_device::device_start()
 	init_tables();
 	init_state();
 
-	m_mix_buffer.resize(m_master_clock / (384/4));
-	m_stream = stream_alloc(0, 4, m_master_clock / 384);
+	// outputs 0-3 = CH0-CH3 (DO1 = CH0/1, DO2 = CH2/3), 4-7 = CH4-CH7 (EXT1 = CH4/5, EXT2 = CH6/7)
+	m_stream = stream_alloc(0, 8, m_master_clock / 384);
 }
-
-//-------------------------------------------------
-//  device_reset - device-specific reset
-//-------------------------------------------------
 
 void ymf271_device::device_reset()
 {
-	for (auto & elem : m_slots)
+	for (int i = 0; i < NUM_SLOTS; i++)
 	{
-		elem.active = 0;
-		elem.volume = 0;
+		opx_slot &s = m_slots[i];
+		s = opx_slot();
+		s.eg_state = EG_OFF;
+		s.eg_att = 0x3FF;
+		s.c_fbtarget = -1;
 	}
+	for (int i = 0; i < NUM_GROUPS; i++)
+	{
+		m_groups[i].sync = 0;
+		m_groups[i].pfm = 0;
+		m_groups[i].dirty = 1;
+	}
+	m_eg_cnt = 0;
+	m_eg_phase = 0;
+	std::fill(std::begin(m_regs_main), std::end(m_regs_main), 0);
 
 	// reset timers and IRQ
 	m_timA->reset();
 	m_timB->reset();
 
-	m_irqstate = 0;
+	m_timerA = 0;
+	m_timerB = 0;
+	m_timer_ctrl = 0;
 	m_status = 0;
-	m_enable = 0;
+	m_end_status = 0;
+	m_irqstate = 0;
+	m_ext_address = 0;
+	m_ext_rw = 0;
+	m_ext_readlatch = 0;
 
 	m_irq_handler(0);
 }
-
-//-------------------------------------------------
-//  device_clock_changed - called whenever the
-//  clock is updated
-//-------------------------------------------------
 
 void ymf271_device::device_clock_changed()
 {
@@ -1769,13 +1330,7 @@ void ymf271_device::device_clock_changed()
 	m_master_clock = clock();
 
 	if (m_master_clock != old_clock)
-	{
-		if (old_clock < m_master_clock)
-			m_mix_buffer.resize(m_master_clock / (384/4));
-
 		m_stream->set_sample_rate(m_master_clock / 384);
-	}
-	calculate_clock_correction();
 }
 
 void ymf271_device::rom_bank_pre_change()
@@ -1791,19 +1346,22 @@ ymf271_device::ymf271_device(const machine_config &mconfig, const char *tag, dev
 	, device_rom_interface(mconfig, *this)
 	, m_timerA(0)
 	, m_timerB(0)
-	, m_irqstate(0)
+	, m_timer_ctrl(0)
 	, m_status(0)
-	, m_enable(0)
+	, m_end_status(0)
+	, m_irqstate(0)
 	, m_ext_address(0)
 	, m_ext_rw(0)
 	, m_ext_readlatch(0)
+	, m_eg_cnt(0)
+	, m_eg_phase(0)
 	, m_master_clock(0)
 	, m_timA(nullptr)
 	, m_timB(nullptr)
 	, m_stream(nullptr)
 	, m_irq_handler(*this)
 {
-	memset(m_slots, 0, sizeof(m_slots));
-	memset(m_groups, 0, sizeof(m_groups));
-	memset(m_regs_main, 0, sizeof(m_regs_main));
+	std::fill(std::begin(m_slots), std::end(m_slots), opx_slot());
+	std::fill(std::begin(m_groups), std::end(m_groups), opx_group());
+	std::fill(std::begin(m_regs_main), std::end(m_regs_main), 0);
 }

--- a/src/devices/sound/ymf271.h
+++ b/src/devices/sound/ymf271.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Olivier Galibert, R. Belmont, hap
+// copyright-holders:superctr
 #ifndef MAME_SOUND_YMF271_H
 #define MAME_SOUND_YMF271_H
 
@@ -20,6 +20,13 @@ public:
 	u8 read(offs_t offset);
 	void write(offs_t offset, u8 data);
 
+	struct opx_alg
+	{
+		uint8_t mods[4];
+		uint8_t car;
+		uint8_t fbsrc;
+	};
+
 protected:
 	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
@@ -36,121 +43,128 @@ protected:
 	TIMER_CALLBACK_MEMBER(timer_b_expired);
 
 private:
-	struct YMF271Slot
+	static constexpr int NUM_SLOTS = 48;
+	static constexpr int NUM_GROUPS = 12;
+
+	struct opx_slot
 	{
+		// function registers (decoded)
+		uint8_t kon;
 		uint8_t ext_en;
 		uint8_t ext_out;
-		uint8_t lfoFreq;
-		uint8_t lfowave;
-		uint8_t pms, ams;
-		uint8_t detune;
-		uint8_t multiple;
+		uint8_t lfo_freq;
+		uint8_t ams, pms, lfo_wave;
+		uint8_t dt, mul;
 		uint8_t tl;
-		uint8_t keyscale;
-		uint8_t ar;
-		uint8_t decay1rate, decay2rate;
-		uint8_t decay1lvl;
-		uint8_t relrate;
+		uint8_t ks, ar;
+		uint8_t d1r;
+		uint8_t d2r;
+		uint8_t d1l, rr;
+		uint16_t fnum;
 		uint8_t block;
-		uint8_t fns_hi;
-		uint32_t fns;
-		uint8_t feedback;
-		uint8_t waveform;
-		uint8_t accon;
-		uint8_t algorithm;
-		uint8_t ch0_level, ch1_level, ch2_level, ch3_level;
+		uint8_t fnum_latch;
+		uint8_t accon, fb, wave;
+		uint8_t alg;
+		uint8_t ch_level[4];
 
-		uint32_t startaddr;
-		uint32_t loopaddr;
-		uint32_t endaddr;
-		uint8_t altloop;
-		uint8_t fs;
-		uint8_t srcnote, srcb;
+		// PCM attribute registers (only meaningful if slot % 4 == 0)
+		uint32_t pcm_start;
+		uint32_t pcm_end;
+		uint32_t pcm_loop;
+		uint8_t pcm_altloop;
+		uint8_t pcm_fs;
+		uint8_t pcm_12bit;
+		uint8_t pcm_srcnote, pcm_srcb;
 
-		uint32_t step;
-		uint64_t stepptr;
+		// runtime state
+		int8_t block_s;
+		uint8_t keycode;
+		uint8_t eg_state;
+		int32_t eg_att;
+		uint32_t phase;
+		int32_t out;
+		int32_t acc;
+		int32_t fb_hist[2];
+		uint32_t lfo_cnt;
+		uint8_t lfo_pos;
+		uint32_t pcm_pos;
+		uint32_t pcm_frac;
+		uint8_t pcm_ended;   // End flag already raised since the last key-on
 
-		uint8_t active;
-		uint8_t bits;
-
-		// envelope generator
-		int32_t volume;
-		int32_t env_state;
-		int32_t env_attack_step;      // volume increase step in attack state
-		int32_t env_decay1_step;
-		int32_t env_decay2_step;
-		int32_t env_release_step;
-
-		int64_t feedback_modulation0;
-		int64_t feedback_modulation1;
-
-		int lfo_phase, lfo_step;
-		int lfo_amplitude;
-		double lfo_phasemod;
+		// connection cache (rebuilt when sync/algorithm changes)
+		uint8_t c_nmod;
+		uint8_t c_mod[3];
+		uint8_t c_fbhead;
+		int8_t c_fbtarget;
+		uint8_t c_carrier;
 	};
 
-	struct YMF271Group
+	struct opx_group
 	{
-		uint8_t sync, pfm;
+		uint8_t sync;
+		uint8_t pfm;
+		uint8_t dirty;
 	};
 
-	void init_state();
 	void init_tables();
-	void calculate_clock_correction();
-	void calculate_step(YMF271Slot *slot);
-	void update_envelope(YMF271Slot *slot);
-	void init_envelope(YMF271Slot *slot);
-	void init_lfo(YMF271Slot *slot);
-	void update_lfo(YMF271Slot *slot);
-	int64_t calculate_slot_volume(YMF271Slot *slot);
-	void update_pcm(int slotnum, int32_t *mixp, int length);
-	int64_t calculate_op(int slotnum, int64_t inp);
-	void set_feedback(int slotnum, int64_t inp);
-	void write_register(int slotnum, int reg, uint8_t data);
-	void ymf271_write_fm(int bank, uint8_t address, uint8_t data);
-	void ymf271_write_pcm(uint8_t address, uint8_t data);
-	void ymf271_write_timer(uint8_t address, uint8_t data);
+	void init_state();
 
-	inline int get_keyscaled_rate(int rate, int keycode, int keyscale);
-	inline int get_internal_keycode(int block, int fns);
-	inline int get_external_keycode(int block, int fns);
-	inline bool check_envelope_end(YMF271Slot *slot);
-	inline void calculate_status_end(int slotnum, bool state);
+	bool is_keyon_slot(int bank, int group) const;
+	int voice_slots(int bank, int group, int *slots) const;
+	static void update_keycode(opx_slot &s, int slotnum);
+	void slot_keyon(int slotnum);
+	void slot_keyoff(int slotnum);
+	void write_slot_reg(int slotnum, int reg, uint8_t data);
+	void write_fm(int bank, uint8_t address, uint8_t data);
+	void write_pcm(uint8_t address, uint8_t data);
+	void write_util(uint8_t address, uint8_t data);
+	void update_irq();
 
-	// lookup tables
-	std::unique_ptr<int16_t[]> m_lut_waves[8];
-	std::unique_ptr<double[]> m_lut_plfo[4][8];
-	std::unique_ptr<int[]> m_lut_alfo[4];
-	double m_lut_ar[64];
-	double m_lut_dc[64];
-	double m_lut_lfo[256];
-	int m_lut_attenuation[16];
-	int m_lut_total_level[128];
-	int m_lut_env_volume[256];
+	void connect(const opx_alg &alg, const int *slots, int n);
+	void rebuild_group(int g);
+	void eg_tick(opx_slot &s);
+	static int eg_rate(int rate2, int rks);
+	static uint32_t lfo_period(uint8_t n);
+	static void lfo_tick(opx_slot &s);
+	static int32_t lfo_pm(const opx_slot &s);
+	static int32_t lfo_am(const opx_slot &s);
+	static uint32_t phase_inc(const opx_slot &s, int32_t lfo_pm);
+	static uint32_t pcm_step(const opx_slot &s, int32_t lfo_pm);
+	int32_t pcm_word(const opx_slot &s, uint32_t pos);
+	int32_t pcm_sample(opx_slot &s, int slotnum, int32_t lfo_pm);
+	int32_t env_mul(int32_t v, uint32_t env) const;
+	int32_t op(uint32_t phase, int wave, uint32_t env) const;
+	static int32_t pan(int32_t v, uint8_t level);
+
+	// lookup tables (generated at start)
+	uint16_t m_logsin[256];
+	uint16_t m_exp[256];
 
 	// internal state
-	YMF271Slot m_slots[48];
-	YMF271Group m_groups[12];
+	opx_slot m_slots[NUM_SLOTS];
+	opx_group m_groups[NUM_GROUPS];
 
 	uint8_t m_regs_main[0x10];
 
-	uint32_t m_timerA;
-	uint32_t m_timerB;
-	uint8_t m_irqstate;
+	uint16_t m_timerA;
+	uint8_t m_timerB;
+	uint8_t m_timer_ctrl;
 	uint8_t m_status;
 	uint16_t m_end_status;
-	uint8_t m_enable;
+	uint8_t m_irqstate;
 
 	uint32_t m_ext_address;
 	uint8_t m_ext_rw;
 	uint8_t m_ext_readlatch;
+
+	uint32_t m_eg_cnt;
+	uint8_t m_eg_phase;
 
 	uint32_t m_master_clock;
 
 	emu_timer *m_timA;
 	emu_timer *m_timB;
 	sound_stream *m_stream;
-	std::vector<int32_t> m_mix_buffer;
 
 	devcb_write_line m_irq_handler;
 };


### PR DESCRIPTION
Replaces the MAME-derived core with a new one. The model follows recordings of real hardware (no chip was available for direct probing):

* FM: OPM-style operators (logsin/exp tables, envelope generator at fs/2 with rate key scaling, detune, per-slot LFO with AM/PM), all 16 4-op algorithms, the 2x2-op and 3-op+PCM sync modes, feedback and the non-sine waveforms.
* PCM: 8-bit and packed 12-bit samples, linear interpolation, Fs divider, loop/end handling with End flags per slot group.
* AccOn (saturating accumulation), Ext En / Ext Out: the extended channels CH4-CH7 (EXT1/EXT2 pins) are exposed as stream outputs 4-7.
* Status register 0 exposes the End flags of slots 12/24/36 as documented; End flags are cleared when the status register is read (required by the Brave Blade sound driver's voice allocator).
* Timers, external memory access and the device interface are unchanged.

AI disclosure: Claude Fable 5.