### PR TITLE
sharp/zaurus.cpp: Add not working Zaurus MI Series PDAs

### DIFF
--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43295,6 +43295,11 @@ x68ksupr
 x68kxvi
 
 @source:sharp/zaurus.cpp
+zmi10
+zmi310
+zmie1
+zmie21
+zmt300s
 zsl5500
 zslc500
 zsl5600

--- a/src/mame/sharp/zaurus.cpp
+++ b/src/mame/sharp/zaurus.cpp
@@ -2,10 +2,17 @@
 // copyright-holders:Angelo Salese, Ryan Holtz
 /****************************************************************************************************************************************
 
-    Sharp Zaurus PDA skeleton driver (SL, ARM/Linux based, 4th generation)
+    Sharp Zaurus PDA skeleton driver for the following series:
+    - MI: SH-3 based, 3rd generation
+    - SL: ARM/Linux based, 4th generation
+
+    Models List:
+    - http://www.areanine.gr.jp/~nyano/zauhistory.html
+    - http://www.ayati.com/compal/model.htm
 
     TODO:
-    - Dumps are questionable
+    - MI flash needs redumps with factory reset user area
+    - SL dumps are questionable
 
 =========================================================================================================================================
 Sharp Zaurus
@@ -477,32 +484,36 @@ Note:
 MI Series
 ---------
 
+Flash storage contains a mix of system and user areas.
+Earlier models' (e.g. MI-310) user area is formatted as a custom filesystem (Sharp Z-FFS).
+Later Models' (e.g. MI-E1) user area is formatted as FAT-12 in SmartMedia NAND flash.
+
 Model: MI-10
 Manufacturer: Sharp
 Nickname/Series: ColorZaurus
 Release Date: June 25, 1996
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: unknown
-Flash (Internal): none
-Other Storage: none
+CPU: 45 MHz Hitachi SH3 32-bit CPU (HD6417702 F45)
+Memory: 2*512 KB (51W4260CLTT-7)
+Flash (Internal): 2 MB (LH28F016SUT-70) + 128 KB (AT29LV010A)
+Other Storage: 5*4 MB Mask ROM (LHMV5Bxx)
 Slots:
 Display: 320x240 16-bit color TFT LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: No
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: http://www.zaumaga.net/kaibo/mi-10/index.htm
 
 Model: MI-10DC
 Manufacturer: Sharp
 Nickname/Series: ColorZaurus
 Release Date: June 25, 1996
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: unknown
-Flash (Internal): none
-Other Storage: none
+CPU: 45 MHz Hitachi SH3 32-bit CPU (HD6417702 F45)
+Memory: 2*512 KB (51W4260CLTT-7)
+Flash (Internal): 2 MB (LH28F016SUT-70) + 128 KB (AT29LV010A)
+Other Storage: 5*4 MB Mask ROM (LHMV5Bxx)
 Slots:
 Display: 320x240 16-bit color TFT LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
@@ -516,44 +527,44 @@ Manufacturer: Sharp
 Nickname/Series: PowerZaurus
 Release Date: July 17, 1997
 Availability: Japan
-CPU: 30 MHz Hitachi SH3 32-bit CPU
-Memory: 1.4 MB
-Flash (Internal):
-Other Storage: none
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S F60)
+Memory: 2 MB (51W18165LTT-7SP)
+Flash (Internal): 2 MB (LH28F016SUT-70) + 512 KB (LH28F400SUE-LC12) (user area approx. 1.4 MB)
+Other Storage: 2*8 MB Mask ROM (MX23L6410) + 2*4 MB Mask ROM (LHMV5Bxx)
 Slots:
 Display: 320x240 16-bit color LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
-I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
+I/O: IrDA, I/O Port - serial PC Link
 Keyboard: No
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: http://www.zaumaga.net/kaibo/mi-506/pz_kaibo_504vs506.htm
 
 Model: MI-506
 Manufacturer: Sharp
 Nickname/Series: PowerZaurus
 Release Date: July 17, 1997
 Availability: Japan
-CPU: 30 MHz Hitachi SH3 32-bit CPU
-Memory: 3.4 MB
-Flash (Internal):
-Other Storage: none
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S F60)
+Memory: 2 MB (51W18165LTT-7SP) + 32 KB (SRM2B256SLT)
+Flash (Internal): 2*2 MB (LH28F016SUT-70) + 512 KB (LH28F400SUE-LC12) + 256 KB (MBM29F200BA) (user area approx. 3.4 MB)
+Other Storage: 2*8 MB Mask ROM (MX23L6410) + 2*4 MB Mask ROM (LHMV5Bxx)
 Slots:
 Display: 320x240 16-bit color LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: No
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: http://www.zaumaga.net/kaibo/mi-506/pz_kaibo_lsi.htm
 
 Model: MI-506DC
 Manufacturer: Sharp
 Nickname/Series: PowerZaurus
 Release Date: July 17, 1997
 Availability: Japan
-CPU: 30 MHz Hitachi SH3 32-bit CPU
-Memory: 3.4 MB
-Flash (Internal):
-Other Storage: none
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S F60)
+Memory: 2 MB (51W18165LTT-7SP) + 32 KB (SRM2B256SLT)
+Flash (Internal): 2*2 MB (LH28F016SUT-70) + 512 KB (LH28F400SUE-LC12) + 256 KB (MBM29F200BA) (user area approx. 3.4 MB)
+Other Storage: 2*8 MB Mask ROM (MX23L6410) + 2*4 MB Mask ROM (LHMV5Bxx)
 Slots:
 Display: 320x240 16-bit color LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
@@ -649,56 +660,39 @@ Note:
 
 Model: MI-310
 Manufacturer: Sharp
-Nickname/Series: PowerZaurus
+Nickname/Series: ColorPocket
 Release Date: September 4, 1998
 Availability: Japan
-CPU: 66 MHz Hitachi SH3 32-bit CPU
-Memory: 10 MB
-Flash (Internal):
-Other Storage: none
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S TF60)
+Memory: 2 MB DRAM (GM71VS18163CLT-6)
+Flash (Internal): 4*2 MB (LH28F016SUT-70)
+Other Storage: 2*16 MB Mask ROM (LHMD1Rxx)
 Slots:
 Display: 320x240 16-bit color reflective TFT LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: No
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: http://www.zaumaga.net/kaibo/mi-310/index.htm
+
+Model: MI-P1-A, MI-P1-W (same specs with distinct shell colors)
+Manufacturer: Sharp
+Nickname/Series: Zaurus i-Geti
+Release Date: March 20, 1999
+Availability: Japan
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S TF60)
+Memory: 2 MB DRAM (GM71VS18163CLT-6)
+Flash (Internal): 4 MB (LH28F320S3TD-L10)
+Other Storage: 16 MB Mask ROM (LHMD1Rxx)
+Slots:
+Display: 320x240 grayscale LCD touchscreen
+OS: Sharp ZaurusOS (Axe XTAL microkernel)
+I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
+Keyboard: Yes
+Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
+Note: http://www.zaumaga.net/kaibo/mi-p1/index.htm / https://jp.sharp/sc/eihon/mip1/text/index.html
 
 Model: MI-P1-LA
-Manufacturer: Sharp
-Nickname/Series: Zaurus i-Geti
-Release Date: March 20, 1999
-Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 6 MB
-Flash (Internal):
-Other Storage: none
-Slots:
-Display: 320x240 grayscale LCD touchscreen
-OS: Sharp ZaurusOS (Axe XTAL microkernel)
-I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
-Keyboard: Yes
-Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
-
-Model: MI-P1-A
-Manufacturer: Sharp
-Nickname/Series: Zaurus i-Geti
-Release Date: March 20, 1999
-Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 6 MB
-Flash (Internal):
-Other Storage: none
-Slots:
-Display: 320x240 grayscale LCD touchscreen
-OS: Sharp ZaurusOS (Axe XTAL microkernel)
-I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
-Keyboard: Yes
-Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
-
-Model: MI-P1-W
 Manufacturer: Sharp
 Nickname/Series: Zaurus i-Geti
 Release Date: March 20, 1999
@@ -720,19 +714,17 @@ Manufacturer: Sharp
 Nickname/Series: Zaurus i-Cruise
 Release Date: April 16, 1999
 Availability: Japan
-CPU: 120 MHz Hitachi SH3 32-bit CPU
-Memory: 8 MB
-Flash (Internal):
-Other Storage: none
+CPU: 120 MHz Hitachi SH3 32-bit CPU (SH7709A 120)
+Memory: 8 MB DRAM (HM5165165LTT-6)
+Flash (Internal): 16 MB (TH58V128FT)
+Other Storage: 2*16 MB Mask ROM (LHMD1Rxx)
 Slots:
 Display: 640x480 VGA 16-bit color TFT LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
-
-=== Note: Every MI-series after this point _might_ not be a Hitachi SH3 CPU, best references so far call them RISC 32-bit CPUs... ===
+Note: https://steward-fu.github.io/website/umpc/mi-ex1_teardown.htm
 
 Model: MI-P2-B
 Manufacturer: Sharp
@@ -756,19 +748,19 @@ Manufacturer: Sharp
 Nickname/Series: Zaurus i-Cruise (customized)
 Release Date: August 1999
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 16 MB
-Flash (Internal):
-Other Storage: none
+CPU: 120 MHz Hitachi SH3 32-bit CPU (SH7709A 120)
+Memory: 8 MB DRAM (HM5165165LTT-6)
+Flash (Internal): 8 MB (TH58V64FT)
+Other Storage: 2*16 MB Mask ROM (LHMD1Rxx)
 Slots:
 Display: 640x480 VGA 16-bit color TFT LCD touchscreen
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: https://steward-fu.github.io/website/umpc/mi-tr1_teardown.htm
 
-Model: MI-C1-S
+Model: MI-C1-A, MI-C1-S (same specs with distinct shell colors)
 Manufacturer: Sharp
 Nickname/Series: PowerZaurus
 Release Date: December 7, 1999
@@ -783,41 +775,24 @@ OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
-
-Model: MI-C1-A
-Manufacturer: Sharp
-Nickname/Series: PowerZaurus
-Release Date: December 7, 1999
-Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 16 MB
-Flash (Internal):
-Other Storage: none
-Slots:
-Display: 320x240 Super Mobile 16-bit color reflective LCD touchscreen
-OS: Sharp ZaurusOS (Axe XTAL microkernel)
-I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
-Keyboard: Yes
-Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: https://jp.sharp/sc/eihon/mic1/text/index.html
 
 Model: MI-P10-S
 Manufacturer: Sharp
 Nickname/Series: Zaurus i-Geti
 Release Date: July 14, 2000
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 16 MB
-Flash (Internal):
-Other Storage: none
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S TF60)
+Memory: 8 MB DRAM (HM5165165FLTT-6)
+Flash (Internal): 8 MB (TC58V64AFT)
+Other Storage: 2*16 MB Mask ROM (LHMD1Uxx)
 Slots:
 Display: 320x240 grayscale LCD touchscreen (not backlit)
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording, more internal software
-Note:
+Note: https://steward-fu.github.io/website/umpc/mi-p10-s_teardown.htm
 
 Model: MI-J1
 Manufacturer: Sharp
@@ -841,10 +816,10 @@ Manufacturer: Sharp
 Nickname/Series:
 Release Date: December 15, 2000
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 16 MB
-Flash (Internal):
-Other Storage: none
+CPU: 120 MHz Hitachi SH3 32-bit CPU (SH7709A 120B)
+Memory: 8 MB DRAM (MT48LC4M16A2)
+Flash (Internal): 8 MB (TC58V64AFT)
+Other Storage: 2*16 MB Mask ROM (LHMD1Uxx)
 Slots: Smart Disk/Secure Digital/MMC, CompactFlash
 Display: 240x320 16-bit color backlit TFT LCD touchscreen (vertical display)
 Audio Controller:
@@ -852,34 +827,34 @@ OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes (mini-keyboard)
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording, MP3 player, MPEG4 video playback, headphone jack
-Note:
+Note: https://steward-fu.github.io/website/umpc/mi-e1_teardown.htm
 
 Model: MI-L1
 Manufacturer: Sharp
 Nickname/Series:
 Release Date: May 21, 2001
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: 16 MB
-Flash (Internal):
-Other Storage: none
+CPU: 120 MHz Hitachi SH3 32-bit CPU (SH7709A 120B)
+Memory: 8 MB DRAM (MT48LC4M16A2)
+Flash (Internal): 8 MB (TC58V64AFT)
+Other Storage: 2*16 MB Mask ROM (LHMD1Uxx)
 Slots: Smart Disk/Secure Digital/MMC, CompactFlash
 Display: 240x320 16-bit color LCD touchscreen (not backlit, vertical display)
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes (mini-keyboard)
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording
-Note:
+Note: https://steward-fu.github.io/website/umpc/mi-l1_teardown.htm
 
 Model: MI-E21
 Manufacturer: Sharp
 Nickname/Series:
 Release Date: September 7, 2001
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU (faster than MI-E1 CPU)
-Memory: 32 MB
-Flash (Internal):
-Other Storage: none
+CPU: 167 MHz Hitachi SH3 32-bit CPU (6417709SBP 167V)
+Memory: 16 MB DRAM (HY57V281620ALT-H)
+Flash (Internal): 16 MB (TC58V128FT)
+Other Storage: 16 MB Mask ROM (LHMD1Uxx) + 8 MB Mask ROM (LHMD09xx)
 Slots: Smart Disk/Secure Digital/MMC, CompactFlash
 Display: 240x320 16-bit color backlit TFT LCD touchscreen (vertical display)
 Audio Controller:
@@ -887,14 +862,14 @@ OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O: IrDA, I/O Port - serial PC Link, internal faxmodem
 Keyboard: Yes (mini-keyboard)
 Features: handwriting recognition, email, external digital mobile phone adapter, Internet, audio recording, MP3 player, MPEG4 video playback, headphone jack
-Note:
+Note: https://steward-fu.github.io/website/umpc/mi-e21_teardown.htm
 
 Model: MI-E25DC
 Manufacturer: Sharp
 Nickname/Series:
 Release Date: March 15, 2002
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU (same as MI-E21)
+CPU: 167 MHz Hitachi SH3 32-bit CPU
 Memory: 32 MB
 Flash (Internal):
 Other Storage: none
@@ -912,77 +887,122 @@ Note:
 MT Series
 ---------
 
-Model: MT-200
+Not technically Zaurus, basically MI technology with a keyboard on top.
+
+Model: MT-200, MT-200-A (same specs with distinct shell colors)
 Manufacturer: Sharp
-Nickname/Series:
+Nickname/Series: Communication Pal (コミュニケーションパル)
 Release Date: December 4, 1998
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: unknown
-Flash (Internal):
-Other Storage:
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S TF60)
+Memory: 2 MB DRAM (GM71VS18163CLT-6)
+Flash (Internal): 2 MB (LH28F016SUT-70) (user area approx. 1.4 MB)
+Other Storage: 16 MB Mask ROM (LHMD1RT6)
 Slots:
 Display:
 Audio Controller:
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O:
-Keyboard:
-Features:
-Note: The "Communication Pals" or "Browser Boards", not technically Zaurus, basically MI technology with a keyboard on top
+Keyboard: Yes
+Features: email, digital mobile phone adapter, Internet (without SSL support)
+Note: http://www.zaumaga.net/kaibo/mt-200/kiban.htm / https://web.archive.org/web/20000519213044/http://www.sharp.co.jp/sc/eihon/mt200/text/index.html
 
-Model: MT-200SA
+Model: MT-200-SA, MT-200-SV (same specs with distinct shell colors)
 Manufacturer: Sharp
-Nickname/Series:
-Release Date:
+Nickname/Series: Communication Pal (コミュニケーションパル)
+Release Date: 1999?
 Availability: Japan
 CPU: unknown MHz Hitachi SH3 32-bit CPU
 Memory: unknown
-Flash (Internal):
-Other Storage:
+Flash (Internal): unknown
+Other Storage: unknown
 Slots:
 Display:
 Audio Controller:
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O:
-Keyboard:
-Features:
-Note: The "Communication Pals" or "Browser Boards", not technically Zaurus, basically MI technology with a keyboard on top
+Keyboard: Yes
+Features: email, digital mobile phone adapter, Internet (with SSL support)
+Note:
 
-Model: MT-300
+Model: MT-300-D, MT-300-S (same specs with distinct shell colors)
 Manufacturer: Sharp
-Nickname/Series:
+Nickname/Series: Communication Pal (コミュニケーションパル)
 Release Date: September 9, 1999
 Availability: Japan
-CPU: unknown MHz Hitachi SH3 32-bit CPU
-Memory: unknown
-Flash (Internal):
-Other Storage:
+CPU: 60 MHz Hitachi SH3 32-bit CPU (HD6417708S TF60)
+Memory: 2 MB DRAM (GM71VS18163CLT-6)
+Flash (Internal): 2 MB (LH28F016SUT-70) (user area approx. 1.4 MB)
+Other Storage: 2*8 MB Mask ROM (MX23L6411)
 Slots:
 Display:
 Audio Controller:
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O:
-Keyboard:
-Features:
-Note: The "Communication Pals" or "Browser Boards", not technically Zaurus, basically MI technology with a keyboard on top
+Keyboard: Yes
+Features: email, supports digital mobile phones/PHS, Internet (with SSL support)
+Note: https://web.archive.org/web/20011031154844/http://www.sharp.co.jp/sc/eihon/mt300/text/index.html
 
-Model: MT-300C
+Model: MT-300C-A
 Manufacturer: Sharp
-Nickname/Series:
-Release Date:
+Nickname/Series: Communication Pal (コミュニケーションパル)
+Release Date: December 25, 1999
 Availability: Japan
 CPU: unknown MHz Hitachi SH3 32-bit CPU
 Memory: unknown
-Flash (Internal):
-Other Storage:
+Flash (Internal): unknown
+Other Storage: unknown
 Slots:
 Display:
 Audio Controller:
 OS: Sharp ZaurusOS (Axe XTAL microkernel)
 I/O:
-Keyboard:
-Features:
-Note: The "Communication Pals" or "Browser Boards", not technically Zaurus, basically MI technology with a keyboard on top
+Keyboard: Yes
+Features: email, supports cdmaOne/PHS, Internet (with SSL support)
+Note: https://web.archive.org/web/20000302192327/http://www.sharp.co.jp/sc/gaiyou/news/991214.html
+
+Model:
+Manufacturer: NTT DoCoMo
+Nickname/Series: BrowserBoard (ブラウザボード)
+Release Date: July 26, 1999
+Availability: Japan
+CPU: unknown MHz Hitachi SH3 32-bit CPU
+Memory: 6 MB (user area approx. 3.4 MB)
+Flash (Internal):
+Other Storage:
+Slots:
+Display: 240x320 16-bit color
+Audio Controller:
+OS: Sharp ZaurusOS (Axe XTAL microkernel)
+I/O:
+Keyboard: Yes
+Features: email, digital mobile phone adapter, Internet
+Note: https://web.archive.org/web/20000106165438/http://www.nttdocomo.co.jp/new/contents/99/whatnew0716.html / https://www.docomo.ne.jp/binary/pdf/corporate/technology/rd/technical_journal/bn/vol7_3/vol7_3_016jp.pdf
+
+============================================================================================
+
+OST Series
+----------
+
+Not technically Zaurus, basically MI technology with a keyboard on top.
+
+Model: OST-2000
+Manufacturer: NTT Communications
+Nickname/Series: Pocket Communication
+Release Date: 2000?
+Availability: Japan
+CPU: unknown MHz Hitachi SH3 32-bit CPU
+Memory: unknown
+Flash (Internal): unknown
+Other Storage: unknown
+Slots:
+Display:
+Audio Controller:
+OS: Sharp ZaurusOS (Axe XTAL microkernel)
+I/O:
+Keyboard: Yes
+Features: email, Internet
+Note: http://web.archive.org/web/20020819110641/http://www.ocn.ne.jp/pda/index.html
 
 ============================================================================================
 
@@ -1401,7 +1421,9 @@ Note:
 
 #include "emu.h"
 #include "cpu/arm7/arm7.h"
+#include "cpu/sh/sh4.h"
 #include "machine/locomo.h"
+#include "machine/nandflash.h"
 #include "machine/pxa255.h"
 #include "machine/sa1110.h"
 #include "machine/scoop.h"
@@ -1411,17 +1433,64 @@ Note:
 #include "screen.h"
 #include "speaker.h"
 
-#define SA1110_CLOCK 206000000
-#define PXA250_CLOCK 400000000
-#define PXA255_CLOCK 400000000
-#define PXA270_CLOCK 416000000
+#define SA1110_CLOCK 206'000'000
+#define PXA250_CLOCK 400'000'000
+#define PXA255_CLOCK 400'000'000
+#define PXA270_CLOCK 416'000'000
 
 namespace {
 
-class zaurus_state : public driver_device
+class zaurus_mi_state : public driver_device
 {
 public:
-	zaurus_state(const machine_config &mconfig, device_type type, const char *tag)
+	zaurus_mi_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+	{ }
+
+	void mi10(machine_config &config) ATTR_COLD;
+	void mi310(machine_config &config) ATTR_COLD;
+	void mt300(machine_config &config) ATTR_COLD;
+	void mie1(machine_config &config) ATTR_COLD;
+	void mie21(machine_config &config) ATTR_COLD;
+
+protected:
+	// driver_device overrides
+	virtual void machine_start() override ATTR_COLD { }
+
+	// devices
+	required_device<cpu_device> m_maincpu;
+
+private:
+	void mi10_map(address_map &map) ATTR_COLD;
+	void mi310_map(address_map &map) ATTR_COLD;
+	void mt300_map(address_map &map) ATTR_COLD;
+};
+
+class zaurus_mie_state : public zaurus_mi_state
+{
+public:
+	zaurus_mie_state(const machine_config &mconfig, device_type type, const char *tag)
+		: zaurus_mi_state(mconfig, type, tag)
+		, m_nand(*this, "nand")
+	{ }
+
+	void mie1(machine_config &config) ATTR_COLD;
+	void mie21(machine_config &config) ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD { }
+
+	required_device<nand_device> m_nand;
+
+private:
+	void mie_map(address_map &map) ATTR_COLD;
+};
+
+class zaurus_sl_state : public driver_device
+{
+public:
+	zaurus_sl_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_ram(*this, "ram")
@@ -1437,11 +1506,11 @@ protected:
 	required_shared_ptr<uint32_t> m_ram;
 };
 
-class zaurus_sa_state : public zaurus_state
+class zaurus_sa_state : public zaurus_sl_state
 {
 public:
 	zaurus_sa_state(const machine_config &mconfig, device_type type, const char *tag)
-		: zaurus_state(mconfig, type, tag)
+		: zaurus_sl_state(mconfig, type, tag)
 		, m_sa_periphs(*this, "sa_periphs")
 		, m_locomo(*this, "locomo")
 		, m_scoop(*this, "scoop")
@@ -1462,11 +1531,11 @@ private:
 	required_device<ucb1200_device> m_codec;
 };
 
-class zaurus_pxa_state : public zaurus_state
+class zaurus_pxa_state : public zaurus_sl_state
 {
 public:
 	zaurus_pxa_state(const machine_config &mconfig, device_type type, const char *tag)
-		: zaurus_state(mconfig, type, tag)
+		: zaurus_sl_state(mconfig, type, tag)
 		, m_pxa_periphs(*this, "pxa_periphs")
 		, m_power(*this, "PWR")
 	{ }
@@ -1484,6 +1553,26 @@ private:
 	required_device<pxa255_periphs_device> m_pxa_periphs;
 	required_ioport m_power;
 };
+
+void zaurus_mi_state::mi10_map(address_map &map)
+{
+	map(0x00000000, 0x003fffff).rom().region("boot", 0);
+}
+
+void zaurus_mi_state::mi310_map(address_map &map)
+{
+	map(0x00000000, 0x00ffffff).rom().region("mc11m0_1", 0);
+}
+
+void zaurus_mi_state::mt300_map(address_map &map)
+{
+	map(0x00000000, 0x007fffff).rom().region("mt30m0", 0);
+}
+
+void zaurus_mie_state::mie_map(address_map &map)
+{
+	map(0x00000000, 0x00ffffff).rom().region("col1m0_1", 0);
+}
 
 void zaurus_sa_state::main_map(address_map &map)
 {
@@ -1503,7 +1592,7 @@ void zaurus_pxa_state::main_map(address_map &map)
 
 void zaurus_sa_state::machine_reset()
 {
-	zaurus_state::machine_reset();
+	zaurus_sl_state::machine_reset();
 
 	m_sa_periphs->gpio_in<1>(1);
 	m_sa_periphs->gpio_in<24>(1);
@@ -1524,12 +1613,46 @@ static INPUT_PORTS_START( zaurus_pxa )
 	PORT_BIT( 0x00000001, IP_ACTIVE_HIGH, IPT_START1 ) PORT_NAME("Start System") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(zaurus_pxa_state::system_start), 0)
 INPUT_PORTS_END
 
-void zaurus_state::machine_start()
+void zaurus_sl_state::machine_start()
 {
 }
 
-void zaurus_state::machine_reset()
+void zaurus_sl_state::machine_reset()
 {
+}
+
+void zaurus_mi_state::mi10(machine_config &config)
+{
+	SH3(config, m_maincpu, 45'000'000); // actually SH7702
+	m_maincpu->set_addrmap(AS_PROGRAM, &zaurus_mi_state::mi10_map);
+}
+
+void zaurus_mi_state::mi310(machine_config &config)
+{
+	SH7708S(config, m_maincpu, 60'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &zaurus_mi_state::mi310_map);
+}
+
+void zaurus_mi_state::mt300(machine_config &config)
+{
+	SH7708S(config, m_maincpu, 60'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &zaurus_mi_state::mt300_map);
+}
+
+void zaurus_mie_state::mie1(machine_config &config)
+{
+	SH7709(config, m_maincpu, 120'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &zaurus_mie_state::mie_map);
+
+	TOSHIBA_TC58256AFT(config, m_nand); // actually TC58V64AFT
+}
+
+void zaurus_mie_state::mie21(machine_config &config)
+{
+	SH7709(config, m_maincpu, 167'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &zaurus_mie_state::mie_map);
+
+	TOSHIBA_TC58256AFT(config, m_nand); // actually TC58128FT
 }
 
 void zaurus_sa_state::zaurus_sa1110(machine_config &config)
@@ -1579,6 +1702,83 @@ void zaurus_pxa_state::zaurus_pxa270(machine_config &config)
 
 ***************************************************************************/
 
+ROM_START( zmi10 )
+	// Pin-compatible with MX29L3211
+	ROM_REGION64_LE(0x400000, "boot", ROMREGION_ERASE00)
+	ROM_LOAD("lhmv5btm.n638.01.b.bin", 0x000000, 0x400000, CRC(585f7023) SHA1(cddac172cd576f422476632a45acefb6697330e1))
+
+	// User area truncated
+	ROM_REGION64_LE(0x200000, "flash", ROMREGION_ERASEFF)
+	ROM_LOAD("lh28f016sut-70.bin", 0x000000, 0x020000, CRC(d187c118) SHA1(ea429df1d66ed1a06a2bd8bc095c207b702c2955) BAD_DUMP )
+
+	ROM_REGION64_LE(0x400000, "mi10_1", ROMREGION_ERASE00)
+	ROM_LOAD("lhmv5by3.n642.02.b.bin", 0x000000, 0x400000, CRC(cdef6a1c) SHA1(26bd3e44b892bf4d0c9776a54c4ba0c167d274b4))
+
+	ROM_REGION64_LE(0x400000, "mi10_2", ROMREGION_ERASE00)
+	ROM_LOAD("lhmv5bty.n642.02.b.bin", 0x000000, 0x400000, CRC(21e71c4a) SHA1(2cf329c1a34da2ab8e0abcbac0c0126311ef02ea))
+
+	ROM_REGION64_LE(0x400000, "mi10_3", ROMREGION_ERASE00)
+	ROM_LOAD("lhmv5btn.n640.01.b.bin", 0x000000, 0x400000, CRC(9484a53c) SHA1(bc41cd6f6ce991cebdbb2c9d41fea170817fcc8a))
+
+	ROM_REGION64_LE(0x400000, "mi10_4", ROMREGION_ERASE00)
+	ROM_LOAD("lhmv5btp.n640.01.b.bin", 0x000000, 0x400000, CRC(788e3124) SHA1(c593360a21c572c9e60e66ef6d644858d9c6aa41))
+
+	ROM_REGION64_LE(0x020000, "mi10pf", ROMREGION_ERASE00)
+	ROM_LOAD("at29lv010a-20tc.bin", 0x000000, 0x020000, CRC(c7802d72) SHA1(520e90e7684154bcc20ad30266da7887a7bcf462))
+ROM_END
+
+ROM_START( zmi310 )
+	// User area truncated
+	ROM_REGION64_LE(0x800000, "flash", ROMREGION_ERASEFF)
+	ROM_LOAD("lh28f016sut-70.1.bin", 0x000000, 0x080000, CRC(b2da8918) SHA1(2912e53ee0ddf2d77d07a8d958032d415a467b97) BAD_DUMP )
+
+	// Sharp memory User's No. LH-MD1Rxx = Model No. LH53BV128R00T
+	// Pin-compatible with MX23L12822
+	ROM_REGION64_LE(0x1000000, "mc11m0_1", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd1rt3.bin", 0x0000000, 0x1000000, CRC(c72e814a) SHA1(7f10ec9a2a701dda9d7717d4340309c9fc63717f))
+
+	ROM_REGION64_LE(0x1000000, "mc11m2_3", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd1rt2.bin", 0x0000000, 0x1000000, CRC(dc4a5393) SHA1(e5550de60c2817c1479ba74da95d3db649f67bc3))
+ROM_END
+
+ROM_START( zmt300s )
+	// User area truncated
+	ROM_REGION64_LE(0x200000, "flash", ROMREGION_ERASEFF)
+	ROM_LOAD("lh28f160s3t-l10a.bin", 0x000000, 0x050000, CRC(c69b8563) SHA1(8a63b973497fd4c691b9ccd8c1e1aa61a2dd27c5) BAD_DUMP )
+
+	ROM_REGION64_LE(0x800000, "mt30m0", ROMREGION_ERASE00)
+	ROM_LOAD("mx23l6411t06.bin", 0x000000, 0x800000, CRC(86c084e6) SHA1(fd6b8429c206c84dc64ac5cd71af3798cba8eda1))
+
+	ROM_REGION64_LE(0x800000, "mt30m1", ROMREGION_ERASE00)
+	ROM_LOAD("mx23l6411t07.bin", 0x000000, 0x800000, CRC(ca4694b5) SHA1(3d3f4c781380128432242ad0ffec108464bcf02e))
+ROM_END
+
+ROM_START( zmie1 )
+	ROM_REGION64_LE(0x1000000, "col1m0_1", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd1uts.bin", 0x0000000, 0x1000000, CRC(0fa5f255) SHA1(079ae1c3e958bc15080dd6fea0b0efca6eb40ef7))
+
+	ROM_REGION64_LE(0x1000000, "col1m2_3", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd1utt.bin", 0x0000000, 0x1000000, CRC(36a5acaf) SHA1(5658b7f9430adfef98cd23c84669aaddfb9c9ba6))
+
+	// User area erased with empty blocks
+	ROM_REGION64_LE(0x840000, "flash", ROMREGION_ERASE00)
+	ROM_LOAD("tc58v64aft.bin", 0x00000, 0x840000, CRC(b61cae8a) SHA1(95f811463769460fbf9d5bf7c15d40a2d8a0c2af) BAD_DUMP )
+ROM_END
+
+ROM_START( zmie21 )
+	ROM_REGION64_LE(0x1000000, "col1m0_1", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd1uy4.bin", 0x0000000, 0x1000000, CRC(766e0671) SHA1(7d2b4f23380854f24fa7e0dcb1cf41edfbef95bb))
+
+	// Sharp memory User's No. LH-MD09xx = Model No. LH53BV64900N/T
+	// Pin-compatible with MX23L6422
+	ROM_REGION64_LE(0x0800000, "col1m2", ROMREGION_ERASE00)
+	ROM_LOAD("lhmd09ub.bin", 0x0000000, 0x0800000, CRC(57da26d1) SHA1(1599dda6d4b89c709dfa9d275e7dfaed434ee77a))
+
+	// User area erased with empty blocks
+	ROM_REGION64_LE(0x1080000, "flash", ROMREGION_ERASE00)
+	ROM_LOAD("tc58128ft.bin", 0x00000, 0x1080000, CRC(fa6d45b7) SHA1(2d514cac6750435da5089af60d91b20d43806463) BAD_DUMP )
+ROM_END
+
 ROM_START( zsl5500 )
 	ROM_REGION32_LE( 0x1000000, "firmware", ROMREGION_ERASE00 )
 	ROM_SYSTEM_BIOS( 0, "2.58", "OS Pack 2.58" )
@@ -1620,10 +1820,16 @@ ROM_END
 
 } // anonymous namespace
 
+COMP( 1996, zmi10, 0, 0, mi10, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MI-10 \"Color Zaurus\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1998, zmi310, 0, 0, mi310, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MI-310 \"Color Pocket\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1999, zmt300s, 0, 0, mt300, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MT-300-S \"Communication Pal\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 2000, zmie1, 0, 0, mie1, 0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E1 (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 2001, zmie21, 0, 0, mie21, 0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E21 (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+
 COMP( 2002, zsl5500,  0, 0, zaurus_sa1110, zaurus_sa,  zaurus_sa_state,  empty_init, "Sharp", "Zaurus SL-5500 \"Collie\"",           MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 2002, zslc500,  0, 0, zaurus_pxa250, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C500",                      MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 2002, zsl5600,  0, 0, zaurus_pxa250, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-5600 / SL-B500 \"Poodle\"", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 2003, zslc750,  0, 0, zaurus_pxa255, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C750 \"Shepherd\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 2004, zslc760,  0, 0, zaurus_pxa255, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C760 \"Husky\" (Japan)",    MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 200?, zslc3000, 0, 0, zaurus_pxa270, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C3000 \"Spitz\" (Japan)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-COMP( 200?, zslc1000, 0, 0, zaurus_pxa270, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C3000 \"Akita\" (Japan)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 200?, zslc1000, 0, 0, zaurus_pxa270, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C1000 \"Akita\" (Japan)",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING )


### PR DESCRIPTION
New systems marked not working
------------------------------
Sharp Zaurus MI-10 "Color Zaurus" (Japan) [QUFB]
Sharp Zaurus MI-310 "Color Pocket" (Japan) [QUFB]
Sharp Zaurus MT-300-S "Communication Pal" (Japan) [QUFB]
Sharp Zaurus MI-E1 (Japan) [QUFB]
Sharp Zaurus MI-E21 (Japan) [QUFB]