### PR TITLE
floppy: fix weak-bit reads; mark working softlist entries [galibert, holub]

### DIFF
--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -3184,16 +3184,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="armagman" supported="no">
+	<software name="armagman" supported="yes">
 		<!-- SPS (CAPS) release 629 -->
 		<description>The Armageddon Man (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Martech</publisher>
-		<notes><![CDATA[
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1050092">
 				<rom name="(sps629)armageddonman,the.ipf" size="1050092" crc="cb04a6bc" sha1="37c66c9cee589308a3da9151c21a184cb9a8cad9"/>
@@ -4637,10 +4634,6 @@ ATK test: failed
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Palace</publisher>
-		<notes><![CDATA[
-Guru Meditation during "The game is loading" phase [FDC] with adkcon=$1100 (fixed)
-ATK test: OK
-]]></notes>
 		<info name="alt_title" value="Barbarian - The Ultimate Warrior" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1050092">
@@ -7414,16 +7407,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="bombjack" supported="no">
+	<software name="bombjack" supported="yes">
 		<!-- SPS (CAPS) release 2797 -->
 		<description>Bomb Jack (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Elite</publisher>
-		<notes><![CDATA[
-ATK test: C:even H:L 1 Sector Bad
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2797)bombjack.ipf" size="1049612" crc="08372886" sha1="02c7d6ed985cad2217f70a89b3e0def36323940d"/>
@@ -13916,17 +13906,13 @@ ATK test: failed
 		</part>
 	</software>
 
-	<software name="demolitn" supported="no">
+	<software name="demolitn" supported="yes">
 		<!-- SPS (CAPS) release 2712 -->
 		<description>Demolition (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1987</year>
 		<publisher>Anco</publisher>
-		<notes><![CDATA[
-Black screen after title screen, [FDC] dsksync (fixed)
-ATK test: OK
-]]></notes>
 		<info name="usage" value="Insert ABUSS when prompted for secret code"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049304">
@@ -16513,17 +16499,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="eco" supported="no">
+	<software name="eco" supported="yes">
 		<!-- SPS (CAPS) release 1139 -->
 		<description>ECO (Europe)</description>
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Ocean</publisher>
-		<notes><![CDATA[
-Guru Meditation during initial boot, [FDC] with adkcon=$1100
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1050092">
 				<rom name="(sps1139)eco.ipf" size="1050092" crc="baede9bf" sha1="53fb3d2bfd87e64b2244180d080b3bec405220bd"/>
@@ -19959,7 +19941,7 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="fbmang2" supported="no">
+	<software name="fbmang2" supported="yes">
 		<!-- SPS (CAPS) release 246 -->
 		<description>Football Manager 2 (Europe)</description>
 		<!-- retail, standalone -->
@@ -19967,10 +19949,6 @@ ATK test: OK
 		<year>1988</year>
 		<!-- Publisher: Prism Leisure -->
 		<publisher>Addictive</publisher>
-		<notes><![CDATA[
-Guru Meditation during Workbench load after pressing left mouse button on Hot Shot advertisement
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049660">
 				<rom name="(sps246)footballmanager2.ipf" size="1049660" crc="93e18d3a" sha1="8346be9f4db729f70477b5b847ab2b2c61cef3f5"/>
@@ -19978,16 +19956,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="fbmang2ek" cloneof="fbmang2" supported="no">
+	<software name="fbmang2ek" cloneof="fbmang2" supported="yes">
 		<!-- SPS (CAPS) release 793 -->
 		<description>Football Manager 2 Expansion Kit (Europe, FM2 &amp; FM2 Expansion Kit)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Addictive</publisher>
-		<notes><![CDATA[
-ATK test: C:0 H:U Bad
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049304">
 				<rom name="(sps793)footballmanager2expansionkit.ipf" size="1049304" crc="0ed424fd" sha1="3f5f4502b137a1599beecbe217fe5f5326629b86"/>
@@ -19995,16 +19970,13 @@ ATK test: C:0 H:U Bad
 		</part>
 	</software>
 
-	<software name="fbmang2eka" cloneof="fbmang2" supported="no">
+	<software name="fbmang2eka" cloneof="fbmang2" supported="yes">
 		<!-- SPS (CAPS) release 2226 -->
 		<description>Football Manager 2 Expansion Kit (Europe, Amiga Sports Pack)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Addictive</publisher>
-		<notes><![CDATA[
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1050140">
 				<rom name="(sps2226)footballmanager2expansionkit.ipf" size="1050140" crc="5e0e0ad6" sha1="6c8e8988ac498e540b125c341e02865dbcfc05e3"/>
@@ -24978,17 +24950,13 @@ ATK test: C:0 H:U Bad
 		</part>
 	</software>
 
-	<software name="ikplus" supported="no">
+	<software name="ikplus" supported="yes">
 		<!-- SPS (CAPS) release 339 -->
 		<description>IK+ (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>System 3</publisher>
-		<notes><![CDATA[
-Doesn't boot with debugger on, otherwise hangs anytime during the boot phase (spurious irqs or unsafe video code)
-ATK test: failed
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="396338">
 				<rom name="(sps339)ik+.ipf" size="396338" crc="e185a90b" sha1="a1e2270ac5133e3565ece889de8bf8c5d4480077"/>
@@ -24996,16 +24964,13 @@ ATK test: failed
 		</part>
 	</software>
 
-	<software name="ikplusa" cloneof="ikplus" supported="no">
+	<software name="ikplusa" cloneof="ikplus" supported="yes">
 		<!-- SPS (CAPS) release 2063 -->
 		<description>IK+ (Europe, Budget)</description>
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>The Hit Squad</publisher>
-		<notes><![CDATA[
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2063)ik+.ipf" size="1049180" crc="eefd220d" sha1="702c31441a3d9ff0c7c0d9959bd49e814b7c55c8"/>
@@ -39243,16 +39208,13 @@ ATK test: failed
 		</part>
 	</software>
 
-	<software name="prison" supported="no">
+	<software name="prison" supported="yes">
 		<!-- SPS (CAPS) release 416 -->
 		<description>Prison (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Krisalis</publisher>
-		<notes><![CDATA[
-ATK test: failed
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1043236">
 				<rom name="(sps416)prison.ipf" size="1043236" crc="bdc1439d" sha1="1c2a4836662f8da75ec3dd8adee58cf57ee28ca4"/>
@@ -52633,16 +52595,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="dizzy2" supported="no">
+	<software name="dizzy2" supported="yes">
 		<!-- SPS (CAPS) release 594 -->
 		<description>Treasure Island Dizzy (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Codemasters</publisher>
-		<notes><![CDATA[
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049946">
 				<rom name="(sps594)treasureislanddizzy.ipf" size="1049946" crc="2647b5b2" sha1="4d47c03307eba1540d2c117566b286ff41440b30"/>
@@ -56007,16 +55966,13 @@ ATK test: OK
 		</part>
 	</software>
 
-	<software name="wizball" supported="no">
+	<software name="wizball" supported="yes">
 		<!-- SPS (CAPS) release 176 -->
 		<description>Wizball (Europe)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Ocean</publisher>
-		<notes><![CDATA[
-ATK test: failed
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1050092">
 				<rom name="(sps176)wizball.ipf" size="1050092" crc="6c16e59f" sha1="b7fc1b931c94370b6e8a05765352ac4d742ead28"/>
@@ -56024,16 +55980,13 @@ ATK test: failed
 		</part>
 	</software>
 
-	<software name="wizballa" cloneof="wizball" supported="no">
+	<software name="wizballa" cloneof="wizball" supported="yes">
 		<!-- SPS (CAPS) release 1380 -->
 		<description>Wizball (Europe, Tenstar Pack)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Ocean</publisher>
-		<notes><![CDATA[
-ATK test: C:0 H:U Bad
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049214">
 				<rom name="(sps1380)wizball.ipf" size="1049214" crc="f72d8106" sha1="8b65155a7238d0c0f0a2d60bbb8d6173756de45f"/>
@@ -56041,16 +55994,13 @@ ATK test: C:0 H:U Bad
 		</part>
 	</software>
 
-	<software name="wizballb" cloneof="wizball" supported="no">
+	<software name="wizballb" cloneof="wizball" supported="yes">
 		<!-- SPS (CAPS) release 1544 -->
 		<description>Wizball (Europe, Budget)</description>
 		<!-- budget, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>The Hit Squad</publisher>
-		<notes><![CDATA[
-ATK test: OK
-]]></notes>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps1544)wizball.ipf" size="1049180" crc="047608f5" sha1="d36c7cb70340dc5bea09078e6c385450771cb69c"/>

--- a/hash/fmtowns_flop_orig.xml
+++ b/hash/fmtowns_flop_orig.xml
@@ -444,8 +444,7 @@ Zurukamashi Ver 2.0                                                 Nichikonren 
 		</part>
 	</software>
 
-	<!-- Triggers the copy protection -->
-	<software name="columns" supported="no">
+	<software name="columns" supported="yes">
 		<description>Columns</description>
 		<year>1990</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>

--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -291,6 +291,7 @@ floppy_image_device::floppy_image_device(const machine_config &mconfig, device_t
 	m_cyl(0),
 	m_subcyl(0),
 	m_amplifier_freakout_time(attotime::from_usec(16)),
+	m_glitch_threshold(attotime::zero),
 	m_image_dirty(false),
 	m_track_dirty(false),
 	m_writing(false),
@@ -1130,7 +1131,6 @@ void floppy_image_device::cache_clear()
 	m_cache_entry = 0;
 	m_cache_weak = false;
 }
-
 void floppy_image_device::cache_fill(const attotime &when)
 {
 	if(m_writing)
@@ -1142,7 +1142,7 @@ void floppy_image_device::cache_fill(const attotime &when)
 		m_cache_end_time = attotime::never;
 		m_cache_index = 0;
 		m_cache_entry = (cells == 1) ? buf[0] : floppy_image::MG_N;
-		cache_weakness_setup();
+		cache_weakness_setup(buf, attotime::zero);
 		return;
 	}
 
@@ -1164,18 +1164,44 @@ void floppy_image_device::cache_fill(const attotime &when)
 	for(;;) {
 		cache_fill_index(buf, index, base);
 		if(m_cache_end_time > when) {
-			cache_weakness_setup();
+			// base now belongs to the entry after the current one;
+			// cache_fill_index wrapped it if index reached zero
+			attotime const base_cur = index ? base : base - m_rev_time;
+			cache_weakness_setup(buf, base_cur);
 			break;
 		}
 	}
 }
 
-void floppy_image_device::cache_weakness_setup()
+void floppy_image_device::cache_weakness_setup(const std::vector<uint32_t> &buf, attotime base)
 {
-	u32 type = m_cache_entry & floppy_image::MG_MASK;
-	if(type == floppy_image::MG_N || type == floppy_image::MG_D) {
+	auto const weak_kind = [] (u32 e) {
+		u32 const t = e & floppy_image::MG_MASK;
+		return t == floppy_image::MG_N || t == floppy_image::MG_D;
+	};
+
+	if(weak_kind(m_cache_entry)) {
+		// Anchor the noise on the start of the weak run, not on the
+		// entry the cache sits on, so a zone serves the same stream
+		// however the decoder chopped it up
 		m_cache_weak = true;
-		m_cache_weak_start = m_cache_start_time;
+		if(buf.size() <= 1) {
+			// Whole track unformatted
+			m_cache_weak_start = m_cache_start_time;
+			return;
+		}
+		int s = m_cache_index;
+		int c = 0;
+		while(c < 1024 && s > 0 && weak_kind(buf[s-1])) {
+			s--;
+			c++;
+		}
+		if(c == 1024 || (s == 0 && weak_kind(buf[buf.size()-1]))) {
+			// Run start not reachable: no anchor, no blip
+			m_cache_weak_start = attotime::never;
+			return;
+		}
+		m_cache_weak_start = position_to_time(base, buf[s] & floppy_image::TIME_MASK);
 		return;
 	}
 
@@ -1184,6 +1210,7 @@ void floppy_image_device::cache_weakness_setup()
 		m_cache_weak_start = attotime::never;
 		return;
 	}
+	// The comparator reference needs time to decay before it follows the noise
 	m_cache_weak_start = m_cache_start_time + attotime::from_usec(16);
 }
 
@@ -1192,25 +1219,35 @@ attotime floppy_image_device::get_next_transition(const attotime &from_when)
 	if(!m_image || m_mon)
 		return attotime::never;
 
-	if(from_when < m_cache_start_time || m_cache_start_time.is_zero() || (!m_cache_end_time.is_never() && from_when >= m_cache_end_time))
-		cache_fill(from_when);
-
-	if(!m_cache_weak)
-		return m_cache_end_time;
-
-	// Put a flux transition in the middle of a 4us interval with a 50% probability
-	uint64_t interval_index = (from_when < m_cache_weak_start) ? 0 : (from_when - m_cache_weak_start).as_ticks(250000);
-	attotime weak_time = m_cache_weak_start + attotime::from_ticks(interval_index*2+1, 500000);
+	attotime from = from_when;
 	for(;;) {
-		if(weak_time >= m_cache_end_time)
-			return m_cache_end_time;
-		if(weak_time > from_when) {
-			u32 test = hash32(hash32(hash32(hash32(m_revolution_count) ^ 0x4242) + m_cache_index) + interval_index);
-			if(test & 1)
-				return weak_time;
+		if(from < m_cache_start_time || m_cache_start_time.is_zero() || (!m_cache_end_time.is_never() && from >= m_cache_end_time))
+			cache_fill(from);
+
+		if(m_cache_weak) {
+			// Weak surface: noise at an unknown rate.  One hash-drawn
+			// blip per zone per revolution, silence for the rest -
+			// entries are skipped like the bounce filter skips ring,
+			// so no entry boundaries leak out as flux.
+			if(m_cache_weak_start.is_never())
+				return attotime::never;
+			attotime const blip = m_cache_weak_start
+				+ attotime::from_nsec(hash32(hash32(m_revolution_count) ^ 0x4242
+						^ u32(m_cache_weak_start.as_ticks(7000000))) % 50000);
+			if(blip > from && blip < m_cache_end_time)
+				return blip;
+			if(m_cache_end_time.is_never())
+				return attotime::never;
+			from = m_cache_end_time;
+			continue;
 		}
-		weak_time += attotime::from_usec(4);
-		interval_index ++;
+		// A change too close after the previous one is read-chain ring,
+		// not signal - drop it
+		if(!m_cache_end_time.is_never() && m_cache_end_time - m_cache_start_time < m_glitch_threshold) {
+			from = m_cache_end_time;
+			continue;
+		}
+		return m_cache_end_time;
 	}
 }
 
@@ -1657,8 +1694,9 @@ void floppy_35_dd::setup_characteristics()
 	m_tracks = 84;
 	m_sides = 2;
 	set_rpm(300);
+	// Changes closer than ~2.1us are read-chain ring; legal DD flux never comes closer than 4us
+	m_glitch_threshold = attotime::from_nsec(2100);
 
-	add_variant(floppy_image::SSSD);
 	add_variant(floppy_image::SSDD);
 	add_variant(floppy_image::DSDD);
 }

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -229,6 +229,8 @@ protected:
 	/* Current floppy zone cache */
 	attotime m_cache_start_time, m_cache_end_time, m_cache_weak_start;
 	attotime m_amplifier_freakout_time;
+	// Read-chain bounce filter threshold; zero disables it
+	attotime m_glitch_threshold;
 	int m_cache_index;
 	u32 m_cache_entry;
 	bool m_cache_weak;
@@ -274,7 +276,7 @@ protected:
 	void cache_clear();
 	void cache_fill_index(const std::vector<uint32_t> &buf, int &index, attotime &base);
 	void cache_fill(const attotime &when);
-	void cache_weakness_setup();
+	void cache_weakness_setup(const std::vector<uint32_t> &buf, attotime base);
 
 	// Sound support
 	bool m_make_sound;

--- a/src/lib/formats/ipf_dsk.cpp
+++ b/src/lib/formats/ipf_dsk.cpp
@@ -461,9 +461,8 @@ bool ipf_format::ipf_decode::generate_track(track_info &t, floppy_image &image)
 		return true;
 
 	if(t.type == 1) {
-		// Noise/unformatted track
-		std::vector<uint32_t> track(t.size_cells, floppy_image::MG_N);
-		timing_set(track, 0, t.size_cells, 2000);
+		// Noise/unformatted track: a single MG_N cell - the surface has no cell structure
+		std::vector<uint32_t> track(1, floppy_image::MG_N | (t.size_cells*2000));
 		generate_track_from_levels(t.cylinder, t.head, track, 0, image);
 		return true;
 	}


### PR DESCRIPTION
Weak zones (unformatted surface, long flux-free spans) read back as one hash-drawn noise blip per zone per revolution and silence otherwise; flux changes closer than 2.1us are read-chain ring and get filtered; type-1 IPF tracks decode to a single MG_N cell.

assisted: GLM-5.1