### PR TITLE
itech/itech32: Drivers Edge wheel output

### DIFF
--- a/src/mame/itech/itech32.cpp
+++ b/src/mame/itech/itech32.cpp
@@ -502,6 +502,9 @@ void drivedge_state::machine_start()
 	itech32_state::machine_start();
 
 	save_item(NAME(m_tms_spinning));
+	save_item(NAME(m_wheel_motor_control));
+	save_item(NAME(m_wheel_motor_data_a));
+	save_item(NAME(m_wheel_motor_data_b));
 #if LOG_DRIVEDGE_UNINIT_RAM
 	save_item(NAME(m_written));
 #endif
@@ -510,6 +513,11 @@ void drivedge_state::machine_start()
 void drivedge_state::machine_reset()
 {
 	itech32_state::machine_reset();
+
+	m_wheel_motor_control = 2;
+	m_wheel_motor_data_a = 0;
+	m_wheel_motor_data_b = 0;
+	m_wheel_motor = 0;
 
 	m_dsp[0]->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
 	m_dsp[1]->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
@@ -621,6 +629,48 @@ u16 drivedge_state::gas_r()
 	return m_gas->read();
 }
 
+void drivedge_state::wheel_motor_control_w(u16 data)
+{
+	m_wheel_motor_control = data;
+	update_wheel_motor();
+}
+
+
+void drivedge_state::wheel_motor_data_a_w(u16 data)
+{
+	m_wheel_motor_data_a = data;
+}
+
+
+void drivedge_state::wheel_motor_data_b_w(u16 data)
+{
+	m_wheel_motor_data_b = data;
+	update_wheel_motor();
+}
+
+
+void drivedge_state::update_wheel_motor()
+{
+	s32 motor = 0;
+
+	if ((m_wheel_motor_control == 0 || m_wheel_motor_control == 1) &&
+		(m_wheel_motor_data_a || m_wheel_motor_data_b))
+	{
+		const u32 total = u32(m_wheel_motor_data_a) + u32(m_wheel_motor_data_b);
+
+		if (total != 0)
+		{
+			s32 magnitude = (u32(m_wheel_motor_data_a) * 31 + total / 2) / total;
+
+			if (magnitude > 31)
+				magnitude = 31;
+
+			motor = (m_wheel_motor_control == 0) ? magnitude : -magnitude;
+		}
+	}
+
+	m_wheel_motor = motor;
+}
 
 /*************************************
  *
@@ -967,10 +1017,11 @@ map(0x000c00, 0x007fff).mirror(0x40000).rw(FUNC(drivedge_state::test2_r), FUNC(d
 	map(0x084001, 0x084001).rw(FUNC(drivedge_state::sound_return_r), FUNC(drivedge_state::sound_data_w));
 //  map(0x086000, 0x08623f).ram(); -- networking -- first 0x40 bytes = our data, next 0x40*8 bytes = their data, r/w on IRQ2
 	map(0x088000, 0x088001).r(FUNC(drivedge_state::steering_r));
-	map(0x08a000, 0x08a001).r(FUNC(drivedge_state::gas_r));
-	map(0x08a000, 0x08a003).nopw();
+	map(0x08a000, 0x08a001).rw(FUNC(drivedge_state::gas_r), FUNC(drivedge_state::wheel_motor_control_w));
 	map(0x08c000, 0x08c003).portr("8c000");
-	map(0x08e000, 0x08e003).portr("8e000").nopw();
+	map(0x08c000, 0x08c001).w(FUNC(drivedge_state::wheel_motor_data_a_w));
+	map(0x08e000, 0x08e003).portr("8e000");
+	map(0x08e000, 0x08e001).w(FUNC(drivedge_state::wheel_motor_data_b_w));
 	map(0x100000, 0x10000f).w(FUNC(drivedge_state::zbuf_control_w)).share(m_zbuf_control);
 	map(0x180001, 0x180001).w(FUNC(drivedge_state::color_w<0>));
 	map(0x1a0000, 0x1bffff).ram().w(m_palette, FUNC(palette_device::write32)).share("palette");

--- a/src/mame/itech/itech32.h
+++ b/src/mame/itech/itech32.h
@@ -217,8 +217,9 @@ public:
 		m_tms2_ram(*this, "tms2_ram"),
 		m_leds(*this, "led%u", 0U),
 		m_steer(*this, "STEER"),
-		m_gas(*this, "GAS")
-	{ }
+		m_gas(*this, "GAS"),
+		m_wheel_motor(*this, "wheel_motor")
+	{}
 
 	void drivedge(machine_config &config);
 
@@ -230,6 +231,11 @@ protected:
 private:
 	u16 steering_r();
 	u16 gas_r();
+
+	void wheel_motor_control_w(u16 data);
+	void wheel_motor_data_a_w(u16 data);
+	void wheel_motor_data_b_w(u16 data);
+	void update_wheel_motor();
 
 #if LOG_DRIVEDGE_UNINIT_RAM
 	u32 test1_r(offs_t offset, u32 mem_mask);
@@ -271,6 +277,12 @@ private:
 	output_finder<4> m_leds;
 	required_ioport m_steer;
 	required_ioport m_gas;
+
+	output_finder<> m_wheel_motor;
+
+	u16 m_wheel_motor_control = 2;
+	u16 m_wheel_motor_data_a = 0;
+	u16 m_wheel_motor_data_b = 0;
 
 	u8 m_tms_spinning[2];
 #if LOG_DRIVEDGE_UNINIT_RAM

--- a/src/mame/williams/midzeus.cpp
+++ b/src/mame/williams/midzeus.cpp
@@ -136,6 +136,7 @@ public:
 		, m_digits(*this, "digit%u", 0U)
 		, m_leds(*this, "led%u", 0U)
 		, m_lamps(*this, "lamp%u", 0U)
+		, m_wheel_motor(*this, "wheel_motor")
 		, m_io_analog(*this, "ANALOG%u", 0U)
 	{ }
 
@@ -167,6 +168,7 @@ private:
 	output_finder<7> m_digits;
 	output_finder<32> m_leds;
 	output_finder<8> m_lamps;
+	output_finder<> m_wheel_motor;
 	required_ioport_array<4> m_io_analog;
 };
 
@@ -560,7 +562,8 @@ void crusnexo_state::crusnexo_leds_w(offs_t offset, uint32_t data)
 {
 	switch (offset)
 	{
-		case 0: // unknown purpose
+		case 0: // steering wheel motor
+			m_wheel_motor = data & 0xff;
 			break;
 
 		case 1: // controls lamps


### PR DESCRIPTION
This adds steering motor output support for Driver's Edge.

The game writes steering motor control data to 0x08a000, 0x08c000 and
0x08e000. These writes were previously not handled by the driver.

The new handlers keep track of the values written by the game and expose
a single signed `wheel_motor` output representing the resulting steering
motor drive.

The game uses control values 0 and 1 for the two motor directions and 2
for the inactive state. The values written to 0x08c000 and 0x08e000 are
a paired set of drive values selected by the game from its internal
lookup table. The driver combines this pair into a 5-bit magnitude and
uses the control state for the direction.

The resulting output range is:

    -31 ... -1  one direction
       0        motor inactive
     1 ... 31   opposite direction

The original input mappings remain unchanged; the existing gas and input
reads at these addresses are preserved.

The internal motor state is also included in save states.

Tested with Driver's Edge and verified that the output changes with the
game's steering forces and stronger motor events.

GPT-5.6 Sol. assisted with research and some coding.