### PR TITLE
unidasm: Fix accidental omission of mb88xxx disassembler

### DIFF
--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -116,6 +116,7 @@ using util::BIT;
 #include "cpu/mb86233/mb86233d.h"
 #include "cpu/mb86235/mb86235d.h"
 #include "cpu/mb88xx/mb88dasm.h"
+#include "cpu/mb88xxx/mb88xxxdasm.h"
 #include "cpu/mc68hc11/hc11dasm.h"
 #include "cpu/mcs40/mcs40dasm.h"
 #include "cpu/mcs48/mcs48dsm.h"
@@ -557,6 +558,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "mb86233",         le, -2, []() -> util::disasm_interface * { return new mb86233_disassembler; } },
 	{ "mb86235",         le, -3, []() -> util::disasm_interface * { return new mb86235_disassembler; } },
 	{ "mb88xx",          le,  0, []() -> util::disasm_interface * { return new mb88_disassembler; } },
+	{ "mb88xxx",         le,  0, []() -> util::disasm_interface * { return new mb88xxx_disassembler; } },
 	{ "mc88100",         be,  0, []() -> util::disasm_interface * { return new mc88100_disassembler; } },
 	{ "mc88110",         be,  0, []() -> util::disasm_interface * { return new mc88110_disassembler; } },
 	{ "mcs48",           le,  0, []() -> util::disasm_interface * { return new mcs48_disassembler(false, false); } },


### PR DESCRIPTION
Additional minor fix to commit da1b03d that restores the include line and table entry constructor for the MB88XXX CPU family in unidasm.cpp.