### PR TITLE
upd765, formats/dsk_dsk: fix non-dma read handshake and disc rotation rate [MT7804]

### DIFF
--- a/hash/cpc_flop.xml
+++ b/hash/cpc_flop.xml
@@ -253,9 +253,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, probably protection (Alkatraz Protetction System) related -->
 	<!-- Identifying 10th Frame (UK) (1986) [Original].zip... --> <!-- CPC Power -->
-	<software name="10frame" supported="no">
+	<software name="10frame">
 		<description>10th Frame (UK)</description>
 		<year>1986</year>
 		<publisher>U.S. Gold</publisher>
@@ -345,9 +344,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, probably protection (Alkatraz Protetction System) related -->
 	<!-- Identifying 1943 (UK) (1988) [Original].zip... --> <!-- CPC Power -->
-	<software name="1943" supported="no">
+	<software name="1943">
 		<description>1943 (UK)</description>
 		<year>1988</year>
 		<publisher>Go! ~ Capcom</publisher>
@@ -474,9 +472,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- Possibly BAD DUMP?? (see CPC Power) Anyway, it resets to BASIC when trying to load -->
 	<!-- Identifying 2112 AD (UK,F,G,S) (128K) (1986) (CPM) [Original].zip... --> <!-- CPC Power -->
-	<software name="2112ad" supported="no">
+	<software name="2112ad">
 		<description>2112 AD (Euro?)</description>
 		<year>1986</year>
 		<publisher>Design Design</publisher>
@@ -861,9 +858,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, probably protection (Alkatraz Protetction System) related -->
 	<!-- Identifying 4x4 Off-Road Racing (UK) (1988) [Original].zip... --> <!-- CPC Power -->
-	<software name="4x4offrd" supported="no">
+	<software name="4x4offrd">
 		<description>4x4 Off-Road Racing (UK)</description>
 		<year>1988</year>
 		<publisher>Epyx</publisher>
@@ -926,9 +922,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, probably protection (Alkatraz Protetction System) related -->
 	<!-- Identifying 720 (UK) (1988) [Original].zip... --> <!-- CPC Power -->
-	<software name="720" supported="no">
+	<software name="720">
 		<description>720° (UK)</description>
 		<year>1988</year>
 		<publisher>U.S. Gold</publisher>
@@ -1561,9 +1556,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, protection related -->
 	<!-- Identifying Ace Of Aces (UK) (1985) [Original] (Weak Sectors).zip... --> <!-- CPC Power -->
-	<software name="aceoface" supported="no">
+	<software name="aceoface">
 		<description>Ace of Aces (UK)</description>
 		<year>1986</year>
 		<publisher>U.S. Gold</publisher>
@@ -1628,9 +1622,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, protection related -->
 	<!-- Identifying Acro Jet The Advanced Flight Simulator (UK) (1986) [Original].zip... --> <!-- CPC Power -->
-	<software name="acrojet" supported="no">
+	<software name="acrojet">
 		<description>AcroJet - The Advanced Flight Simulator (UK)</description>
 		<year>1986</year>
 		<publisher>Microprose</publisher>
@@ -1668,9 +1661,8 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, probably protection related -->
 	<!-- Identifying Action Force (UK) (1988) (CPM) [Original].zip... --> <!-- CPC Power -->
-	<software name="actforce" supported="no">
+	<software name="actforce">
 		<description>Action Force (UK)</description>
 		<year>1988</year>
 		<publisher>Virgin Games</publisher>
@@ -2044,7 +2036,6 @@ is shared by a lot of sets... is it a generic boot disk?
 		</part>
 	</software>
 
-<!-- goes back to BASIC, protection related -->
 	<!-- Identifying Adidas Championship Football (UK) (1990) (Spain retail version) [Original].zip... --> <!-- CPC Power -->
 	<software name="adidasfb">
 		<description>Adidas Championship Football (Spa)</description> <!-- Game in English, was the same disk sold in UK too? -->
@@ -40423,7 +40414,7 @@ stick to CPC-Power disks, when available)
 	</software>
 
 	<!-- Identifying Goody (S) (1987) (CPM) [Original].zip... --> <!-- CPC Power -->
-	<software name="goodys19" supported="no">
+	<software name="goodys19">
 		<description>Goody (Spa) (CPM) [Original]</description>
 		<year>1987</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -253494,7 +253485,7 @@ stick to CPC-Power disks, when available)
 	</software>
 
 	<!-- Identifying 3D 4 en Raya &amp; Space Trucker &amp; Base Lunar Alfa &amp; Cargamento Espacial &amp; Frutties &amp; Santas Grotty &amp; Egg Blitz &amp; Smaley vs Grumpis &amp; Space Base (nongoodcpc).dsk... --> <!-- NonGoodCPC -->
-	<software name="3d4enray" supported="no">
+	<software name="3d4enray">
 		<description>3D 4 en Raya &amp; Space Trucker &amp; Base Lunar Alfa &amp; Cargamento Espacial &amp; Frutties &amp; Santas Grotty &amp; Egg Blitz &amp; Smaley vs Grumpis &amp; Space Base</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>

--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -584,7 +584,7 @@ uint8_t upd765_family_device::msr_r()
 		break;
 	case PHASE_EXEC:
 		msr |= MSR_CB;
-		if(spec & SPEC_ND)
+		if((spec & SPEC_ND) && internal_drq)
 			msr |= MSR_EXM;
 		if(internal_drq) {
 			msr |= MSR_RQM;

--- a/src/lib/formats/dsk_dsk.cpp
+++ b/src/lib/formats/dsk_dsk.cpp
@@ -490,8 +490,15 @@ bool dsk_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 				else
 					pos += 128 << tr.sector_size_code;
 			}
-			// larger cell count (was 100000) to allow for slightly out of spec images (theatre europe on einstein)
-			build_pc_track_mfm(track, side, image, 105000, tr.number_of_sector, sects, tr.gap3_length);
+			// A double-density track at 300 rpm holds 100000 2 us cells; padding standard
+			// tracks to more makes the disc spin faster than a real drive. Allow larger
+			// out-of-spec layouts (theatre europe on einstein) by sizing to the layout
+			// when it genuinely needs the extra cells.
+			int min_cells = 0;
+			for(int j=0;j<tr.number_of_sector;j++)
+				min_cells += sects[j].actual_size;
+			min_cells = 149*16 + (tr.number_of_sector*62 + min_cells)*16;
+			build_pc_track_mfm(track, side, image, min_cells > 100000 ? min_cells : 100000, tr.number_of_sector, sects, tr.gap3_length);
 		}
 	}
 	return true;


### PR DESCRIPTION
Goody (Spa) [Original] (cpc_flop goodys19) froze after its custom loader finished reading the disc. Two independent defects:

- upd765: in non-dma mode msr bit 5 (execution phase) was asserted for the whole execution phase instead of only while a byte is actually available, so the loader's poll loop lost its per-byte handshake.
- dsk_dsk: standard double-density tracks were padded to 105000 cells instead of the 100000 a 300 rpm / 250 kbps track holds, so the disc spun ~4.75% fast and timing-sensitive loaders polling between bytes fell behind and dropped data. Size the track from its actual sector layout, keeping the extra cells only for layouts that need them (theatre europe on einstein).

assisted: GLM-5.1