### PR TITLE
cpu/sharc: fix circular buffer wrap when the index lands on B+L

### DIFF
--- a/src/devices/cpu/sharc/sharcdrc.cpp
+++ b/src/devices/cpu/sharc/sharcdrc.cpp
@@ -1719,13 +1719,13 @@ void adsp21062_device::generate_update_circular_buffer(drcuml_block &block, comp
 
 		UML_ADD(block, I0, PM_B(i), PM_L(i));
 		UML_CMP(block, PM_I(i), I0);
-		UML_JMPc(block, COND_LE, label2);
+		UML_JMPc(block, COND_L, label2);
 		UML_SUB(block, PM_I(i), PM_I(i), PM_L(i));
 		UML_JMP(block, end);
 
 		UML_LABEL(block, label2);
 		UML_CMP(block, PM_I(i), PM_B(i));
-		UML_JMPc(block, COND_G, end);
+		UML_JMPc(block, COND_GE, end);
 		UML_ADD(block, PM_I(i), PM_I(i), PM_L(i));
 
 		UML_LABEL(block, end);
@@ -1740,13 +1740,13 @@ void adsp21062_device::generate_update_circular_buffer(drcuml_block &block, comp
 
 		UML_ADD(block, I0, DM_B(i), DM_L(i));
 		UML_CMP(block, DM_I(i), I0);
-		UML_JMPc(block, COND_LE, label2);
+		UML_JMPc(block, COND_L, label2);
 		UML_SUB(block, DM_I(i), DM_I(i), DM_L(i));
 		UML_JMP(block, end);
 
 		UML_LABEL(block, label2);
 		UML_CMP(block, DM_I(i), DM_B(i));
-		UML_JMPc(block, COND_G, end);
+		UML_JMPc(block, COND_GE, end);
 		UML_ADD(block, DM_I(i), DM_I(i), DM_L(i));
 
 		UML_LABEL(block, end);

--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
@@ -31,11 +31,14 @@
 #define UIREG(x)    uint32_t(m_core->r[x].r)
 #define FREG(x)     (m_core->r[x].f)
 
+// The ADSP-2106x circular buffer occupies [B, B+L), so a post-modified index that reaches B+L
+// must wrap by subtracting L.  Using '>' here fails to wrap an index landing exactly on B+L,
+// so the word following the buffer is read in place of the first element.
 #define UPDATE_CIRCULAR_BUFFER_PM(x)                        \
 	{                                                       \
 		if (PM_REG_L(x) != 0)                               \
 		{                                                   \
-			if (PM_REG_I(x) > PM_REG_B(x)+PM_REG_L(x))      \
+			if (PM_REG_I(x) >= PM_REG_B(x)+PM_REG_L(x))     \
 			{                                               \
 				PM_REG_I(x) -= PM_REG_L(x);                 \
 			}                                               \
@@ -50,7 +53,7 @@
 	{                                                       \
 		if (DM_REG_L(x) != 0)                               \
 		{                                                   \
-			if (DM_REG_I(x) > DM_REG_B(x)+DM_REG_L(x))      \
+			if (DM_REG_I(x) >= DM_REG_B(x)+DM_REG_L(x))     \
 			{                                               \
 				DM_REG_I(x) -= DM_REG_L(x);                 \
 			}                                               \


### PR DESCRIPTION
Two related off-by-one errors in ADSP-2106x DAG circular buffer wrapping, one in the interpreter and one in the DRC. Both cause a circular read to fetch the wrong word at the buffer boundary; there is no crash, just silently corrupted data.

A circular buffer occupies `[B, B+L)`. After a post-modify the index must wrap back by subtracting `L` once it *reaches* `B+L`, since `B+L` is the first address past the end of the buffer. Wrapping in the other direction adds `L` only when the index falls *below* `B`; `I == B` is the first valid element and must be left alone.

# Interpreter: index landing exactly on B+L is not wrapped

`UPDATE_CIRCULAR_BUFFER_PM` / `UPDATE_CIRCULAR_BUFFER_DM` in `sharcops.hxx` compare with `>` rather than `>=`, so an index that lands exactly on `B+L` is left unwrapped and the next access reads the word *following* the buffer instead of its first element. Shown here with fixes:

```diff
--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
 #define UPDATE_CIRCULAR_BUFFER_PM(x)                        \
     {                                                       \
         if (PM_REG_L(x) != 0)                               \
         {                                                   \
-            if (PM_REG_I(x) > PM_REG_B(x)+PM_REG_L(x))      \
+            if (PM_REG_I(x) >= PM_REG_B(x)+PM_REG_L(x))     \
             {                                               \
                 PM_REG_I(x) -= PM_REG_L(x);                 \
             }                                               \
```

```diff
--- a/src/devices/cpu/sharc/sharcops.hxx
+++ b/src/devices/cpu/sharc/sharcops.hxx
 #define UPDATE_CIRCULAR_BUFFER_DM(x)                        \
     {                                                       \
         if (DM_REG_L(x) != 0)                               \
         {                                                   \
-            if (DM_REG_I(x) > DM_REG_B(x)+DM_REG_L(x))      \
+            if (DM_REG_I(x) >= DM_REG_B(x)+DM_REG_L(x))     \
             {                                               \
                 DM_REG_I(x) -= DM_REG_L(x);                 \
             }                                               \
```

The `else if (I < B) I += L` branch below each of these is already correct and is unchanged.

# DRC: same missing wrap, plus an incorrect wrap when the index equals B

`generate_update_circular_buffer` in `sharcdrc.cpp` emits the same comparison, and additionally gets the underflow side wrong: it skips the `+= L` only when `I > B`, so an index sitting exactly on `B` -- the first element of the buffer -- is pushed forward by `L` to just past the end. Shown here with fixes (identical hunks exist for the PM and DM halves of the function):

```diff
--- a/src/devices/cpu/sharc/sharcdrc.cpp
+++ b/src/devices/cpu/sharc/sharcdrc.cpp
     UML_ADD(block, I0, PM_B(i), PM_L(i));
     UML_CMP(block, PM_I(i), I0);
-    UML_JMPc(block, COND_LE, label2);
+    UML_JMPc(block, COND_L, label2);
     UML_SUB(block, PM_I(i), PM_I(i), PM_L(i));
     UML_JMP(block, end);

     UML_LABEL(block, label2);
     UML_CMP(block, PM_I(i), PM_B(i));
-    UML_JMPc(block, COND_G, end);
+    UML_JMPc(block, COND_GE, end);
     UML_ADD(block, PM_I(i), PM_I(i), PM_L(i));
```

`COND_LE` -> `COND_L` matches the interpreter's `>=`, and `COND_G` -> `COND_GE` stops the generated code from wrapping up at `I == B`. After the change the emitted code is equivalent to the interpreter's:

```c
if (I >= B + L)  I -= L;
else if (I < B)  I += L;
```

# How this shows up

Found on Sega Model 2B, whose geometry code reads a twelve-element object matrix through a circular buffer with `b2 = 0x30020`, `l2 = 0xc`, `m = +1`. The twelfth post-modify lands on `0x3002c`, which is exactly `B+L`. Unwrapped, the following fetch returns the next word in memory (the focal value) as a matrix coefficient instead of wrapping to `0x30020`, corrupting the transform for every object drawn through that path.

Nothing about this is Model 2 specific -- it affects any ADSP-2106x code that walks a circular buffer up to its boundary, on both the interpreter and DRC paths.

# Testing

TODO: I tested this in an environment where I was experimenting with getting the Sega Model2B Geometry SHARC working and succeeded. I tested this against a full build of MAME with debug=1.

AI USE STATEMENT: AI was used in the research and finding of this, and I realize AI may not be right all the time but this seemed like a fix to submit while I had a game under the microscope.

Model and version used at the time of discovery: Claude Opus 4.8 (1M context)
Model and version used to write summary: Claude Opus 5 (effort: high)
