### PR TITLE
amstrad/amstrad_m.cpp: don't let the PC2 strobe re-arm itself [MT8744]

### DIFF
--- a/src/mame/amstrad/amstrad.h
+++ b/src/mame/amstrad/amstrad.h
@@ -110,6 +110,7 @@ private:
 	int m_plus_irq_cause = 0;
 
 	emu_timer *m_pc2_low_timer = nullptr;
+	bool m_in_pc2_strobe = false;
 	emu_timer *m_video_update_timer = nullptr;
 	emu_timer *m_set_resolution_timer = nullptr;
 

--- a/src/mame/amstrad/amstrad_m.cpp
+++ b/src/mame/amstrad/amstrad_m.cpp
@@ -223,7 +223,10 @@ void amstrad_state::amstrad_cpc_green_palette(palette_device &palette) const
 /* on PC2. Apparently PC2 is always low on the CPC. ?!? */
 TIMER_CALLBACK_MEMBER(amstrad_state::amstrad_pc2_low)
 {
+	// MT 8744: strobe-induced port B read must not re-arm the strobe
+	m_in_pc2_strobe = true;
 	m_ppi->pc2_w(0);
+	m_in_pc2_strobe = false;
 }
 
 
@@ -2606,9 +2609,9 @@ uint8_t amstrad_state::amstrad_ppi_portb_r()
 			data |= 0x02;
 	}
 
-//logerror("amstrad_ppi_portb_r\n");
-	/* Schedule a write to PC2 */
-	m_pc2_low_timer->adjust(attotime::zero);
+	// schedule a PC2 strobe unless this read is the strobe itself re-entering (MT 8744)
+	if (!m_in_pc2_strobe)
+		m_pc2_low_timer->adjust(attotime::zero);
 
 	return data;
 }
@@ -3065,6 +3068,7 @@ MACHINE_RESET_MEMBER(amstrad_state,gx4000)
 	m_asic.dma_prescaler[2] = 0;
 	m_asic.dma_clear = 1;  // by default, DMA interrupts must be cleared by writing to the DSCR (&6c0f)
 	m_plus_irq_cause = 6;
+	m_in_pc2_strobe = false;
 
 	amstrad_common_init();
 	amstrad_reset_machine();


### PR DESCRIPTION
gx4000 plotting froze before the game started: the cart programs 8255 group B mode 1 at the title-to-game transition, and the driver-scheduled PC2 strobe calls the port B input callback synchronously.  The resulting portb_r re-armed the strobe timer at attotime::zero, livelocking the scheduler before the CPU could run again.  Visible since 0.240, when 51e0c3a216e made pc2_w always latch on strobe (the previous !m_ibf check had incidentally limited the cycle to one iteration).

A strobe input pin cannot cause itself: keep the re-entry flag so strobes originate only from external events (vsync edge or CPU-initiated read).  Mode 0 behaviour is unchanged.  Reset the flag in the gx4000 machine reset.

assisted: GLM-5.1