### PR TITLE
zaurus: Fixed metadata spacing for MI/MT systems

### DIFF
--- a/src/mame/sharp/zaurus.cpp
+++ b/src/mame/sharp/zaurus.cpp
@@ -1820,11 +1820,11 @@ ROM_END
 
 } // anonymous namespace
 
-COMP( 1996, zmi10, 0, 0, mi10, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MI-10 \"Color Zaurus\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-COMP( 1998, zmi310, 0, 0, mi310, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MI-310 \"Color Pocket\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-COMP( 1999, zmt300s, 0, 0, mt300, 0, zaurus_mi_state, empty_init, "Sharp", "Zaurus MT-300-S \"Communication Pal\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-COMP( 2000, zmie1, 0, 0, mie1, 0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E1 (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-COMP( 2001, zmie21, 0, 0, mie21, 0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E21 (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1996, zmi10,   0, 0, mi10,  0, zaurus_mi_state,  empty_init, "Sharp", "Zaurus MI-10 \"Color Zaurus\" (Japan)",         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1998, zmi310,  0, 0, mi310, 0, zaurus_mi_state,  empty_init, "Sharp", "Zaurus MI-310 \"Color Pocket\" (Japan)",        MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 1999, zmt300s, 0, 0, mt300, 0, zaurus_mi_state,  empty_init, "Sharp", "Zaurus MT-300-S \"Communication Pal\" (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 2000, zmie1,   0, 0, mie1,  0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E1 (Japan)",                          MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+COMP( 2001, zmie21,  0, 0, mie21, 0, zaurus_mie_state, empty_init, "Sharp", "Zaurus MI-E21 (Japan)",                         MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 COMP( 2002, zsl5500,  0, 0, zaurus_sa1110, zaurus_sa,  zaurus_sa_state,  empty_init, "Sharp", "Zaurus SL-5500 \"Collie\"",           MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 COMP( 2002, zslc500,  0, 0, zaurus_pxa250, zaurus_pxa, zaurus_pxa_state, empty_init, "Sharp", "Zaurus SL-C500",                      MACHINE_NO_SOUND | MACHINE_NOT_WORKING )


### PR DESCRIPTION
A small cleanup pass for sharp/zaurus.cpp.