### PR TITLE
minitel2: Fix interpretation of the modem's RPTF register

### DIFF
--- a/src/mame/philips/minitel_2_rpic.cpp
+++ b/src/mame/philips/minitel_2_rpic.cpp
@@ -234,9 +234,9 @@ void minitel_state::sound_stream_update(sound_stream &stream)
 		for (s32 i = 0; i < stream.samples(); i++)
 		{
 			double val = 0;
-			if (modem_rptf_reg != 0x8) // unless high-only filtered
+			if (modem_rptf_reg != 0x4) // unless high-only filtered
 				val += sin(modem_dtmf_phase1);
-			if (modem_rptf_reg != 0x4) // unless low-only filtered
+			if (modem_rptf_reg != 0x8) // unless low-only filtered
 				val += sin(modem_dtmf_phase2);
 			stream.put(0, i, 0.5 * val); // mixed sine waves
 			modem_dtmf_phase1 = fmod(modem_dtmf_phase1 + rate1, 2.0 * pi);


### PR DESCRIPTION
The RPTF register (Transmission Filter Programming Register) of the TS7514 modem chip lets you filter only one of the two frequencies of generated DTMF tones. This technique, combined with line monitoring (RWLO register), is used by the "demov1" ROM in one of its screen to play single notes via loudspeaker.

This commit fixes which one of the two frequencies is selected, whose logic I had misunderstood from my first read of the TS7514 datasheet. The new logic has been validated against the real chip.