### PR TITLE
Fujitsu MB8840x/MB8850xH series dissasembler and MCU emulator

### DIFF
--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -1496,6 +1496,23 @@ if opt_tool(CPUS, "MB88XX") then
 end
 
 --------------------------------------------------
+-- Fujitsu MB88xxx
+--@src/devices/cpu/mb88xxx/mb88xxx.h,CPUS["MB88XXX"] = true
+--------------------------------------------------
+
+if CPUS["MB88XXX"] then
+	files {
+		MAME_DIR .. "src/devices/cpu/mb88xxx/mb88xxx.cpp",
+		MAME_DIR .. "src/devices/cpu/mb88xxx/mb88xxx.h",
+	}
+end
+
+if opt_tool(CPUS, "MB88XXX") then
+	table.insert(disasm_files , MAME_DIR .. "src/devices/cpu/mb88xxx/mb88xxxdasm.cpp")
+	table.insert(disasm_files , MAME_DIR .. "src/devices/cpu/mb88xxx/mb88xxxdasm.h")
+end
+
+--------------------------------------------------
 -- Fujitsu MB86233
 --@src/devices/cpu/mb86233/mb86233.h,CPUS["MB86233"] = true
 --------------------------------------------------

--- a/src/devices/cpu/mb88xxx/mb88xxx.cpp
+++ b/src/devices/cpu/mb88xxx/mb88xxx.cpp
@@ -1,0 +1,1097 @@
+// license:BSD-3-Clause
+// copyright-holders:trwgQ26xxx
+/***************************************************************************
+
+	Fujitsu MB8840x / MB8850xH series 4-bit MCU emulator.
+
+	Written by trwgQ26xxx, based on Ernesto Corvi's MB88xx MCU emulator.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "mb88xxx.h"
+#include "mb88xxxdasm.h"
+
+DEFINE_DEVICE_TYPE(MB88401,  mb88401_cpu_device,  "mb88401",  "Fujitsu MB88401")
+DEFINE_DEVICE_TYPE(MB88501H, mb88501h_cpu_device, "mb88501h", "Fujitsu MB88501H")
+DEFINE_DEVICE_TYPE(MB88503H, mb88503h_cpu_device, "mb88503h", "Fujitsu MB88503H")
+DEFINE_DEVICE_TYPE(MB88505H, mb88505h_cpu_device, "mb88505h", "Fujitsu MB88505H")
+
+/***************************************************************************
+	CONSTANTS
+***************************************************************************/
+
+#define SERIAL_PRESCALE			6		// serial bit-clock divisor (same as MB88xx)
+#define TIMER_PRESCALE			32		// internal timer tick divisor (same as MB88xx)
+
+#define SERIAL_DISABLE_THRESH	1000	// give up driving serial after this many unread bits
+
+#define INT_CAUSE_SERIAL		0x01	// PIO bit 0
+#define INT_CAUSE_TIMER			0x02	// PIO bit 1
+#define INT_CAUSE_EXTERNAL		0x04	// PIO bit 2
+#define INT_CAUSE_CLOCK			0x08	// PIO bit 3
+
+/***************************************************************************
+	MACROS
+***************************************************************************/
+
+#define READOP(a)			(m_cache.read_byte(a))
+#define RDMEM(a)			(m_data.read_byte(a) & 0x0f)
+#define WRMEM(a, v)			(m_data.write_byte((a), (v) & 0x0f))
+
+#define TEST_ST()			(m_st & 1)
+#define TEST_ZF()			(m_zf & 1)
+#define TEST_CF()			(m_cf & 1)
+#define TEST_VF()			(m_vf & 1)
+#define TEST_SF()			(m_sf & 1)
+#define TEST_IF()			(m_if & 1)
+
+// ST=0 when carry-out (bit 4 set), else ST=1
+#define UPDATE_ST_C(v)		m_st = ((v) & 0x10) ? 0 : 1
+// ST=1 when non-zero, ST=0 when zero
+#define UPDATE_ST_Z(v)		m_st = ((v) == 0) ? 0 : 1
+
+#define UPDATE_CF(v)		m_cf = (((v) & 0x10) == 0) ? 0 : 1
+#define UPDATE_ZF(v)		m_zf = ((v) != 0) ? 0 : 1
+
+// Full 12-bit program counter: PA is 6 bits, PC is 6 bits
+#define GETPC()				(((int)m_PA << 6) + m_PC)
+// Effective data address: X is 4 bits (page), Y is 4 bits (offset)
+#define GETEA()				((m_X << 4) + m_Y)
+
+// Increment PC; roll over into PA when PC reaches 64
+#define INCPC() do { m_PC++; if (m_PC >= 0x40) { m_PC = 0; m_PA = (m_PA + 1) & 0x3f; } } while (0)
+
+/***************************************************************************
+	ADDRESS MAPS
+***************************************************************************/
+
+void mb88xxx_cpu_device::program_12bit(address_map &map)
+{
+	map(0x000, 0xfff).rom();	// 4 KiB (MB88401, MB88501H, MB88505H)
+}
+
+void mb88xxx_cpu_device::program_11bit(address_map &map)
+{
+	map(0x000, 0x7ff).rom();	// 2 KiB (MB88503H)
+}
+
+void mb88xxx_cpu_device::data_c0(address_map &map)
+{
+	map(0x00, 0xbf).ram();		// 192 nibbles (MB88401)
+}
+
+void mb88xxx_cpu_device::data_100(address_map &map)
+{
+	map(0x00, 0xff).ram();		// 256 nibbles (MB8850xH)
+}
+
+
+/***************************************************************************
+	CONSTRUCTORS
+***************************************************************************/
+
+mb88xxx_cpu_device::mb88xxx_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, int program_width, int data_width, u8 sb_bits)
+	: cpu_device(mconfig, type, tag, owner, clock)
+	, m_program_config("program", ENDIANNESS_BIG, 8, program_width, 0,
+		(program_width == 11)
+			? address_map_constructor(FUNC(mb88xxx_cpu_device::program_11bit), this)
+			: address_map_constructor(FUNC(mb88xxx_cpu_device::program_12bit), this))
+	, m_data_config("data", ENDIANNESS_BIG, 8, data_width, 0,
+		(type == MB88401)
+			? address_map_constructor(FUNC(mb88xxx_cpu_device::data_c0), this)
+			: address_map_constructor(FUNC(mb88xxx_cpu_device::data_100), this))
+	, m_sb_bits(sb_bits)
+	, m_pla_data(nullptr)
+	, m_pla_bits(8)
+	, m_read_k(*this, 0)
+	, m_write_o(*this)
+	, m_write_p(*this)
+	, m_read_r(*this, 0)
+	, m_write_r(*this)
+	, m_read_si(*this, 0)
+	, m_write_so(*this)
+{
+}
+
+// MB88401: NMOS, 4K ROM, 192-nibble RAM, 4-bit serial
+mb88401_cpu_device::mb88401_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: mb88xxx_cpu_device(mconfig, MB88401, tag, owner, clock, 12, 8, 4)
+{
+}
+
+// MB88501H: CMOS, 4K ROM, 256-nibble RAM, 4-bit serial
+mb88501h_cpu_device::mb88501h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: mb88xxx_cpu_device(mconfig, MB88501H, tag, owner, clock, 12, 8, 4)
+{
+}
+
+// MB88503H: CMOS, 2K ROM, 256-nibble RAM, 4-bit serial
+mb88503h_cpu_device::mb88503h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+: mb88xxx_cpu_device(mconfig, MB88503H, tag, owner, clock, 11, 8, 4)
+{
+}
+
+// MB88505H: CMOS, 4K ROM, 256-nibble RAM, 8-bit serial
+mb88505h_cpu_device::mb88505h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: mb88xxx_cpu_device(mconfig, MB88505H, tag, owner, clock, 12, 8, 8)
+{
+}
+
+/***************************************************************************
+	MEMORY SPACE CONFIG
+***************************************************************************/
+
+device_memory_interface::space_config_vector mb88xxx_cpu_device::memory_space_config() const
+{
+	return space_config_vector {
+		std::make_pair(AS_PROGRAM, &m_program_config),
+		std::make_pair(AS_DATA, &m_data_config)
+	};
+}
+
+std::unique_ptr<util::disasm_interface> mb88xxx_cpu_device::create_disassembler()
+{
+	return std::make_unique<mb88xxx_disassembler>();
+}
+
+
+/***************************************************************************
+	INITIALIZATION AND RESET
+***************************************************************************/
+
+void mb88xxx_cpu_device::device_start()
+{
+	space(AS_PROGRAM).cache(m_cache);
+	space(AS_PROGRAM).specific(m_program);
+	space(AS_DATA).specific(m_data);
+
+	m_serial = timer_alloc(FUNC(mb88xxx_cpu_device::serial_timer), this);
+
+	m_if = 0;
+	m_ctr = 0;
+	m_o_output = 0;
+
+	save_item(NAME(m_PC));
+	save_item(NAME(m_PA));
+	save_item(NAME(m_SP));
+	save_item(NAME(m_SI));
+	save_item(NAME(m_A));
+	save_item(NAME(m_X));
+	save_item(NAME(m_Y));
+	save_item(NAME(m_st));
+	save_item(NAME(m_zf));
+	save_item(NAME(m_cf));
+	save_item(NAME(m_vf));
+	save_item(NAME(m_sf));
+	save_item(NAME(m_if));
+	save_item(NAME(m_pio));
+	save_item(NAME(m_TH));
+	save_item(NAME(m_TL));
+	save_item(NAME(m_TP));
+	save_item(NAME(m_ctr));
+	save_item(NAME(m_SB));
+	save_item(NAME(m_SBcount));
+	save_item(NAME(m_o_output));
+	save_item(NAME(m_pending_irq));
+	save_item(NAME(m_in_irq));
+
+	state_add(MB88XXX_PC,  "PC",  m_PC).formatstr("%02X");
+	state_add(MB88XXX_PA,  "PA",  m_PA).formatstr("%02X");
+	state_add(MB88XXX_SI,  "SI",  m_SI).formatstr("%01X");
+	state_add(MB88XXX_A,   "A",   m_A).formatstr("%01X");
+	state_add(MB88XXX_X,   "X",   m_X).formatstr("%01X");
+	state_add(MB88XXX_Y,   "Y",   m_Y).formatstr("%01X");
+	state_add(MB88XXX_PIO, "PIO", m_pio).formatstr("%02X");
+	state_add(MB88XXX_TH,  "TH",  m_TH).formatstr("%01X");
+	state_add(MB88XXX_TL,  "TL",  m_TL).formatstr("%01X");
+	state_add(MB88XXX_SB,  "SB",  m_SB).formatstr("%02X");
+
+	state_add(STATE_GENPC, "GENPC", m_debugger_pc).callimport().callexport().noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_debugger_pc).callimport().callexport().noshow();
+	state_add(STATE_GENFLAGS, "GENFLAGS", m_debugger_flags).callimport().callexport().formatstr("%6s").noshow();
+
+	set_icountptr(m_icount);
+}
+
+void mb88xxx_cpu_device::state_import(const device_state_entry &entry)
+{
+	switch (entry.index())
+	{
+		case STATE_GENFLAGS:
+			m_st = (m_debugger_flags & 0x01) ? 1 : 0;
+			m_zf = (m_debugger_flags & 0x02) ? 1 : 0;
+			m_cf = (m_debugger_flags & 0x04) ? 1 : 0;
+			m_vf = (m_debugger_flags & 0x08) ? 1 : 0;
+			m_sf = (m_debugger_flags & 0x10) ? 1 : 0;
+			m_if = (m_debugger_flags & 0x20) ? 1 : 0;
+			break;
+
+		case STATE_GENPC:
+		case STATE_GENPCBASE:
+			m_PC = m_debugger_pc & 0x3f;
+			m_PA = (m_debugger_pc >> 6) & 0x3f;
+			break;
+	}
+}
+
+void mb88xxx_cpu_device::state_export(const device_state_entry &entry)
+{
+	switch (entry.index())
+	{
+		case STATE_GENFLAGS:
+			m_debugger_flags = 0;
+			if (TEST_ST()) m_debugger_flags |= 0x01;
+			if (TEST_ZF()) m_debugger_flags |= 0x02;
+			if (TEST_CF()) m_debugger_flags |= 0x04;
+			if (TEST_VF()) m_debugger_flags |= 0x08;
+			if (TEST_SF()) m_debugger_flags |= 0x10;
+			if (TEST_IF()) m_debugger_flags |= 0x20;
+			break;
+
+		case STATE_GENPC:
+		case STATE_GENPCBASE:
+			m_debugger_pc = GETPC();
+			break;
+	}
+}
+
+void mb88xxx_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
+{
+	switch (entry.index())
+	{
+		case STATE_GENFLAGS:
+			str = string_format("%c%c%c%c%c%c",
+				TEST_ST() ? 'T' : 't',
+				TEST_ZF() ? 'Z' : 'z',
+				TEST_CF() ? 'C' : 'c',
+				TEST_VF() ? 'V' : 'v',
+				TEST_SF() ? 'S' : 's',
+				TEST_IF() ? 'I' : 'i');
+			break;
+	}
+}
+void mb88xxx_cpu_device::device_reset()
+{
+	// Zero registers and flags.
+	m_PC = 0;
+	m_PA = 0;
+	m_SP[0] = m_SP[1] = m_SP[2] = m_SP[3] = 0;
+	m_SP[4] = m_SP[5] = m_SP[6] = m_SP[7] = 0;
+
+	m_SI = 0;
+	m_A = 0;
+	m_X = 0;
+	m_Y = 0;
+
+	m_st = 1;	// ST starts high (first conditional branch is not taken).
+	m_zf = 0;
+	m_cf = 0;
+	m_vf = 0;
+	m_sf = 0;
+	m_if = 0;
+
+	m_pio = 0;
+
+	m_TH = 0;
+	m_TL = 0;
+	m_TP = 0;
+
+	m_SB = 0;
+	m_SBcount = 0;
+
+	m_o_output = 0;
+
+	m_pending_irq = 0;
+	m_in_irq = false;
+	m_serial->adjust(attotime::never);
+}
+
+/***************************************************************************
+	SERIAL TIMER
+***************************************************************************/
+
+TIMER_CALLBACK_MEMBER(mb88xxx_cpu_device::serial_timer)
+{
+	m_SBcount++;
+
+	// Stop driving if the program never reads the buffer
+	if (m_SBcount >= SERIAL_DISABLE_THRESH)
+	{
+		m_serial->adjust(attotime::never);
+	}
+
+	// Shift in one bit from SI; do not overwrite an unread full buffer
+	if (!m_sf)
+	{
+		m_SB = (m_SB >> 1) | (m_read_si() ? (1 << (m_sb_bits - 1)) : 0);
+
+		if (m_SBcount >= m_sb_bits)
+		{
+			m_sf = 1;
+			m_pending_irq |= INT_CAUSE_SERIAL;
+		}
+	}
+}
+
+/***************************************************************************
+	PLA / O-PORT WRITE
+***************************************************************************/
+
+void mb88xxx_cpu_device::write_pla(u8 index)
+{
+	u8 mask = 0xff;
+
+	if (m_pla_bits == 8)
+	{
+		// 8-bit mode: CF selects which nibble of O-port gets the accumulator
+		// CF=0 -> O[3:0] <- A; CF=1 -> O[7:4] <- A
+		const u8 shift = (index & 0x10) ? 4 : 0;
+		mask = 0xf << shift;
+		m_o_output = (m_o_output & ~mask) | (index << shift & mask);
+	}
+	else
+	{
+		// 4-bit PLA mode: look up full 8-bit output from table
+		// If the driver has not supplied PLA data, just output the index.
+		if (m_pla_data)
+			m_o_output = m_pla_data[index];
+		else
+			m_o_output = index;
+	}
+
+	m_write_o(0, m_o_output, mask);
+}
+
+/***************************************************************************
+	EXTERNAL INPUTS
+***************************************************************************/
+
+void mb88xxx_cpu_device::execute_set_input(int inputnum, int state)
+{
+	state = state ? 1 : 0;
+
+	switch (inputnum)
+	{
+		case MB88XXX_IRQ_LINE:
+			// Trigger on a rising logical edge of the IRQ input.
+			// Only latch when the external interrupt source is enabled.
+			if (!m_if && state && (m_pio & INT_CAUSE_EXTERNAL))
+				m_pending_irq |= INT_CAUSE_EXTERNAL;
+
+			m_if = state;
+			break;
+
+		case MB88XXX_TC_LINE:
+			// Falling edge of TC increments the counter when TC is started (PIO b7)
+			if (m_ctr && !state && (m_pio & 0x80))
+				increment_timer();
+
+			m_ctr = state;
+			break;
+
+		default:
+			break;
+	}
+}
+
+/***************************************************************************
+	PERIPHERAL ENABLE / DISABLE
+***************************************************************************/
+
+void mb88xxx_cpu_device::pio_enable(u8 newpio)
+{
+	// Bit 6 (0x40) = SC: serial port start/stop
+	if ((m_pio ^ newpio) & 0x40)
+	{
+		if (!(newpio & 0x40))
+		{
+			m_serial->adjust(attotime::never);
+		}
+		else
+		{
+			m_serial->adjust(attotime::from_hz(clock() / SERIAL_PRESCALE), 0, attotime::from_hz(clock() / SERIAL_PRESCALE));
+		}
+	}
+
+	m_pio = newpio;
+}
+
+/***************************************************************************
+	TIMER
+***************************************************************************/
+
+void mb88xxx_cpu_device::increment_timer()
+{
+	m_TL = (m_TL + 1) & 0x0f;
+	if (m_TL == 0)
+	{
+		m_TH = (m_TH + 1) & 0x0f;
+		if (m_TH == 0)
+		{
+			m_vf = 1;
+			m_pending_irq |= INT_CAUSE_TIMER;
+		}
+	}
+}
+
+/***************************************************************************
+	CYCLE BURN + INTERRUPT DISPATCH
+***************************************************************************/
+
+void mb88xxx_cpu_device::burn_cycles(int cycles)
+{
+	m_icount -= cycles;
+
+	// Internal timer: PIO bit 7 (TC) starts the timer in internal-clock mode
+	if (m_pio & 0x80)
+	{
+		m_TP += cycles;
+		while (m_TP >= TIMER_PRESCALE)
+		{
+			m_TP -= TIMER_PRESCALE;
+			increment_timer();
+		}
+	}
+
+	// TODO: Implement clock (INT_CAUSE_CLOCK) interrupt generation.
+	// The available data sheet documents its enable bit,
+	// but not the request period or assertion condition.
+
+	// Dispatch a pending interrupt (highest priority wins)
+	if (!m_in_irq && (m_pending_irq & m_pio))
+	{
+		m_in_irq = true;
+		const u16 intpc = GETPC();
+
+		// Save return address and flags onto stack (same layout as MB88xx)
+		m_SP[m_SI] = intpc;
+		m_SP[m_SI] |= (u16)TEST_CF() << 15;
+		m_SP[m_SI] |= (u16)TEST_ZF() << 14;
+		m_SP[m_SI] |= (u16)TEST_ST() << 13;
+		m_SI = (m_SI + 1) & 7;
+
+		// External, timer, serial, and clock interrupt vectors.
+		if (m_pending_irq & m_pio & INT_CAUSE_EXTERNAL)
+		{
+			standard_irq_callback(0, intpc);
+			m_PC = 0x02;
+		}
+		else if (m_pending_irq & m_pio & INT_CAUSE_TIMER)
+		{
+			standard_irq_callback(1, intpc);
+			m_PC = 0x04;
+		}
+		else if (m_pending_irq & m_pio & INT_CAUSE_SERIAL)
+		{
+			standard_irq_callback(2, intpc);
+			m_PC = 0x06;
+		}
+		else if (m_pending_irq & m_pio & INT_CAUSE_CLOCK)
+		{
+			standard_irq_callback(3, intpc);
+			m_PC = 0x08;
+		}
+
+		m_PA = 0x00;
+		m_st = 1;
+		m_pending_irq = 0;
+
+		burn_cycles(3);
+	}
+}
+
+/***************************************************************************
+	CORE EXECUTION LOOP
+***************************************************************************/
+
+void mb88xxx_cpu_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		u8 opcode, arg, oc;
+
+		// Fetch the opcode.
+		debugger_instruction_hook(GETPC());
+		opcode = READOP(GETPC());
+
+		// Increment the PC.
+		INCPC();
+
+		// Start with one cycle; multi-byte/multi-step instructions add to this.
+		oc = 1;
+
+		switch (opcode)
+		{
+			case 0x00: // NOP ZCS:...
+				m_st = 1;
+				break;
+
+			case 0x01: // OUTO ZCS:...
+				// CF selects upper (O[7:4]) or lower ([3:0]) nibble of O-port
+				write_pla((TEST_CF() << 4) | m_A);
+				m_st = 1;
+				break;
+
+			case 0x02: // OUTP ZCS:...
+				m_write_p(m_A);
+				m_st = 1;
+				break;
+
+			case 0x03: // OUT ZCS:...
+				arg = m_Y;
+				m_write_r[arg & 3](m_A);
+				m_st = 1;
+				break;
+
+			case 0x04: // TAY ZCS:...
+				m_Y = m_A;
+				m_st = 1;
+				break;
+
+			case 0x05: // TATH ZCS:...
+				m_TH = m_A;
+				m_st = 1;
+				break;
+
+			case 0x06: // TATL ZCS:...
+				m_TL = m_A;
+				m_st = 1;
+				break;
+
+			case 0x07: // TAS ZCS:...
+				m_SB = m_A;
+				m_st = 1;
+				break;
+
+			case 0x08: // ICY ZCS:x.x
+				m_Y++;
+				UPDATE_ST_C(m_Y);
+				m_Y &= 0x0f;
+				UPDATE_ZF(m_Y);
+				break;
+
+			case 0x09: // ICM ZCS:x.x
+				arg = RDMEM(GETEA());
+				arg++;
+				UPDATE_ST_C(arg);
+				arg &= 0x0f;
+				UPDATE_ZF(arg);
+				WRMEM(GETEA(), arg);
+				break;
+
+			case 0x0a: // STIC ZCS:x.x
+				WRMEM(GETEA(), m_A);
+				m_Y++;
+				UPDATE_ST_C(m_Y);
+				m_Y &= 0x0f;
+				UPDATE_ZF(m_Y);
+				break;
+
+			case 0x0b: // X ZCS:x..
+				arg = RDMEM(GETEA());
+				WRMEM(GETEA(), m_A);
+				m_A = arg;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x0c: // ROL ZCS:xxx
+				m_A <<= 1;
+				m_A |= TEST_CF();
+				UPDATE_ST_C(m_A);
+				m_cf = m_st ^ 1;
+				m_A &= 0x0f;
+				UPDATE_ZF(m_A);
+				break;
+
+			case 0x0d: // L ZCS:x..
+				m_A = RDMEM(GETEA());
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x0e: // ADC ZCS:xxx
+				arg = RDMEM(GETEA());
+				arg += m_A;
+				arg += TEST_CF();
+				UPDATE_ST_C(arg);
+				m_cf = m_st ^ 1;
+				m_A = arg & 0x0f;
+				UPDATE_ZF(m_A);
+				break;
+
+			case 0x0f: // AND ZCS:x.x
+				m_A &= RDMEM(GETEA());
+				UPDATE_ZF(m_A);
+				m_st = m_zf ^ 1;
+				break;
+
+			case 0x10: // DAA ZCS:.xx
+				if (TEST_CF() || m_A > 9) m_A += 6;
+				UPDATE_ST_C(m_A);
+				m_cf = m_st ^ 1;
+				m_A &= 0x0f;
+				break;
+
+			case 0x11: // DAS ZCS:.xx
+				if (TEST_CF() || m_A > 9) m_A += 10;
+				UPDATE_ST_C(m_A);
+				m_cf = m_st ^ 1;
+				m_A &= 0x0f;
+				break;
+
+			case 0x12: // INK ZCS:x..
+				m_A = m_read_k() & 0x0f;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x13: // IN ZCS:x..
+				arg = m_Y;
+				m_A = m_read_r[arg & 3]() & 0x0f;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x14: // TYA ZCS:x..
+				m_A = m_Y;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x15: // TTHA ZCS:x..
+				m_A = m_TH;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x16: // TTLA ZCS:x..
+				m_A = m_TL;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x17: // TSA ZCS:x..
+				// MB88505H 8-bit serial mode: TSA transfers SBL->A and SBH->X.
+				// 4-bit variants keep legacy behavior (A from low nibble only).
+				m_A = m_SB & 0x0f;
+				if (m_sb_bits == 8)
+					m_X = (m_SB >> 4) & 0x0f;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x18: // DCY ZCS:..x
+				m_Y--;
+				UPDATE_ST_C(m_Y);
+				m_Y &= 0x0f;
+				// Note: ZF is not updated by DCY.
+				break;
+
+			case 0x19: // DCM ZCS:x.x
+				arg = RDMEM(GETEA());
+				arg--;
+				UPDATE_ST_C(arg);
+				arg &= 0x0f;
+				UPDATE_ZF(arg);
+				WRMEM(GETEA(), arg);
+				break;
+
+			case 0x1a: // STDC ZCS:x.x
+				WRMEM(GETEA(), m_A);
+				m_Y--;
+				UPDATE_ST_C(m_Y);
+				m_Y &= 0x0f;
+				UPDATE_ZF(m_Y);
+				break;
+
+			case 0x1b: // XX ZCS:x..
+				arg = m_X;
+				m_X = m_A;
+				m_A = arg;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x1c: // ROR ZCS:xxx
+				m_A |= TEST_CF() << 4;
+				UPDATE_ST_C(m_A << 4);
+				m_cf = m_st ^ 1;
+				m_A >>= 1;
+				m_A &= 0x0f;
+				UPDATE_ZF(m_A);
+				break;
+
+			case 0x1d: // ST ZCS:x..
+				WRMEM(GETEA(), m_A);
+				m_st = 1;
+				break;
+
+			case 0x1e: // SBC ZCS:xxx
+				arg = RDMEM(GETEA());
+				arg -= m_A;
+				arg -= TEST_CF();
+				UPDATE_ST_C(arg);
+				m_cf = m_st ^ 1;
+				m_A = arg & 0x0f;
+				UPDATE_ZF(m_A);
+				break;
+
+			case 0x1f: // OR ZCS:x.x
+				m_A |= RDMEM(GETEA());
+				UPDATE_ZF(m_A);
+				m_st = m_zf ^ 1;
+				break;
+
+			case 0x20: // SETR ZCS:...
+				arg = m_read_r[m_Y >> 2]() & 0x0f;
+				m_write_r[m_Y >> 2](arg | (1 << (m_Y & 3)));
+				m_st = 1;
+				break;
+
+			case 0x21: // SETC ZCS:.xx
+				m_cf = 1;
+				m_st = 1;
+				break;
+
+			case 0x22: // RSTR ZCS:...
+				arg = m_read_r[m_Y >> 2]() & 0x0f;
+				m_write_r[m_Y >> 2](arg & ~(1 << (m_Y & 3)));
+				m_st = 1;
+				break;
+
+			case 0x23: // RSTC ZCS:.xx
+				m_cf = 0;
+				m_st = 1;
+				break;
+
+			case 0x24: // TSTR ZCS:..x
+				arg = m_read_r[m_Y >> 2]() & 0x0f;
+				m_st = (arg & (1 << (m_Y & 3))) ? 0 : 1;
+				break;
+
+			case 0x25: // TSTI ZCS:..x
+				m_st = m_if ^ 1;
+				break;
+
+			case 0x26: // TSTV ZCS:..x
+				m_st = m_vf ^ 1;
+				m_vf = 0;
+				break;
+
+			case 0x27: // TSTS ZCS:..x
+				m_st = m_sf ^ 1;
+				if (m_sf)
+				{
+					// Re-arm serial timer if it had been silenced
+					if (m_SBcount >= SERIAL_DISABLE_THRESH)
+						m_serial->adjust(attotime::from_hz(clock() / SERIAL_PRESCALE), 0, attotime::from_hz(clock() / SERIAL_PRESCALE));
+
+					m_SBcount = 0;
+				}
+				m_sf = 0;
+				break;
+
+			case 0x28: // TSTC ZCS:..x
+				m_st = m_cf ^ 1;
+				break;
+
+			case 0x29: // TSTZ ZCS:..x
+				m_st = m_zf ^ 1;
+				break;
+
+			case 0x2a: // STS ZCS:x..
+				WRMEM(GETEA(), m_SB);
+				UPDATE_ZF(m_SB);
+				m_st = 1;
+				break;
+
+			case 0x2b: // LS ZCS:x..
+				m_SB = RDMEM(GETEA());
+				UPDATE_ZF(m_SB);
+				m_st = 1;
+				break;
+
+			case 0x2c: // RTS ZCS:...
+				m_SI = (m_SI - 1) & 7;
+				m_PC = m_SP[m_SI] & 0x3f;
+				m_PA = (m_SP[m_SI] >> 6) & 0x3f;
+				m_st = 1;
+				break;
+
+			case 0x2d: // NEG ZCS:..x
+				m_A = (~m_A) + 1;
+				m_A &= 0x0f;
+				UPDATE_ST_Z(m_A);
+				break;
+
+			case 0x2e: // C ZCS:xxx
+				arg = RDMEM(GETEA());
+				arg -= m_A;
+				UPDATE_CF(arg);
+				arg &= 0x0f;
+				UPDATE_ST_Z(arg);
+				m_zf = m_st ^ 1;
+				break;
+
+			case 0x2f: // EOR ZCS:x.x
+				m_A ^= RDMEM(GETEA());
+				UPDATE_ST_Z(m_A);
+				m_zf = m_st ^ 1;
+				break;
+
+			case 0x30: case 0x31: case 0x32: case 0x33: // SBIT bp ZCS:...
+				arg = RDMEM(GETEA());
+				WRMEM(GETEA(), arg | (1 << (opcode & 3)));
+				m_st = 1;
+				break;
+
+			case 0x34: case 0x35: case 0x36: case 0x37: // RBIT bp ZCS:...
+				arg = RDMEM(GETEA());
+				WRMEM(GETEA(), arg & ~(1 << (opcode & 3)));
+				m_st = 1;
+				break;
+
+			case 0x38: case 0x39: case 0x3a: case 0x3b: // TBIT bp ZCS:..x
+				arg = RDMEM(GETEA());
+				m_st = (arg & (1 << (opcode & 3))) ? 0 : 1;
+				break;
+
+			case 0x3c: // RTI ZCS:...
+				// Restore address and saved state flags from stack high bits.
+				m_in_irq = false;
+				m_SI = (m_SI - 1) & 7;
+				m_PC = m_SP[m_SI] & 0x3f;
+				m_PA = (m_SP[m_SI] >> 6) & 0x3f;
+				m_st = (m_SP[m_SI] >> 13) & 1;
+				m_zf = (m_SP[m_SI] >> 14) & 1;
+				m_cf = (m_SP[m_SI] >> 15) & 1;
+				break;
+
+			case 0x3d: // EXT ZCS:...
+				// EXT is a multi-byte instruction; the next byte is an extended opcode.
+			{
+				arg = READOP(GETPC());
+				INCPC();
+				oc++;
+
+				if ((arg >= 0x00) && (arg <= 0x1f)) // JPXY $page ZCS:..x
+				{
+					// PA = 5-bit page number from EXT byte
+					// PC = (X<<4|Y)&0x3f - X provides upper 2 bits, Y lower 4
+					m_PA = arg & 0x1f;
+					m_PC = ((m_X << 4) | m_Y) & 0x3f;
+					m_st = 1;
+				}
+				else if ((arg >= 0x20) && (arg <= 0x3f)) // LRXA #imm ZCS:x..
+				{
+					// ROM addr = imm[4:0] | X[3:0] | Y[3:0] (12 bits).
+					const u16 romaddr = (u16(arg & 0x1f) << 8) | ((m_X & 0x0f) << 4) | (m_Y & 0x0f);
+					const u8 romdata = READOP(romaddr & 0xfff);
+					m_X = (romdata >> 4) & 0x0f;
+					m_A = romdata & 0x0f;
+					UPDATE_ZF(m_A);
+					m_st = 1;
+					oc++;
+				}
+				else if ((arg >= 0x80) && (arg <= 0x8f)) // AI #imm ZCS:xxx
+				{
+					const u8 imm = arg & 0x0f;
+					const u8 v = m_A + imm;
+					UPDATE_ST_C(v);
+					m_cf = m_st ^ 1;
+					m_A = v & 0x0f;
+					UPDATE_ZF(m_A);
+				}
+				else if ((arg >= 0x90) && (arg <= 0x9f)) // LXID #imm ZCS:x..
+				{
+					m_X = arg & 0x0f;
+					UPDATE_ZF(m_X);
+					m_st = 1;
+				}
+				else if ((arg >= 0xa0) && (arg <= 0xa3)) // SBA bp ZCS:...
+				{
+					m_A |= (1 << (arg & 3));
+					m_A &= 0x0f;
+					m_st = 1;
+				}
+				else if ((arg >= 0xa4) && (arg <= 0xa7)) // RBA bp ZCS:...
+				{
+					m_A &= ~(1 << (arg & 3));
+					m_A &= 0x0f;
+					m_st = 1;
+				}
+				else if (arg == 0xac) // ICX ZCS:x.x
+				{
+					m_X++;
+					UPDATE_ST_C(m_X);
+					m_cf = m_st ^ 1;
+					m_X &= 0x0f;
+					UPDATE_ZF(m_X);
+				}
+				else if (arg == 0xad) // RST ZCS:...
+				{
+					device_reset();
+					m_st = 1; // device_reset() sets m_st=1 anyway, kept explicit.
+				}
+				else // Undefined EXT opcode; treat as NOP.
+				{
+					m_st = 1;
+				}
+				break;
+			}
+
+			case 0x3e: // EN #imm ZCS:...
+				arg = READOP(GETPC());
+				// If bit 5 (0x20) is set, clear the internal timer prescaler accumulator (TP).
+				if (arg & 0x20)
+				{
+					m_TP = 0;
+				}
+				pio_enable(m_pio | arg);
+				INCPC();
+				oc++;
+				m_st = 1;
+				break;
+
+			case 0x3f: // DIS #imm ZCS:...
+				pio_enable(m_pio & ~(READOP(GETPC())));
+				INCPC();
+				oc++;
+				m_st = 1;
+				break;
+
+			case 0x40: case 0x41: case 0x42: case 0x43: // SETD d ZCS:...
+				arg = m_read_r[0]() & 0x0f;
+				arg |= (1 << (opcode & 3));
+				m_write_r[0](arg);
+				m_st = 1;
+				break;
+
+			case 0x44: case 0x45: case 0x46: case 0x47: // RSTD d ZCS:...
+				arg = m_read_r[0]() & 0x0f;
+				arg &= ~(1 << (opcode & 3));
+				m_write_r[0](arg);
+				m_st = 1;
+				break;
+
+			case 0x48: case 0x49: case 0x4a: case 0x4b: // TSTD d ZCS:..x
+				// It tests R[11:8], not R[3:0] as the other SETD/RSTD.
+				arg = m_read_r[2]() & 0x0f;
+				m_st = (arg & (1 << (opcode & 3))) ? 0 : 1;
+				break;
+
+			case 0x4c: case 0x4d: case 0x4e: case 0x4f: // TBA d ZCS:..x
+				m_st = (m_A & (1 << (opcode & 3))) ? 0 : 1;
+				break;
+
+			case 0x50: case 0x51: case 0x52: case 0x53: // XD d ZCS:x..
+				arg = RDMEM(opcode & 3);
+				WRMEM((opcode & 3), m_A);
+				m_A = arg;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0x54: case 0x55: case 0x56: case 0x57: // XYD d ZCS:x..
+				arg = RDMEM((opcode & 3) + 4);
+				WRMEM((opcode & 3) + 4, m_Y);
+				m_Y = arg;
+				UPDATE_ZF(m_Y);
+				m_st = 1;
+				break;
+
+			case 0x58: case 0x59: case 0x5a: case 0x5b:
+			case 0x5c: case 0x5d: case 0x5e: case 0x5f: // LXI #imm ZCS:x..
+				// X[3] is explicitly cleared; only X[2:0] are loaded.
+				m_X = opcode & 7;
+				UPDATE_ZF(m_X);
+				m_st = 1;
+				break;
+
+			// 12-bit target: (opcode[3:0] << 8) | arg
+			case 0x60: case 0x61: case 0x62: case 0x63:
+			case 0x64: case 0x65: case 0x66: case 0x67:
+			case 0x68: case 0x69: case 0x6a: case 0x6b:
+			case 0x6c: case 0x6d: case 0x6e: case 0x6f: // CALL addr ZCS:..x
+				arg = READOP(GETPC());
+				INCPC();
+				oc++;
+				if (TEST_ST())
+				{
+					m_SP[m_SI] = GETPC();
+					m_SI = (m_SI + 1) & 7;
+					m_PC = arg & 0x3f;
+					m_PA = ((opcode & 0x0f) << 2) | (arg >> 6);
+				}
+				m_st = 1;
+				break;
+
+			// 12-bit target: (opcode[3:0] << 8) | arg
+			case 0x70: case 0x71: case 0x72: case 0x73:
+			case 0x74: case 0x75: case 0x76: case 0x77:
+			case 0x78: case 0x79: case 0x7a: case 0x7b:
+			case 0x7c: case 0x7d: case 0x7e: case 0x7f: // JPL addr ZCS:..x
+				arg = READOP(GETPC());
+				INCPC();
+				oc++;
+				if (TEST_ST())
+				{
+					m_PC = arg & 0x3f;
+					m_PA = ((opcode & 0x0f) << 2) | (arg >> 6);
+				}
+				m_st = 1;
+				break;
+
+			case 0x80: case 0x81: case 0x82: case 0x83:
+			case 0x84: case 0x85: case 0x86: case 0x87:
+			case 0x88: case 0x89: case 0x8a: case 0x8b:
+			case 0x8c: case 0x8d: case 0x8e: case 0x8f: // LYI #imm ZCS:x..
+				m_Y = opcode & 0x0f;
+				UPDATE_ZF(m_Y);
+				m_st = 1;
+				break;
+
+			case 0x90: case 0x91: case 0x92: case 0x93:
+			case 0x94: case 0x95: case 0x96: case 0x97:
+			case 0x98: case 0x99: case 0x9a: case 0x9b:
+			case 0x9c: case 0x9d: case 0x9e: case 0x9f: // LI #imm ZCS:x..
+				m_A = opcode & 0x0f;
+				UPDATE_ZF(m_A);
+				m_st = 1;
+				break;
+
+			case 0xa0: case 0xa1: case 0xa2: case 0xa3:
+			case 0xa4: case 0xa5: case 0xa6: case 0xa7:
+			case 0xa8: case 0xa9: case 0xaa: case 0xab:
+			case 0xac: case 0xad: case 0xae: case 0xaf: // CYI #imm ZCS:xxx
+				arg = (opcode & 0x0f) - m_Y;
+				UPDATE_CF(arg);
+				arg &= 0x0f;
+				UPDATE_ST_Z(arg);
+				m_zf = m_st ^ 1;
+				break;
+
+			case 0xb0: case 0xb1: case 0xb2: case 0xb3:
+			case 0xb4: case 0xb5: case 0xb6: case 0xb7:
+			case 0xb8: case 0xb9: case 0xba: case 0xbb:
+			case 0xbc: case 0xbd: case 0xbe: case 0xbf: // CI #imm ZCS:xxx
+				arg = (opcode & 0x0f) - m_A;
+				UPDATE_CF(arg);
+				arg &= 0x0f;
+				UPDATE_ST_Z(arg);
+				m_zf = m_st ^ 1;
+				break;
+
+			default: // JMP addr ZCS:..x
+				if (TEST_ST())
+					m_PC = opcode & 0x3f;
+				m_st = 1;
+				break;
+		}
+
+		// Update cycle count, also update interrupts, serial and timer flags
+		burn_cycles(oc);
+	}
+}

--- a/src/devices/cpu/mb88xxx/mb88xxx.h
+++ b/src/devices/cpu/mb88xxx/mb88xxx.h
@@ -1,0 +1,240 @@
+// license:BSD-3-Clause
+// copyright-holders:trwgQ26xxx
+/***************************************************************************
+
+	Fujitsu MB8840x / MB8850xH series 4-bit MCU emulator.
+
+	Written by trwgQ26xxx, based on Ernesto Corvi's MB88xx MCU emulator.
+
+	MB8840x series (NMOS): MB88401
+	MB8850xH series (CMOS): MB88501H, MB88503H, MB88505H
+	Evolved from the MB8840 series.  Key differences vs. the older MB88xx:
+		- 12-bit program address space (4 KiB max ROM)
+		- 8-bit data address space (up to 256 nibbles RAM)
+		- Opcode 0x3D is a two-byte EXT prefix (JPXY/LRXA/AI/LXID/SBA/RBA/
+		ICX/RST) instead of the old single-byte JPA instruction
+		- CALL/JPL use a 4-bit page field from the opcode (0x60-0x6F / 0x70-0x7F)
+		giving a full 12-bit target address
+
+****************************************************************************
+              ___________                         ___________
+       R4  1 |]          | 42 Vcc          R4  1 |]          | 42 Vcc
+       R5  2 |]          | 41 VM           R5  2 |]          | 41 START
+       R6  3 |]          | 40 R3           R6  3 |]          | 40 R3
+       R7  4 |]          | 39 R2           R7  4 |]          | 39 R2
+       R8  5 |]          | 38 R1           R8  5 |]          | 38 R1
+       R9  6 |]          | 37 R0           R9  6 |]          | 37 R0
+      R10  7 |]          | 36 P3          R10  7 |]          | 36 P3
+      R11  8 |]          | 35 P2          R11  8 |]          | 35 P2
+      R12  9 |] MB8840x  | 34 P1          R12  9 |] MB8850xH | 34 P1
+      R13 10 |]          | 33 P0          R13 10 |]          | 33 P0
+      R14 11 |]          | 32 O7          R14 11 |]          | 32 O7
+       K0 12 |]          | 31 O6           K0 12 |]          | 31 O6
+       K1 13 |]          | 30 O5           K1 13 |]          | 30 O5
+       K2 14 |]          | 29 O4           K2 14 |]          | 29 O4
+       K3 15 |]          | 28 O3           K3 15 |]          | 28 O3
+       EX 16 |]          | 27 O2           EX 16 |]          | 27 O2
+        X 17 |]          | 26 O1            X 17 |]          | 26 O1
+   _RESET 18 |]          | 25 O0       _RESET 18 |]          | 25 O0
+     _IRQ 19 |]          | 24 SO         _IRQ 19 |]          | 24 SO
+      _TC 20 |]          | 23 SI          _TC 20 |]          | 23 SI
+      Vss 21 |]__________| 22 _SC/_TO     Vss 21 |]__________| 22 _SC/_TO
+
+                MB8840x SERIES                    MB8850xH SERIES
+****************************************************************************/
+
+#ifndef MAME_CPU_MB88XXX_MB88XXX_H
+#define MAME_CPU_MB88XXX_MB88XXX_H
+
+#pragma once
+
+/***************************************************************************
+	REGISTER ENUMERATION
+***************************************************************************/
+
+enum
+{
+	MB88XXX_IRQ_LINE = 0,
+	MB88XXX_TC_LINE
+};
+
+enum
+{
+	MB88XXX_PC = 1,
+	MB88XXX_PA,
+	MB88XXX_FLAGS,
+	MB88XXX_SI,
+	MB88XXX_A,
+	MB88XXX_X,
+	MB88XXX_Y,
+	MB88XXX_PIO,
+	MB88XXX_TH,
+	MB88XXX_TL,
+	MB88XXX_SB
+};
+
+class mb88xxx_cpu_device : public cpu_device
+{
+public:
+	// K (K3-K0): 4-bit parallel input-only port
+	auto read_k() { return m_read_k.bind(); }
+
+	// O (O7-O4 = OH, O3-O0 = OL): 8-bit output through optional PLA
+	auto write_o() { return m_write_o.bind(); }
+
+	// P (P3-P0): 4-bit output-only port
+	auto write_p() { return m_write_p.bind(); }
+
+	// R ports (#0 = R3-R0, #1 = R7-R4, #2 = R11-R8, #3 = R14-R12)
+	template <std::size_t Port> auto read_r() { return m_read_r[Port].bind(); }
+	template <std::size_t Port> auto write_r() { return m_write_r[Port].bind(); }
+
+	// SI: serial data input
+	auto read_si() { return m_read_si.bind(); }
+	// SO: serial data output
+	auto write_so() { return m_write_so.bind(); }
+
+	// PLA configuration (default: 8-bit pass-through)
+	void set_pla_bits(u8 bits) { m_pla_bits = bits; }
+	void set_pla_data(u8 *pla) { m_pla_data = pla; }
+
+	void data_c0(address_map &map) ATTR_COLD;		// 192 nibbles (MB88401)
+	void data_100(address_map &map) ATTR_COLD;		// 256 nibbles (MB8850xH)
+	void program_12bit(address_map &map) ATTR_COLD;	// 4 KiB ROM
+	void program_11bit(address_map &map) ATTR_COLD;	// 2 KiB ROM (MB88503H)
+
+protected:
+	mb88xxx_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, int program_width, int data_width, u8 sb_bits);
+
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	// device_execute_interface overrides
+	virtual u32 execute_min_cycles() const noexcept override { return 1; }
+	virtual u32 execute_max_cycles() const noexcept override { return 3 + 3; } // LRXA(3) + IRQ overhead(3)
+	virtual void execute_run() override;
+	virtual void execute_set_input(int inputnum, int state) override;
+	virtual bool execute_input_edge_triggered(int inputnum) const noexcept override { return inputnum == MB88XXX_IRQ_LINE || inputnum == MB88XXX_TC_LINE; }
+	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 6 - 1) / 6; }
+	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return (cycles * 6); }
+
+	// device_memory_interface overrides
+	virtual space_config_vector memory_space_config() const override;
+
+	// device_state_interface overrides
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
+	virtual void state_import(const device_state_entry &entry) override;
+	virtual void state_export(const device_state_entry &entry) override;
+
+	// device_disasm_interface overrides
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+private:
+	address_space_config m_program_config;
+	address_space_config m_data_config;
+
+	// Registers
+	u8	m_PC;		// Program counter, 6 bits (offset within page)
+	u8	m_PA;		// Page address, 6 bits -> full addr = (PA<<6)|PC
+	u16	m_SP[8];	// 8-deep stack: bits[11:0]=addr, [13]=ST, [14]=ZF, [15]=CF
+	u8	m_SI;		// Stack index, 3 bits
+	u8	m_A;		// Accumulator, 4 bits
+	u8	m_X;		// X register, 4 bits
+	u8	m_Y;		// Y register, 4 bits
+
+	// Flags
+	u8	m_st;		// Status/condition flag, 1bit
+	u8	m_zf;		// Zero flag, 1bit
+	u8	m_cf;		// Carry flag, 1bit
+	u8	m_vf;		// Timer overflow flag, 1bit
+	u8	m_sf;		// Serial buffer full/empty flag, 1bit
+	u8	m_if;		// IRQ pin state (logical level, 1=active), 1bit
+
+	// Peripheral control (EN/DIS register)
+	u8	m_pio;		// 8-bit: b0=SBI b1=TMR b2=IRQ b3=CLK b4=TO b5=PSC b6=SC b7=TC
+
+	// Timer registers
+	u8	m_TH;		// Timer High, 4 bits
+	u8	m_TL;		// Timer Low, 4 bits
+	u8	m_TP;		// Timer Prescale, 6 bits
+	u8	m_ctr;// Last TC pin state (for edge detection)
+
+	// Serial
+	u8	m_SB;			// serial buffer, 4 or 8 bits depending on variant
+	u16	m_SBcount;		// bits received since last read
+	u8	m_sb_bits;		// 4 for most variants, 8 for MB88505H
+	emu_timer *m_serial;// timer for serial input/output
+
+	// PLA
+	u8 *m_pla_data;	// pointer to PLA data (8-bit pass-through by default)
+	u8 m_pla_bits;	// number of bits in PLA output (4 or 8)
+	u8 m_o_output;	// latched O-port byte
+
+	// Port callbacks
+	devcb_read8 m_read_k;				// 4-bit parallel input-only port
+	devcb_write8 m_write_o;				// 8-bit output through optional PLA
+	devcb_write8 m_write_p;				// 4-bit output-only port
+	devcb_read8::array<4> m_read_r;		// 4-bit input-output ports (R0-R3, R4-R7, R8-R11, R12-R14)
+	devcb_write8::array<4> m_write_r;	// 4-bit input-output ports (R0-R3, R4-R7, R8-R11, R12-R14)
+	devcb_read_line m_read_si;			// serial data input
+	devcb_write_line m_write_so;		// serial data output
+
+	// Interrupt handling
+	u8 m_pending_irq;	// pending IRQ state (logical level, 1=active)
+	bool m_in_irq;		// whether currently servicing an IRQ (to prevent re-entry)
+
+	// Memory interfaces (12-bit program, 8-bit data for all variants)
+	memory_access<12, 0, 0, ENDIANNESS_BIG>::cache m_cache;		// 12-bit program space cache
+	memory_access<12, 0, 0, ENDIANNESS_BIG>::specific m_program;// 12-bit program space access
+	memory_access< 8, 0, 0, ENDIANNESS_BIG>::specific m_data;	// 8-bit data space access
+
+	int m_icount;		// instruction cycle counter
+
+	// Debugger shadow registers
+	u16 m_debugger_pc;	// shadow PC (12 bits)
+	u8 m_debugger_flags;// shadow flags (ST/ZF/CF/VF/SF/IF)
+
+	TIMER_CALLBACK_MEMBER(serial_timer);
+	void write_pla(u8 index);
+	void pio_enable(u8 newpio);
+	void increment_timer();
+	void burn_cycles(int cycles);
+};
+
+/***************************************************************************
+	DEVICE TYPE DECLARATIONS
+***************************************************************************/
+
+// MB88400 series (NMOS)
+class mb88401_cpu_device : public mb88xxx_cpu_device
+{
+public:
+	mb88401_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+// MB88500H series (CMOS, high-speed)
+class mb88501h_cpu_device : public mb88xxx_cpu_device
+{
+public:
+	mb88501h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+class mb88503h_cpu_device : public mb88xxx_cpu_device  // 2 KiB ROM variant
+{
+public:
+	mb88503h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+class mb88505h_cpu_device : public mb88xxx_cpu_device  // 8-bit serial buffer variant
+{
+public:
+	mb88505h_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+};
+
+DECLARE_DEVICE_TYPE(MB88401,  mb88401_cpu_device)
+DECLARE_DEVICE_TYPE(MB88501H, mb88501h_cpu_device)
+DECLARE_DEVICE_TYPE(MB88503H, mb88503h_cpu_device)
+DECLARE_DEVICE_TYPE(MB88505H, mb88505h_cpu_device)
+
+#endif // MAME_CPU_MB88XXX_MB88XXX_H

--- a/src/devices/cpu/mb88xxx/mb88xxxdasm.cpp
+++ b/src/devices/cpu/mb88xxx/mb88xxxdasm.cpp
@@ -1,0 +1,213 @@
+// license:BSD-3-Clause
+// copyright-holders:trwgQ26xxx
+/*******************************************************************************
+
+	Fujitsu MB8840x / MB8850xH series 4-bit MCU disassembler.
+
+	Written by trwgQ26xxx, based on Ernesto Corvi's MB88xx series MCU disassembler.
+
+	Instruction set differences vs. the older MB88xx (MB8841/MB8843 etc.):
+		- 0x3D is a two-byte EXT prefix, not the single-byte JPA
+		- CALL uses opcodes 0x60-0x6F (16 variants, 4-bit page), not 0x60-0x67
+		- JPL  uses opcodes 0x70-0x7F (16 variants, 4-bit page), not 0x68-0x6F
+		- AI / ICA / DCA live under the EXT prefix (3D 8x), not at 0x70-0x7F
+		- Added: JPXY, LRXA, LXID, SBA, RBA, ICX, RST (all under EXT)
+
+*******************************************************************************/
+
+#include "emu.h"
+#include "mb88xxxdasm.h"
+
+offs_t mb88xxx_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	const offs_t startpc = pc;
+	const u8 op = opcodes.r8(pc++);
+	const u8 arg = opcodes.r8(pc);	// second byte - peeked, may not be consumed
+
+	switch (op)
+	{
+		// -- 1-byte / 1-cycle -------------------------------------------------
+		case 0x00: util::stream_format(stream, "NOP"); break;
+		case 0x01: util::stream_format(stream, "OUTO"); break;
+		case 0x02: util::stream_format(stream, "OUTP"); break;
+		case 0x03: util::stream_format(stream, "OUT"); break;
+		case 0x04: util::stream_format(stream, "TAY"); break;
+		case 0x05: util::stream_format(stream, "TATH"); break;
+		case 0x06: util::stream_format(stream, "TATL"); break;
+		case 0x07: util::stream_format(stream, "TAS"); break;
+		case 0x08: util::stream_format(stream, "ICY"); break;
+		case 0x09: util::stream_format(stream, "ICM"); break;
+		case 0x0a: util::stream_format(stream, "STIC"); break;
+		case 0x0b: util::stream_format(stream, "X"); break;
+		case 0x0c: util::stream_format(stream, "ROL"); break;
+		case 0x0d: util::stream_format(stream, "L"); break;
+		case 0x0e: util::stream_format(stream, "ADC"); break;
+		case 0x0f: util::stream_format(stream, "AND"); break;
+		case 0x10: util::stream_format(stream, "DAA"); break;
+		case 0x11: util::stream_format(stream, "DAS"); break;
+		case 0x12: util::stream_format(stream, "INK"); break;
+		case 0x13: util::stream_format(stream, "IN"); break;
+		case 0x14: util::stream_format(stream, "TYA"); break;
+		case 0x15: util::stream_format(stream, "TTHA"); break;
+		case 0x16: util::stream_format(stream, "TTLA"); break;
+		case 0x17: util::stream_format(stream, "TSA"); break;
+		case 0x18: util::stream_format(stream, "DCY"); break;
+		case 0x19: util::stream_format(stream, "DCM"); break;
+		case 0x1a: util::stream_format(stream, "STDC"); break;
+		case 0x1b: util::stream_format(stream, "XX"); break;
+		case 0x1c: util::stream_format(stream, "ROR"); break;
+		case 0x1d: util::stream_format(stream, "ST"); break;
+		case 0x1e: util::stream_format(stream, "SBC"); break;
+		case 0x1f: util::stream_format(stream, "OR"); break;
+		case 0x20: util::stream_format(stream, "SETR"); break;
+		case 0x21: util::stream_format(stream, "SETC"); break;
+		case 0x22: util::stream_format(stream, "RSTR"); break;
+		case 0x23: util::stream_format(stream, "RSTC"); break;
+		case 0x24: util::stream_format(stream, "TSTR"); break;
+		case 0x25: util::stream_format(stream, "TSTI"); break;
+		case 0x26: util::stream_format(stream, "TSTV"); break;
+		case 0x27: util::stream_format(stream, "TSTS"); break;
+		case 0x28: util::stream_format(stream, "TSTC"); break;
+		case 0x29: util::stream_format(stream, "TSTZ"); break;
+		case 0x2a: util::stream_format(stream, "STS"); break;
+		case 0x2b: util::stream_format(stream, "LS"); break;
+		case 0x2c: util::stream_format(stream, "RTS"); break;
+		case 0x2d: util::stream_format(stream, "NEG"); break;
+		case 0x2e: util::stream_format(stream, "C"); break;
+		case 0x2f: util::stream_format(stream, "EOR"); break;
+
+		case 0x30: case 0x31: case 0x32: case 0x33:
+			util::stream_format(stream, "SBIT  %d", op & 0x3); break;
+		case 0x34: case 0x35: case 0x36: case 0x37:
+			util::stream_format(stream, "RBIT  %d", op & 0x3); break;
+		case 0x38: case 0x39: case 0x3a: case 0x3b:
+			util::stream_format(stream, "TBIT  %d", op & 0x3); break;
+
+		case 0x3c: util::stream_format(stream, "RTI"); break;
+
+		// -- EXT prefix (2 bytes / 2 cycles; LRXA = 2 bytes / 3 cycles) ------
+		case 0x3d:
+		{
+			const u8 ext = opcodes.r8(pc++);
+
+			if ((ext >= 0x00) && (ext <= 0x1f))
+			{
+				// JPXY $page  - unconditional branch to page ext, PC from X/Y
+				util::stream_format(stream, "JPXY  $%02X", ext & 0x1f);
+			}
+			else if ((ext >= 0x20) && (ext <= 0x3f))
+			{
+				// LRXA #imm  - load ROM nibble pair into X (high) and A (low)
+				util::stream_format(stream, "LRXA  #$%02X", ext & 0x1f);
+			}
+			else if ((ext >= 0x80) && (ext <= 0x8f))
+			{
+				// AI / ICA / DCA
+				const u8 imm = ext & 0x0f;
+				if (imm == 0x1)
+					util::stream_format(stream, "ICA");
+				else if (imm == 0xf)
+					util::stream_format(stream, "DCA");
+				else
+					util::stream_format(stream, "AI    #$%1X", imm);
+			}
+			else if ((ext >= 0x90) && (ext <= 0x9f))
+			{
+				util::stream_format(stream, "LXID  #$%1X", ext & 0xf);
+			}
+			else if ((ext >= 0xa0) && (ext <= 0xa3))
+			{
+				util::stream_format(stream, "SBA   %d", ext & 0x3);
+			}
+			else if ((ext >= 0xa4) && (ext <= 0xa7))
+			{
+				util::stream_format(stream, "RBA   %d", ext & 0x3);
+			}
+			else if (ext == 0xac)
+			{
+				util::stream_format(stream, "ICX");
+			}
+			else if (ext == 0xad)
+			{
+				util::stream_format(stream, "RST");
+			}
+			else
+			{
+				util::stream_format(stream, "EXT   #$%02X", ext); // undefined
+			}
+			break;
+		}
+
+		// -- EN / DIS (2 bytes / 2 cycles) ------------------------------------
+		case 0x3e: util::stream_format(stream, "EN    #$%02X", arg); pc++; break;
+		case 0x3f: util::stream_format(stream, "DIS   #$%02X", arg); pc++; break;
+
+		// -- Port bit operations (1 byte / 1 cycle) ---------------------------
+		case 0x40: case 0x41: case 0x42: case 0x43:
+			util::stream_format(stream, "SETD  %d", op & 0x3); break;
+		case 0x44: case 0x45: case 0x46: case 0x47:
+			util::stream_format(stream, "RSTD  %d", op & 0x3); break;
+		case 0x48: case 0x49: case 0x4a: case 0x4b:
+			util::stream_format(stream, "TSTD  %d", (op & 0x3) + 8); break;
+		case 0x4c: case 0x4d: case 0x4e: case 0x4f:
+			util::stream_format(stream, "TBA   %d", op & 0x3); break;
+
+		// -- Memory exchange (1 byte / 1 cycle) -------------------------------
+		case 0x50: case 0x51: case 0x52: case 0x53:
+			util::stream_format(stream, "XD    %d", op & 0x3); break;
+		case 0x54: case 0x55: case 0x56: case 0x57:
+			util::stream_format(stream, "XYD   %d", (op & 0x3) + 4); break;
+
+		// -- LXI (1 byte / 1 cycle) -------------------------------------------
+		case 0x58: case 0x59: case 0x5a: case 0x5b:
+		case 0x5c: case 0x5d: case 0x5e: case 0x5f:
+			util::stream_format(stream, "LXI   #$%1X", op & 0x7); break;
+
+		// -- CALL (2 bytes / 2 cycles) - 4-bit page from opcode ---------------
+		case 0x60: case 0x61: case 0x62: case 0x63:
+		case 0x64: case 0x65: case 0x66: case 0x67:
+		case 0x68: case 0x69: case 0x6a: case 0x6b:
+		case 0x6c: case 0x6d: case 0x6e: case 0x6f:
+			util::stream_format(stream, "CALL  $%04X", (u16(op & 0xf) << 8) | arg); pc++; break;
+
+		// -- JPL (2 bytes / 2 cycles) - 4-bit page from opcode ----------------
+		case 0x70: case 0x71: case 0x72: case 0x73:
+		case 0x74: case 0x75: case 0x76: case 0x77:
+		case 0x78: case 0x79: case 0x7a: case 0x7b:
+		case 0x7c: case 0x7d: case 0x7e: case 0x7f:
+			util::stream_format(stream, "JPL   $%04X", (u16(op & 0xf) << 8) | arg); pc++; break;
+
+		// -- Immediate loads / compares (1 byte / 1 cycle) --------------------
+		case 0x80: case 0x81: case 0x82: case 0x83:
+		case 0x84: case 0x85: case 0x86: case 0x87:
+		case 0x88: case 0x89: case 0x8a: case 0x8b:
+		case 0x8c: case 0x8d: case 0x8e: case 0x8f:
+			util::stream_format(stream, "LYI   #$%1X", op & 0xf); break;
+
+		case 0x90: // CLA (alias for LI #0)
+			util::stream_format(stream, "CLA"); break;
+		case 0x91: case 0x92: case 0x93:
+		case 0x94: case 0x95: case 0x96: case 0x97:
+		case 0x98: case 0x99: case 0x9a: case 0x9b:
+		case 0x9c: case 0x9d: case 0x9e: case 0x9f:
+			util::stream_format(stream, "LI    #$%1X", op & 0xf); break;
+
+		case 0xa0: case 0xa1: case 0xa2: case 0xa3:
+		case 0xa4: case 0xa5: case 0xa6: case 0xa7:
+		case 0xa8: case 0xa9: case 0xaa: case 0xab:
+		case 0xac: case 0xad: case 0xae: case 0xaf:
+			util::stream_format(stream, "CYI   #$%1X", op & 0xf); break;
+
+		case 0xb0: case 0xb1: case 0xb2: case 0xb3:
+		case 0xb4: case 0xb5: case 0xb6: case 0xb7:
+		case 0xb8: case 0xb9: case 0xba: case 0xbb:
+		case 0xbc: case 0xbd: case 0xbe: case 0xbf:
+			util::stream_format(stream, "CI    #$%1X", op & 0xf); break;
+
+		// -- JMP (1 byte / 1 cycle) - short branch within current 64-byte page
+		default: // 0xC0-0xFF
+			util::stream_format(stream, "JMP   $%04X", (pc & ~offs_t(0x3f)) | (op & 0x3f)); break;
+	}
+
+	return (pc - startpc) | SUPPORTED;
+}

--- a/src/devices/cpu/mb88xxx/mb88xxxdasm.h
+++ b/src/devices/cpu/mb88xxx/mb88xxxdasm.h
@@ -1,0 +1,26 @@
+// license:BSD-3-Clause
+// copyright-holders:trwgQ26xxx
+/*******************************************************************************
+
+	Fujitsu MB8840x / MB8850xH series 4-bit MCU disassembler.
+
+	Written by trwgQ26xxx, based on Ernesto Corvi's MB88xx series MCU disassembler.
+
+*******************************************************************************/
+
+#ifndef MAME_CPU_MB88XXX_MB88XXXDASM_H
+#define MAME_CPU_MB88XXX_MB88XXXDASM_H
+
+#pragma once
+
+class mb88xxx_disassembler : public util::disasm_interface
+{
+public:
+	mb88xxx_disassembler() = default;
+	virtual ~mb88xxx_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override { return 1; }
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+};
+
+#endif // MAME_CPU_MB88XXX_MB88XXXDASM_H

--- a/src/mame/fujitsu/fm7.cpp
+++ b/src/mame/fujitsu/fm7.cpp
@@ -1890,7 +1890,7 @@ void fm7_state::fm7(machine_config &config)
 	config.set_perfect_quantum(m_sub);
 
 	// FM-7 keyboard MCU (MB88401 at IC125)
-	MB88401(config, m_kbmcu, 4_MHz_XTAL);
+	MB88401(config, m_kbmcu, 4_MHz_XTAL).set_disable(); // No ROM dump available
 
 	SPEAKER(config, "mono").front_center();
 	AY8913(config, m_psg, 4.9152_MHz_XTAL / 4).add_route(ALL_OUTPUTS,"mono", 1.00);
@@ -2180,6 +2180,9 @@ ROM_START( fmnew7 )
 	ROM_REGION( 0x800, "boot", 0 )
 	ROM_LOAD( "boot_bas.rom", 0x0200,  0x0200, CRC(c70f0c74) SHA1(53b63a301cba7e3030e79c59a4d4291eab6e64b0) BAD_DUMP ) // actually 0.5K banks of the same ROM
 	ROM_LOAD( "boot_dos.rom", 0x0600,  0x0200, CRC(198614ff) SHA1(037e5881bd3fed472a210ee894a6446965a8d2ef) BAD_DUMP )
+
+	ROM_REGION( 0x1000, "kbmcu", 0 )
+	ROM_LOAD( "mb88401.ic125", 0x0000, 0x1000, NO_DUMP )
 
 	// optional Kanji ROM
 	ROM_REGION( 0x20000, "kanji1", 0 )

--- a/src/mame/fujitsu/fm7.cpp
+++ b/src/mame/fujitsu/fm7.cpp
@@ -1889,6 +1889,9 @@ void fm7_state::fm7(machine_config &config)
 	m_sub->set_irq_acknowledge_callback(FUNC(fm7_state::sub_irq_ack));
 	config.set_perfect_quantum(m_sub);
 
+	// FM-7 keyboard MCU (MB88401 at IC125)
+	MB88401(config, m_kbmcu, 4_MHz_XTAL);
+
 	SPEAKER(config, "mono").front_center();
 	AY8913(config, m_psg, 4.9152_MHz_XTAL / 4).add_route(ALL_OUTPUTS,"mono", 1.00);
 	BEEP(config, "beeper", 1200).add_route(ALL_OUTPUTS, "mono", 0.50);

--- a/src/mame/fujitsu/fm7.h
+++ b/src/mame/fujitsu/fm7.h
@@ -13,6 +13,7 @@
 
 #include "machine/buffer.h"
 #include "bus/centronics/ctronics.h"
+#include "cpu/mb88xxx/mb88xxx.h"
 #include "imagedev/cassette.h"
 #include "imagedev/floppy.h"
 #include "sound/ay8910.h"
@@ -33,6 +34,7 @@ public:
 		m_vectors(*this, "vectors"),
 		m_maincpu(*this, "maincpu"),
 		m_sub(*this, "sub"),
+		m_kbmcu(*this, "kbmcu"),
 		m_cassette(*this, "cassette"),
 		m_beeper(*this, "beeper"),
 		m_psg(*this, "psg"),
@@ -253,6 +255,7 @@ protected:
 
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_sub;
+	optional_device<mb88401_cpu_device> m_kbmcu;
 	required_device<cassette_image_device> m_cassette;
 	required_device<beep_device> m_beeper;
 	optional_device<ay8910_device> m_psg;

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -117,6 +117,7 @@ using util::BIT;
 #include "cpu/mb86233/mb86233d.h"
 #include "cpu/mb86235/mb86235d.h"
 #include "cpu/mb88xx/mb88dasm.h"
+#include "cpu/mb88xxx/mb88xxxdasm.h"
 #include "cpu/mc68hc11/hc11dasm.h"
 #include "cpu/mcs40/mcs40dasm.h"
 #include "cpu/mcs48/mcs48dsm.h"
@@ -556,6 +557,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "mb86233",         le, -2, []() -> util::disasm_interface * { return new mb86233_disassembler; } },
 	{ "mb86235",         le, -3, []() -> util::disasm_interface * { return new mb86235_disassembler; } },
 	{ "mb88xx",          le,  0, []() -> util::disasm_interface * { return new mb88_disassembler; } },
+	{ "mb88xxx",         le,  0, []() -> util::disasm_interface * { return new mb88xxx_disassembler; } },
 	{ "mc88100",         be,  0, []() -> util::disasm_interface * { return new mc88100_disassembler; } },
 	{ "mc88110",         be,  0, []() -> util::disasm_interface * { return new mc88110_disassembler; } },
 	{ "mcs48",           le,  0, []() -> util::disasm_interface * { return new mcs48_disassembler(false, false); } },


### PR DESCRIPTION
Hi!

I’m not actually from the gaming industry ;), but not long ago I started reverse-engineering an ECU based on the Fujitsu MB88401 MCU.

Using the MAME sources for the similar MB8841 as a starting point, I implemented a functional Python disassembler and extended it to support the Fujitsu MB8840x/MB8850xH instruction set. You can find the project on my [GitHub](https://github.com/trwgQ26xxx/MB88xxx_disassembler) 

While working on this, I thought it would also make sense to add support for these MCUs directly to MAME. Since I’d like to contribute to the project, I prepared an implementation of the Fujitsu MB8840x/MB8850xH family and integrated it with MAME.

Hopefully this can be useful for other projects that rely on these MCUs as well.

Best regards,
trwgQ26xxx