### PR TITLE
Armadillo Racing (adillor, adillorj) - Additional dev inputs

### DIFF
--- a/src/mame/namco/namcos22.cpp
+++ b/src/mame/namco/namcos22.cpp
@@ -3521,7 +3521,12 @@ static INPUT_PORTS_START( adillor )
 	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_PLAYER(2) PORT_NAME("Dev Service Right") // when in normal testmode, press this to enter the extra testmode
 	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_PLAYER(2) PORT_NAME("Dev Service Up")
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_PLAYER(2) PORT_NAME("Dev Service Down")
-	PORT_BIT( 0xffc0, IP_ACTIVE_LOW, IPT_UNKNOWN ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01)
+	// left/right above are the coarse step; these two are the fine step
+	// without them most fields cannot reach every value
+	// eg. in SPRITE CG TEST the CHR NO index moves by 8 with Right and by 1 with Fine Inc.
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_PLAYER(2) PORT_NAME("Dev Service Fine Dec")
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_PLAYER(2) PORT_NAME("Dev Service Fine Inc")
+	PORT_BIT( 0xff00, IP_ACTIVE_LOW, IPT_UNKNOWN ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01)
 	PORT_BIT( 0xffff, IP_ACTIVE_LOW, IPT_UNUSED ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x00)
 INPUT_PORTS_END
 

--- a/src/mame/namco/namcos22.cpp
+++ b/src/mame/namco/namcos22.cpp
@@ -3485,7 +3485,12 @@ static INPUT_PORTS_START( adillor )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_START1 )
-	PORT_BIT( 0xfe00, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	// enabled with DSW4-8; P1 Start becomes frame advance while paused
+	// not on the dev panel, but also not wired in the cabinet, so hidden behind
+	// the dev machine config
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_OTHER ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x01) PORT_NAME("Dev Freeze Toggle")
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_UNKNOWN ) PORT_CONDITION("DEV", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0xfc00, IP_ACTIVE_LOW, IPT_UNKNOWN )
 
 	PORT_START("OPT.0")
 	PORT_BIT( 0xffff, 0x0000, IPT_TRACKBALL_X ) PORT_SENSITIVITY(0x100) PORT_KEYDELTA(0x10)


### PR DESCRIPTION
There is an existing set of dev inputs hidden behind a machine configuration. This adds a couple more:

- A "fine adjustment" inc/dec setting for use on the dev test menu. The currently mapped left/right values step by 8, which makes some values unselectable in the menus.
- Pause button - not on the dev panel, but not wired in the cabinet; when DIP switch 4-8 is set, this line toggles a developer pause mode, with P1 Start advancing by one frame.
