### PR TITLE
gb_lcd: test for LYXX_M0_2 instead of repeating LYXX_M0

### DIFF
--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -2336,7 +2336,7 @@ void dmg_ppu_device::update_state()
 			}
 			assert(state_cycles > 0);
 
-			if (m_state == GB_LCD_STATE_LYXX_M3 || m_state == GB_LCD_STATE_LYXX_M3_2 || m_state == GB_LCD_STATE_LYXX_M0 || m_state == GB_LCD_STATE_LYXX_M0)
+			if (m_state == GB_LCD_STATE_LYXX_M3 || m_state == GB_LCD_STATE_LYXX_M3_2 || m_state == GB_LCD_STATE_LYXX_M0 || m_state == GB_LCD_STATE_LYXX_M0_2)
 			{
 				// Execute <cycles> M3 cycles
 				if (m_enable_experimental_engine)


### PR DESCRIPTION
The same state test is written twice in `gb_lcd.cpp`, once at line 2027 and once at 2339, and only the first one lists `GB_LCD_STATE_LYXX_M0_2`. At 2339 the fourth operand repeats `GB_LCD_STATE_LYXX_M0`, so while the LCD sits in `M0_2` the experimental line engine does not get its `update_line_state` call and those cycles go unaccounted for. The correct form 300 lines above is what makes this readable as a slip rather than intent.

Found it reading the file, not running it, so I have not measured what it changes on a real title.
