### PR TITLE
floppy, upd765: debounce motor-off, abort when spindle stops mid-command

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -562,6 +562,7 @@ void floppy_image_device::device_start()
 	m_wpt = 0;
 	m_dskchg = exists() ? 1 : 0;
 	m_index_timer = timer_alloc(FUNC(floppy_image_device::index_resync), this);
+	m_motor_off_timer = timer_alloc(FUNC(floppy_image_device::motor_off_tick), this);
 	m_image_dirty = false;
 	m_ready = true;
 	m_ready_counter = 0;
@@ -819,37 +820,63 @@ bool floppy_image_device::wpt_r()
 	return m_wpt || (m_phases & 2);
 }
 
+TIMER_CALLBACK_MEMBER(floppy_image_device::motor_off_tick)
+{
+	if(m_mon)
+		return;
+	m_mon = 1;
+	if(m_image_dirty)
+		commit_image();
+	cache_clear();
+	m_revolution_start_time = attotime::never;
+	m_index_timer->adjust(attotime::zero);
+	set_ready(true);
+}
+
 /* motor on, active low */
 void floppy_image_device::mon_w(int state)
 {
-	if(m_mon == state)
-		return;
-
-	m_mon = state;
-
 	/* off -> on */
-	if (!m_mon && m_image)
+	if (!state)
 	{
-		m_revolution_start_time = machine().time();
-		cache_clear();
-		if (m_motor_always_on) {
-			// Drives with motor that is always spinning are immediately ready when a disk is loaded
-			// because there is no spin-up time
-			set_ready(false);
-		} else {
-			m_ready_counter = 2;
+		// A transition to motor-on cancels any pending mechanical
+		// spin-down.  When the line only dropped for a moment the spindle
+		// never stopped, so the drive keeps turning as if nothing had
+		// happened.
+		if(m_motor_off_timer->enabled())
+		{
+			m_motor_off_timer->adjust(attotime::never);
+			if(!m_mon)
+				return;
 		}
-		index_resync(0);
+
+		if(!m_mon)
+			return;
+
+		m_mon = 0;
+		if (m_image)
+		{
+			m_revolution_start_time = machine().time();
+			cache_clear();
+			if (m_motor_always_on) {
+				// Drives with motor that is always spinning are immediately ready when a disk is loaded
+				// because there is no spin-up time
+				set_ready(false);
+			} else {
+				m_ready_counter = 2;
+			}
+			index_resync(0);
+		}
 	}
 
 	/* on -> off */
-	else {
-		if(m_image_dirty)
-			commit_image();
-		cache_clear();
-		m_revolution_start_time = attotime::never;
-		m_index_timer->adjust(attotime::zero);
-		set_ready(true);
+	else if(!m_mon || m_motor_off_timer->enabled()) {
+		// The spindle does not stop the instant the motor line is released;
+		// it coasts.  Keep turning (and ready) for a while so that short
+		// drops of the line - loaders flipping memory paging on the same
+		// port do that constantly - do not interrupt a spin, and only take
+		// the mechanical stop once the line has stayed off long enough.
+		m_motor_off_timer->adjust(attotime::from_msec(100));
 	}
 
 	// Create a motor sound (loaded or empty)

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -173,6 +173,7 @@ protected:
 	virtual const software_list_loader &get_software_list_loader() const override;
 
 	TIMER_CALLBACK_MEMBER(index_resync);
+	TIMER_CALLBACK_MEMBER(motor_off_tick);
 
 	virtual void track_changed();
 	virtual void setup_characteristics() = 0;
@@ -189,6 +190,7 @@ protected:
 	std::vector<fs_info>  m_fs;
 	std::vector<const fs::manager_t *> m_fs_managers;
 	emu_timer             *m_index_timer;
+	emu_timer             *m_motor_off_timer;
 
 	/* Physical characteristics, filled by setup_characteristics */
 	int m_tracks; /* addressable tracks */

--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -925,8 +925,21 @@ void upd765_family_device::live_run(attotime limit)
 			limit = cur_live.fi->dev->time_next_index();
 		if(limit == attotime::never) {
 			// Happens when there's no disk or if the fdc is not
-			// connected to a drive, hence no index pulse. Force a
-			// sync from time to time in that case, so that the main
+			// connected to a drive, hence no index pulse, or when the
+			// drive stopped turning since the command started.  In the
+			// latter case no flux will ever show up, so end the command
+			// with not ready instead of searching forever.
+			if(cur_live.fi->dev && !get_ready(cur_live.fi->id)) {
+				floppy_info &fi(*cur_live.fi);
+				live_abort();
+				fi.st0 = ST0_NR | ST0_FAIL | fi.id;
+				st1 = st2 = 0;
+				fi.sub_state = COMMAND_DONE;
+				general_continue(fi);
+				return;
+			}
+
+			// Force a sync from time to time so that the main
 			// cpu timeout isn't too painful.  Avoids looping into
 			// infinity looking for data too.
 


### PR DESCRIPTION
The disc motor line is shared with memory paging bits on some machines (Spectrum +3 port 1ffd bit 3), so loaders flipping the paging register glitch the motor line constantly during loads.  The spindle cannot stop (and restart) within microseconds: model the mechanical coast.

- mon_w defers the mechanical stop on an off transition and cancels it again on any on transition; the drive only stops once the line has stayed off for a while.  A key detail: the on transition must cancel a pending stop even when the motor was never released (m_mon unchanged), which is exactly the +3 paging-glitch case - previously the armed timer killed a still-turning drive mid-load, breaking specpls3_flop:ineedspe (track reads aborted not-ready mid-file).
- live_run: when the drive stopped turning while a command was in flight (no index, not ready), no flux will ever arrive; end the command with ST0_NR instead of searching forever, mirroring the not-ready abort at command start.

ineedspe now boots to the game (all tracks read clean); +3 hostages improves (loads sequentially instead of dying in an endless not-ready retry loop at track 1); cpc6128 goodys19 still boots.

assisted: GLM-5.1