### PR TITLE
Minor fixes to NEC V60 CPU emulation

### DIFF
--- a/src/devices/cpu/v60/am2.hxx
+++ b/src/devices/cpu/v60/am2.hxx
@@ -941,13 +941,13 @@ uint32_t v60_device::bam2DirectAddressDeferredIndexed()
 
 uint32_t v60_device::am2Immediate()
 {
-	// ignore LDPR
+	m_amflag = 0;
 	return am1Immediate();
 }
 
 uint32_t v60_device::am2ImmediateQuick()
 {
-	// ignore LDPR
+	m_amflag = 0;
 	return am1ImmediateQuick();
 }
 

--- a/src/devices/cpu/v60/op12.hxx
+++ b/src/devices/cpu/v60/op12.hxx
@@ -733,7 +733,7 @@ uint32_t v60_device::opLDPR()
 	F12DecodeOperands(&v60_device::ReadAMAddress, 2,&v60_device::ReadAM, 2);
 	if (m_op2 <= 28)
 	{
-		if (m_flag1 &&(!(OpRead8(PC + 1)&0x80 && OpRead8(PC + 2) == 0xf4 ) ))
+		if (m_flag1)
 			m_reg[m_op2 + 36] = m_reg[m_op1];
 		else
 			m_reg[m_op2 + 36] = m_op1;

--- a/src/devices/cpu/v60/v60d.cpp
+++ b/src/devices/cpu/v60/v60d.cpp
@@ -424,7 +424,7 @@ u32 v60_disassembler::decode_F1(const char *opnm, int opsize1, int opsize2, unsi
 	} else {
 		out_AM_Register(code & 0x1f, stream);
 		stream << ", ";
-		return decode_AM(ipc, pc+1, code & 0x40, opsize1, opcodes, stream) + 2;
+		return decode_AM(ipc, pc+1, code & 0x40, opsize2, opcodes, stream) + 2;
 	}
 }
 
@@ -700,16 +700,16 @@ DEFINE_EASY_OPCODE(CVTDPZ, "cvtd.pz", F7c, 0, 1)
 DEFINE_EASY_OPCODE(CVTDZP, "cvtd.zp", F7c, 1, 0)
 DEFINE_EASY_OPCODE_EX(DBGT, "dbgt", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBGE, "dbge", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBLT, "dbgt", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBLE, "dbge", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBLT, "dblt", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBLE, "dble", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBH, "dbh", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBNL, "dbnl", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBL, "dbl", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBNH, "dbnh", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBE, "dbe", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBNE, "dbne", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBV, "dbe", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBNV, "dbne", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBV, "dbv", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBNV, "dbnv", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBN, "dbn", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBP, "dbp", F6, 0, 0, STEP_COND)
 DEFINE_EASY_OPCODE_EX(DBR, "dbr", F6, 0, 0, STEP_COND)


### PR DESCRIPTION
The first two relate to printed disassembly and are relatively low importance; the third can cause a SIGSEGV

# Incorrectly printed opcodes DBLT/DBLE/DBV/DBNV in disassembly

The string representations in the disassembly for four opcodes were incorrect. Looks like a simple copy/paste issue. Shown here with fixes:

```diff
--- src/devices/cpu/v60/v60d.cpp
+++ src/devices/cpu/v60/v60d.cpp
-DEFINE_EASY_OPCODE_EX(DBLT, "dbgt", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBLE, "dbge", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBLT, "dblt", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBLE, "dble", F6, 0, 0, STEP_COND)
```

```diff
--- src/devices/cpu/v60/v60d.cpp
+++ src/devices/cpu/v60/v60d.cpp
-DEFINE_EASY_OPCODE_EX(DBV, "dbe", F6, 0, 0, STEP_COND)
-DEFINE_EASY_OPCODE_EX(DBNV, "dbne", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBV, "dbv", F6, 0, 0, STEP_COND)
+DEFINE_EASY_OPCODE_EX(DBNV, "dbnv", F6, 0, 0, STEP_COND)
```

# Latent issue with incorrect opsize usage in disassembly

`v60_disassembler::decode_F1` in `v60d.cpp` takes `opsize2` as a param but it is not used in the function body. Shown here with fix:

```diff
--- a/src/devices/cpu/v60/v60d.cpp
+++ b/src/devices/cpu/v60/v60d.cpp
u32 v60_disassembler::decode_F1(const char *opnm, int opsize1, int opsize2, ...)
{
    unsigned char code = opcodes.r8(pc);
    util::stream_format(stream, "%-8s", opnm);
    if(code & 0x20) {
        int ret = decode_AM(ipc, pc+1, code & 0x40, opsize1, opcodes, stream) + 2;
        stream << ", ";
        out_AM_Register(code & 0x1f, stream);
        return ret;
    } else {
        out_AM_Register(code & 0x1f, stream);
        stream << ", ";
-        return decode_AM(ipc, pc+1, code & 0x40, opsize1, opcodes, stream) + 2;
+        return decode_AM(ipc, pc+1, code & 0x40, opsize2, opcodes, stream) + 2;
    }
}
```

In the else branch (direction flag unset: Rn, <AM>), it needs to operand 2 as the addressing mode and thus should use `opsize2`. `decode_F2` method right below it does this as expected, so this was likely a simple oversight.

# Stale m_amflag causes segfault when LDPR reads outside m_reg[]

Can cause an application crash from a legal, correctly-encoded instruction. 

Shown here with fix:

```diff
--- a/src/devices/cpu/v60/am2.hxx
+++ b/src/devices/cpu/v60/am2.hxx
 uint32_t v60_device::am2Immediate()
 {
-	// ignore LDPR
+	m_amflag = 0;
 	return am1Immediate();
 }

 uint32_t v60_device::am2ImmediateQuick()
 {
-	// ignore LDPR
+	m_amflag = 0;
 	return am1ImmediateQuick();
 }
```

`m_amflag` is assigned in all AM2 operations in the file except these two, which delegate it to AM1 handling. `m_amflag` is never assigned at all in the AM1 handling. Thus it holds the value from the *previous* decode.

In opLDPR() in `op12.hxx`, `F12DecodeOperands` copies the (stale) `m_amflag` into `m_flag1`, which it then switches on while also attempting to patch out coverage for the reads mentioned above with a guard after the m_flag1 check. Shown here with proposed fix (in conjunction with the `m_amflag` assignment above):

```diff
--- a/src/devices/cpu/v60/op12.hxx
+++ b/src/devices/cpu/v60/op12.hxx
uint32_t v60_device::opLDPR()
{
	F12DecodeOperands(&v60_device::ReadAMAddress, 2,&v60_device::ReadAM, 2);
	if (m_op2 <= 28)
	{
-		if (m_flag1 &&(!(OpRead8(PC + 1)&0x80 && OpRead8(PC + 2) == 0xf4 ) ))
+		if (m_flag1)
			m_reg[m_op2 + 36] = m_reg[m_op1];
		else
			m_reg[m_op2 + 36] = m_op1;
	}
	else
	{
		fatalerror("Invalid operand on LDPR PC=%x\n", PC);
	}
	F12END();
}
```

However, the guard has 3 blind spots: it catches Format 2 Immediate mode, but Format 2 Immediate Quick, Format 1 Immediate and Format 1 Immediate Quick are also *legal* modes per the LDPR entry in the V60 manual - page 7-52 which indicates instruction format 1/2 supported, with Immediate/Immediate Quick listed as valid Addressing Modes.

As such, if it encounters one of the 3 missed layouts for an LDPR opcode, it uses the stale `m_amflag`/`m_flag1` as an index into m_reg and will likely cause a segfault.

The quickest fix is to simply remove the guard and test on `m_flag1` since it is now guaranteed to be zero with the accompanying changes to am2Immediate/am2ImmediateQuick.

All fixes here have been tested locally. No observed issues after extended use on several V60 based games and crashes from LDPR opcodes on the current version are not observed in the fixed build.

This has not been an issue since no commercial games have used any of the 3 layouts not covered by the guard (at least that I have found). It can happen during debugging/research, however. Besides that, it should be addressed for the sake of accuracy.

AI USE STATEMENT: In the interest of transparency, these issue were found during separate work to develop a V60/V70 core for Ghidra, where Claude Code used a combination of the official V60 manual and the MAME source. **All findings were followed up with by a human (myself) and studied/verified. I understand the code I am submitting and the reasoning behind the fix.** This PR was hand written and not generated by AI.