### PR TITLE
formats/ipf_dsk: support raw-encoder blocks and fix gap description decoding

### DIFF
--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -7255,9 +7255,6 @@ ATK test: OK
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Titus</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1028720">
 				<rom name="(sps3081)bluesbrothers,the.ipf" size="1028720" crc="5dd15801" sha1="5071b71f7d76fd7fe16a5dffe04498df1ccc1104"/>
@@ -7272,9 +7269,6 @@ fatalerrors when trying to mount "Incompatible image format or corrupted data"
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Titus</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1028720">
 				<rom name="(sps3082)bluesbrothers,the.ipf" size="1028720" crc="99b57dfd" sha1="06cc9e6dd233c41b57f938b78cc51142345f62a7"/>
@@ -14205,16 +14199,13 @@ ATK test: C:0 H:U Bad
 		</part>
 	</software>
 
-	<software name="dicktr" supported="no">
+	<software name="dicktr" supported="yes">
 		<!-- SPS (CAPS) release 3083 -->
 		<description>Dick Tracy (Europe, Titus)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Titus</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="853776">
 				<rom name="(sps3083)dicktracy.ipf" size="853776" crc="4bf9beba" sha1="02589a4204c294c91a54514cd9d6289c45f785fe"/>
@@ -14517,9 +14508,6 @@ ATK test: OK
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Elite</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1016901">
 				<rom name="dogsofwar.ipf" size="1016901" crc="e738511f" sha1="5581ab144292d0e1283beaa6188addd111bb4099" status="baddump"/>
@@ -30375,16 +30363,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="lxcess">
+	<software name="lxcess" supported="no">
 		<!-- SPS (CAPS) release 3058 -->
 		<description>Lethal Xcess (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, NTSC) -->
 		<year>1991</year>
 		<publisher>Eclipse</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1004597">
@@ -33939,16 +33924,13 @@ ATK test: C:0 H:U Bad
 		</part>
 	</software>
 
-	<software name="monstbus">
+	<software name="monstbus" supported="yes">
 		<!-- SPS (CAPS) release 3032 -->
 		<description>Monster Business (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL / Atari ST, PAL) -->
 		<year>1991</year>
 		<publisher>Eclipse</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1009109">
 				<rom name="monster business (europe) (amiga + st).ipf" size="1009109" crc="be6095a0" sha1="c6d0706c363f3fd7f5e40864b49568ac9e157c8b" />
@@ -56894,7 +56876,7 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="xr35b" cloneof="xr35" supported="no">
+	<software name="xr35b" cloneof="xr35" supported="yes">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 34 -->
 		<description>XR-35 Fighter Mission (Europe, bad?)</description>
@@ -56902,9 +56884,6 @@ ATK test: OK
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Anco</publisher>
-		<notes><![CDATA[
-fatalerrors when trying to mount "Incompatible image format or corrupted data"
-]]></notes>
 		<part name="flop7" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 7" />
 			<dataarea name="flop" size="1049768">

--- a/src/lib/formats/ipf_dsk.cpp
+++ b/src/lib/formats/ipf_dsk.cpp
@@ -49,7 +49,7 @@ struct ipf_format::ipf_decode {
 	void track_write_raw(std::vector<uint32_t>::iterator &tpos, const uint8_t *data, uint32_t cells, bool &context);
 	void track_write_mfm(std::vector<uint32_t>::iterator &tpos, const uint8_t *data, uint32_t start_offset, uint32_t patlen, uint32_t cells, bool &context);
 	void track_write_weak(std::vector<uint32_t>::iterator &tpos, uint32_t cells);
-	bool generate_block_data(const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator tpos, std::vector<uint32_t>::iterator tlimit, bool dmb, bool &context);
+	bool generate_block_data(const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator tpos, std::vector<uint32_t>::iterator tlimit, bool dmb, bool raw, bool &context);
 
 	bool gap_description_to_reserved_size(const uint8_t *&data, const uint8_t *dlimit, uint32_t &res_size);
 	bool generate_gap_from_description(const uint8_t *&data, const uint8_t *dlimit, std::vector<uint32_t>::iterator tpos, uint32_t size, bool pre, bool &context);
@@ -487,13 +487,11 @@ bool ipf_format::ipf_decode::generate_track(track_info &t, floppy_image &image)
 	bool context = false;
 	uint32_t pos = 0;
 	for(uint32_t i = 0; i != t.block_count; i++) {
-		if(!generate_block(t, i, i == t.block_count-1 ? t.size_cells - t.index_cells : 0xffffffff, track, pos, data_pos[i], gap_pos[i], splice_pos[i], context)) {
+		if(!generate_block(t, i, i == t.block_count-1 ? t.size_cells - t.index_cells : 0xffffffff, track, pos, data_pos[i], gap_pos[i], splice_pos[i], context))
 			return false;
-		}
 	}
-	if(pos != t.size_cells) {
+	if(pos != t.size_cells || t.index_cells >= t.size_cells)
 		return false;
-	}
 
 	data_pos[t.block_count] = pos;
 
@@ -539,7 +537,7 @@ void ipf_format::ipf_decode::track_write_weak(std::vector<uint32_t>::iterator &t
 		*tpos++ = floppy_image::MG_N;
 }
 
-bool ipf_format::ipf_decode::generate_block_data(const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator tpos, std::vector<uint32_t>::iterator tlimit, bool dmb, bool &context)
+bool ipf_format::ipf_decode::generate_block_data(const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator tpos, std::vector<uint32_t>::iterator tlimit, bool dmb, bool raw, bool &context)
 {
 	for(;;) {
 		if(data >= dlimit)
@@ -555,7 +553,9 @@ bool ipf_format::ipf_decode::generate_block_data(const uint8_t *data, const uint
 		case 0: // End of description
 			return !tleft;
 
-		case 1: // Raw bytes
+		case 1: // Sync mark, unencoded cells
+			if(raw)
+				return false;
 			if(bitcount > tleft || bytecount > uint64_t(dlimit-data))
 				return false;
 			track_write_raw(tpos, data, uint32_t(bitcount), context);
@@ -564,13 +564,27 @@ bool ipf_format::ipf_decode::generate_block_data(const uint8_t *data, const uint
 
 		case 2: // MFM-decoded data bytes
 		case 3: // MFM-decoded gap bytes
+			if(raw)
+				return false;
 			if(2*bitcount > tleft || bytecount > uint64_t(dlimit-data))
 				return false;
 			track_write_mfm(tpos, data, 0, uint32_t(bitcount), uint32_t(2*bitcount), context);
 			data += bytecount;
 			break;
+		case 4: // Raw cell bits, size in bytes regardless of the data size mode
+			if(!raw)
+				return false;
+			bitcount = uint64_t(param)*8;
+			bytecount = param;
+			if(bitcount > tleft || bytecount > uint64_t(dlimit-data))
+				return false;
+			track_write_raw(tpos, data, uint32_t(bitcount), context);
+			data += bytecount;
+			break;
 
 		case 5: // Weak bytes
+			if(raw)
+				return false;
 			if(2*bitcount > tleft)
 				return false;
 			track_write_weak(tpos, uint32_t(2*bitcount));
@@ -650,13 +664,6 @@ bool ipf_format::ipf_decode::generate_gap_from_description(const uint8_t *&data,
 			break;
 
 		case 2:
-			// You can't have a pattern at the start of a pre-slice
-			// gap if there's a size afterwards
-			if(pre && res_size && !block_size)
-				return false;
-			// You can't have two consecutive patterns
-			if(pattern_size)
-				return false;
 			pattern_size = param;
 			if(pattern_size > sizeof(pattern)*8)
 				return false;
@@ -664,13 +671,13 @@ bool ipf_format::ipf_decode::generate_gap_from_description(const uint8_t *&data,
 			memcpy(pattern, data, (pattern_size+7)/8);
 			data += (pattern_size+7)/8;
 			if(pre) {
-				if(!block_size)
-					block_size = size;
-				else if(pos + block_size == res_size)
+				// The last data sample of a forward gap stream is the loop point
+				if(data < dlimit && !(*data & 0x1f))
 					block_size = size - pos;
+				else if(!block_size)
+					block_size = pattern_size;
 				if(pos + block_size > size)
 					return false;
-				//              printf("pat=%02x size=%d pre\n", pattern[0], block_size);
 				track_write_mfm(tpos, pattern, 0, pattern_size, block_size, context);
 				pos += block_size;
 			} else {
@@ -680,7 +687,6 @@ bool ipf_format::ipf_decode::generate_gap_from_description(const uint8_t *&data,
 					block_size = size - res_size;
 				if(pos + block_size > size)
 					return false;
-				//              printf("pat=%02x block_size=%d size=%d res_size=%d post\n", pattern[0], block_size, size, res_size);
 				track_write_mfm(tpos, pattern, -block_size, pattern_size, block_size, context);
 				pos += block_size;
 			}
@@ -709,29 +715,48 @@ bool ipf_format::ipf_decode::generate_block_gap_2(uint32_t gap_cells, uint32_t &
 	return generate_gap_from_description(data, dlimit, tpos, gap_cells, false, context);
 }
 
-bool ipf_format::ipf_decode::generate_block_gap_3(uint32_t gap_cells, uint32_t &spos, uint32_t ipos, const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator &tpos,  bool &context)
+bool ipf_format::ipf_decode::generate_block_gap_3(uint32_t gap_cells, uint32_t &spos, uint32_t ipos, const uint8_t *data, const uint8_t *dlimit, std::vector<uint32_t>::iterator &tpos, bool &context)
 {
-	if(ipos >= 16 && ipos < gap_cells-16)
-		spos = ipos;
-	else {
-		uint32_t presize, postsize;
-		const uint8_t *data1 = data;
-		if(!gap_description_to_reserved_size(data1, dlimit, presize))
-			return false;
-		if(!gap_description_to_reserved_size(data1, dlimit, postsize))
-			return false;
-		if(presize+postsize > gap_cells)
-			return false;
+	uint32_t presize, postsize;
+	const uint8_t *data1 = data;
+	if(!gap_description_to_reserved_size(data1, dlimit, presize))
+		return false;
+	if(!gap_description_to_reserved_size(data1, dlimit, postsize))
+		return false;
 
-		spos = presize + (gap_cells - presize - postsize)/2;
+	uint32_t delta = gap_cells & 1;
+	uint32_t usable = gap_cells - delta;
+
+	if(presize + postsize > usable) {
+		// Trim both gap streams evenly like the reference decoder
+		uint32_t rem = presize + postsize - usable;
+		uint32_t rem0 = rem >> 1, rem1 = rem - rem0;
+		if(presize < rem0) {
+			rem1 += rem0 - presize;
+			rem0 = presize;
+		}
+		if(postsize < rem1) {
+			rem0 += rem1 - postsize;
+			rem1 = postsize;
+		}
+		presize -= rem0;
+		postsize -= rem1;
 	}
+
+	if(ipos >= 16 && ipos < gap_cells-16) {
+		// Keep the index splice within the region the descriptions can fill
+		spos = ipos;
+		if(spos < presize)
+			spos = presize;
+		if(spos > usable - postsize)
+			spos = usable - postsize;
+	} else
+		spos = presize + (usable - presize - postsize)/2;
+
 	if(!generate_gap_from_description(data, dlimit, tpos, spos, true, context))
 		return false;
-	uint32_t delta = 0;
-	if(gap_cells & 1) {
+	if(delta)
 		tpos[spos] = MG_0;
-		delta++;
-	}
 
 	return generate_gap_from_description(data, dlimit, tpos+spos+delta, gap_cells - spos - delta, false, context);
 }
@@ -762,15 +787,19 @@ bool ipf_format::ipf_decode::generate_block(const track_info &t, uint32_t idx, u
 
 	if(gap_cells < 8)
 		gap_cells = 0;
-
 	// +8  = gap description offset / datasize in bytes (when gap type = 0)
 	//       -- old CAPS_ENCODER (v1): "blocksize", unused, rounded duplicate of data_cells
 	// +12 =                      1 / gap size in bytes (when gap type = 0)
 	//       -- old CAPS_ENCODER (v1): "gapsize", unused, rounded duplicate of gap_cells
-	// +16 = 1
+	// +16 = block encoder type: 1 = MFM, 2 = raw cells (no encoding)
 	// +20 = flags: bits 0-1 = gap type, bit 2 = data size mode (DMB, bits vs bytes)
 	// +24 = type 0 gap pattern (8 bits) / speed mask for sector 0 track type 9
 	// +28 = data description offset
+
+	uint32_t encoder = get_u32be(thead+16);
+	if(encoder != 1 && encoder != 2)
+		return false;
+	bool raw = encoder == 2;
 
 	uint32_t flags = encoder_type == 1 ? 0 : get_u32be(thead+20);
 	uint32_t gap_type = flags & 3;
@@ -781,7 +810,7 @@ bool ipf_format::ipf_decode::generate_block(const track_info &t, uint32_t idx, u
 	pos = gpos + gap_cells;
 	if(pos > t.size_cells)
 		return false;
-	if(!generate_block_data(data + get_u32be(thead+28), data_end, track.begin()+dpos, track.begin()+gpos, dmb, context))
+	if(!generate_block_data(data + get_u32be(thead+28), data_end, track.begin()+dpos, track.begin()+gpos, dmb, raw, context))
 		return false;
 	if(!generate_block_gap(gap_type, gap_cells, get_u32be(thead+24), spos, ipos > gpos ? ipos-gpos : 0, data + get_u32be(thead+8), data_end, track.begin()+gpos, context))
 		return false;


### PR DESCRIPTION
Reference: IPF Documentation v1.6 (J.L. Guerin),
https://www.kryoflux.com/download/ipf_documentation_v1.6.pdf

assisted: GLM-5.1