### PR TITLE
tests: add filename utility coverage

### DIFF
--- a/scripts/src/tests.lua
+++ b/scripts/src/tests.lua
@@ -65,6 +65,7 @@ project("mametests")
 		MAME_DIR .. "tests/main.cpp",
 		MAME_DIR .. "tests/lib/util/corestr.cpp",
 		MAME_DIR .. "tests/lib/util/options.cpp",
+                MAME_DIR .. "tests/lib/util/path.cpp",
 		MAME_DIR .. "tests/emu/attotime.cpp",
 		MAME_DIR .. "tests/emu/video/rgbutil.cpp",
 	}

--- a/tests/lib/util/path.cpp
+++ b/tests/lib/util/path.cpp
@@ -1,0 +1,25 @@
+#include "catch.hpp"
+
+#include "path.h"
+
+TEST_CASE("Filename base extraction", "[util]")
+{
+    REQUIRE(core_filename_extract_base("pacman.zip", true) == "pacman");
+    REQUIRE(core_filename_extract_base("pacman", true) == "pacman");
+    REQUIRE(core_filename_extract_base("/roms/pacman.zip", true) == "pacman");
+}
+
+TEST_CASE("Filename extension extraction", "[util]")
+{
+    REQUIRE(core_filename_extract_extension("pacman.zip", true) == "zip");
+    REQUIRE(core_filename_extract_extension("pacman.zip", false) == ".zip");
+    REQUIRE(core_filename_extract_extension("pacman", true) == "");
+}
+
+TEST_CASE("Filename extension matching", "[util]")
+{
+    REQUIRE(core_filename_ends_with("game.zip", ".zip"));
+    REQUIRE(core_filename_ends_with("game.ZIP", ".zip"));
+    REQUIRE_FALSE(core_filename_ends_with("game.zip", ".chd"));
+    REQUIRE_FALSE(core_filename_ends_with("game", ".zip"));
+}


### PR DESCRIPTION
Adds Catch2 test coverage for the filename utility functions in
src/lib/util/path.cpp:

- core_filename_extract_base()
- core_filename_extract_extension()
- core_filename_ends_with()

Registers the new test source in scripts/src/tests.lua.