### PR TITLE
Sound Canvas SC-88/SC-88 Pro support

### DIFF
--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -3691,6 +3691,23 @@ if CPUS["SWP30"] then
 end
 
 --------------------------------------------------
+-- Roland XP PCM chip and effect DSP
+--@src/devices/sound/roland_xp.h,CPUS["ROLANDXP"] = true
+--------------------------------------------------
+
+if CPUS["ROLANDXP"] then
+	files {
+		MAME_DIR .. "src/devices/sound/roland_xp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_xp.h",
+	}
+end
+
+if opt_tool(CPUS, "ROLANDXP") then
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_xpd.cpp")
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_xpd.h")
+end
+
+--------------------------------------------------
 -- Yamaha DSPV
 --@src/devices/sound/dspv.h,CPUS["DSPV"] = true
 --------------------------------------------------

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -3708,6 +3708,23 @@ if opt_tool(CPUS, "ROLANDXP") then
 end
 
 --------------------------------------------------
+-- Roland LSP (Fujitsu MB87837)
+--@src/devices/sound/roland_lsp.h,CPUS["ROLANDLSP"] = true
+--------------------------------------------------
+
+if CPUS["ROLANDLSP"] then
+	files {
+		MAME_DIR .. "src/devices/sound/roland_lsp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_lsp.h",
+	}
+end
+
+if opt_tool(CPUS, "ROLANDLSP") then
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_lspd.cpp")
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_lspd.h")
+end
+
+--------------------------------------------------
 -- Yamaha DSPV
 --@src/devices/sound/dspv.h,CPUS["DSPV"] = true
 --------------------------------------------------

--- a/src/devices/cpu/h8500/h8510.cpp
+++ b/src/devices/cpu/h8500/h8510.cpp
@@ -51,7 +51,7 @@ void h8510_device::device_add_mconfig(machine_config &config)
 	H8_PORT(config, m_port5, *this, h8500_device::PORT_5, 0xff, 0x00);
 	H8_PORT(config, m_port6, *this, h8500_device::PORT_6, 0xff, 0x00);
 	H8_PORT(config, m_port7, *this, h8500_device::PORT_7, 0xff, 0xf0);
-	H8_PORT(config, m_port8, *this, h8500_device::PORT_8, 0xff, 0x00);
+	H8_PORT(config, m_port8, *this, h8500_device::PORT_8, 0x00, 0x00); // reset to inputs: the IRQ pins are read back through it
 	H8_SCI(config, m_sci[0], 0, *this, m_intc, 52, 53, 54, 55);
 	H8_SCI(config, m_sci[1], 1, *this, m_intc, 56, 57, 58, 59);
 	// the interval interrupt shares the IRQ0 priority level in IPRA but has its own vector
@@ -121,6 +121,8 @@ void h8510_device::internal_map(address_map &map)
 	map(0xff0b, 0xff0b).rw(m_intc, FUNC(h8500_intc_device::dted_r), FUNC(h8500_intc_device::dted_w));
 	map(0xff1c, 0xff1c).rw(m_intc, FUNC(h8500_intc_device::nmicr_r), FUNC(h8500_intc_device::nmicr_w));
 	map(0xff1d, 0xff1d).rw(m_intc, FUNC(h8500_intc_device::irqcr_r), FUNC(h8500_intc_device::irqcr_w));
+
+	map(0xff10, 0xff11).rw(m_watchdog, FUNC(h8_watchdog_device::wd_r), FUNC(h8_watchdog_device::wd_w));
 
 #if 0
 	map(0xfed8, 0xfed8).rw(FUNC(h8510_device::rfshcr_r), FUNC(h8510_device::rfshcr_w));

--- a/src/devices/sound/roland_lsp.cpp
+++ b/src/devices/sound/roland_lsp.cpp
@@ -1,0 +1,461 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+// thanks-to: giulioz
+/*
+ *  Roland LSP (Fujitsu MB87837)
+ *
+ *  Effect processor of the Boss ME-6 and, as the insertion-effect DSP, of the Roland
+ *  SC-88Pro and successors. A 384-instruction program runs once per sample -
+ *  the clock is 2 x 384 x Fs and the program is the sample period, so the chip
+ *  is a CPU with a fixed schedule rather than a streaming sound device: the host PCM
+ *  chip writes the serial inputs, runs one pass and reads the outputs back.
+ *
+ *  Host window: sixteen byte registers, a 24-bit data latch committed by the write of
+ *  the address low byte, a read latch loaded by the read address, and a configuration
+ *  word that starts and halts the program. The address space is 128 words of internal
+ *  RAM below the 384 program words, and the firmware patches individual program words
+ *  while the program runs - the coefficient bytes are the effect's parameters and there
+ *  are no parameter registers.
+ *
+ *  Datapath: two 24-bit accumulators over the internal RAM, which is a delay line whose
+ *  pointer steps back once per sample, so an instruction's 7-bit offset is a fixed
+ *  delay. A store writes the accumulator as it stood three slots earlier, saturating or
+ *  merely narrowed depending on the store field, and it lands before the same slot reads
+ *  its operand. Long delays live in an external DRAM that steps back the same way; an
+ *  access carries no address of its own, but assembles one from the three-bit external
+ *  RAM field of the six slots following an opener eight slots before a write and twelve
+ *  before a read, and it keeps twenty of a word's twenty-four bits. Stereo is by program
+ *  position: the first half of the program is one channel and the second half the other.
+ *
+ *  In the SC-88Pro, the XP is the pump, so the device is halted as far as the scheduler
+ *  is concerned and execute_run() serves the debugger; run_once() is one sample.
+ *
+ *  TODO:
+ *  - the DRAM row/column walk, modelled here as a flat ring
+ *  - what raises INT, and the busy bit's timing
+ *  - the serial word width the configuration word selects
+ *  - whether the program can write the program area
+ */
+#include "emu.h"
+#include "roland_lsp.h"
+
+#include "roland_lspd.h"
+
+#include <algorithm>
+
+#define LOG_HOST    (1U << 1)
+#define LOG_CONFIG  (1U << 2)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(ROLAND_LSP, roland_lsp_device, "roland_lsp", "Roland LSP")
+
+namespace {
+
+// offsets 1 to 4 are not memory reads but a power-of-two operand, so the coefficient is an immediate
+constexpr s32 IMMEDIATE[5] = { 0, 1 << 7, 1 << 12, 1 << 17, 1 << 22 };
+
+constexpr bool is_immediate(int offset) { return offset >= 1 && offset <= 4; }
+
+} // anonymous namespace
+
+roland_lsp_device::roland_lsp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: cpu_device(mconfig, ROLAND_LSP, tag, owner, clock)
+	, m_program_config("program", ENDIANNESS_BIG, 32, 9, -2, address_map_constructor(FUNC(roland_lsp_device::program_map), this))
+{
+}
+
+void roland_lsp_device::program_map(address_map &map)
+{
+	map(0x000, 0x1ff).rw(FUNC(roland_lsp_device::internal_r), FUNC(roland_lsp_device::internal_w));
+}
+
+device_memory_interface::space_config_vector roland_lsp_device::memory_space_config() const
+{
+	return space_config_vector { std::make_pair(AS_PROGRAM, &m_program_config) };
+}
+
+std::unique_ptr<util::disasm_interface> roland_lsp_device::create_disassembler()
+{
+	return std::make_unique<roland_lsp_disassembler>();
+}
+
+void roland_lsp_device::device_start()
+{
+	m_eram = make_unique_clear<s32[]>(ERAM_SIZE);
+	set_icountptr(m_icount);
+
+	state_add(STATE_GENPC, "GENPC", m_pc).noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_pc).noshow();
+	state_add(0, "PC", m_pc);
+	state_add(1, "ACCA", m_acc[0]);
+	state_add(2, "ACCB", m_acc[1]);
+	state_add(3, "BUF", m_buffer_pos);
+	state_add(4, "ERAM", m_eram_pos);
+	state_add(5, "MUL0", m_multiplier[0]);
+	state_add(6, "MUL1", m_multiplier[1]);
+	state_add(7, "TAP", m_tap);
+
+	save_pointer(NAME(m_eram), ERAM_SIZE);
+	save_item(NAME(m_program));
+	save_item(NAME(m_iram));
+	save_item(NAME(m_pc));
+	save_item(NAME(m_slot));
+	save_item(NAME(m_configuration));
+	save_item(NAME(m_running));
+	save_item(NAME(m_halted));
+	save_item(NAME(m_acc));
+	save_item(NAME(m_history));
+	save_item(NAME(m_prev_offset));
+	save_item(NAME(m_eram_read));
+	save_item(NAME(m_multiplier));
+	save_item(NAME(m_eram_latch));
+	save_item(NAME(m_tap));
+	save_item(NAME(m_buffer_pos));
+	save_item(NAME(m_eram_pos));
+	save_item(NAME(m_jump_target));
+	save_item(NAME(m_jump_delay));
+	save_item(NAME(m_serial_in));
+	save_item(NAME(m_serial_out));
+	save_item(NAME(m_audio_out));
+	save_item(NAME(m_host_data));
+	save_item(NAME(m_host_read));
+	save_item(NAME(m_host_address));
+}
+
+void roland_lsp_device::device_reset()
+{
+	std::fill(std::begin(m_program), std::end(m_program), 0);
+	std::fill(std::begin(m_iram), std::end(m_iram), 0);
+	std::fill_n(m_eram.get(), ERAM_SIZE, 0);
+
+	m_icount = 0;
+	m_pc = PROGRAM_BASE;
+	m_slot = 0;
+	m_configuration = 0;
+	m_running = false;
+	m_halted = true;
+
+	m_acc[0] = m_acc[1] = 0;
+	std::fill(&m_history[0][0], &m_history[0][0] + 6, 0);
+	m_prev_offset = 0;
+	m_eram_read = 0;
+	m_multiplier[0] = m_multiplier[1] = 0;
+	m_eram_latch = 0;
+	m_tap = 0;
+	m_buffer_pos = 0;
+	m_eram_pos = 0;
+	m_jump_target = PROGRAM_BASE;
+	m_jump_delay = 0;
+
+	m_serial_in[0] = m_serial_in[1] = 0;
+	m_serial_out[0] = m_serial_out[1] = 0;
+	m_audio_out = 0;
+
+	m_host_data = 0;
+	m_host_read = 0;
+	m_host_address = 0;
+}
+
+roland_lsp_device::instruction roland_lsp_device::decode(u32 word)
+{
+	instruction s;
+	s.opcode = (word >> 21) & 7;
+	s.store = (word >> 19) & 3;
+	s.eram_cmd = (word >> 16) & 7;
+	s.offset = (word >> 8) & 0x7f;
+	s.coefficient = word & 0xff;
+	s.shift = BIT(word, 15) ? 5 : 7;
+	return s;
+}
+
+u32 roland_lsp_device::internal_r(offs_t address)
+{
+	return (address < PROGRAM_BASE) ? (m_iram[address] & 0xffffff) : m_program[address - PROGRAM_BASE];
+}
+
+void roland_lsp_device::internal_w(offs_t address, u32 data)
+{
+	if (address < PROGRAM_BASE)
+		m_iram[address] = narrow(data);
+	else
+		m_program[address - PROGRAM_BASE] = data & 0xffffff;
+}
+
+void roland_lsp_device::configure(u16 word)
+{
+	LOGMASKED(LOG_CONFIG, "configure %04x\n", word);
+
+	m_configuration = word;
+	if (BIT(word, 12))
+		m_running = false;
+	else if (!m_running)
+	{
+		m_running = true;
+		m_pc = PROGRAM_BASE;
+		m_slot = 0;
+		m_jump_delay = 0;
+	}
+}
+
+u8 roland_lsp_device::host_r(offs_t offset)
+{
+	switch (offset & 0x0f)
+	{
+	case HOST_ADDRESS_LOW:  return m_host_read & 0xff;
+	case HOST_ADDRESS_HIGH: return (m_host_read >> 8) & 0xff;
+	case HOST_DATA_LOW:     return (m_host_read >> 16) & 0xff;
+	case HOST_DATA_MID:     return 0;
+	}
+	return 0;
+}
+
+void roland_lsp_device::host_w(offs_t offset, u8 data)
+{
+	switch (offset & 0x0f)
+	{
+	case HOST_ADDRESS_LOW:
+		m_host_address = (m_host_address & 0xff00) | data;
+		LOGMASKED(LOG_HOST, "write %03x = %06x\n", m_host_address & 0x1ff, m_host_data);
+		internal_w(m_host_address & 0x1ff, m_host_data);
+		break;
+
+	case HOST_ADDRESS_HIGH:
+		m_host_address = (m_host_address & 0x00ff) | (data << 8);
+		break;
+
+	case HOST_DATA_LOW:
+		m_host_data = (m_host_data & 0xffff00) | data;
+		break;
+
+	case HOST_DATA_MID:
+		m_host_data = (m_host_data & 0xff00ff) | (data << 8);
+		break;
+
+	case HOST_DATA_HIGH:
+		m_host_data = (m_host_data & 0x00ffff) | (data << 16);
+		break;
+
+	case HOST_CONFIGURE:
+		configure(m_host_data & 0xffff);
+		break;
+
+	case HOST_READ_LOW:
+		m_host_address = (m_host_address & 0xff00) | data;
+		m_host_read = internal_r(m_host_address & 0x1ff);
+		break;
+
+	case HOST_READ_HIGH:
+		m_host_address = (m_host_address & 0x00ff) | (data << 8);
+		break;
+	}
+}
+
+u16 roland_lsp_device::eram_address(int opener, bool read) const
+{
+	u16 base = 0;
+
+	if (opener >= 0)
+	{
+		if ((eram_cmd_at(opener) & 6) == 4)
+		{
+			if (eram_cmd_at(opener + 1) == 2)
+				base = 1;
+			if (read)
+				base += m_tap;
+		}
+		else
+		{
+			for (int n = 0; n < 5; n++)
+				base += eram_cmd_at(opener + 1 + n) << (n * 3);
+			if (BIT(eram_cmd_at(opener + 6), 0))
+				base += eram_cmd_at(opener + 6) << 15;
+		}
+	}
+
+	return m_eram_pos + base;
+}
+
+s32 roland_lsp_device::source(const instruction &s) const
+{
+	const s32 value = m_history[s.store == 2][2];
+	return (s.store == 3) ? narrow(value) : saturate(value);
+}
+
+void roland_lsp_device::multiply(const instruction &s, s32 operand)
+{
+	const u8 code = s.coefficient;
+	const s32 reg = m_multiplier[BIT(code, 1)];
+	s32 &acc = m_acc[BIT(code, 4)];
+	s32 product;
+
+	if (BIT(code, 6))
+		product = s32(((s64(operand) * ((reg & 0xffff) >> 9)) >> s.shift) >> 7);
+	else
+		product = s32((s64(operand) * (reg >> 16)) >> s.shift);
+
+	if (BIT(code, 2))
+		product = -product;
+	if (!code)
+		product = 0;
+
+	acc = (BIT(code, 3) && !BIT(code, 6)) ? product : add(saturate(acc), product);
+}
+
+void roland_lsp_device::special(const instruction &s)
+{
+	const int slot = s.slot();
+	s32 value = s.store ? source(s) : 0;
+	s32 &acc = m_acc[s.opcode & 1];
+
+	switch (slot)
+	{
+	case SLOT_JUMP_NEGATIVE:
+	case SLOT_JUMP_POSITIVE:
+	case SLOT_JUMP:
+		if (slot == SLOT_JUMP || (value < 0) == (slot == SLOT_JUMP_NEGATIVE))
+		{
+			m_jump_target = (s.coefficient << 1) & 0x1ff;
+			m_jump_delay = 2;
+		}
+		return;
+
+	case SLOT_ERAM_WRITE:
+		if (s.store)
+			m_eram_latch = value;
+		else
+		{
+			const s32 previous = is_immediate(m_prev_offset) ? IMMEDIATE[m_prev_offset] : m_iram[iram_address(m_prev_offset)];
+			acc = add(s.replace() ? 0 : acc, s32(((s64(previous) * s.coefficient) >> 8) >> s.shift));
+		}
+		return;
+
+	case SLOT_TAP:
+		if (s.store == 3)
+		{
+			const s32 raw = m_history[0][2];
+			m_tap = u16(raw >> 10);
+			m_multiplier[0] = (raw & 0x3ff) << 13;
+		}
+		return;
+
+	case SLOT_MULTIPLIER:
+	case SLOT_MULTIPLIER + 1:
+		m_multiplier[slot - SLOT_MULTIPLIER] = value;
+		return;
+
+	case SLOT_AUDIO_OUT:
+		m_audio_out = value;
+		if (first_half())
+			m_serial_out[1] = value;
+		break;
+
+	case SLOT_ERAM_READ:
+	case SLOT_ERAM_READ + 1:
+	case SLOT_ERAM_READ + 2:
+	case SLOT_ERAM_READ + 3:
+		if (s.store)
+			m_eram_read = m_eram[eram_address(m_pc - 12 - PROGRAM_BASE, true)] << 4;
+		value = m_eram_read;
+		break;
+
+	case SLOT_AUDIO_IN:
+		value = m_serial_in[first_half()];
+		break;
+
+	default:
+		return;
+	}
+
+	m_iram[iram_address(0x60 + slot)] = value;
+	acc = add(s.replace() ? 0 : acc, s32((s64(value) * s8(s.coefficient)) >> s.shift));
+}
+
+void roland_lsp_device::step()
+{
+	const u32 raw = m_program[m_pc - PROGRAM_BASE];
+	const instruction s = decode(raw);
+
+	if (raw && s.opcode >= OP_SPECIAL_A)
+		special(s);
+	else if (raw)
+	{
+		const int address = iram_address(s.offset);
+		if (s.store)
+			m_iram[address] = source(s);
+
+		const s32 operand = s.immediate() ? IMMEDIATE[s.offset] : m_iram[address];
+		const s32 product = s32((s64(operand) * s8(s.coefficient)) >> s.shift);
+
+		switch (s.opcode)
+		{
+		case OP_MAC_A: m_acc[0] = add(m_acc[0], product); break;
+		case OP_SET_A: m_acc[0] = product; break;
+		case OP_MAC_B: m_acc[1] = add(m_acc[1], product); break;
+		case OP_SET_B: m_acc[1] = product; break;
+		case OP_MUL:   multiply(s, s.immediate() ? operand * s8(s.coefficient) : operand); break;
+		case OP_ABS:   m_acc[0] = std::abs(product); break;
+		}
+	}
+
+	for (int n = 0; n < 2; n++)
+	{
+		m_history[n][2] = m_history[n][1];
+		m_history[n][1] = m_history[n][0];
+		m_history[n][0] = m_acc[n];
+	}
+	m_prev_offset = s.offset;
+
+	if (raw && s.opcode >= OP_SPECIAL_A && s.slot() == SLOT_ERAM_WRITE && s.store)
+		m_eram[eram_address(m_pc - 8 - PROGRAM_BASE, false)] = m_eram_latch >> 4;
+
+	if (m_jump_delay && !--m_jump_delay)
+		m_pc = m_jump_target;
+	else if (++m_pc >= PROGRAM_BASE + PROGRAM_SIZE)
+		m_pc = PROGRAM_BASE;
+
+	if (++m_slot >= PROGRAM_SIZE || m_pc == PROGRAM_BASE)
+	{
+		finish_sample();
+		m_pc = PROGRAM_BASE;
+		m_slot = 0;
+	}
+}
+
+void roland_lsp_device::finish_sample()
+{
+	m_serial_out[0] = m_audio_out;
+	m_jump_delay = 0;
+	m_buffer_pos = (m_buffer_pos - 1) & 0x7f;
+	m_eram_pos--;
+}
+
+void roland_lsp_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		if (m_halted || !m_running)
+		{
+			m_icount = 0;
+			return;
+		}
+
+		debugger_instruction_hook(m_pc);
+		step();
+		m_icount--;
+	}
+}
+
+void roland_lsp_device::run_once()
+{
+	m_halted = false;
+	for (int n = 0; m_running && n < PROGRAM_SIZE; n++)
+	{
+		m_icount = 1;
+		execute_run();
+		if (!m_slot)
+			break;
+	}
+	m_halted = true;
+}

--- a/src/devices/sound/roland_lsp.h
+++ b/src/devices/sound/roland_lsp.h
@@ -1,0 +1,140 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_LSP_H
+#define MAME_SOUND_ROLAND_LSP_H
+
+#pragma once
+
+class roland_lsp_device : public cpu_device
+{
+public:
+	static constexpr int PROGRAM_SIZE = 384;
+	static constexpr int PROGRAM_BASE = 0x080;
+	static constexpr int IRAM_SIZE = 0x80;
+	static constexpr int ERAM_SIZE = 0x10000;
+
+	// the slots of the two special opcodes, by slot number
+	enum special_slot
+	{
+		SLOT_JUMP_NEGATIVE = 0x0d, SLOT_JUMP_POSITIVE = 0x0e, SLOT_JUMP = 0x0f,
+		SLOT_ERAM_WRITE = 0x10, SLOT_TAP = 0x13, SLOT_MULTIPLIER = 0x14,
+		SLOT_AUDIO_OUT = 0x18, SLOT_ERAM_READ = 0x1a, SLOT_AUDIO_IN = 0x1e
+	};
+
+	// the sixteen host registers at CA0-3
+	enum host_register
+	{
+		HOST_ADDRESS_LOW = 0x00, HOST_ADDRESS_HIGH = 0x01, HOST_DATA_LOW = 0x02,
+		HOST_DATA_MID = 0x03, HOST_DATA_HIGH = 0x04, HOST_CONFIGURE = 0x06,
+		HOST_READ_LOW = 0x08, HOST_READ_HIGH = 0x09
+	};
+
+	roland_lsp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	u8 host_r(offs_t offset);
+	void host_w(offs_t offset, u8 data);
+
+	// TRR in and TRS0 out, channel 0 left and 1 right, one pair per sample
+	void ser_w(int channel, s32 sample) { m_serial_in[channel & 1] = sample; }
+	s32 ser_r(int channel) const { return m_serial_out[channel & 1]; }
+	void run_once();
+
+protected:
+	// device_t implementation
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	// device_execute_interface implementation
+	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 1) / 2; }
+	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return cycles * 2; }
+	virtual u32 execute_min_cycles() const noexcept override { return 1; }
+	virtual u32 execute_max_cycles() const noexcept override { return 1; }
+	virtual void execute_run() override;
+
+	// device_memory_interface implementation
+	virtual space_config_vector memory_space_config() const override;
+
+	// device_disasm_interface implementation
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+	// one instruction word, split into its fields
+	struct instruction
+	{
+		u8 opcode;
+		u8 store;
+		u8 eram_cmd;
+		u8 offset;
+		u8 coefficient;
+		u8 shift;
+
+		int slot() const { return offset & 0x1f; }
+		bool replace() const { return BIT(offset, 5); }
+		bool immediate() const { return offset >= 1 && offset <= 4; }
+	};
+
+	enum opcode_family
+	{
+		OP_MAC_A = 0, OP_SET_A = 1, OP_MAC_B = 2, OP_SET_B = 3,
+		OP_MUL = 4, OP_ABS = 5, OP_SPECIAL_A = 6, OP_SPECIAL_B = 7
+	};
+
+	static instruction decode(u32 word);
+
+	static s32 saturate(s32 value) { return std::clamp<s32>(value, -0x800000, 0x7fffff); }
+	static s32 narrow(s32 value) { return s32(u32(value) << 8) >> 8; }
+	static s32 add(s32 accumulator, s32 term) { return s32(u32(accumulator) + u32(term)); }
+
+	void program_map(address_map &map) ATTR_COLD;
+
+	u32 internal_r(offs_t address);
+	void internal_w(offs_t address, u32 data);
+	void configure(u16 word);
+
+	u8 eram_cmd_at(int index) const { return (m_program[index % PROGRAM_SIZE] >> 16) & 7; }
+	u16 eram_address(int opener, bool read) const;
+	int iram_address(int offset) const { return (offset + m_buffer_pos) & 0x7f; }
+	bool first_half() const { return m_pc < PROGRAM_BASE + PROGRAM_SIZE / 2; }
+
+	s32 source(const instruction &s) const;
+	void multiply(const instruction &s, s32 operand);
+	void special(const instruction &s);
+	void step();
+	void finish_sample();
+
+	address_space_config m_program_config;
+
+	std::unique_ptr<s32[]> m_eram;
+	u32 m_program[PROGRAM_SIZE];
+	s32 m_iram[IRAM_SIZE];
+
+	int m_icount;
+	u16 m_pc;
+	u16 m_slot;
+	u16 m_configuration;
+	bool m_running;
+	bool m_halted;
+
+	s32 m_acc[2];
+	s32 m_history[2][3];
+	s32 m_eram_read;
+	u8 m_prev_offset;
+	s32 m_multiplier[2];
+	s32 m_eram_latch;
+	u16 m_tap;
+	u8 m_buffer_pos;
+	u16 m_eram_pos;
+	u16 m_jump_target;
+	u8 m_jump_delay;
+
+	s32 m_serial_in[2];
+	s32 m_serial_out[2];
+	s32 m_audio_out;
+
+	u32 m_host_data;
+	u32 m_host_read;
+	u16 m_host_address;
+};
+
+DECLARE_DEVICE_TYPE(ROLAND_LSP, roland_lsp_device)
+
+#endif // MAME_SOUND_ROLAND_LSP_H

--- a/src/devices/sound/roland_lspd.cpp
+++ b/src/devices/sound/roland_lspd.cpp
@@ -1,0 +1,130 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/*
+ *  Roland LSP (MB87837) disassembler
+ */
+#include "emu.h"
+#include "roland_lspd.h"
+
+namespace {
+
+const char *const ACCUMULATOR[4] = { "", "accA", "accB", "accA!" };
+
+// offsets 1 to 4 read a power of two instead of memory, so the coefficient becomes an immediate
+const int IMMEDIATE[5] = { 0, 7, 12, 17, 22 };
+
+void operand(std::ostream &stream, u8 offset)
+{
+	if (offset >= 1 && offset <= 4)
+		util::stream_format(stream, "#%d", IMMEDIATE[offset]);
+	else
+		util::stream_format(stream, "$%02x", offset);
+}
+
+void product(std::ostream &stream, u8 offset, u8 coefficient, int shift)
+{
+	operand(stream, offset);
+	util::stream_format(stream, "*%c%02x>>%d", BIT(coefficient, 7) ? '-' : '+', BIT(coefficient, 7) ? -s8(coefficient) & 0xff : coefficient, shift);
+}
+
+void slot_source(std::ostream &stream, int slot, u8 coefficient)
+{
+	switch (slot)
+	{
+	case 0x18: stream << "audio_out"; break;
+	case 0x1a: case 0x1b: case 0x1c: case 0x1d: util::stream_format(stream, "eram%d", slot - 0x1a); break;
+	case 0x1e: stream << "audio_in"; break;
+	default:   util::stream_format(stream, "slot%02x", slot); break;
+	}
+}
+
+} // anonymous namespace
+
+void roland_lsp_disassembler::describe(std::ostream &stream, offs_t pc, u32 word)
+{
+	const int op = (word >> 21) & 7;
+	const int store = (word >> 19) & 3;
+	const int eram = (word >> 16) & 7;
+	const int shift = BIT(word, 15) ? 5 : 7;
+	const u8 offset = (word >> 8) & 0x7f;
+	const u8 coefficient = word & 0xff;
+	const int slot = offset & 0x1f;
+	const bool replace = BIT(offset, 5);
+
+	if (op < 6 && store)
+		util::stream_format(stream, "[$%02x] = %s, ", offset, ACCUMULATOR[store]);
+
+	switch (op)
+	{
+	case 0: case 1: case 2: case 3:
+		util::stream_format(stream, "acc%c %s ", (op & 2) ? 'B' : 'A', (op & 1) ? " =" : "+=");
+		product(stream, offset, coefficient, shift);
+		break;
+
+	case 4:
+		util::stream_format(stream, "acc%c %s %c", BIT(coefficient, 4) ? 'B' : 'A',
+			(BIT(coefficient, 3) && !BIT(coefficient, 6)) ? " =" : "+=", BIT(coefficient, 2) ? '-' : ' ');
+		operand(stream, offset);
+		util::stream_format(stream, "*mul%d%s>>%d", BIT(coefficient, 1), BIT(coefficient, 6) ? ".lo" : ".hi", shift);
+		break;
+
+	case 5:
+		stream << "accA  = |";
+		product(stream, offset, coefficient, shift);
+		stream << '|';
+		break;
+
+	default:
+		switch (slot)
+		{
+		case 0x0d: case 0x0e: case 0x0f:
+			util::stream_format(stream, "%s %03x", (slot == 0x0d) ? "jmpn" : (slot == 0x0e) ? "jmpp" : "jmp ", coefficient << 1);
+			if (store)
+				util::stream_format(stream, ", %s", ACCUMULATOR[store]);
+			break;
+
+		case 0x10:
+			if (store)
+				util::stream_format(stream, "eram = %s", ACCUMULATOR[store]);
+			else
+			{
+				util::stream_format(stream, "acc%c %s prev*%02x>>%d", (op & 1) ? 'B' : 'A', replace ? " =" : "+=", coefficient, 8 + shift);
+			}
+			break;
+
+		case 0x13:
+			util::stream_format(stream, "tap:mul0 = %s", ACCUMULATOR[store]);
+			break;
+
+		case 0x14: case 0x15:
+			util::stream_format(stream, "mul%d = %s", slot - 0x14, ACCUMULATOR[store]);
+			break;
+
+		case 0x18:
+			util::stream_format(stream, "audio_out = %s", ACCUMULATOR[store]);
+			if (replace)
+				util::stream_format(stream, ", acc%c = 0", (op & 1) ? 'B' : 'A');
+			break;
+
+		case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e:
+			util::stream_format(stream, "acc%c %s ", (op & 1) ? 'B' : 'A', replace ? " =" : "+=");
+			slot_source(stream, slot, coefficient);
+			util::stream_format(stream, "*%c%02x>>%d", BIT(coefficient, 7) ? '-' : '+', BIT(coefficient, 7) ? -s8(coefficient) & 0xff : coefficient, shift);
+			break;
+
+		default:
+			util::stream_format(stream, "slot%02x = %s", slot, ACCUMULATOR[store]);
+			break;
+		}
+		break;
+	}
+
+	if (eram)
+		util::stream_format(stream, "  ; e%d", eram);
+}
+
+offs_t roland_lsp_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	describe(stream, pc, opcodes.r32(pc) & 0xffffff);
+	return 1 | SUPPORTED;
+}

--- a/src/devices/sound/roland_lspd.h
+++ b/src/devices/sound/roland_lspd.h
@@ -1,0 +1,20 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_LSPD_H
+#define MAME_SOUND_ROLAND_LSPD_H
+
+#pragma once
+
+class roland_lsp_disassembler : public util::disasm_interface
+{
+public:
+	roland_lsp_disassembler() = default;
+	virtual ~roland_lsp_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override { return 1; }
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
+	static void describe(std::ostream &stream, offs_t pc, u32 word);
+};
+
+#endif // MAME_SOUND_ROLAND_LSPD_H

--- a/src/devices/sound/roland_xp.cpp
+++ b/src/devices/sound/roland_xp.cpp
@@ -1,0 +1,1284 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+// thanks-to: giulioz
+/*
+ *  Roland XP (MBCS30109/RA01-005)
+ *
+ *  64-voice custom sound generator with built-in microcoded effect DSP.
+ *
+ *  Host window: 44 voice pages of 64 x 32 bits (page * 0x100 + voice * 4, high word first,
+ *  committed by the low word), CRAM/IRAM/PRAM of the effect DSP, the control block at 0x3900
+ *  (run mask, readback latch, interrupt status/acknowledge, ROM window page/bank), four
+ *  banks of mixer sends at 0x3a00 and the wave ROM access window at 0x3c00.
+ *
+ *  Voice: DPCM reader with forward, alternate and reverse loops over 1 MB ROM regions,
+ *  4-tap 128-phase interpolator, Chamberlin state-variable filter, two amplitude gains and
+ *  four sends (10-bit level, 6-bit destination word). The five ramps per voice (pitch,
+ *  cutoff, resonance, two amplitudes) update every 8 frames, the first amplitude every 2,
+ *  with a rate, a hold divider and a law selected by their control word. Pitch and cutoff
+ *  registers are logarithmic (16384 per octave, unity 0x38000 for pitch), decoded through
+ *  a 257-entry exponential.
+ *
+ *  DSP: 256 instruction slots per frame over 256 24-bit words of internal RAM (the 64 mixer
+ *  bus words land in words 0x40-0x7f, words 0xf0-0xff are the host-ramped gain registers)
+ *  and a 64K-word external delay ring addressed relative to a cursor that steps back once
+ *  per frame. Each slot reads a word into the operand register, forms one product (operand
+ *  x coefficient, or x a gain register under the 42xx coefficient codes) and applies its
+ *  ALU operation to the previous slot's product, so the pipeline is three slots deep; ERAM
+ *  accesses span two slots and a read lands two slots after its start; a third access kind
+ *  stores the sample on the chip's serial input. The mixer bus enters the DSP four bits down
+ *  (the SC-88 program's output stage is x32 on its dry words; with less a loud GS song
+ *  saturates the output words).
+ *
+ *  Outputs: the program's output stage stores into RAM words 00-07, and the chip's three serial
+ *  data lines clock six of them out a frame, one per line per half. The stream carries all eight
+ *  as the lines present them - the word one bit up, saturated to 24 bits - and the board's DACs
+ *  take whichever pairs its program stores (SC-88 01/04; SC-88Pro 02/03 and 06/07 for its two
+ *  DAC pairs; JV-1080 00/03, 01/04, 02/05 for its three), which is the driver's routing. How the
+ *  chip's own configuration words pick the six is not known.
+ *
+ *  Serial link: once a frame the chip clocks a stereo pair out of two of its RAM words on the
+ *  same terms (set_serial_output_words(), the SC-88Pro's effect-processor send) and takes a pair back.
+ *  An ext strobe of 1 presents one channel of that pair - the first strobe of a frame the
+ *  first channel, the next the other - and it lands on the external RAM bus two slots later,
+ *  the same latency a read has, so a write in that slot stores it instead of the accumulator;
+ *  the third kind of access stores it wherever it is issued. The program reads the cells back
+ *  in its output stage, one per channel. Which words a board sends is a per-board fact, as the
+ *  DAC pair is; the exchange is one callback each way, so the processor on the other end is
+ *  the driver's business.
+ *
+ *  The DSP program is the chip's schedule - one pass of the 256 slots is one sample - so the
+ *  device is a CPU as much as a sound chip: execute_run() steps slots, the voices run when the
+ *  program wraps, and the output stream is synchronous, taking whatever the pass left in the
+ *  output words.
+ *
+ *  TODO:
+ *  - readback timing
+ *  - wait states
+ *  - master/slave configuration (used by SC-8850)
+ *  - the rest of the DSP ext (serial I/O strobe) field: which pins a strobe drives
+ *  - DSP branch/PRNG
+ *  - fetch-overload or filter ramp interrupts (not used on SC-88 family)
+ *  - figure out the meaning of the unnamed voice pages and of the configuration words
+ */
+#include "emu.h"
+#include "roland_xp.h"
+
+#include "roland_xpd.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#define LOG_VOICE   (1U << 1)
+#define LOG_CRAM    (1U << 2)
+#define LOG_IRAM    (1U << 3)
+#define LOG_PRAM    (1U << 4)
+#define LOG_RUNMASK (1U << 5)
+#define LOG_CTRL    (1U << 6)
+#define LOG_MIX     (1U << 7)
+#define LOG_READ    (1U << 8)
+#define LOG_UNKNOWN (1U << 9)
+
+#define VERBOSE (LOG_GENERAL | LOG_UNKNOWN)
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(ROLAND_XP, roland_xp_device, "roland_xp", "Roland XP")
+
+namespace {
+
+const s16 interp_weights[3][128] = {
+	{
+		3385, 3401, 3417, 3432, 3448, 3463, 3478, 3492, 3506, 3521, 3534, 3548, 3562, 3575, 3588, 3601,
+		3614, 3626, 3638, 3650, 3662, 3673, 3685, 3696, 3707, 3718, 3728, 3739, 3749, 3759, 3768, 3778,
+		3787, 3796, 3805, 3814, 3823, 3831, 3839, 3847, 3855, 3863, 3870, 3878, 3885, 3892, 3899, 3905,
+		3912, 3918, 3924, 3930, 3936, 3942, 3948, 3953, 3958, 3963, 3968, 3973, 3978, 3983, 3987, 3991,
+		3995, 4000, 4004, 4007, 4011, 4015, 4018, 4022, 4025, 4028, 4031, 4034, 4037, 4040, 4042, 4045,
+		4047, 4050, 4052, 4054, 4057, 4059, 4061, 4063, 4064, 4066, 4068, 4070, 4071, 4073, 4074, 4076,
+		4077, 4078, 4079, 4081, 4082, 4083, 4084, 4085, 4086, 4086, 4087, 4088, 4089, 4089, 4090, 4091,
+		4091, 4092, 4092, 4093, 4093, 4094, 4094, 4094, 4094, 4095, 4095, 4095, 4095, 4095, 4095, 4095,
+	},
+	{
+		 710,  726,  742,  758,  775,  792,  809,  826,  844,  861,  879,  897,  915,  933,  952,  971,
+		 990, 1009, 1028, 1047, 1067, 1087, 1106, 1126, 1147, 1167, 1188, 1208, 1229, 1250, 1271, 1292,
+		1314, 1335, 1357, 1379, 1400, 1423, 1445, 1467, 1489, 1512, 1534, 1557, 1580, 1602, 1625, 1648,
+		1671, 1695, 1718, 1741, 1764, 1788, 1811, 1835, 1858, 1882, 1906, 1929, 1953, 1977, 2000, 2024,
+		2048, 2069, 2095, 2119, 2143, 2166, 2190, 2214, 2237, 2261, 2284, 2308, 2331, 2355, 2378, 2401,
+		2425, 2448, 2471, 2494, 2517, 2539, 2562, 2585, 2607, 2630, 2652, 2674, 2696, 2718, 2740, 2762,
+		2783, 2805, 2826, 2847, 2868, 2889, 2910, 2931, 2951, 2971, 2991, 3011, 3031, 3051, 3070, 3089,
+		3108, 3127, 3146, 3164, 3182, 3200, 3218, 3236, 3253, 3271, 3288, 3304, 3321, 3338, 3354, 3370,
+	},
+	{
+		   0,    0,    0,    1,    1,    1,    2,    2,    3,    3,    3,    4,    4,    5,    5,    6,
+		   6,    7,    8,    8,    9,   10,   10,   11,   12,   13,   14,   15,   16,   17,   18,   19,
+		  20,   22,   23,   24,   26,   27,   29,   30,   32,   34,   36,   38,   40,   42,   44,   46,
+		  49,   51,   53,   56,   59,   62,   65,   68,   71,   74,   77,   81,   84,   88,   92,   96,
+		 100,  104,  109,  113,  118,  122,  127,  132,  137,  143,  148,  154,  160,  165,  171,  178,
+		 184,  191,  197,  204,  211,  219,  226,  234,  241,  249,  257,  266,  274,  283,  292,  301,
+		 310,  319,  329,  339,  349,  359,  369,  380,  391,  402,  413,  424,  436,  448,  460,  472,
+		 484,  497,  510,  523,  536,  549,  563,  577,  591,  605,  619,  634,  648,  663,  679,  694,
+	},
+};
+
+const u32 hold_masks[4] = { 0, 7, 31, 127 };
+
+constexpr s32 wrap_add(s32 a, s32 b) { return s32(u32(a) + u32(b)); }
+
+} // anonymous namespace
+
+
+//-------------------------------------------------
+//  ramps
+//-------------------------------------------------
+
+s32 roland_xp_device::exp_decode(s32 value) const
+{
+	if (value == 0)
+		return 0;
+
+	const int index = (value >> 6) & 0xff;
+	const int fraction = value & 0x3f;
+	s32 v = m_exp_table[index] * (64 - fraction) + m_exp_table[index + 1] * fraction;
+	v = (v + (v < 0 ? 63 : 0)) >> 6;
+	return v >> (15 - ((value >> 14) & 15));
+}
+
+u32 roland_xp_device::ramp::hold_mask() const
+{
+	return hold_masks[(control >> 12) & 3];
+}
+
+roland_xp_device::ramp_law roland_xp_device::ramp::control_law() const
+{
+	switch (control >> 14)
+	{
+	case 0: return LAW_EXPONENTIAL;
+	case 1: return LAW_LINEAR;
+	default: return LAW_S_CURVE;
+	}
+}
+
+void roland_xp_device::ramp::seed(s32 value, ramp_law law)
+{
+	current = value;
+	previous = value;
+	counter = 0;
+	accumulator = s32(u32(value) << 10);
+	arm(law);
+}
+
+void roland_xp_device::ramp::retarget(s32 value, ramp_law law)
+{
+	target = value;
+	accumulator = s32(u32(current) << 10);
+	arm(law);
+}
+
+void roland_xp_device::ramp::configure(u16 value, ramp_law law)
+{
+	control = value;
+	arm(law);
+}
+
+void roland_xp_device::ramp::configure(u16 value)
+{
+	control = value;
+	arm(control_law());
+}
+
+void roland_xp_device::ramp::arm(ramp_law law)
+{
+	switch (law)
+	{
+	case LAW_LINEAR:
+		step = s32((s64(target) - current) * rate() >> 13);
+		if (step == 0 && target > current)
+			step = 1;
+		active = current != target;
+		break;
+
+	case LAW_EXPONENTIAL:
+		active = current != target;
+		break;
+
+	case LAW_S_CURVE:
+		target = 0;
+		step = 0;
+		midpoint = current / 2;
+		active = current != 0;
+		break;
+	}
+}
+
+bool roland_xp_device::ramp::update(ramp_law law)
+{
+	previous = current;
+	if (!active)
+		return false;
+
+	counter++;
+	if (counter & hold_mask())
+		return false;
+
+	switch (law)
+	{
+	case LAW_LINEAR:
+		current += step;
+		current = (step > 0) ? std::min(current, target) : std::max(current, target);
+		if (current == target)
+		{
+			step = 0;
+			active = false;
+		}
+		break;
+
+	case LAW_EXPONENTIAL:
+	{
+		const s32 error = s16((s32(u32(target) << 10) - accumulator) >> 13);
+		s32 delta = error * rate();
+		delta = (delta < 0) ? std::min(delta, -0x400) : std::max(delta, 0x400);
+		accumulator += delta;
+		current = accumulator >> 10;
+		active = current != target;
+		break;
+	}
+
+	case LAW_S_CURVE:
+		if (current > midpoint)
+		{
+			step -= rate();
+			current += step;
+		}
+		else
+		{
+			step += rate();
+			current = (step > 0) ? 0 : current + step;
+		}
+		if (current == 0)
+			active = false;
+		break;
+	}
+
+	return !active;
+}
+
+s32 roland_xp_device::ramp::value_at(int phase, int period) const
+{
+	return previous + s32((s64(current - previous) * (phase + 1)) / period);
+}
+
+s16 roland_xp_device::ramp::coefficient() const
+{
+	return s16(std::clamp<s32>(current >> 3, -0x8000, 0x7fff));
+}
+
+s16 roland_xp_device::ramp::coefficient(int phase, int period) const
+{
+	return s16(std::clamp<s32>(value_at(phase, period) >> 3, -0x8000, 0x7fff));
+}
+
+
+//-------------------------------------------------
+//  device
+//-------------------------------------------------
+
+roland_xp_device::roland_xp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: cpu_device(mconfig, ROLAND_XP, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_pram_config("pram", ENDIANNESS_BIG, 32, 10, -2, address_map_constructor(FUNC(roland_xp_device::pram_map), this))
+	, m_wave_config("wave", ENDIANNESS_LITTLE, 8, 27)
+	, m_iram_config("iram", ENDIANNESS_BIG, 32, 10, -2, address_map_constructor(FUNC(roland_xp_device::iram_map), this))
+	, m_eram_config("eram", ENDIANNESS_BIG, 32, 18, -2, address_map_constructor(FUNC(roland_xp_device::eram_map), this))
+	, m_int_callback(*this)
+	, m_serial_out_cb(*this)
+	, m_serial_in_cb(*this, 0)
+	, m_stream(nullptr)
+	, m_run_mask(0)
+	, m_read_latch(0)
+	, m_frame_counter(0)
+	, m_noise(0)
+	, m_irq_head(0)
+	, m_irq_count(0)
+	, m_int_state(false)
+	, m_landing_valid(0)
+	, m_program_dirty(true)
+	, m_dsp_enabled(false)
+	, m_icount(0)
+	, m_pc(0)
+	, m_serial_out_word{ 0, 0 }
+	, m_serial_frame{ 0, 0 }
+	, m_serial_in(0)
+	, m_serial_phase(0)
+{
+}
+
+void roland_xp_device::pram_map(address_map &map)
+{
+	map(0x000, 0x3ff).rw(FUNC(roland_xp_device::pram_r), FUNC(roland_xp_device::pram_w));
+}
+
+void roland_xp_device::iram_map(address_map &map)
+{
+	map(0x000, 0x3ff).rw(FUNC(roland_xp_device::iram_r), FUNC(roland_xp_device::iram_w));
+}
+
+void roland_xp_device::eram_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).rw(FUNC(roland_xp_device::eram_r), FUNC(roland_xp_device::eram_w));
+}
+
+device_memory_interface::space_config_vector roland_xp_device::memory_space_config() const
+{
+	return space_config_vector {
+		std::make_pair(AS_PROGRAM, &m_pram_config),
+		std::make_pair(AS_WAVE, &m_wave_config),
+		std::make_pair(AS_IRAM, &m_iram_config),
+		std::make_pair(AS_ERAM, &m_eram_config)
+	};
+}
+
+std::unique_ptr<util::disasm_interface> roland_xp_device::create_disassembler()
+{
+	return std::make_unique<roland_xp_disassembler>(this);
+}
+
+u32 roland_xp_device::pram_r(offs_t address)
+{
+	const int word = (PRAM_BASE >> 1) + (address & 0xff) * 2;
+	return (u32(m_regs[word]) << 16) | m_regs[word | 1];
+}
+
+void roland_xp_device::pram_w(offs_t address, u32 data)
+{
+	const int word = (PRAM_BASE >> 1) + (address & 0xff) * 2;
+	m_regs[word] = u16(data >> 16);
+	m_regs[word | 1] = u16(data);
+	m_program_dirty = true;
+}
+
+void roland_xp_device::device_start()
+{
+	m_regs = make_unique_clear<u16[]>(0x2000);
+	m_eram = make_unique_clear<s32[]>(ERAM_SIZE);
+	space(AS_WAVE).cache(m_wave_cache);
+	m_stream = stream_alloc(0, OUTPUT_WORDS, clock() / 768, STREAM_SYNCHRONOUS);
+
+	for (int i = 0; i < 256; i++)
+		m_exp_table[i] = s32(std::floor(std::exp2(17.0 + i / 257.0)));
+	m_exp_table[256] = 1 << 18;
+
+	set_icountptr(m_icount);
+
+	state_add(STATE_GENPC, "GENPC", m_pc).noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_pc).noshow();
+	state_add(0, "PC", m_pc);
+	state_add(1, "ACC", m_dsp.acc);
+	state_add(2, "R", m_dsp.r);
+	state_add(3, "MEM", m_dsp.mem);
+	state_add(4, "P", m_dsp.product);
+	state_add(5, "LATCH", m_dsp.latch);
+	state_add(6, "G", m_dsp.gain);
+	state_add(7, "CURSOR", m_dsp.cursor);
+	state_add(8, "F", m_dsp.fraction);
+
+	save_pointer(NAME(m_regs), 0x2000);
+	save_pointer(NAME(m_eram), ERAM_SIZE);
+	save_item(NAME(m_iram));
+	save_item(NAME(m_iram_ramping));
+	save_item(NAME(m_dsp.acc));
+	save_item(NAME(m_dsp.acc_before));
+	save_item(NAME(m_dsp.acc_before_prev));
+	save_item(NAME(m_dsp.product));
+	save_item(NAME(m_dsp.product_prev));
+	save_item(NAME(m_dsp.r));
+	save_item(NAME(m_dsp.r_prev));
+	save_item(NAME(m_dsp.mem));
+	save_item(NAME(m_dsp.mem_prev));
+	save_item(NAME(m_dsp.now));
+	save_item(NAME(m_dsp.latch));
+	save_item(NAME(m_dsp.gain));
+	save_item(NAME(m_dsp.r_age));
+	save_item(NAME(m_dsp.latch_age));
+	save_item(NAME(m_dsp.now_valid));
+	save_item(NAME(m_dsp.fraction));
+	save_item(NAME(m_dsp.cursor));
+	save_item(NAME(m_landing));
+	save_item(NAME(m_landing_valid));
+	save_item(NAME(m_dsp_enabled));
+	save_item(NAME(m_pc));
+	save_item(NAME(m_serial_out_word));
+	save_item(NAME(m_serial_frame));
+	save_item(NAME(m_serial_in));
+	save_item(NAME(m_serial_phase));
+	save_item(NAME(m_bus));
+	save_item(NAME(m_run_mask));
+	save_item(NAME(m_read_latch));
+	save_item(NAME(m_frame_counter));
+	save_item(NAME(m_noise));
+	save_item(NAME(m_irq_queue));
+	save_item(NAME(m_irq_head));
+	save_item(NAME(m_irq_count));
+	save_item(NAME(m_int_state));
+
+	save_item(STRUCT_MEMBER(m_voices, region));
+	save_item(STRUCT_MEMBER(m_voices, start));
+	save_item(STRUCT_MEMBER(m_voices, address));
+	save_item(STRUCT_MEMBER(m_voices, loop));
+	save_item(STRUCT_MEMBER(m_voices, end));
+	save_item(STRUCT_MEMBER(m_voices, start_pending));
+	save_item(STRUCT_MEMBER(m_voices, alternate));
+	save_item(STRUCT_MEMBER(m_voices, reverse));
+	save_item(STRUCT_MEMBER(m_voices, backward));
+	save_item(STRUCT_MEMBER(m_voices, reading));
+	save_item(STRUCT_MEMBER(m_voices, loop_reported));
+	save_item(STRUCT_MEMBER(m_voices, done_reported));
+	save_item(STRUCT_MEMBER(m_voices, sub_phase));
+	save_item(STRUCT_MEMBER(m_voices, predictor));
+	save_item(STRUCT_MEMBER(m_voices, filter_low));
+	save_item(STRUCT_MEMBER(m_voices, filter_band));
+
+	for (int n = 0; n < MAX_VOICES; n++)
+	{
+		ramp *const ramps[5] = { &m_voices[n].pitch, &m_voices[n].tvf, &m_voices[n].reso, &m_voices[n].tva1, &m_voices[n].tva2 };
+		for (int k = 0; k < 5; k++)
+		{
+			ramp &r = *ramps[k];
+			const int index = n * 5 + k;
+			save_item(NAME(r.current), index);
+			save_item(NAME(r.previous), index);
+			save_item(NAME(r.target), index);
+			save_item(NAME(r.step), index);
+			save_item(NAME(r.accumulator), index);
+			save_item(NAME(r.midpoint), index);
+			save_item(NAME(r.control), index);
+			save_item(NAME(r.counter), index);
+			save_item(NAME(r.active), index);
+		}
+	}
+}
+
+void roland_xp_device::device_reset()
+{
+	std::fill_n(m_regs.get(), 0x2000, 0);
+	std::fill_n(m_eram.get(), ERAM_SIZE, 0);
+	std::fill(std::begin(m_bus), std::end(m_bus), 0);
+	std::fill(std::begin(m_iram), std::end(m_iram), 0);
+	std::fill(std::begin(m_iram_ramping), std::end(m_iram_ramping), 0);
+	for (voice &v : m_voices)
+		v = voice();
+	m_dsp = dsp_state();
+	m_dsp.latch_age = 0xff;
+	m_dsp.r_age = 0xff;
+	std::fill(std::begin(m_landing), std::end(m_landing), 0);
+	m_landing_valid = 0;
+	m_program_dirty = true;
+	m_dsp_enabled = false;
+	m_pc = 0;
+
+	m_run_mask = 0;
+	m_read_latch = 0;
+	m_frame_counter = 0;
+	m_noise = 0x2545f491;
+	m_irq_head = 0;
+	m_irq_count = 0;
+	update_int();
+}
+
+void roland_xp_device::device_clock_changed()
+{
+	m_stream->set_sample_rate(clock() / 768);
+}
+
+void roland_xp_device::device_post_load()
+{
+	m_program_dirty = true;
+}
+
+void roland_xp_device::update_int()
+{
+	const bool state = m_irq_count != 0;
+	if (state != m_int_state)
+	{
+		m_int_state = state;
+		m_int_callback(state ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+void roland_xp_device::raise_irq(int voice, int reason)
+{
+	if (m_irq_count == MAX_VOICES)
+		return;
+
+	m_irq_queue[(m_irq_head + m_irq_count) % MAX_VOICES] = u16((voice << 8) | reason);
+	m_irq_count++;
+	update_int();
+}
+
+
+//-------------------------------------------------
+//  host interface
+//-------------------------------------------------
+
+u32 roland_xp_device::page(int voice, int index) const
+{
+	const int word = ((index & 0xff) << 7) | ((voice & 63) << 1);
+	return (u32(m_regs[word]) << 16) | m_regs[word | 1];
+}
+
+bool roland_xp_device::ramp_current(const voice &v, int index, u32 &value) const
+{
+	switch (index)
+	{
+	case PITCH_SEED: value = u32(v.pitch.current); return true;
+	case TVF_SEED:   value = u32(v.tvf.current); return true;
+	case TVA2_SEED:  value = u32(v.tva2.current); return true;
+	case TVA1_SEED:  value = u32(v.tva1.current); return true;
+	case RESO_SEED:  value = u32(v.reso.current) << 2; return true;
+	default:         return false;
+	}
+}
+
+// offset is the word index; the byte address is offset << 1
+void roland_xp_device::load_latch(offs_t address)
+{
+	const voice &v = m_voices[(address >> 2) & 63];
+
+	if (address >= IRAM3_BASE + 8 && address < IRAM3_BASE + 12)
+		m_read_latch = m_noise;
+	else if (address < CRAM_BASE && ramp_current(v, address >> 8, m_read_latch))
+		;
+	else if (address >= CRAM_BASE && address < IRAM_BASE)
+		m_read_latch = m_regs[address >> 1];
+	else if (address >= IRAM_BASE && address < IRAM3_TARGET_BASE)
+		m_read_latch = u32(m_iram[iram_word(address)]);
+	else
+		m_read_latch = (u32(m_regs[(address >> 1) & ~1]) << 16) | m_regs[(address >> 1) | 1];
+}
+
+u16 roland_xp_device::read(offs_t offset, u16 mem_mask)
+{
+	const offs_t address = (offset << 1) & 0x3ffe;
+	u16 data = m_regs[address >> 1];
+
+	if (address < RUN_MASK)
+	{
+		if (!machine().side_effects_disabled())
+			load_latch(address);
+	}
+	else if (address < SEND_BASE)
+	{
+		switch (address)
+		{
+		case READBACK_LOW:
+			data = m_read_latch & 0xffff;
+			break;
+		case READBACK_HIGH:
+			data = m_read_latch >> 16;
+			break;
+		case IRQ_STATUS:
+			data = m_irq_count ? m_irq_queue[m_irq_head] : 0;
+			break;
+		case IRQ_ACK:
+			if (!machine().side_effects_disabled())
+			{
+				if (m_irq_count)
+				{
+					m_irq_head = (m_irq_head + 1) % MAX_VOICES;
+					m_irq_count--;
+				}
+				update_int();
+			}
+			data = 0;
+			break;
+		}
+	}
+	else if (address >= ROM_WINDOW)
+	{
+		const u32 word = (u32(m_regs[ROM_BANK >> 1] & 0x7f) << 20) | (u32(m_regs[ROM_PAGE >> 1] & 0x7ff) << 9) | ((address - ROM_WINDOW) >> 1);
+		data = m_wave_cache.read_byte(word * 2) | (u16(m_wave_cache.read_byte(word * 2 + 1)) << 8);
+	}
+
+	if (!machine().side_effects_disabled())
+		LOGMASKED(LOG_READ, "%s: read %04x = %04x\n", machine().describe_context(), address, data);
+	return data;
+}
+
+void roland_xp_device::write(offs_t offset, u16 data, u16 mem_mask)
+{
+	const offs_t address = (offset << 1) & 0x3ffe;
+	COMBINE_DATA(&m_regs[address >> 1]);
+
+	if (address < CRAM_BASE)
+	{
+		LOGMASKED(LOG_VOICE, "%s: voice %2d page %02x%s = %04x\n", machine().describe_context(), (address >> 2) & 0x3f, address >> 8, BIT(address, 1) ? "+2" : "  ", data);
+		if (BIT(address, 1))
+		{
+			const int voice = (address >> 2) & 63;
+			const int index = address >> 8;
+			write_page(voice, index, page(voice, index));
+		}
+	}
+	else if (address < IRAM_BASE)
+	{
+		LOGMASKED(LOG_CRAM, "%s: cram %3d = %04x\n", machine().describe_context(), (address - CRAM_BASE) >> 1, data);
+		m_program_dirty = true;
+	}
+	else if (address < IRAM3_TARGET_BASE)
+	{
+		LOGMASKED(LOG_IRAM, "%s: iram%d %2d%s = %04x\n", machine().describe_context(), ((address - IRAM_BASE) >> 8) + 1, (address & 0xff) >> 2, BIT(address, 1) ? "+2" : "  ", data);
+		if (BIT(address, 1))
+			write_iram(iram_word(address), (u32(m_regs[(address >> 1) & ~1]) << 16) | m_regs[address >> 1]);
+	}
+	else if (address < PRAM_BASE)
+	{
+		LOGMASKED(LOG_IRAM, "%s: iram4 %2d   = %04x\n", machine().describe_context(), (address & 0xff) >> 1, data);
+		write_iram_target(0xc0 + ((address & 0xff) >> 1), m_regs[address >> 1]);
+	}
+	else if (address < RUN_MASK)
+	{
+		LOGMASKED(LOG_PRAM, "%s: pram %3d%s = %04x\n", machine().describe_context(), (address - PRAM_BASE) >> 2, BIT(address, 1) ? "+2" : "  ", data);
+		m_program_dirty = true;
+	}
+	else if (address < SEND_BASE)
+	{
+		if (address < 0x3908)
+		{
+			LOGMASKED(LOG_RUNMASK, "%s: runmask %04x = %04x\n", machine().describe_context(), address, data);
+			write_run_mask((address - RUN_MASK) >> 1, m_regs[address >> 1]);
+		}
+		else if (address < 0x3910 || address == 0x3914 || address == 0x3924 || address == 0x3926 || address == 0x3932)
+		{
+			LOGMASKED(LOG_UNKNOWN, "%s: unknown %04x = %04x\n", machine().describe_context(), address, data);
+		}
+		else
+		{
+			LOGMASKED(LOG_CTRL, "%s: ctrl %04x = %04x\n", machine().describe_context(), address, data);
+		}
+	}
+	else if (address < ROM_WINDOW)
+		LOGMASKED(LOG_MIX, "%s: mix bank %d voice %2d = %04x\n", machine().describe_context(), (address - SEND_BASE) >> 7, (address >> 1) & 0x3f, data);
+	else
+		LOGMASKED(LOG_CTRL, "%s: window write %04x = %04x\n", machine().describe_context(), address, data);
+}
+
+void roland_xp_device::write_page(int n, int index, u32 value)
+{
+	voice &v = m_voices[n];
+
+	switch (index)
+	{
+	case CONTROL:
+		if (BIT(value, 15))
+			v.start_pending = 1;
+		break;
+
+	case PITCH_SEED:    v.pitch.seed(s32(value), LAW_LINEAR); break;
+	case PITCH_TARGET:  v.pitch.retarget(s32(value), LAW_LINEAR); break;
+	case PITCH_CONTROL: v.pitch.configure(u16(value), LAW_LINEAR); break;
+
+	case TVF_SEED:      v.tvf.seed(exp_decode(s32(value)), LAW_LINEAR); break;
+	case TVF_TARGET:    v.tvf.retarget(exp_decode(s32(value)), LAW_LINEAR); break;
+	case TVF_CONTROL:   v.tvf.configure(u16(value), LAW_LINEAR); break;
+
+	case RESO_SEED:    v.reso.seed(s32(value) >> 2, LAW_EXPONENTIAL); break;
+	case RESO_TARGET:  v.reso.retarget(s32(value), LAW_EXPONENTIAL); break;
+	case RESO_CONTROL: v.reso.configure(u16(value), LAW_EXPONENTIAL); break;
+
+	case TVA2_SEED:     v.tva2.seed(s32(value), LAW_EXPONENTIAL); break;
+	case TVA2_TARGET:   v.tva2.retarget(s32(value), LAW_EXPONENTIAL); break;
+	case TVA2_CONTROL:  v.tva2.configure(u16(value), LAW_EXPONENTIAL); break;
+
+	case TVA1_SEED:     v.tva1.seed(s32(value), v.tva1.control_law()); break;
+	case TVA1_TARGET:   v.tva1.retarget(s32(value), v.tva1.control_law()); break;
+	case TVA1_CONTROL:
+		v.tva1.configure(u16(value));
+		if (v.tva1.control_law() == LAW_S_CURVE && !v.tva1.active && !v.done_reported)
+		{
+			v.done_reported = 1;
+			raise_irq(n, IRQ_VOICE_DONE);
+		}
+		break;
+
+	default:
+		break;
+	}
+}
+
+void roland_xp_device::write_run_mask(int word, u16 data)
+{
+	const u64 before = m_run_mask;
+	m_run_mask = (m_run_mask & ~(u64(0xffff) << (word * 16))) | (u64(data) << (word * 16));
+
+	for (int n = word * 16; n < word * 16 + 16; n++)
+	{
+		if (BIT(before, n) && !BIT(m_run_mask, n))
+		{
+			voice &v = m_voices[n];
+			v.reading = 0;
+			v.predictor = 0;
+			v.filter_low = 0;
+			v.filter_band = 0;
+		}
+	}
+}
+
+
+//-------------------------------------------------
+//  address generator and DPCM
+//-------------------------------------------------
+
+s32 roland_xp_device::delta_at(const voice &v, u32 address)
+{
+	const s8 delta = s8(rom_byte(v, address));
+	const u8 shifts = rom_byte(v, address >> 5);
+	const int shift = BIT(address, 4) ? (shifts >> 4) : (shifts & 0x0f);
+	return s32(u32(s32(delta)) << (shift + 10));
+}
+
+void roland_xp_device::start_reader(int n)
+{
+	voice &v = m_voices[n];
+	const u32 control = page(n, CONTROL);
+
+	v.start_pending = 0;
+	v.region = control & 0x7f;
+	v.alternate = BIT(control, 12);
+	v.reverse = BIT(control, 11);
+	v.start = page(n, ADDRESS) & 0xfffff;
+	v.loop = page(n, LOOP) & 0xfffff;
+	v.end = page(n, END) & 0xfffff;
+
+	v.backward = v.reverse;
+	v.address = v.reverse ? v.end : v.start;
+	v.sub_phase = 0;
+	v.reading = 1;
+	v.loop_reported = 0;
+	v.done_reported = 0;
+	v.filter_low = 0;
+	v.filter_band = 0;
+
+	v.predictor = 0;
+	for (u32 a = v.address & ~0x1f; a < v.address; a++)
+		v.predictor = wrap_add(v.predictor, delta_at(v, a));
+}
+
+roland_xp_device::address_step roland_xp_device::advance(const voice &v, address_step s) const
+{
+	const bool looping = v.loop < v.end;
+
+	if (!s.backward)
+	{
+		if (!looping)
+		{
+			if (s.address + 1 >= v.end)
+				return { s.address, false, true };
+			return { s.address + 1, false, false };
+		}
+		if (s.address >= v.end)
+		{
+			if (v.alternate)
+				return { s.address, true, false };
+			return { v.loop, false, false };
+		}
+		return { s.address + 1, false, false };
+	}
+
+	const u32 bound = (v.alternate && looping) ? v.loop : (v.reverse ? v.start : v.loop);
+	if (s.address <= bound)
+	{
+		if (v.alternate && looping)
+			return { s.address, false, false };
+		return { s.address, true, true };
+	}
+	return { s.address - 1, true, false };
+}
+
+
+//-------------------------------------------------
+//  the voice
+//-------------------------------------------------
+
+void roland_xp_device::run_voice(int n)
+{
+	voice &v = m_voices[n];
+	if (!running(n))
+		return;
+
+	if (v.start_pending)
+		start_reader(n);
+
+	if ((m_frame_counter & 7) == 0)
+	{
+		if (v.pitch.update(LAW_LINEAR) && v.pitch.current == 0)
+		{
+			v.reading = 0;
+			v.predictor = 0;
+			v.done_reported = 1;
+		}
+		v.tvf.update(LAW_LINEAR);
+		v.reso.update(LAW_EXPONENTIAL);
+		v.tva2.update(LAW_EXPONENTIAL);
+	}
+
+	if ((m_frame_counter & 1) == 0)
+	{
+		const bool arrived = v.tva1.update(v.tva1.control_law());
+
+		if (arrived && v.tva1.current == 0 && !v.done_reported)
+		{
+			v.done_reported = 1;
+			raise_irq(n, IRQ_VOICE_DONE);
+		}
+	}
+
+	s32 sample = 0;
+	if (v.reading)
+	{
+		const int phase = v.sub_phase >> 9;
+		address_step s{ v.address, bool(v.backward), false };
+		s64 weighted = 0;
+		for (int i = 0; i < 3 && !s.stopped; i++)
+		{
+			weighted += s64(interp_weights[i][phase]) * delta_at(v, s.address);
+			s = advance(v, s);
+		}
+		sample = wrap_add(v.predictor, s32(weighted >> 12)) >> 4;
+
+		const u32 phase_sum = u32(v.sub_phase) + u32(exp_decode(v.pitch.value_at(m_frame_counter & 7, 8)));
+		v.sub_phase = phase_sum & 0xffff;
+		for (u32 carry = phase_sum >> 16; carry && v.reading; carry--)
+		{
+			v.predictor = wrap_add(v.predictor, delta_at(v, v.address));
+			const address_step next = advance(v, { v.address, bool(v.backward), false });
+			if (next.stopped)
+			{
+				v.reading = 0;
+				v.predictor = 0;
+				if (!v.done_reported)
+				{
+					v.done_reported = 1;
+					raise_irq(n, IRQ_VOICE_DONE);
+				}
+				break;
+			}
+			v.address = next.address;
+			v.backward = next.backward;
+
+			if (!v.loop_reported && (v.backward ? v.address <= v.loop : v.address >= v.loop))
+			{
+				v.loop_reported = 1;
+				raise_irq(n, IRQ_LOOP_REACHED);
+			}
+		}
+	}
+
+	const u32 filter = page(n, FILTER);
+	if (!(filter & 0xf000))
+	{
+		const s32 f = v.tvf.coefficient(m_frame_counter & 7, 8);
+		const s32 q = v.reso.coefficient(m_frame_counter & 7, 8);
+		v.filter_low += s32((s64(f) * v.filter_band) >> 14);
+		const s32 high = sample - (s32((s64(q) * v.filter_band) >> 14) + v.filter_low);
+		v.filter_band += s32((s64(f) * high) >> 14);
+		switch ((filter >> 10) & 3)
+		{
+		case 0: sample = v.filter_low; break;
+		case 1: sample = v.filter_band; break;
+		case 2: sample = high; break;
+		case 3: sample = v.filter_low - high; break;
+		}
+	}
+
+	sample = s32((s64(sample) * v.tva1.coefficient(m_frame_counter & 1, 2)) >> 14);
+	sample = s32((s64(sample) * v.tva2.coefficient(m_frame_counter & 7, 8)) >> 14);
+
+	for (int bank = 0; bank < 4; bank++)
+	{
+		const u16 s = send(n, bank);
+		m_bus[s & 63] += s32((s64(sample) * (s >> 6)) >> 10);
+	}
+}
+
+//-------------------------------------------------
+//  the DSP
+//-------------------------------------------------
+
+void roland_xp_device::write_iram(int word, u32 value)
+{
+	m_iram[word & 0xff] = s32(value << 8) >> 8;
+	m_iram_ramping[word & 0xff] = 0;
+}
+
+void roland_xp_device::write_iram_target(int word, u16 value)
+{
+	m_iram_ramping[word & 0xff] = 1;
+}
+
+void roland_xp_device::update_iram_ramps()
+{
+	for (int word = 0xc0; word < IRAM_SIZE; word++)
+	{
+		if (!m_iram_ramping[word])
+			continue;
+
+		const s32 target = s32(m_regs[(IRAM3_TARGET_BASE >> 1) + (word - 0xc0)]) << 13;
+		const s32 rate = m_regs[(IRAM3_RATE >> 1) + ((word - 0xc0) >> 4)];
+		s32 &current = m_iram[word];
+		if (current < target)
+			current = std::min(current + rate, target);
+		else
+			current = std::max(current - rate, target);
+		if (current == target)
+			m_iram_ramping[word] = 0;
+	}
+}
+
+void roland_xp_device::decode_program()
+{
+	static const u8 shifts[4] = { 0, 1, 2, 4 };
+
+	for (int i = 0; i < DSP_SLOTS; i++)
+	{
+		const u32 w = (u32(m_regs[(PRAM_BASE >> 1) + i * 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 1];
+		const u16 c = m_regs[(CRAM_BASE >> 1) + i];
+		const s32 mantissa = s32(s16(c << 2)) >> 2;
+		dsp_slot &s = m_program[i];
+		s.st = (w >> 14) & 3;
+		s.word = (w >> 6) & 0xff;
+		s.col = w & 0x3f;
+		s.ext = (w >> 25) & 7;
+		s.eram_op = 0;
+		s.eram_offset = 0;
+		s.read_bypass = s.col == 0x30 && (c & 0x3e3f) == 0x0221;
+		s.cram = c;
+		s.coefficient = mantissa << shifts[c >> 14];
+		s.raw = BIT(c, 15) ? s32((c & 0x3fff) << 13) : mantissa;
+	}
+
+	for (int i = 0; i < DSP_SLOTS - 1; )
+	{
+		const u32 w = (u32(m_regs[(PRAM_BASE >> 1) + i * 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 1];
+		const u32 next = (u32(m_regs[(PRAM_BASE >> 1) + i * 2 + 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 3];
+		const int op = (w >> 23) & 3;
+		if (op)
+		{
+			m_program[i].eram_op = op;
+			m_program[i].eram_offset = (((w >> 16) & 0x7f) << 9) | ((next >> 16) & 0x1ff);
+			i += 2;
+		}
+		else
+			i++;
+	}
+
+	m_program_dirty = false;
+}
+
+s32 roland_xp_device::operand(const dsp_slot &s) const
+{
+	const dsp_state &d = m_dsp;
+
+	switch (s.col >> 4)
+	{
+	case 1:
+		return d.acc;
+
+	case 3:
+		if (d.latch_age < 4)
+			return d.latch;
+		if (s.st == 1)
+			return d.now_valid ? d.now : 0;
+		if (s.st == 2)
+			return d.latch;
+		break;
+	}
+
+	return (d.r_age <= 3) ? d.r_prev : 0;
+}
+
+void roland_xp_device::execute(const dsp_slot &s)
+{
+	dsp_state &d = m_dsp;
+	const int nibble = s.col & 0xf;
+	const s32 o = operand(s);
+
+	if (s.col == 0x30 && s.cram <= 0x000f)
+	{
+		d.product = d.now_valid ? d.now : 0;
+		switch (s.cram & 0xf)
+		{
+		case 0:
+		case 2: d.acc += d.mem_prev; break;
+		case 4: d.acc = d.mem_prev; break;
+		case 5: d.acc = d.product_prev; break;
+		case 9: d.acc = d.mem_prev + d.product_prev; break;
+		default: d.acc += d.product_prev; break;
+		}
+		return;
+	}
+
+	if (s.col == 0x30 && (s.cram & 0x3e80) == 0x0280)
+	{
+		const int code = s.cram & 0xf;
+		const int select = (s.cram >> 4) & 3;
+
+		if (code == 5)
+		{
+			s32 value;
+			if (select == 1)
+				value = (s.st == 3) ? d.acc : d.acc_before_prev;
+			else if (select == 2)
+				value = d.mem_prev;
+			else
+				value = (d.latch_age < 4 || d.now_valid) ? o : d.mem_prev;
+			d.product = multiply(value, d.gain);
+			d.acc = d.product_prev;
+			return;
+		}
+
+		if (code == 3 && select == 2)
+			d.product = multiply(d.mem_prev, d.gain);
+		else if (code == 1 && select == 2)
+			d.product = multiply(d.now_valid ? d.now : (d.r_age <= 3) ? d.r_prev : 0, d.gain);
+		else if ((code == 1 || code == 3) && select == 3)
+			d.product = multiply(o, d.gain);
+		else if (code == 1 || code == 2 || code == 3)
+			d.product = multiply(d.acc, d.gain);
+		else
+			d.product = o;
+
+		if (code == 2 || code == 3)
+			d.acc += d.product_prev;
+		else
+			d.acc = multiply(d.acc, d.gain) + d.product_prev;
+		return;
+	}
+
+	if (s.col == 0x30 && (s.cram == 0x1001 || s.cram == 0x2801 || s.cram == 0x0231 || s.cram == 0x0325))
+	{
+		d.product = 0;
+		switch (s.cram)
+		{
+		case 0x1001: d.acc = wrap24(d.acc); break;
+		case 0x2801: d.acc = std::abs(wrap24(d.acc)); break;
+		case 0x0231:
+		{
+			const s32 first = d.now_valid ? d.now : 0;
+			d.acc = first + s32((s64(d.latch - first) * d.fraction) >> 12);
+			break;
+		}
+		default: break;
+		}
+		return;
+	}
+
+	if (s.col == 0x0c)
+	{
+		d.product = multiply(m_serial_in, s.coefficient);
+		return;
+	}
+
+	d.product = (nibble == 0 && s.col != 0x30) ? o : multiply(o, s.coefficient);
+	const s32 p = d.product_prev;
+
+	switch (s.col)
+	{
+	case 0x11:
+		if (d.now_valid)
+			d.acc = d.now;
+		return;
+	case 0x14:
+		d.acc = d.mem_prev;
+		return;
+	case 0x0f:
+		d.acc += s.raw;
+		return;
+	case 0x1f:
+		d.acc = d.mem_prev + s.raw;
+		return;
+	case 0x2f:
+		d.acc = p + s.raw;
+		return;
+	case 0x20:
+	case 0x21:
+		return;
+	case 0x32:
+		d.acc += p;
+		return;
+	default:
+		break;
+	}
+
+	switch (nibble)
+	{
+	case 0:
+	case 3:
+		d.acc += p;
+		break;
+	case 5:
+		d.acc = p;
+		break;
+	case 9:
+		d.acc = d.mem_prev + p;
+		break;
+	default:
+		break;
+	}
+}
+
+void roland_xp_device::exchange_serial()
+{
+	if (!m_serial_out_cb.isunset())
+	{
+		for (int channel = 0; channel < 2; channel++)
+			m_serial_out_cb(channel, u32(output_word(m_serial_out_word[channel])));
+	}
+
+	if (!m_serial_in_cb.isunset())
+	{
+		for (int channel = 0; channel < 2; channel++)
+			m_serial_frame[channel] = wrap24(s32(m_serial_in_cb(channel)));
+	}
+	m_serial_phase = 0;
+}
+
+void roland_xp_device::dsp_frame_start()
+{
+	m_dsp_enabled = BIT(m_regs[DSP_MODE >> 1], 1);
+	if (!m_dsp_enabled)
+		return;
+
+	if (m_program_dirty)
+		decode_program();
+
+	update_iram_ramps();
+
+	for (int n = 0; n < BUS_COUNT; n++)
+		m_iram[0x40 + n] = clamp24(m_bus[n] >> DSP_INPUT_SHIFT);
+
+	exchange_serial();
+
+	m_dsp.acc_before_prev = m_dsp.acc;
+	m_dsp.product_prev = 0;
+}
+
+void roland_xp_device::dsp_step()
+{
+	if (!m_pc)
+		dsp_frame_start();
+
+	if (m_dsp_enabled)
+	{
+		const dsp_slot &s = m_program[m_pc];
+		dsp_state &d = m_dsp;
+
+		if (BIT(m_landing_valid, 0))
+		{
+			d.latch = m_landing[0];
+			d.latch_age = 0;
+		}
+		m_landing[0] = m_landing[1];
+		m_landing_valid >>= 1;
+
+		if (s.eram_op == 1)
+		{
+			m_landing[1] = m_eram[(s.eram_offset + d.cursor) & 0xffff];
+			m_landing_valid |= 2;
+		}
+		if (s.col == 0x20)
+		{
+			m_landing[1] = m_eram[(d.cursor + (d.acc >> 12)) & 0xffff];
+			m_landing_valid |= 2;
+			d.fraction = d.acc & 0xfff;
+		}
+
+		if (s.ext == 1)
+			m_serial_in = m_serial_frame[m_serial_phase++ & 1];
+
+		d.r_prev = d.r;
+		d.mem_prev = d.mem;
+		if (d.r_age < 0xff)
+			d.r_age++;
+		d.now_valid = 0;
+
+		s32 gain_pending = 0;
+		bool gain_arrives = false;
+		if (s.st == 1)
+		{
+			const s32 v = m_iram[s.word];
+			if (s.word >= 0xf0)
+			{
+				gain_pending = v >> 8;
+				gain_arrives = true;
+			}
+			else
+			{
+				d.now = v;
+				d.now_valid = 1;
+				d.r = v;
+				d.r_age = 0;
+				if (!s.read_bypass)
+					d.mem = v;
+			}
+		}
+
+		d.acc_before = d.acc;
+		execute(s);
+
+		if (gain_arrives)
+			d.gain = gain_pending;
+		if (d.latch_age < 0xff)
+			d.latch_age++;
+
+		if (s.st == 2)
+			m_iram[s.word] = d.latch;
+		else if (s.st == 3)
+			m_iram[s.word] = clamp24(d.acc_before);
+
+		if (s.eram_op == 3)
+			m_eram[(s.eram_offset + d.cursor) & 0xffff] = clamp24(d.acc_before);
+		else if (s.eram_op == 2)
+			m_eram[(s.eram_offset + d.cursor) & 0xffff] = d.r_prev;
+
+		d.acc_before_prev = d.acc_before;
+		d.product_prev = d.product;
+	}
+
+	if (++m_pc >= DSP_SLOTS)
+	{
+		m_pc = 0;
+		if (m_dsp_enabled)
+			m_dsp.cursor--;
+	}
+}
+
+void roland_xp_device::run_voices()
+{
+	std::fill(std::begin(m_bus), std::end(m_bus), 0);
+
+	for (int n = 0; n < MAX_VOICES; n++)
+		run_voice(n);
+
+	m_frame_counter++;
+	m_noise ^= m_noise << 13;
+	m_noise ^= m_noise >> 17;
+	m_noise ^= m_noise << 5;
+}
+
+void roland_xp_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		if (!m_pc)
+			run_voices();
+
+		debugger_instruction_hook(m_pc);
+		dsp_step();
+		m_icount--;
+	}
+}
+
+void roland_xp_device::sound_stream_update(sound_stream &stream)
+{
+	for (int n = 0; n < OUTPUT_WORDS; n++)
+		stream.put_int(n, 0, output_word(n), 1 << 23);
+}

--- a/src/devices/sound/roland_xp.h
+++ b/src/devices/sound/roland_xp.h
@@ -1,0 +1,281 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_XP_H
+#define MAME_SOUND_ROLAND_XP_H
+
+#pragma once
+
+#include "roland_xpd.h"
+
+class roland_xp_device : public cpu_device, public device_sound_interface, public roland_xp_disassembler::info
+{
+public:
+	static constexpr feature_type imperfect_features() { return feature::SOUND; }
+
+	// the wave ROM, the internal RAM and the external delay RAM, beside the program
+	enum { AS_WAVE = AS_DATA, AS_IRAM = AS_IO, AS_ERAM = AS_OPCODES + 1 };
+
+	static constexpr int MAX_VOICES = 64;
+	static constexpr int BUS_COUNT = 64;
+	static constexpr int DSP_SLOTS = 256;
+	static constexpr int IRAM_SIZE = 256;
+	static constexpr int ERAM_SIZE = 0x10000;
+	static constexpr int DSP_INPUT_SHIFT = 4;
+	static constexpr int OUTPUT_WORDS = 8;
+
+	// the per-voice pages, by page number
+	enum page_index
+	{
+		CONTROL = 0x00, ADDRESS = 0x01, LOOP = 0x02, END = 0x03,
+		RESO_TARGET = 0x11, PITCH_TARGET = 0x12, TVF_TARGET = 0x13, TVA2_TARGET = 0x14, TVA1_TARGET = 0x15,
+		RESO_CONTROL = 0x16, PITCH_CONTROL = 0x17, TVF_CONTROL = 0x18, TVA2_CONTROL = 0x19, TVA1_CONTROL = 0x1a,
+		PITCH_SEED = 0x1b, TVF_SEED = 0x1c, TVA2_SEED = 0x1d, TVA1_SEED = 0x1e,
+		FILTER = 0x20, RESO_SEED = 0x21
+	};
+
+	// the control block and the other blocks, by byte address
+	enum register_address
+	{
+		CRAM_BASE = 0x2c00, IRAM_BASE = 0x3000, IRAM3_BASE = 0x3200, IRAM3_TARGET_BASE = 0x3300, PRAM_BASE = 0x3400,
+		RUN_MASK = 0x3900, READBACK_LOW = 0x3910, READBACK_HIGH = 0x3912, DSP_MODE = 0x3916,
+		IRQ_STATUS = 0x3918, IRQ_ACK = 0x391a, ROM_PAGE = 0x3920, ROM_BANK = 0x3922, IRAM3_RATE = 0x3928,
+		SEND_BASE = 0x3a00, ROM_WINDOW = 0x3c00
+	};
+
+	enum irq_reason { IRQ_VOICE_DONE = 4, IRQ_LOOP_REACHED = 5 };
+
+	roland_xp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	auto int_callback() { return m_int_callback.bind(); }
+
+	// the DSP RAM words the board's serial link clocks out to its effect processor
+	void set_serial_output_words(int left, int right) { m_serial_out_word[0] = left & 0xff; m_serial_out_word[1] = right & 0xff; }
+
+	// a stereo pair out and one sample back a frame, the effect processor's send and return
+	auto serial_out_callback() { return m_serial_out_cb.bind(); }
+	auto serial_in_callback() { return m_serial_in_cb.bind(); }
+
+	u16 read(offs_t offset, u16 mem_mask = ~0);
+	void write(offs_t offset, u16 data, u16 mem_mask = ~0);
+
+	// roland_xp_disassembler::info implementation
+	virtual u16 xpd_cram_r(offs_t address) const override { return m_regs[(CRAM_BASE >> 1) + (address & 0xff)]; }
+
+protected:
+	// device_t implementation
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_clock_changed() override;
+	virtual void device_post_load() override;
+
+	// device_execute_interface implementation
+	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 1) / 3; }
+	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return cycles * 3; }
+	virtual u32 execute_min_cycles() const noexcept override { return 1; }
+	virtual u32 execute_max_cycles() const noexcept override { return 1; }
+	virtual void execute_run() override;
+
+	// device_memory_interface implementation
+	virtual space_config_vector memory_space_config() const override;
+
+	// device_disasm_interface implementation
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+	// device_sound_interface implementation
+	virtual void sound_stream_update(sound_stream &stream) override;
+
+	enum ramp_law { LAW_LINEAR, LAW_EXPONENTIAL, LAW_S_CURVE };
+
+	// a parameter ramp: a current value moving towards a target under one of three laws
+	struct ramp
+	{
+		s32 current = 0;
+		s32 previous = 0;
+		s32 target = 0;
+		s32 step = 0;
+		s32 accumulator = 0;
+		s32 midpoint = 0;
+		u16 control = 0;
+		u32 counter = 0;
+		bool active = false;
+
+		int rate() const { return control & 0xfff; }
+		u32 hold_mask() const;
+		ramp_law control_law() const;
+
+		void seed(s32 value, ramp_law law);
+		void retarget(s32 value, ramp_law law);
+		void configure(u16 value, ramp_law law);
+		void configure(u16 value);
+		bool update(ramp_law law);
+		s32 value_at(int phase, int period) const;
+		s16 coefficient() const;
+		s16 coefficient(int phase, int period) const;
+
+	private:
+		void arm(ramp_law law);
+	};
+
+	struct voice
+	{
+		ramp pitch, tvf, reso, tva1, tva2;
+
+		u32 region = 0;
+		u32 start = 0;
+		u32 address = 0;
+		u32 loop = 0;
+		u32 end = 0;
+		u8 start_pending = 0;
+		u8 alternate = 0;
+		u8 reverse = 0;
+		u8 backward = 0;
+		u8 reading = 0;
+		u8 loop_reported = 0;
+		u8 done_reported = 0;
+		u16 sub_phase = 0;
+		s32 predictor = 0;
+
+		s32 filter_low = 0;
+		s32 filter_band = 0;
+	};
+
+	struct address_step
+	{
+		u32 address;
+		bool backward;
+		bool stopped;
+	};
+
+	// one decoded DSP instruction with its coefficient
+	struct dsp_slot
+	{
+		u8 st;
+		u8 word;
+		u8 col;
+		u8 ext;
+		u8 eram_op;
+		bool read_bypass;
+		u16 eram_offset;
+		u16 cram;
+		s32 coefficient;
+		s32 raw;
+	};
+
+	// the DSP datapath registers that live across slots and samples
+	struct dsp_state
+	{
+		s32 acc = 0;
+		s32 acc_before = 0;
+		s32 acc_before_prev = 0;
+		s32 product = 0;
+		s32 product_prev = 0;
+		s32 r = 0;
+		s32 r_prev = 0;
+		s32 mem = 0;
+		s32 mem_prev = 0;
+		s32 now = 0;
+		s32 latch = 0;
+		s32 gain = 0;
+		u8 r_age = 0;
+		u8 latch_age = 0;
+		u8 now_valid = 0;
+		u16 fraction = 0;
+		u16 cursor = 0;
+	};
+
+	s32 exp_decode(s32 value) const;
+
+	u32 page(int voice, int index) const;
+	u16 send(int voice, int bank) const { return m_regs[(SEND_BASE >> 1) + (bank & 3) * 64 + (voice & 63)]; }
+	bool running(int voice) const { return BIT(m_run_mask, voice & 63); }
+
+	void write_page(int voice, int index, u32 value);
+	void write_run_mask(int word, u16 data);
+	bool ramp_current(const struct voice &v, int index, u32 &value) const;
+	void load_latch(offs_t address);
+	void update_int();
+	void raise_irq(int voice, int reason);
+
+	u8 rom_byte(const struct voice &v, u32 offset) { return m_wave_cache.read_byte((v.region << 20) | (offset & 0xfffff)); }
+	s32 delta_at(const struct voice &v, u32 address);
+	void start_reader(int n);
+	address_step advance(const struct voice &v, address_step s) const;
+
+	void run_voice(int n);
+
+	static s32 clamp24(s64 value) { return s32(std::clamp<s64>(value, -0x800000, 0x7fffff)); }
+	static s32 wrap24(s32 value) { return s32(u32(value) << 8) >> 8; }
+	s32 output_word(int word) const { return clamp24(s64(m_iram[word]) * 2); }
+	s32 multiply(s32 operand, s32 coefficient) const { return s32((s64(operand) * coefficient + 0x1000) >> 13); }
+	static int iram_word(offs_t address) { return (address < IRAM3_BASE ? 0 : 0x40) + ((address - IRAM_BASE) >> 2); }
+	void write_iram(int word, u32 value);
+	void write_iram_target(int word, u16 value);
+	void decode_program();
+	void update_iram_ramps();
+	s32 operand(const dsp_slot &s) const;
+	void execute(const dsp_slot &s);
+	void exchange_serial();
+	void dsp_frame_start();
+	void dsp_step();
+	void run_voices();
+
+	void pram_map(address_map &map) ATTR_COLD;
+	void iram_map(address_map &map) ATTR_COLD;
+	void eram_map(address_map &map) ATTR_COLD;
+
+	u32 pram_r(offs_t address);
+	void pram_w(offs_t address, u32 data);
+	u32 iram_r(offs_t address) { return m_iram[address & 0xff] & 0xffffff; }
+	void iram_w(offs_t address, u32 data) { write_iram(address & 0xff, data); }
+	u32 eram_r(offs_t address) { return m_eram[address & 0xffff] & 0xffffff; }
+	void eram_w(offs_t address, u32 data) { m_eram[address & 0xffff] = wrap24(data); }
+
+	address_space_config m_pram_config;
+	address_space_config m_wave_config;
+	address_space_config m_iram_config;
+	address_space_config m_eram_config;
+	memory_access<27, 0, 0, ENDIANNESS_LITTLE>::cache m_wave_cache;
+
+	devcb_write_line m_int_callback;
+	devcb_write32 m_serial_out_cb;
+	devcb_read32 m_serial_in_cb;
+
+	sound_stream *m_stream;
+
+	std::unique_ptr<u16[]> m_regs;
+	struct voice m_voices[MAX_VOICES];
+	s32 m_bus[BUS_COUNT];
+
+	u64 m_run_mask;
+	u32 m_read_latch;
+	u32 m_frame_counter;
+	u32 m_noise;
+
+	u16 m_irq_queue[MAX_VOICES];
+	u8 m_irq_head;
+	u8 m_irq_count;
+	bool m_int_state;
+
+	std::unique_ptr<s32[]> m_eram;
+	s32 m_exp_table[257];
+	s32 m_iram[IRAM_SIZE];
+	u8 m_iram_ramping[IRAM_SIZE];
+	dsp_slot m_program[DSP_SLOTS];
+	dsp_state m_dsp;
+	s32 m_landing[2];
+	u8 m_landing_valid;
+	bool m_program_dirty;
+	bool m_dsp_enabled;
+
+	int m_icount;
+	u16 m_pc;
+
+	u8 m_serial_out_word[2];
+	s32 m_serial_frame[2];
+	s32 m_serial_in;
+	u8 m_serial_phase;
+};
+
+DECLARE_DEVICE_TYPE(ROLAND_XP, roland_xp_device)
+
+#endif // MAME_SOUND_ROLAND_XP_H

--- a/src/devices/sound/roland_xpd.cpp
+++ b/src/devices/sound/roland_xpd.cpp
@@ -1,0 +1,174 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/*
+ *  Roland XP (MBCS30109) effect DSP disassembler
+ */
+#include "emu.h"
+#include "roland_xpd.h"
+
+namespace {
+
+// col[5:4] names the operand the slot multiplies
+const char *const OPERAND[4] = { "R", "acc", "R", "now" };
+
+std::string word_name(int word)
+{
+	return util::string_format("$%02x", word);
+}
+
+} // anonymous namespace
+
+void roland_xp_disassembler::append(std::string &r, const std::string &e)
+{
+	if (!r.empty())
+		r += ", ";
+	r += e;
+}
+
+std::string roland_xp_disassembler::coefficient(offs_t pc) const
+{
+	if (!has_coefficient())
+		return "C";
+
+	const u16 c = coefficient_word(pc);
+	static const int SHIFT[4] = { 0, 1, 2, 4 };
+	const s32 mantissa = s32(s16(c << 2)) >> 2;
+	return util::string_format("%g", double(mantissa << SHIFT[c >> 14]) / 8192.0);
+}
+
+std::string roland_xp_disassembler::constant(offs_t pc) const
+{
+	if (!has_coefficient())
+		return "K";
+
+	const u16 c = coefficient_word(pc);
+	return util::string_format("%d", BIT(c, 15) ? s32(c & 0x3fff) << 13 : s32(s16(c << 2)) >> 2);
+}
+
+// an external RAM access spans two slots, so the second slot's field is address, not command
+bool roland_xp_disassembler::continuation(offs_t pc, const data_buffer &opcodes)
+{
+	bool second = false;
+	for (offs_t slot = 0; slot < (pc & 0xff); slot++)
+		second = !second && ((opcodes.r32(slot) >> 23) & 3) != 0;
+	return second;
+}
+
+offs_t roland_xp_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	const u32 w = opcodes.r32(pc);
+	const u16 cram = coefficient_word(pc);
+	const int ext = (w >> 25) & 7;
+	const int st = (w >> 14) & 3;
+	const int word = (w >> 6) & 0xff;
+	const int col = w & 0x3f;
+	const int nibble = col & 0xf;
+	const std::string source = word_name(word);
+
+	std::string r;
+
+	const bool ramp = col == 0x30 && (cram & 0x3e80) == 0x0280 && has_coefficient();
+
+	if (st == 1)
+		append(r, util::string_format("%s = %s", word >= 0xf0 ? "G" : (ramp && (cram & 0x3f) == 0x21) ? "now" : "R", source));
+
+	if (col == 0x30 && cram <= 0x000f && has_coefficient())
+	{
+		append(r, util::string_format("P = %s", source));
+		switch (cram & 0xf)
+		{
+		case 0: case 2: append(r, "acc += R"); break;
+		case 4:         append(r, "acc = R"); break;
+		case 5:         append(r, "acc = p"); break;
+		case 9:         append(r, "acc = R + p"); break;
+		default:        append(r, "acc += p"); break;
+		}
+		append(r, util::string_format("[%04x]", cram));
+	}
+	else if (ramp)
+	{
+		const int code = cram & 0xf;
+		const int select = (cram >> 4) & 3;
+
+		if (code == 5)
+		{
+			append(r, util::string_format("P = %s*G", select == 1 ? (st == 3 ? "stored" : "acc''") : select == 2 ? "R" : "now"));
+			append(r, "acc = p");
+		}
+		else
+		{
+			if (code == 1 || code == 2 || code == 3)
+				append(r, util::string_format("P = %s*G", (select == 2 && code == 3) ? "R" : (select == 2 && code == 1) ? ((st == 1 && word < 0xf0) ? "now" : "R") : (select == 3 && code != 2) ? "now" : "acc"));
+			else
+				append(r, util::string_format("P = %s", OPERAND[col >> 4]));
+			append(r, (code == 2 || code == 3) ? "acc += p" : "acc = acc*G + p");
+		}
+		append(r, util::string_format("[%04x]", cram));
+	}
+	else if (col == 0x30 && has_coefficient() && (cram == 0x1001 || cram == 0x2801 || cram == 0x0231 || cram == 0x0325))
+	{
+		switch (cram)
+		{
+		case 0x1001: append(r, "acc = wrap(acc)"); break;
+		case 0x2801: append(r, "acc = abs(wrap(acc))"); break;
+		case 0x0231: append(r, util::string_format("acc = lerp(%s, now, f)", source)); break;
+		default:     append(r, "nop"); break;
+		}
+		append(r, util::string_format("[%04x]", cram));
+	}
+	else if (col == 0x0c)
+		append(r, util::string_format("P = ser*%s", coefficient(pc)));
+	else
+	{
+		const std::string operand = OPERAND[col >> 4];
+		append(r, (nibble == 0 && col != 0x30) ? util::string_format("P = %s", operand)
+				: util::string_format("P = %s*%s", operand, coefficient(pc)));
+
+		switch (col)
+		{
+		case 0x11: append(r, util::string_format("acc = %s", source)); break;
+		case 0x14: append(r, "acc = R"); break;
+		case 0x0f: append(r, util::string_format("acc += #%s", constant(pc))); break;
+		case 0x1f: append(r, util::string_format("acc = R + #%s", constant(pc))); break;
+		case 0x2f: append(r, util::string_format("acc = p + #%s", constant(pc))); break;
+		case 0x20: append(r, "eread [acc>>12], f = acc"); break;
+		case 0x21: break;
+		case 0x32: append(r, "acc += p"); break;
+		default:
+			switch (nibble)
+			{
+			case 0: case 3: append(r, "acc += p"); break;
+			case 5:         append(r, "acc = p"); break;
+			case 9:         append(r, "acc = R + p"); break;
+			default:        break;
+			}
+			break;
+		}
+	}
+
+	if (st == 2)
+		append(r, util::string_format("%s = latch", source));
+	else if (st == 3)
+		append(r, util::string_format("%s = acc", source));
+
+	if (!continuation(pc, opcodes))
+	{
+		const u16 offset = u16(((w >> 16) & 0x7f) << 9) | u16((opcodes.r32(pc + 1) >> 16) & 0x1ff);
+		switch ((w >> 23) & 3)
+		{
+		case 1: append(r, util::string_format("latch = eram[+%04x]", offset)); break;
+		case 2: append(r, util::string_format("eram[+%04x] = R", offset)); break;
+		case 3: append(r, util::string_format("eram[+%04x] = acc", offset)); break;
+		default: break;
+		}
+	}
+
+	if (ext)
+		append(r, util::string_format("ext %d", ext));
+
+	if (r.empty())
+		r = "nop";
+
+	stream << r;
+	return 1 | SUPPORTED;
+}

--- a/src/devices/sound/roland_xpd.h
+++ b/src/devices/sound/roland_xpd.h
@@ -1,0 +1,38 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_XPD_H
+#define MAME_SOUND_ROLAND_XPD_H
+
+#pragma once
+
+class roland_xp_disassembler : public util::disasm_interface
+{
+public:
+	// the coefficient of a slot lives in a second memory the disassembler cannot address
+	class info
+	{
+	public:
+		virtual ~info() = default;
+
+		virtual u16 xpd_cram_r(offs_t address) const = 0;
+	};
+
+	roland_xp_disassembler(info *inf = nullptr) : m_info(inf) { }
+	virtual ~roland_xp_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override { return 1; }
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
+private:
+	info *m_info;
+
+	bool has_coefficient() const { return m_info != nullptr; }
+	u16 coefficient_word(offs_t pc) const { return m_info ? m_info->xpd_cram_r(pc) : 0; }
+	std::string coefficient(offs_t pc) const;
+	std::string constant(offs_t pc) const;
+
+	static bool continuation(offs_t pc, const data_buffer &opcodes);
+	static void append(std::string &r, const std::string &e);
+};
+
+#endif // MAME_SOUND_ROLAND_XPD_H

--- a/src/mame/layout/roland_sc88.lay
+++ b/src/mame/layout/roland_sc88.lay
@@ -1,0 +1,268 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+copyright-holders:superctr
+
+Roland Sound Canvas SC-88 front panel.
+
+The display is the RCM2024T glass of the SC-55mkII, rendered into the screen
+bitmap by the driver; the field labels printed on the glass are overlaid here.
+-->
+<mamelayout version="2">
+
+	<element name="panel"><rect><color red="0.22" green="0.22" blue="0.23"/></rect></element>
+	<element name="bezel"><rect><color red="0.02" green="0.02" blue="0.02"/></rect></element>
+	<element name="trim"><rect><color red="0.30" green="0.30" blue="0.32"/></rect></element>
+
+	<element name="button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="round_button" defstate="0">
+		<disk state="0"><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="1"><color red="0.30" green="0.30" blue="0.30"/></disk>
+	</element>
+	<element name="led_button" defstate="0">
+		<disk state="0"><color red="0.72" green="0.72" blue="0.70"/></disk>
+		<disk state="1"><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_circle" defstate="0">
+		<disk><color red="0.45" green="0.45" blue="0.45"/></disk>
+		<disk state="0"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.25" green="0.08" blue="0.05"/></disk>
+		<disk state="1"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_triangle" defstate="0">
+		<text state="0" string="&gt;"><color red="0.40" green="0.40" blue="0.40"/></text>
+		<text state="1" string="&gt;"><color red="1.0" green="0.20" blue="0.10"/></text>
+	</element>
+	<element name="knob" defstate="0">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="0"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.15" green="0.15" blue="0.15"/></disk>
+		<disk state="1"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.30" green="0.30" blue="0.30"/></disk>
+		<rect><bounds x="0.47" y="0.18" width="0.06" height="0.3"/><color red="0.70" green="0.70" blue="0.70"/></rect>
+	</element>
+	<element name="power_button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="jack">
+		<disk><color red="0.55" green="0.55" blue="0.55"/></disk>
+		<disk><bounds x="0.25" y="0.25" width="0.5" height="0.5"/><color red="0.02" green="0.02" blue="0.02"/></disk>
+	</element>
+	<element name="midi_jack">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.1" y="0.1" width="0.8" height="0.8"/><color red="0.60" green="0.60" blue="0.60"/></disk>
+		<disk><bounds x="0.44" y="0.72" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.22" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.66" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.15" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.73" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+	</element>
+	<element name="divider"><rect><color red="0.10" green="0.10" blue="0.11"/></rect></element>
+
+	<element name="arrow_l"><text string="&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_r"><text string="&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_up"><text string="&#9650;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_down"><text string="&#9660;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_power"><text string="POWER"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_volume"><text string="VOLUME"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_preview"><text string="PREVIEW(PUSH)"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midiinb"><text string="MIDI IN B"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_phones"><text string="PHONES"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_part"><text string="PART"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_level"><text string="LEVEL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_pan"><text string="PAN"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_reverb"><text string="REVERB"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_chorus"><text string="CHORUS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_keyshift"><text string="KEY SHIFT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midich"><text string="MIDI CH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_all"><text string="ALL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_mute"><text string="MUTE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc55"><text string="SC-55"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_map"><text string="MAP"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_eq"><text string="EQ"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_userinstedit"><text string="USER INST EDIT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_onoff"><text string="ON/OFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_select"><text string="SELECT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibrate"><text string="VIB RATE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_attack"><text string="ATTACK"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_delay"><text string="DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdepth"><text string="VIB DEPTH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_cutoff"><text string="CUTOFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_decay"><text string="DECAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument2"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdelay"><text string="VIB DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_resonance"><text string="RESONANCE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_release"><text string="RELEASE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_variation"><text string="VARIATION"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_roland"><text string="Roland"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_soundcanvas"><text string="SOUND Canvas"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_gs"><text string="GS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_model"><text string="SC-88"><color red="0.95" green="0.55" blue="0.10"/></text></element>
+	<element name="glass_level"><text string="LEVEL" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_pan"><text string="PAN" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_reverb"><text string="REVERB" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_chorus"><text string="CHORUS" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_kshift"><text string="K SHIFT" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_midich"><text string="MIDI CH" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_1"><text string="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_2"><text string="2"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_3"><text string="3"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_4"><text string="4"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_5"><text string="5"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_6"><text string="6"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_7"><text string="7"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_8"><text string="8"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_9"><text string="9"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_10"><text string="10"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_11"><text string="11"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_12"><text string="12"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_13"><text string="13"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_14"><text string="14"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_15"><text string="15"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_16"><text string="16"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+
+	<view name="Front Panel">
+		<bounds x="0" y="0" width="1800" height="640"/>
+		<element ref="panel"><bounds x="0" y="0" width="1800" height="640"/></element>
+		<element ref="divider"><bounds x="0" y="440" width="1800" height="6"/></element>
+
+		<!-- power, volume / preview, front jacks -->
+		<element ref="label_power"><bounds x="40" y="50" width="160" height="26"/></element>
+		<element ref="power_button"><bounds x="50" y="85" width="140" height="55"/></element>
+		<element ref="midi_jack"><bounds x="65" y="215" width="110" height="110"/></element>
+		<element ref="label_midiinb"><bounds x="35" y="335" width="170" height="24"/></element>
+		<element ref="label_volume"><bounds x="215" y="50" width="120" height="26"/></element>
+		<element ref="knob" inputtag="KEY0" inputmask="0x80"><bounds x="230" y="85" width="90" height="90"/></element>
+		<element ref="label_preview"><bounds x="195" y="182" width="160" height="22"/></element>
+		<element ref="jack"><bounds x="245" y="245" width="60" height="60"/></element>
+		<element ref="label_phones"><bounds x="215" y="335" width="120" height="24"/></element>
+
+		<!-- display -->
+		<element ref="trim"><bounds x="355" y="70" width="770" height="322"/></element>
+		<element ref="bezel"><bounds x="365" y="80" width="750" height="302"/></element>
+		<screen index="0"><bounds x="380" y="95" width="720" height="272"/></screen>
+		<element ref="label_part"><bounds x="400" y="44" width="80" height="22"/></element>
+		<element ref="label_instrument"><bounds x="520" y="44" width="160" height="22"/></element>
+		<element ref="glass_level"><bounds x="404" y="161" width="90" height="12"/></element>
+		<element ref="glass_pan"><bounds x="523" y="161" width="90" height="12"/></element>
+		<element ref="glass_reverb"><bounds x="404" y="225" width="90" height="12"/></element>
+		<element ref="glass_chorus"><bounds x="523" y="225" width="90" height="12"/></element>
+		<element ref="glass_kshift"><bounds x="404" y="289" width="90" height="12"/></element>
+		<element ref="glass_midich"><bounds x="523" y="289" width="90" height="12"/></element>
+		<element ref="glass_1"><bounds x="663" y="349" width="24" height="12"/></element>
+		<element ref="glass_2"><bounds x="689" y="349" width="24" height="12"/></element>
+		<element ref="glass_3"><bounds x="715" y="349" width="24" height="12"/></element>
+		<element ref="glass_4"><bounds x="741" y="349" width="24" height="12"/></element>
+		<element ref="glass_5"><bounds x="767" y="349" width="24" height="12"/></element>
+		<element ref="glass_6"><bounds x="793" y="349" width="24" height="12"/></element>
+		<element ref="glass_7"><bounds x="819" y="349" width="24" height="12"/></element>
+		<element ref="glass_8"><bounds x="845" y="349" width="24" height="12"/></element>
+		<element ref="glass_9"><bounds x="871" y="349" width="24" height="12"/></element>
+		<element ref="glass_10"><bounds x="897" y="349" width="24" height="12"/></element>
+		<element ref="glass_11"><bounds x="923" y="349" width="24" height="12"/></element>
+		<element ref="glass_12"><bounds x="949" y="349" width="24" height="12"/></element>
+		<element ref="glass_13"><bounds x="975" y="349" width="24" height="12"/></element>
+		<element ref="glass_14"><bounds x="1001" y="349" width="24" height="12"/></element>
+		<element ref="glass_15"><bounds x="1027" y="349" width="24" height="12"/></element>
+		<element ref="glass_16"><bounds x="1053" y="349" width="24" height="12"/></element>
+		<element ref="label_delay"><bounds x="400" y="398" width="80" height="20"/></element>
+		<element ref="label_part"><bounds x="810" y="398" width="60" height="20"/></element>
+
+		<!-- ALL / MUTE / SC-55 MAP / EQ -->
+		<element ref="label_all"><bounds x="1145" y="79" width="65" height="30"/></element>
+		<element name="led0" ref="led_button" inputtag="KEY0" inputmask="0x40"><bounds x="1215" y="69" width="50" height="50"/></element>
+		<element ref="label_mute"><bounds x="1135" y="163" width="75" height="30"/></element>
+		<element name="led1" ref="led_button" inputtag="KEY0" inputmask="0x20"><bounds x="1215" y="153" width="50" height="50"/></element>
+		<element ref="arrow_up"><bounds x="1160" y="212" width="40" height="22"/></element>
+		<element ref="label_sc55"><bounds x="1135" y="236" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="258" width="75" height="22"/></element>
+		<element name="led2" ref="led_button" inputtag="KEY0" inputmask="0x04"><bounds x="1215" y="237" width="50" height="50"/></element>
+		<element ref="label_eq"><bounds x="1145" y="331" width="65" height="30"/></element>
+		<element ref="arrow_down"><bounds x="1160" y="366" width="40" height="22"/></element>
+		<element name="led3" ref="led_button" inputtag="KEY0" inputmask="0x02"><bounds x="1215" y="321" width="50" height="50"/></element>
+
+		<!-- parameter buttons -->
+		<element ref="label_part"><bounds x="1300" y="40" width="206" height="24"/></element>
+		<element ref="round_button" inputtag="KEY2" inputmask="0x40"><bounds x="1324" y="70" width="48" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="81" width="35" height="26"/></element>
+		<element ref="round_button" inputtag="KEY1" inputmask="0x40"><bounds x="1430" y="70" width="48" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="81" width="35" height="26"/></element>
+		<element ref="label_instrument"><bounds x="1546" y="40" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x08"><bounds x="1546" y="70" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="81" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x10"><bounds x="1652" y="70" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="81" width="35" height="26"/></element>
+		<element ref="label_level"><bounds x="1300" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x10"><bounds x="1300" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x20"><bounds x="1406" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="165" width="35" height="26"/></element>
+		<element ref="label_pan"><bounds x="1546" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x10"><bounds x="1546" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x20"><bounds x="1652" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="165" width="35" height="26"/></element>
+		<element ref="label_reverb"><bounds x="1300" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x04"><bounds x="1300" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x08"><bounds x="1406" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="249" width="35" height="26"/></element>
+		<element ref="label_chorus"><bounds x="1546" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x04"><bounds x="1546" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x08"><bounds x="1652" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="249" width="35" height="26"/></element>
+		<element ref="label_keyshift"><bounds x="1300" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x01"><bounds x="1300" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x02"><bounds x="1406" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="333" width="35" height="26"/></element>
+		<element ref="label_midich"><bounds x="1546" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x01"><bounds x="1546" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x02"><bounds x="1652" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="333" width="35" height="26"/></element>
+
+		<!-- lower panel: user instrument editing -->
+		<element ref="label_gs"><bounds x="50" y="500" width="60" height="30"/></element>
+		<element ref="label_soundcanvas"><bounds x="120" y="520" width="300" height="40"/></element>
+		<element ref="label_model"><bounds x="430" y="522" width="180" height="36"/></element>
+
+		<element name="led7" ref="lens_circle"><bounds x="700" y="532" width="34" height="34"/></element>
+		<element ref="label_userinstedit"><bounds x="745" y="500" width="200" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x01"><bounds x="750" y="528" width="90" height="42"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x02"><bounds x="846" y="528" width="90" height="42"/></element>
+		<element ref="label_onoff"><bounds x="745" y="578" width="100" height="22"/></element>
+		<element ref="label_select"><bounds x="846" y="578" width="100" height="22"/></element>
+
+		<element name="led4" ref="lens_triangle"><bounds x="975" y="464" width="22" height="22"/></element>
+		<element name="led5" ref="lens_triangle"><bounds x="975" y="486" width="22" height="22"/></element>
+		<element name="led6" ref="lens_triangle"><bounds x="975" y="510" width="22" height="22"/></element>
+		<element ref="label_vibrate"><bounds x="1010" y="462" width="206" height="22"/></element>
+		<element ref="label_attack"><bounds x="1010" y="506" width="206" height="22"/></element>
+		<element ref="label_delay"><bounds x="1010" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x04"><bounds x="1010" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1042" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x08"><bounds x="1116" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1148" y="544" width="35" height="26"/></element>
+		<element ref="label_vibdepth"><bounds x="1256" y="462" width="206" height="22"/></element>
+		<element ref="label_cutoff"><bounds x="1256" y="486" width="206" height="22"/></element>
+		<element ref="label_decay"><bounds x="1256" y="510" width="206" height="22"/></element>
+		<element ref="label_instrument2"><bounds x="1256" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x10"><bounds x="1256" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1288" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x20"><bounds x="1362" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1394" y="544" width="35" height="26"/></element>
+		<element ref="label_vibdelay"><bounds x="1502" y="462" width="206" height="22"/></element>
+		<element ref="label_resonance"><bounds x="1502" y="486" width="206" height="22"/></element>
+		<element ref="label_release"><bounds x="1502" y="510" width="206" height="22"/></element>
+		<element ref="label_variation"><bounds x="1502" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x40"><bounds x="1502" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1534" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x80"><bounds x="1608" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1640" y="544" width="35" height="26"/></element>
+	</view>
+
+</mamelayout>

--- a/src/mame/layout/roland_sc88pro.lay
+++ b/src/mame/layout/roland_sc88pro.lay
@@ -1,0 +1,283 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+copyright-holders:superctr
+
+Roland Sound Canvas SC-88Pro front panel.
+
+The display is the RCM2024T glass of the SC-55mkII, rendered into the screen
+bitmap by the driver; the field labels printed on the glass are overlaid here.
+
+The bottom lens holds a dual-die LED: the green die (led7) sits on the
+SC-88's lens position in the LED matrix, the red die (led8) is driven
+directly by the gate array.  Red alone marks user editing, both lit show
+orange in EFX mode.
+-->
+<mamelayout version="2">
+
+	<element name="panel"><rect><color red="0.22" green="0.22" blue="0.23"/></rect></element>
+	<element name="bezel"><rect><color red="0.02" green="0.02" blue="0.02"/></rect></element>
+	<element name="trim"><rect><color red="0.30" green="0.30" blue="0.32"/></rect></element>
+
+	<element name="button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="round_button" defstate="0">
+		<disk state="0"><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="1"><color red="0.30" green="0.30" blue="0.30"/></disk>
+	</element>
+	<element name="led_button" defstate="0">
+		<disk state="0"><color red="0.72" green="0.72" blue="0.70"/></disk>
+		<disk state="1"><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_circle" defstate="0">
+		<disk><color red="0.45" green="0.45" blue="0.45"/></disk>
+		<disk state="0"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.12" green="0.10" blue="0.08"/></disk>
+		<disk state="1"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.30" green="1.0" blue="0.25"/></disk>
+	</element>
+	<element name="lens_red_overlay" defstate="0">
+		<disk state="0"><color red="0.0" green="0.0" blue="0.0" alpha="0.0"/></disk>
+		<disk state="1"><color red="1.0" green="0.12" blue="0.08" alpha="0.65"/></disk>
+	</element>
+	<element name="lens_triangle" defstate="0">
+		<text state="0" string="&gt;"><color red="0.40" green="0.40" blue="0.40"/></text>
+		<text state="1" string="&gt;"><color red="1.0" green="0.20" blue="0.10"/></text>
+	</element>
+	<element name="knob" defstate="0">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="0"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.15" green="0.15" blue="0.15"/></disk>
+		<disk state="1"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.30" green="0.30" blue="0.30"/></disk>
+		<rect><bounds x="0.47" y="0.18" width="0.06" height="0.3"/><color red="0.70" green="0.70" blue="0.70"/></rect>
+	</element>
+	<element name="power_button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="jack">
+		<disk><color red="0.55" green="0.55" blue="0.55"/></disk>
+		<disk><bounds x="0.25" y="0.25" width="0.5" height="0.5"/><color red="0.02" green="0.02" blue="0.02"/></disk>
+	</element>
+	<element name="midi_jack">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.1" y="0.1" width="0.8" height="0.8"/><color red="0.60" green="0.60" blue="0.60"/></disk>
+		<disk><bounds x="0.44" y="0.72" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.22" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.66" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.15" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.73" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+	</element>
+	<element name="divider"><rect><color red="0.10" green="0.10" blue="0.11"/></rect></element>
+
+	<element name="arrow_l"><text string="&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_r"><text string="&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_up"><text string="&#9650;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_down"><text string="&#9660;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_power"><text string="POWER"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_volume"><text string="VOLUME"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_preview"><text string="PREVIEW(PUSH)"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midiinb"><text string="MIDI IN B"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_phones"><text string="PHONES"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_part"><text string="PART"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_level"><text string="LEVEL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_pan"><text string="PAN"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_reverb"><text string="REVERB"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_chorus"><text string="CHORUS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_keyshift"><text string="KEY SHIFT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midich"><text string="MIDI CH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_all"><text string="ALL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_mute"><text string="MUTE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc55"><text string="SC-55"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc88"><text string="SC-88"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_map"><text string="MAP"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_userinst"><text string="USER INST"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_select"><text string="SELECT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibrate"><text string="VIB RATE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_attack"><text string="ATTACK"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_delay"><text string="DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdepth"><text string="VIB DEPTH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_cutoff"><text string="CUTOFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_decay"><text string="DECAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdelay"><text string="VIB DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_resonance"><text string="RESONANCE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_release"><text string="RELEASE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_roland"><text string="Roland"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_soundcanvas"><text string="SOUND Canvas"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_gs"><text string="GS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_model"><text string="SC-88 Pro"><color red="0.95" green="0.55" blue="0.10"/></text></element>
+	<element name="efx"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_onoff"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="ON/OFF"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_type"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX TYPE"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_param"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX PARAM"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_value"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX VALUE"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="glass_level"><text string="LEVEL" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_pan"><text string="PAN" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_reverb"><text string="REVERB" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_chorus"><text string="CHORUS" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_kshift"><text string="K SHIFT" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_midich"><text string="MIDI CH" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_1"><text string="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_2"><text string="2"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_3"><text string="3"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_4"><text string="4"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_5"><text string="5"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_6"><text string="6"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_7"><text string="7"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_8"><text string="8"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_9"><text string="9"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_10"><text string="10"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_11"><text string="11"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_12"><text string="12"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_13"><text string="13"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_14"><text string="14"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_15"><text string="15"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_16"><text string="16"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+
+	<view name="Front Panel">
+		<bounds x="0" y="0" width="1800" height="640"/>
+		<element ref="panel"><bounds x="0" y="0" width="1800" height="640"/></element>
+		<element ref="divider"><bounds x="0" y="440" width="1800" height="6"/></element>
+
+		<!-- power, volume / preview, front jacks -->
+		<element ref="label_power"><bounds x="40" y="50" width="160" height="26"/></element>
+		<element ref="power_button"><bounds x="50" y="85" width="140" height="55"/></element>
+		<element ref="midi_jack"><bounds x="65" y="215" width="110" height="110"/></element>
+		<element ref="label_midiinb"><bounds x="35" y="335" width="170" height="24"/></element>
+		<element ref="label_volume"><bounds x="215" y="50" width="120" height="26"/></element>
+		<element ref="knob" inputtag="KEY0" inputmask="0x80"><bounds x="230" y="85" width="90" height="90"/></element>
+		<element ref="label_preview"><bounds x="195" y="182" width="160" height="22"/></element>
+		<element ref="jack"><bounds x="245" y="245" width="60" height="60"/></element>
+		<element ref="label_phones"><bounds x="215" y="335" width="120" height="24"/></element>
+
+		<!-- display -->
+		<element ref="trim"><bounds x="355" y="70" width="770" height="322"/></element>
+		<element ref="bezel"><bounds x="365" y="80" width="750" height="302"/></element>
+		<screen index="0"><bounds x="380" y="95" width="720" height="272"/></screen>
+		<element ref="label_part"><bounds x="400" y="44" width="80" height="22"/></element>
+		<element ref="label_instrument"><bounds x="520" y="44" width="160" height="22"/></element>
+		<element ref="glass_level"><bounds x="404" y="161" width="90" height="12"/></element>
+		<element ref="glass_pan"><bounds x="523" y="161" width="90" height="12"/></element>
+		<element ref="glass_reverb"><bounds x="404" y="225" width="90" height="12"/></element>
+		<element ref="glass_chorus"><bounds x="523" y="225" width="90" height="12"/></element>
+		<element ref="glass_kshift"><bounds x="404" y="289" width="90" height="12"/></element>
+		<element ref="glass_midich"><bounds x="523" y="289" width="90" height="12"/></element>
+		<element ref="glass_1"><bounds x="663" y="349" width="24" height="12"/></element>
+		<element ref="glass_2"><bounds x="689" y="349" width="24" height="12"/></element>
+		<element ref="glass_3"><bounds x="715" y="349" width="24" height="12"/></element>
+		<element ref="glass_4"><bounds x="741" y="349" width="24" height="12"/></element>
+		<element ref="glass_5"><bounds x="767" y="349" width="24" height="12"/></element>
+		<element ref="glass_6"><bounds x="793" y="349" width="24" height="12"/></element>
+		<element ref="glass_7"><bounds x="819" y="349" width="24" height="12"/></element>
+		<element ref="glass_8"><bounds x="845" y="349" width="24" height="12"/></element>
+		<element ref="glass_9"><bounds x="871" y="349" width="24" height="12"/></element>
+		<element ref="glass_10"><bounds x="897" y="349" width="24" height="12"/></element>
+		<element ref="glass_11"><bounds x="923" y="349" width="24" height="12"/></element>
+		<element ref="glass_12"><bounds x="949" y="349" width="24" height="12"/></element>
+		<element ref="glass_13"><bounds x="975" y="349" width="24" height="12"/></element>
+		<element ref="glass_14"><bounds x="1001" y="349" width="24" height="12"/></element>
+		<element ref="glass_15"><bounds x="1027" y="349" width="24" height="12"/></element>
+		<element ref="glass_16"><bounds x="1053" y="349" width="24" height="12"/></element>
+		<element ref="label_delay"><bounds x="400" y="398" width="80" height="20"/></element>
+		<element ref="label_part"><bounds x="810" y="398" width="60" height="20"/></element>
+
+		<!-- ALL / MUTE / SC-55 MAP / SC-88 MAP -->
+		<element ref="label_all"><bounds x="1145" y="79" width="65" height="30"/></element>
+		<element name="led0" ref="led_button" inputtag="KEY0" inputmask="0x40"><bounds x="1215" y="69" width="50" height="50"/></element>
+		<element ref="label_mute"><bounds x="1135" y="163" width="75" height="30"/></element>
+		<element name="led1" ref="led_button" inputtag="KEY0" inputmask="0x20"><bounds x="1215" y="153" width="50" height="50"/></element>
+		<element ref="arrow_up"><bounds x="1160" y="212" width="40" height="22"/></element>
+		<element ref="label_sc55"><bounds x="1135" y="236" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="258" width="75" height="22"/></element>
+		<element name="led2" ref="led_button" inputtag="KEY0" inputmask="0x04"><bounds x="1215" y="237" width="50" height="50"/></element>
+		<element ref="label_sc88"><bounds x="1135" y="321" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="343" width="75" height="22"/></element>
+		<element name="led3" ref="led_button" inputtag="KEY0" inputmask="0x02"><bounds x="1215" y="321" width="50" height="50"/></element>
+		<element ref="arrow_down"><bounds x="1160" y="376" width="40" height="22"/></element>
+
+		<!-- parameter buttons -->
+		<element ref="label_part"><bounds x="1300" y="40" width="206" height="24"/></element>
+		<element ref="round_button" inputtag="KEY2" inputmask="0x40"><bounds x="1324" y="70" width="48" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="81" width="35" height="26"/></element>
+		<element ref="round_button" inputtag="KEY1" inputmask="0x40"><bounds x="1430" y="70" width="48" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="81" width="35" height="26"/></element>
+		<element ref="label_instrument"><bounds x="1546" y="40" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x08"><bounds x="1546" y="70" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="81" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x10"><bounds x="1652" y="70" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="81" width="35" height="26"/></element>
+		<element ref="label_level"><bounds x="1300" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x10"><bounds x="1300" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x20"><bounds x="1406" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="165" width="35" height="26"/></element>
+		<element ref="label_pan"><bounds x="1546" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x10"><bounds x="1546" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x20"><bounds x="1652" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="165" width="35" height="26"/></element>
+		<element ref="label_reverb"><bounds x="1300" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x04"><bounds x="1300" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x08"><bounds x="1406" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="249" width="35" height="26"/></element>
+		<element ref="label_chorus"><bounds x="1546" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x04"><bounds x="1546" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x08"><bounds x="1652" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="249" width="35" height="26"/></element>
+		<element ref="label_keyshift"><bounds x="1300" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x01"><bounds x="1300" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x02"><bounds x="1406" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="333" width="35" height="26"/></element>
+		<element ref="label_delay"><bounds x="1300" y="376" width="206" height="20"/></element>
+		<element ref="label_midich"><bounds x="1546" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x01"><bounds x="1546" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x02"><bounds x="1652" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="333" width="35" height="26"/></element>
+
+		<!-- lower panel: user instrument editing / EFX -->
+		<element ref="label_gs"><bounds x="50" y="500" width="60" height="30"/></element>
+		<element ref="label_soundcanvas"><bounds x="120" y="520" width="300" height="40"/></element>
+		<element ref="label_model"><bounds x="430" y="522" width="230" height="36"/></element>
+
+		<element name="led7" ref="lens_circle"><bounds x="700" y="532" width="34" height="34"/></element>
+		<element name="led8" ref="lens_red_overlay"><bounds x="706" y="538" width="22" height="22"/></element>
+		<element ref="label_userinst"><bounds x="745" y="500" width="100" height="22"/></element>
+		<element ref="label_select"><bounds x="846" y="500" width="90" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x01"><bounds x="750" y="528" width="90" height="42"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x02"><bounds x="846" y="528" width="90" height="42"/></element>
+		<element ref="efx"><bounds x="750" y="580" width="90" height="24"/></element>
+		<element ref="efx_onoff"><bounds x="846" y="580" width="90" height="24"/></element>
+
+		<element name="led4" ref="lens_triangle"><bounds x="975" y="460" width="22" height="22"/></element>
+		<element name="led5" ref="lens_triangle"><bounds x="975" y="484" width="22" height="22"/></element>
+		<element name="led6" ref="lens_triangle"><bounds x="975" y="508" width="22" height="22"/></element>
+		<element ref="label_vibrate"><bounds x="1010" y="460" width="206" height="22"/></element>
+		<element ref="label_attack"><bounds x="1010" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x04"><bounds x="1010" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1042" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x08"><bounds x="1116" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1148" y="544" width="35" height="26"/></element>
+		<element ref="efx_type"><bounds x="1010" y="580" width="206" height="24"/></element>
+		<element ref="label_vibdepth"><bounds x="1256" y="460" width="206" height="22"/></element>
+		<element ref="label_cutoff"><bounds x="1256" y="484" width="206" height="22"/></element>
+		<element ref="label_decay"><bounds x="1256" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x10"><bounds x="1256" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1288" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x20"><bounds x="1362" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1394" y="544" width="35" height="26"/></element>
+		<element ref="efx_param"><bounds x="1256" y="580" width="206" height="24"/></element>
+		<element ref="label_vibdelay"><bounds x="1502" y="460" width="206" height="22"/></element>
+		<element ref="label_resonance"><bounds x="1502" y="484" width="206" height="22"/></element>
+		<element ref="label_release"><bounds x="1502" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x40"><bounds x="1502" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1534" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x80"><bounds x="1608" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1640" y="544" width="35" height="26"/></element>
+		<element ref="efx_value"><bounds x="1502" y="580" width="206" height="24"/></element>
+	</view>
+
+</mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -40299,6 +40299,7 @@ sc55mk2
 sc88
 sc88vl
 sc88pro
+vegspro
 
 @source:roland/roland_tb303.cpp
 tb303

--- a/src/mame/roland/roland_sc88.cpp
+++ b/src/mame/roland/roland_sc88.cpp
@@ -1,15 +1,70 @@
 // license:BSD-3-Clause
-// copyright-holders:AJR
+// copyright-holders:AJR, superctr
 /****************************************************************************
 
-    Skeleton driver for Roland SC-88 MIDI sound generator.
+    Roland SC-88 family of MIDI sound generators.
+
+    The SC-88 is the successor of the SC-55mkII: two 16-part banks with the
+    SC-55 and a new native tone set, a second MIDI IN, an equalizer and an
+    editable user instrument set, driven by the "XP" PCM chip.
+
+    Main board (service notes, June 1994):
+    - IC29 H8/510 (HD6415108) at 20 MHz, mode 4 (16-bit external bus,
+      A20/A21 unused); both on-chip SCIs are unused, all serial traffic goes
+      through the sub CPU
+    - IC27 uPD65622 gate array: chip select decoder, LCD interface, front
+      panel LEDs, interrupt and wait control
+    - IC11 M38881M2 sub CPU (Roland R00232667, 8 KB ROM, undumped): scans the
+      panel switch matrix, merges MIDI IN A/B and the RS-422/RS-232 computer
+      port, talks to the main CPU through a shared window on /CS5
+    - IC15 MBCS30109 "XP" PCM chip at 24.576 MHz on /CS3, four 2 MB wave
+      ROMs, 2 x 256K x 4 effect DRAM, PCM69AU DAC
+    - RCM2024T LCD unit: the SC-55mkII glass on an HD44780 command set
+    - IC17 512 KB program ROM on /CS0, 2 x 32 KB battery backed SRAM on /CS1
+
+    Interrupts: IRQ0 gate array, IRQ1 XP, IRQ2 sub CPU.  The analog inputs
+    read the backup battery (AN0) and the rear COMPUTER selector (AN1-AN3).
+
+    SC-88VL: compact (1U half-rack) version of SC-88 with standby function
+
+    SC-88Pro: the SC-88 with expanded sample ROM and external effect processor
+    (LSP) for insertion effects. Address decoding is handled by the LSP rather
+    than the gate array.
+
+    VE-GSPro: the SC-88Pro tone generator as a voice expansion board for the
+    MC-80 and A-70/A-90. Does not have the sub MCU, rather receives MIDI
+    directly using the H8/510 SCIs.
+
+    SK-88Pro: 37-key keyboard with a built in SC-88Pro compatible tone
+    generator. Contains a 4M overlay ROM.
 
 ****************************************************************************/
 
 #include "emu.h"
+
+#include "sc88_sub.h"
+
+#include "bus/midi/midiinport.h"
+#include "bus/midi/midioutport.h"
 #include "cpu/h8500/h8510.h"
-//#include "cpu/m6502/m38881.h"
 #include "machine/nvram.h"
+#include "sound/roland_lsp.h"
+#include "sound/roland_xp.h"
+#include "video/hd44780.h"
+
+#include "emupal.h"
+#include "screen.h"
+#include "speaker.h"
+
+#include "roland_sc88.lh"
+#include "roland_sc88pro.lh"
+
+#define LOG_GA      (1U << 1)
+#define LOG_PORT    (1U << 2)
+#define LOG_SUB     (1U << 3)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
 
 
 namespace {
@@ -20,70 +75,695 @@ public:
 	roland_sc88_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_subcpu(*this, "subcpu")
+		, m_xp(*this, "xp")
+		, m_lsp(*this, "lsp")
+		, m_nvram(*this, "nvram")
+		, m_screen(*this, "screen")
+		, m_lcd(*this, "lcd")
+		, m_keys(*this, "KEY%u", 0U)
+		, m_computer_sw(*this, "COMPUTER")
+		, m_leds(*this, "led%u", 0U)
 	{
 	}
 
 	void sc88(machine_config &config);
 	void sc88vl(machine_config &config);
 	void sc88pro(machine_config &config);
+	void vegspro(machine_config &config);
+
+	void init_sc88() ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
 
 private:
+	HD44780_PIXEL_UPDATE(lcd_pixel_update);
+	void lcd_palette(palette_device &palette) const;
+
 	void main_map(address_map &map) ATTR_COLD;
-	void pro_map(address_map &map) ATTR_COLD;
+	void sc88pro_map(address_map &map) ATTR_COLD;
+	void vegspro_map(address_map &map) ATTR_COLD;
+	void xp_rom_map(address_map &map) ATTR_COLD;
+	void pro_xp_rom_map(address_map &map) ATTR_COLD;
+
+	u8 ga_r(offs_t offset);
+	void ga_w(offs_t offset, u8 data);
+	void ga_int_update();
+	TIMER_CALLBACK_MEMBER(lcd_done);
+	// the upper half of the battery RAM is also selected in pages 0 and E
+	u16 ram_alias_r(offs_t offset) { return m_nvram[0x4000 + offset]; }
+	void ram_alias_w(offs_t offset, u16 data, u16 mem_mask) { COMBINE_DATA(&m_nvram[0x4000 + offset]); }
+	void xp_int_w(int state);
+	void lsp_serial_w(offs_t channel, u32 data);
+	u32 lsp_serial_r(offs_t channel);
+	void lsp_mute_w(u8 data);
+	u8 port4_r();
+	void port4_w(u8 data);
+	u8 port8_r();
+	u16 battery_r();
+	u16 computer_sw_r();
 
 	required_device<h8510_device> m_maincpu;
+	optional_device<sc88_sub_device> m_subcpu;
+	required_device<roland_xp_device> m_xp;
+	optional_device<roland_lsp_device> m_lsp;
+	required_shared_ptr<u16> m_nvram;
+	optional_device<screen_device> m_screen;
+	optional_device<hd44780_device> m_lcd;
+	optional_ioport_array<4> m_keys;
+	optional_ioport m_computer_sw;
+	output_finder<9> m_leds;
+
+	u8 m_ga_regs[0x100]{};
+	u8 m_ga_int_mask = 0;
+	u8 m_ga_int_pending = 0;
+	u8 m_lcd_fifo[13]{};
+	u8 m_lcd_fifo_count = 0;
+	bool m_lcd_command_pending = false;
+	emu_timer *m_lcd_timer = nullptr;
+	bool m_xp_int = false;
+	bool m_lsp_mute = true;
 };
 
+
+// The wave ROMs are stored as dumped; the board wiring permutes address lines
+// within each 256 KB block and the data lines.
+void roland_sc88_state::init_sc88()
+{
+	memory_region *region = memregion("waverom");
+	u8 *rom = region->base();
+	const u32 size = region->bytes();
+
+	static const u8 address_lines[18] = { 0, 4, 2, 3, 1, 13, 7, 12, 5, 10, 16, 9, 6, 8, 14, 17, 11, 15 };
+	static const u8 data_lines[8] = { 2, 0, 4, 5, 7, 6, 3, 1 };
+
+	std::vector<u8> scrambled(rom, rom + size);
+	for (u32 i = 0; i < size; i++)
+	{
+		u32 address = i & ~0x3ffff;
+		for (int bit = 0; bit < 18; bit++)
+			if (BIT(i, bit))
+				address |= 1 << address_lines[bit];
+
+		const u8 source = scrambled[address];
+		u8 data = 0;
+		for (int bit = 0; bit < 8; bit++)
+			if (BIT(source, data_lines[bit]))
+				data |= 1 << bit;
+		rom[i] = data;
+	}
+}
+
+void roland_sc88_state::machine_start()
+{
+	m_lcd_timer = timer_alloc(FUNC(roland_sc88_state::lcd_done), this);
+
+	save_item(NAME(m_ga_regs));
+	save_item(NAME(m_ga_int_mask));
+	save_item(NAME(m_ga_int_pending));
+	save_item(NAME(m_lcd_fifo));
+	save_item(NAME(m_lcd_fifo_count));
+	save_item(NAME(m_lcd_command_pending));
+	save_item(NAME(m_xp_int));
+	save_item(NAME(m_lsp_mute));
+}
+
+void roland_sc88_state::machine_reset()
+{
+	std::fill(std::begin(m_ga_regs), std::end(m_ga_regs), 0);
+	m_ga_int_mask = 0xff;
+	m_ga_int_pending = 0;
+	m_lcd_fifo_count = 0;
+	m_lcd_command_pending = false;
+	m_lcd_timer->adjust(attotime::never);
+
+}
+
+
+//-------------------------------------------------
+//  gate array: LEDs, interrupt aggregator on IRQ0 and the LCD interface.
+//  The LCD is written through a command register and a data FIFO; the
+//  strobe transfers both and raises interrupt source 0 when done.
+//
+//    00     LEDs                 04     1 + pending interrupt source (read)
+//    01-02  ?                    05     interrupt mask, bit n masks source n
+//    03/07  LCD setup            1e     LCD strobe    1f  LCD command
+//                                20-2c  LCD data FIFO
+//-------------------------------------------------
+
+void roland_sc88_state::ga_int_update()
+{
+	m_maincpu->set_input_line(0, (m_ga_int_pending & ~m_ga_int_mask) ? ASSERT_LINE : CLEAR_LINE);
+}
+
+TIMER_CALLBACK_MEMBER(roland_sc88_state::lcd_done)
+{
+	m_ga_int_pending |= 1;
+	ga_int_update();
+}
+
+u8 roland_sc88_state::ga_r(offs_t offset)
+{
+	u8 data = m_ga_regs[offset];
+	switch (offset)
+	{
+	case 0x04:
+	{
+		// 1 + number of the lowest pending source, 0 when none; reading acknowledges it
+		const u8 active = m_ga_int_pending & ~m_ga_int_mask;
+		data = 0;
+		for (int source = 0; source < 8 && !data; source++)
+			if (BIT(active, source))
+			{
+				data = source + 1;
+				if (!machine().side_effects_disabled())
+				{
+					m_ga_int_pending &= ~(1 << source);
+					ga_int_update();
+				}
+			}
+		return data;
+	}
+	default:
+		break;
+	}
+	if (!machine().side_effects_disabled())
+		LOGMASKED(LOG_GA, "%s: gate array read %02x = %02x\n", machine().describe_context(), offset, data);
+	return data;
+}
+
+void roland_sc88_state::ga_w(offs_t offset, u8 data)
+{
+	LOGMASKED(LOG_GA, "%s: ga w %02x = %02x\n", machine().describe_context(), offset, data);
+	m_ga_regs[offset] = data;
+	switch (offset)
+	{
+	case 0x00:
+	case 0x01:
+	{
+		// 00 = LED data (ALL, MUTE, INST MAP, EQ, EDIT (upper, middle, lower),
+		// USER INST), gated by the common in 01 bit 0 (active low).  01 bit 1
+		// drives the SC-88Pro's second lens die directly (red; the green one is
+		// on the USER INST data line, and both lit show orange in EFX mode).
+		const u8 data = m_ga_regs[0x00];
+		const u8 commons = m_ga_regs[0x01];
+		for (int i = 0; i < 8; i++)
+			m_leds[i] = BIT(data, i) && !BIT(commons, 0);
+		m_leds[8] = BIT(commons, 1);
+		break;
+	}
+	case 0x05:
+		m_ga_int_mask = data;
+		ga_int_update();
+		break;
+	case 0x1e:
+	{
+		int bytes = m_lcd_fifo_count;
+		if (m_lcd_command_pending)
+		{
+			m_lcd->write(0, m_ga_regs[0x1f]);
+			bytes++;
+		}
+		for (int i = 0; i < m_lcd_fifo_count; i++)
+			m_lcd->write(1, m_lcd_fifo[i]);
+		m_lcd_command_pending = false;
+		m_lcd_fifo_count = 0;
+		m_lcd_timer->adjust(attotime::from_usec(40 * (bytes + 1)));
+		break;
+	}
+	case 0x1f:
+		m_lcd_command_pending = true;
+		break;
+	case 0x20: case 0x21: case 0x22: case 0x23: case 0x24: case 0x25:
+	case 0x26: case 0x27: case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c:
+		if (m_lcd_fifo_count < 13)
+			m_lcd_fifo[m_lcd_fifo_count++] = data;
+		break;
+	default:
+		LOGMASKED(LOG_GA, "%s: gate array write %02x = %02x\n", machine().describe_context(), offset, data);
+		break;
+	}
+}
+
+
+//-------------------------------------------------
+//  XP PCM chip on IRQ1; the interrupt handler polls the pin through port 8
+//-------------------------------------------------
+
+void roland_sc88_state::xp_int_w(int state)
+{
+	m_xp_int = state;
+	m_maincpu->set_input_line(1, state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+//-------------------------------------------------
+//  the XP clocks the LSP: SDOB carries the EFX send to TRR, TRS0 comes back on SDIA5
+//-------------------------------------------------
+
+void roland_sc88_state::lsp_serial_w(offs_t channel, u32 data)
+{
+	// the XP presents its word one bit up; the return comes back nine bits down and inverted. A linear
+	// effect only ever sees the product of the two, so it took a clipping one to tell the split apart
+	m_lsp->ser_w(channel, s32(data));
+	if (channel)
+		m_lsp->run_once();
+}
+
+// the pair comes back a half-frame rotated
+u32 roland_sc88_state::lsp_serial_r(offs_t channel)
+{
+	return m_lsp_mute ? 0 : u32(-(m_lsp->ser_r(channel ^ 1) >> 9));
+}
+
+// P3-7 is LSPMUTE, the second input of the gate the return passes through: the firmware holds it low
+// while it uploads a program, and for ten seconds over the boot.
+void roland_sc88_state::lsp_mute_w(u8 data)
+{
+	m_lsp_mute = !BIT(data, 7);
+}
+
+//-------------------------------------------------
+//  port 4: the LCD contrast ladder and the audio mute
+//-------------------------------------------------
+
+// bit 4-7: LCD contrast
+// bit 3: timer output
+// bit 2: analog mute
+// bit 1: timer clock in
+// bit 0: sub-CPU reset (88VL only)
+u8 roland_sc88_state::port4_r()
+{
+	return 0xff;
+}
+
+void roland_sc88_state::port4_w(u8 data)
+{
+	LOGMASKED(LOG_PORT, "%s: port 4 = %02x (contrast %2d, mute %s)\n", machine().describe_context(),
+			data, ~data >> 4 & 0x0f, BIT(data, 2) ? "off" : "on");
+	if (m_subcpu.found())
+		m_subcpu->reset_w(BIT(data, 0));
+}
+
+u8 roland_sc88_state::port8_r()
+{
+	return m_xp_int ? 0xfd : 0xff;
+}
+
+
+//-------------------------------------------------
+//  analog inputs
+//-------------------------------------------------
+
+u16 roland_sc88_state::battery_r()
+{
+	return 0x2a0;
+}
+
+// the rear selector is a resistor ladder into three inputs; until the
+// thresholds are known each position pulls one input high
+u16 roland_sc88_state::computer_sw_r()
+{
+	return m_computer_sw.read_safe(0) ? 0x3ff : 0;
+}
+
+
+//-------------------------------------------------
+//  memory maps
+//-------------------------------------------------
 
 void roland_sc88_state::main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom().region("progrom", 0);
-	map(0x080000, 0x08ffff).ram().share("nvram");
+	map(0x008000, 0x00ffff).rw(FUNC(roland_sc88_state::ram_alias_r), FUNC(roland_sc88_state::ram_alias_w));
+	map(0x080000, 0x08ffff).ram().share(m_nvram);
+	map(0x0e8000, 0x0effff).rw(FUNC(roland_sc88_state::ram_alias_r), FUNC(roland_sc88_state::ram_alias_w));
+	map(0x0e0000, 0x0e3fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0x0f0000, 0x0f00ff).rw(m_subcpu, FUNC(sc88_sub_device::read), FUNC(sc88_sub_device::write));
+	map(0x0fc100, 0x0fc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
 }
 
-void roland_sc88_state::pro_map(address_map &map)
+void roland_sc88_state::sc88pro_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom().region("progrom", 0);
-	map(0x100000, 0x10ffff).ram().share("nvram");	// TODO: probably incorrect
+	map(0xc00000, 0xc0ffff).ram().share(m_nvram);
+	map(0xc80000, 0xc83fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0xe00000, 0xe000ff).rw(m_subcpu, FUNC(sc88_sub_device::read), FUNC(sc88_sub_device::write));
+	map(0xefc100, 0xefc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
+	map(0xf00000, 0xf000ff).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
 }
 
+void roland_sc88_state::vegspro_map(address_map &map)
+{
+	map(0x000000, 0x0fffff).rom().region("progrom", 0);
+	map(0xc00000, 0xc0ffff).ram().share(m_nvram);
+	map(0xc80000, 0xc83fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0xefc100, 0xefc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
+	map(0xf00000, 0xf000ff).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
+}
+
+// the XP's region number: bits 6-4 select the ROM chip, bits 3-0 the 1 MB page in it
+void roland_sc88_state::xp_rom_map(address_map &map)
+{
+	map(0x0000000, 0x01fffff).rom().region("waverom", 0x000000);
+	map(0x1000000, 0x11fffff).rom().region("waverom", 0x200000);
+	map(0x2000000, 0x21fffff).rom().region("waverom", 0x400000);
+	map(0x3000000, 0x31fffff).rom().region("waverom", 0x600000);
+}
+
+// five 32 Mbit ROMs, XWCS0-4 = IC20-IC24 (service notes, main circuit diagram)
+void roland_sc88_state::pro_xp_rom_map(address_map &map)
+{
+	map(0x0000000, 0x03fffff).rom().region("waverom", 0x000000);
+	map(0x1000000, 0x13fffff).rom().region("waverom", 0x400000);
+	map(0x2000000, 0x23fffff).rom().region("waverom", 0x800000);
+	map(0x3000000, 0x33fffff).rom().region("waverom", 0xc00000);
+	map(0x4000000, 0x43fffff).rom().region("waverom", 0x1000000);
+}
+
+
+//-------------------------------------------------
+//  LCD: the RCM2024T glass of the SC-55mkII, see roland_sc55mk2.cpp
+//-------------------------------------------------
+
+void roland_sc88_state::lcd_palette(palette_device &palette) const
+{
+	palette.set_pen_color(0, rgb_t(0xf8, 0xc8, 0x40)); // background
+	palette.set_pen_color(1, rgb_t(0x20, 0x10, 0x00)); // segment on
+}
+
+static constexpr int LCD_CHAR_PITCH = 35;
+static constexpr int LCD_DOT_PITCH = 6;
+static constexpr int LCD_DOT_SIZE = 5;
+static constexpr int LCD_COL0_X = 24;
+static constexpr int LCD_COL1_X = 143;
+static constexpr int LCD_ROW_Y[4] = { 14, 78, 142, 206 };
+static constexpr int LCD_BAR_X = 283;
+static constexpr int LCD_BAR_Y = 74;
+static constexpr int LCD_BAR_PITCH_X = 26;
+static constexpr int LCD_BAR_PITCH_Y = 11;
+static constexpr int LCD_BAR_W = 24;
+static constexpr int LCD_BAR_H = 9;
+static constexpr int LCD_LR_X = 254;
+static constexpr int LCD_LR_Y[2] = { 74, 234 };
+
+static void lcd_fill(bitmap_ind16 &bitmap, int x, int y, int w, int h, int state)
+{
+	for (int yy = y; yy < y + h; yy++)
+		for (int xx = x; xx < x + w; xx++)
+			bitmap.pix(yy, xx) = state;
+}
+
+HD44780_PIXEL_UPDATE(roland_sc88_state::lcd_pixel_update)
+{
+	if (pos >= 20 && pos < 24 && line < 2)
+	{
+		int const bar = (pos - 20) * 5 + x;
+		if (bar < 16)
+			lcd_fill(bitmap, LCD_BAR_X + bar * LCD_BAR_PITCH_X, LCD_BAR_Y + (line * 8 + y) * LCD_BAR_PITCH_Y, LCD_BAR_W, LCD_BAR_H, state);
+		return;
+	}
+
+	if (line == 1 && pos == 18)
+	{
+		if (y == 0 && x == 4)
+		{
+			static constexpr u16 L_SHAPE[12] = { 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x7ff, 0x7ff };
+			static constexpr u16 R_SHAPE[12] = { 0x7fc, 0x7fe, 0x606, 0x606, 0x606, 0x7fe, 0x7fc, 0x630, 0x618, 0x60c, 0x606, 0x603 };
+			for (int i = 0; i < 12; i++)
+				for (int j = 0; j < 11; j++)
+				{
+					if (BIT(L_SHAPE[i], 10 - j))
+						bitmap.pix(LCD_LR_Y[0] + i, LCD_LR_X + j) = state;
+					if (BIT(R_SHAPE[i], 10 - j))
+						bitmap.pix(LCD_LR_Y[1] + i, LCD_LR_X + j) = state;
+				}
+		}
+		return;
+	}
+
+	if (y >= 7)
+		return;
+
+	int cx, cy;
+	if (line == 0)
+	{
+		if (pos < 3)
+			cx = LCD_COL0_X + pos * LCD_CHAR_PITCH;
+		else if (pos < 19)
+			cx = LCD_COL1_X + (pos - 3) * LCD_CHAR_PITCH;
+		else
+			return;
+		cy = LCD_ROW_Y[0];
+	}
+	else if (line == 1 && pos < 18)
+	{
+		int const field = pos / 3;
+		static constexpr int FIELD_COL[6] = { 0, 1, 1, 0, 0, 1 };
+		static constexpr int FIELD_ROW[6] = { 1, 1, 2, 2, 3, 3 };
+		cx = (FIELD_COL[field] ? LCD_COL1_X : LCD_COL0_X) + (pos % 3) * LCD_CHAR_PITCH;
+		cy = LCD_ROW_Y[FIELD_ROW[field]];
+	}
+	else
+		return;
+
+	lcd_fill(bitmap, cx + x * LCD_DOT_PITCH, cy + y * LCD_DOT_PITCH, LCD_DOT_SIZE, LCD_DOT_SIZE, state);
+}
+
+
+//-------------------------------------------------
+//  machine configuration
+//-------------------------------------------------
+
+// front panel switch matrix: SSC0-SSC3 strobes select the columns, SD0-SD7 are
+// the rows (switch board, service notes p.15); PREVIEW is the volume knob's
+// push switch on the VR board, on SSC0/SD7.
 static INPUT_PORTS_START(sc88)
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EQ")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-55 Map")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument <")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument >")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Mute")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("All")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Preview")
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part >")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst Edit On/Off")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst Edit Select")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / Delay <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / Delay >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release >")
+
+	// rear panel selector, read through the analog inputs as a resistor ladder
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x03, 0x00, "Computer Switch")
+	PORT_CONFSETTING(0x00, "MIDI")
+	PORT_CONFSETTING(0x01, "PC-1")
+	PORT_CONFSETTING(0x02, "PC-2")
+	PORT_CONFSETTING(0x03, "Mac")
 INPUT_PORTS_END
 
-static INPUT_PORTS_START(sc88vl)
-INPUT_PORTS_END
-
+// same matrix positions as the SC-88; SC-88 MAP replaces EQ, and the lower
+// row doubles as the EFX controls
 static INPUT_PORTS_START(sc88pro)
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-88 Map")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-55 Map")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument <")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument >")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Mute")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("All")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Preview")
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part >")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift / Delay <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift / Delay >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst / EFX")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Select / EFX On/Off")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / EFX Type <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / EFX Type >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay / EFX Param <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay / EFX Param >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release / EFX Value <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release / EFX Value >")
+
+	// rear panel selector, read through the analog inputs as a resistor ladder
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x03, 0x00, "Computer Switch")
+	PORT_CONFSETTING(0x00, "MIDI")
+	PORT_CONFSETTING(0x01, "PC-1")
+	PORT_CONFSETTING(0x02, "PC-2")
+	PORT_CONFSETTING(0x03, "Mac")
 INPUT_PORTS_END
 
 void roland_sc88_state::sc88(machine_config &config)
 {
 	HD6415108(config, m_maincpu, 20_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::main_map);
+	m_maincpu->read_adc<0>().set(FUNC(roland_sc88_state::battery_r));
+	m_maincpu->read_adc<1>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<2>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<3>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_port4().set(FUNC(roland_sc88_state::port4_r));
+	m_maincpu->write_port4().set(FUNC(roland_sc88_state::port4_w));
+	m_maincpu->read_port8().set(FUNC(roland_sc88_state::port8_r));
 
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // ??
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // 2 x SRM2A256 + battery
 
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	SC88_SUB(config, m_subcpu, 20_MHz_XTAL / 2); // M38881M2, clocked from the H8's phi output
+	m_subcpu->int_callback().set_inputline(m_maincpu, 2); // IRQ2
+	m_subcpu->keys_callback<0>().set_ioport("KEY0");
+	m_subcpu->keys_callback<1>().set_ioport("KEY1");
+	m_subcpu->keys_callback<2>().set_ioport("KEY2");
+	m_subcpu->keys_callback<3>().set_ioport("KEY3");
+	m_subcpu->tx_callback().set("mdout", FUNC(midi_port_device::write_txd));
+
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_subcpu, FUNC(sc88_sub_device::rxd_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_subcpu, FUNC(sc88_sub_device::rxd_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	SCREEN(config, m_screen).set_lcd();
+	m_screen->set_refresh_hz(80);
+	m_screen->set_screen_update("lcd", FUNC(hd44780_device::screen_update));
+	m_screen->set_size(720, 272);
+	m_screen->set_visarea_full();
+	m_screen->set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(roland_sc88_state::lcd_palette), 2);
+
+	HD44780(config, m_lcd, 270'000);
+	m_lcd->set_lcd_size(2, 40);
+	m_lcd->set_pixel_update_cb(FUNC(roland_sc88_state::lcd_pixel_update));
+
+	config.set_default_layout(layout_roland_sc88);
+
+	SPEAKER(config, "speaker", 2).front();
+
+	ROLAND_XP(config, m_xp, 24.576_MHz_XTAL);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::xp_rom_map);
+	m_xp->int_callback().set(FUNC(roland_sc88_state::xp_int_w));
+	m_xp->add_route(1, "speaker", 1.0, 0);
+	m_xp->add_route(4, "speaker", 1.0, 1);
 }
 
 void roland_sc88_state::sc88vl(machine_config &config)
 {
-	HD6415108(config, m_maincpu, 20_MHz_XTAL);
-	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::main_map);
-
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // SRM2A256SLM-70 x2 + battery
-
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	sc88(config);
 }
 
 void roland_sc88_state::sc88pro(machine_config &config)
 {
+	sc88(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::sc88pro_map);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::pro_xp_rom_map);
+
+	// two DAC pairs: OUTPUT1 takes words 02/03, OUTPUT2 words 06/07
+	SPEAKER(config, "output2", 2).front();
+	m_xp->reset_routes();
+	m_xp->add_route(2, "speaker", 1.0, 0);
+	m_xp->add_route(3, "speaker", 1.0, 1);
+	m_xp->add_route(6, "output2", 1.0, 0);
+	m_xp->add_route(7, "output2", 1.0, 1);
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+
+	// the EFX send leaves in RAM words 01/05; TRS0 comes back into the DSP's own serial capture
+	m_xp->set_serial_output_words(0x01, 0x05);
+	m_xp->serial_out_callback().set(FUNC(roland_sc88_state::lsp_serial_w));
+	m_xp->serial_in_callback().set(FUNC(roland_sc88_state::lsp_serial_r));
+	m_maincpu->write_port3().set(FUNC(roland_sc88_state::lsp_mute_w));
+
+	config.set_default_layout(layout_roland_sc88pro);
+}
+
+void roland_sc88_state::vegspro(machine_config &config)
+{
 	HD6415108(config, m_maincpu, 20_MHz_XTAL);
-	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::pro_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::vegspro_map);
+	m_maincpu->read_adc<0>().set(FUNC(roland_sc88_state::battery_r));
+	// the expansion board has no rear selector, but the SC-88Pro's firmware still polls the ladder
+	m_maincpu->read_adc<1>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<2>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<3>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_port4().set(FUNC(roland_sc88_state::port4_r));
+	m_maincpu->write_port4().set(FUNC(roland_sc88_state::port4_w));
+	m_maincpu->read_port8().set(FUNC(roland_sc88_state::port8_r));
+	m_maincpu->write_sci_tx<0>().set("mdout", FUNC(midi_port_device::write_txd));
 
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // ??
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	// MIDI IN A/B go straight to the H8's serial ports, MIDI OUT comes from SCI1
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_maincpu, FUNC(hd6415108_device::sci_rx_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_maincpu, FUNC(hd6415108_device::sci_rx_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	SPEAKER(config, "speaker", 2).front();
+	SPEAKER(config, "output2", 2).front();
+
+	ROLAND_XP(config, m_xp, 24.576_MHz_XTAL);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::pro_xp_rom_map);
+	m_xp->int_callback().set(FUNC(roland_sc88_state::xp_int_w));
+	m_xp->add_route(2, "speaker", 1.0, 0);
+	m_xp->add_route(3, "speaker", 1.0, 1);
+	m_xp->add_route(6, "output2", 1.0, 0);
+	m_xp->add_route(7, "output2", 1.0, 1);
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+
+	// the EFX send leaves in RAM words 01/05; TRS0 comes back into the DSP's own serial capture
+	m_xp->set_serial_output_words(0x01, 0x05);
+	m_xp->serial_out_callback().set(FUNC(roland_sc88_state::lsp_serial_w));
+	m_xp->serial_in_callback().set(FUNC(roland_sc88_state::lsp_serial_r));
+	m_maincpu->write_port3().set(FUNC(roland_sc88_state::lsp_mute_w));
 }
 
 #define ROM_LOAD16_WORD_SWAP_BIOS(bios,name,offset,length,hash) \
@@ -93,7 +773,7 @@ void roland_sc88_state::sc88pro(machine_config &config)
 
 ROM_START(sc88)
 	ROM_REGION16_BE(0x80000, "progrom", 0)
-	ROM_DEFAULT_BIOS("102")
+	ROM_DEFAULT_BIOS("104")
 	ROM_SYSTEM_BIOS(0, "102", "Control ROM 1.0.2")	// v1.02, 1994-06-16, 18:43 (offset 0x7cff6)
 	ROM_LOAD16_WORD_SWAP_BIOS(0, "roland_sc88-control-1.02-hn27c4096h.ic17", 0x00000, 0x80000, CRC(9e9c56f9) SHA1(9291a4e4ac0fea9fb5a39777be501ab3d34877c8))
 	ROM_SYSTEM_BIOS(1, "103", "Control ROM 1.0.3")	// v1.03, 1994-07-01, 10:48 (offset 0x7d136)
@@ -105,7 +785,7 @@ ROM_START(sc88)
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("subcpu.ic11", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x800000, "waverom", 0)
+	ROM_REGION(0x800000, "waverom", 0)
 	ROM_LOAD("sc88-pcm-ic-325.ic14", 0x000000, 0x200000, CRC(f9dd9e49) SHA1(860dcd9804ded4cd46aab38bfc3764a1ad7a6b65))
 	ROM_LOAD("sc88-pcm-ic-326.ic8",  0x200000, 0x200000, CRC(05f939f2) SHA1(ac95c26c46c40aacb944f5d45634c93bee9e6d90))
 	ROM_LOAD("sc88-pcm-ic-327.ic7",  0x400000, 0x200000, CRC(a6fc7393) SHA1(d88bf13c3d74097991b783295d95ccfae2c9282d))
@@ -119,31 +799,69 @@ ROM_START(sc88vl)
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("roland-r00232667-m38881m2-150gp.ic23", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x800000, "waverom", 0)
-	ROM_LOAD("roland-r00785356-hn624316fbc25.ic10", 0x000000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00785367-hn624316fbc26.ic7",  0x200000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00788489-hn624316fbc27.ic4",  0x400000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00788490-hn624316fbc28.ic2",  0x600000, 0x200000, NO_DUMP)
+	ROM_REGION(0x800000, "waverom", 0)
+	// the VL's own mask ROMs (roland-r00785356-hn624316fbc25.ic10, roland-r00785367-hn624316fbc26.ic7,
+	// roland-r00788489-hn624316fbc27.ic4, roland-r00788490-hn624316fbc28.ic2) are undumped;
+	// the sample data should be identical to the SC-88's, so use the parent's images
+	ROM_LOAD("sc88-pcm-ic-325.ic14", 0x000000, 0x200000, BAD_DUMP CRC(f9dd9e49) SHA1(860dcd9804ded4cd46aab38bfc3764a1ad7a6b65))
+	ROM_LOAD("sc88-pcm-ic-326.ic8",  0x200000, 0x200000, BAD_DUMP CRC(05f939f2) SHA1(ac95c26c46c40aacb944f5d45634c93bee9e6d90))
+	ROM_LOAD("sc88-pcm-ic-327.ic7",  0x400000, 0x200000, BAD_DUMP CRC(a6fc7393) SHA1(d88bf13c3d74097991b783295d95ccfae2c9282d))
+	ROM_LOAD("sc88-pcm-ic-328.ic6",  0x600000, 0x200000, BAD_DUMP CRC(7bc514aa) SHA1(03e70ae2efd190f41af24be01b1abaa84bfa93d9))
 ROM_END
 
 ROM_START(sc88pro)
 	ROM_REGION16_BE(0x100000, "progrom", 0)
-	ROM_LOAD16_WORD_SWAP("roland-r01780078.ic26", 0x00000, 0x100000, CRC(6cf8fc8b) SHA1(c07cbbd026781428ae83f4b897a51cb7bcdafeb6))
+	ROM_DEFAULT_BIOS("104")
+	ROM_SYSTEM_BIOS(0, "102", "Control ROM 1.0.2")	// v1.02, 1996-09-17, 08:01 (offset 0xcf554)
+	ROM_LOAD16_WORD_BIOS(0, "roland_sc88pro-1.02.ic26", 0x00000, 0x100000, CRC(7b0d392d) SHA1(19906eea7655bc105ef5077ce4fac10c21678225))
+	ROM_SYSTEM_BIOS(1, "104", "Control ROM 1.0.4")	// v1.04, 1997-02-18, 12:11 (offset 0xcf45c)
+	ROM_LOAD16_WORD_BIOS(1, "roland_sc88pro-1.04.ic26", 0x00000, 0x100000, CRC(820824d2) SHA1(6d06f00a1f8195a76b3af600ca708003f9a3abdc))
 
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("subcpu.ic10", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x1400000, "waverom", 0)
-	// source unverified - the SC-88Pro service manual lists IC20..24 but the dumped files were called:
-	// "R01567167 301 (Samples A).bin", "R01567178 302 (Samples B).BIN" and "R01233667 314 (Samples C).BIN"
-	ROM_LOAD("roland-r01567167-301.ic20-21", 0x0000000, 0x800000, CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
-	ROM_LOAD("roland-r01567178-302.ic22-23", 0x0800000, 0x800000, CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
-	ROM_LOAD("roland-r01233667-314.ic24",    0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+	ROM_REGION(0x1400000, "waverom", 0)
+	// Wave ROM reconstructed from vegspro (same sample data, wider chips)
+	ROM_LOAD("roland-r01017834-378.ic20", 0x0000000, 0x400000, BAD_DUMP CRC(84dfea65) SHA1(1af429154193dfcda17d609fd73719750c133220))
+	ROM_LOAD("roland-r01017845-379.ic21", 0x0400000, 0x400000, BAD_DUMP CRC(60210227) SHA1(5a453a1bd93d1ddee7cc809430768d4a08739d2b))
+	ROM_LOAD("roland-r01124778-519.ic22", 0x0800000, 0x400000, BAD_DUMP CRC(5f883ddd) SHA1(78b17450d969c23fba5e9e3f8e4cbc4178096674))
+	ROM_LOAD("roland-r01124789-520.ic23", 0x0c00000, 0x400000, BAD_DUMP CRC(ecb4dd39) SHA1(a6b29144b165248162bef8ba4cded49efa4f5b90))
+	ROM_LOAD("roland-r01124790-521.ic24", 0x1000000, 0x400000, BAD_DUMP CRC(93541e95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+ROM_END
+
+/*
+ROM_START(sk88pro)
+	ROM_REGION16_BE(0x100000, "progrom", 0)
+	ROM_LOAD("roland-r01348078.ic8", 0x00000, 0x100000, NO_DUMP)
+	ROM_LOAD("roland_r01454223.ic7", 0x00000, 0x80000, NO_DUMP) // overlay
+
+	ROM_REGION(0x2000, "subcpu", 0)
+	ROM_LOAD("roland-r01235734-m38881m2-152gp.ic5", 0x0000, 0x2000, NO_DUMP)
+
+	ROM_REGION(0x1400000, "waverom", 0)
+	ROM_LOAD("roland-r01348723.ic13", 0x0000000, 0x800000, BAD_DUMP CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
+	ROM_LOAD("roland-r01348734.ic15", 0x0800000, 0x800000, BAD_DUMP CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
+	ROM_LOAD("roland-r01233667-314.ic17", 0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+ROM_END
+*/
+
+ROM_START(vegspro)
+	ROM_REGION16_BE(0x100000, "progrom", 0)
+	// "SC88PRO (MK03B)" v1.02, 1997-05-19
+	ROM_LOAD16_WORD_SWAP("roland-r01780078.bin", 0x00000, 0x100000, CRC(6cf8fc8b) SHA1(c07cbbd026781428ae83f4b897a51cb7bcdafeb6))
+
+	ROM_REGION(0x1400000, "waverom", 0)
+	// dumped as "R01567167 301 (Samples A).bin", "R01567178 302 (Samples B).BIN", "R01233667 314 (Samples C).BIN"
+	ROM_LOAD("roland-r01567167-301.bin", 0x0000000, 0x800000, CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
+	ROM_LOAD("roland-r01567178-302.bin", 0x0800000, 0x800000, CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
+	ROM_LOAD("roland-r01233667-314.bin", 0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
 ROM_END
 
 } // anonymous namespace
 
 
-SYST(1994, sc88, 0, 0, sc88, sc88, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-SYST(1995, sc88vl, 0, 0, sc88vl, sc88vl, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88VL", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-SYST(1996, sc88pro, 0, 0, sc88pro, sc88pro, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88Pro", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+SYST(1994, sc88, 0, 0, sc88, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88", 0)
+SYST(1995, sc88vl, sc88, 0, sc88vl, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88VL", MACHINE_NOT_WORKING) // needs its own panel layout and input assignments
+SYST(1996, sc88pro, 0, 0, sc88pro, sc88pro, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88Pro", 0)
+//SYST(1998, sk88pro, 0, 0, sk88pro, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SK-88Pro", MACHINE_NOT_WORKING)
+SYST(1998, vegspro, 0, 0, vegspro, 0, roland_sc88_state, init_sc88, "Roland", "VE-GSPro Voice Expansion Board", MACHINE_NOT_WORKING)

--- a/src/mame/roland/sc88_sub.cpp
+++ b/src/mame/roland/sc88_sub.cpp
@@ -1,0 +1,535 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/****************************************************************************
+
+    Roland SC-88 sub CPU (M38881M2, Roland R00232667) - high level emulation.
+
+    The chip is a Mitsubishi 3888 group protocol controller whose program
+    is not dumped.  On the SC-88 it receives MIDI IN A, MIDI IN B and the
+    computer port on its three UARTs, parses the streams and hands the main
+    CPU one message per interrupt through the 3888's system bus interface;
+    the main CPU scans the front panel switch matrix through the same
+    window and sends MIDI OUT data back through a ring in the dual port RAM.
+
+    System bus side of the chip (3888 group data sheet, fig. 16):
+
+      00-d7  dual port RAM         dc-df  IPC error registers (sub -> main)
+      d8-db  IPC mode registers    e0-fa  access flags
+             (main -> sub)         fd     semaphore, bit 7 = ready flag
+                                   fe/ff  port data / port control
+
+    Message protocol as reconstructed from the main CPU program (v1.04):
+
+      IPCER0  code    01-07 channel voice message, (status >> 4) - 7
+                      20-bf Roland exclusive, selecting the parameter block
+                      e7    continuation of an exclusive block
+                      ee/ef universal exclusive (GM on / master volume)
+                      10/12 display data
+      IPCER1  flags   bits 0-3 channel, bits 4-5 source (0 IN A, 1 IN B,
+                      2 computer), bit 6 more data follows, bit 7 payload
+                      is a block in the dual port RAM
+      IPCER2/3        data bytes, or block length / offset for a payload
+
+    Payload blocks are the exclusive bytes after F0 up to and including
+    the checksum (the F7 is not counted); they are guarded by block semaphore bit 0/1/2 (the source), which
+    the main CPU clears after copying the block.  Bit 7 of IPCER2 marks the
+    block as a request (RQ1) rather than a data set (DT1); the rest of the
+    byte is the length either way.
+
+    The code does not carry the address MSB directly.  It names one of the
+    parameter blocks of the address map, and for most of them the low three
+    bits are the high nibble of the address middle byte, so a block covers
+    eight of them:
+
+      20  00 0n   system            60  40 0n   patch common (A)
+      28  08 0n                     68  48 0n
+      30  08 0n / 0c 0n             70  50 0n   patch common (B)
+      40  20 0n   user tone bank    78  58 0n
+      48  28 0n                     80  41 0n   drum setup (A)
+      50  21 0n   user drum set     88  49 0n
+      58  29 0n                     90  51 0n   drum setup (B)
+                                    98  59 0n
+      a0  22 0n   user EFX          b0  23 00   user patch common
+      a8  2a 0n                     b1  24 00   user patch part
+                                    b8  2b 0n
+
+    The low nibble of the middle byte is not in the block at all: it travels
+    in the channel field of IPCER1, which is how a request names one of the
+    sixteen parts.  b0-b4 are the exception, a run of address MSBs rather
+    than a run of middle bytes; the SC-88 has neither them nor a0/a8/b8.
+    30 answers to two addresses depending on the parameter asked for and 38
+    to none that could be found, so neither is listed below; both are
+    outside the published map.
+
+    A request is answered on MIDI OUT.  The main CPU sends through the ring
+    at 24-bf, D5 being its write pointer and D4 the sub CPU's read pointer,
+    under block semaphore bit 5.  The ring carries packets, not a byte
+    stream: a length byte followed by that many bytes of MIDI, the next
+    packet starting at the following multiple of four.  A packet may
+    straddle the wrap at c0.
+
+****************************************************************************/
+
+#include "emu.h"
+#include "sc88_sub.h"
+
+#define LOG_MSG     (1U << 1)
+#define LOG_TX      (1U << 2)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(SC88_SUB, sc88_sub_device, "sc88_sub", "Roland SC-88 sub CPU (HLE)")
+
+namespace {
+
+constexpr u8 SOURCE_FLAGS[3] = { 0x00, 0x10, 0x20 };
+constexpr int BLOCK_SIZE = 0x24;        // dual port RAM 00-23 carries payload blocks
+constexpr int MAX_EXCLUSIVE = 0x8a;     // the main CPU's reassembly buffer
+constexpr int TX_RING_START = 0x24;
+constexpr int TX_RING_END = 0xc0;
+constexpr int TX_WRITE_PTR = 0xd5;
+constexpr int TX_READ_PTR = 0xd4;
+
+struct exclusive_block { u8 address; u8 code; bool paged; };
+
+constexpr exclusive_block BLOCKS[] = {
+	{ 0x00, 0x20, true }, { 0x08, 0x28, true },
+	{ 0x20, 0x40, true }, { 0x28, 0x48, true },
+	{ 0x21, 0x50, true }, { 0x29, 0x58, true },
+	{ 0x40, 0x60, true }, { 0x48, 0x68, true },
+	{ 0x50, 0x70, true }, { 0x58, 0x78, true },
+	{ 0x41, 0x80, true }, { 0x49, 0x88, true },
+	{ 0x51, 0x90, true }, { 0x59, 0x98, true },
+	{ 0x22, 0xa0, true }, { 0x2a, 0xa8, true },
+	{ 0x23, 0xb0, false }, { 0x24, 0xb1, false }, { 0x25, 0xb2, false },
+	{ 0x26, 0xb3, false }, { 0x27, 0xb4, false },
+	{ 0x2b, 0xb8, true },
+};
+
+} // anonymous namespace
+
+
+//-------------------------------------------------
+//  UART receiver, one per MIDI source
+//-------------------------------------------------
+
+DEFINE_DEVICE_TYPE(SC88_SUB_RX, sc88_sub_rx_device, "sc88_sub_rx", "Roland SC-88 sub CPU UART")
+
+sc88_sub_rx_device::sc88_sub_rx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, SC88_SUB_RX, tag, owner, clock)
+	, device_serial_interface(mconfig, *this)
+	, m_byte_cb(*this)
+{
+}
+
+void sc88_sub_rx_device::device_start()
+{
+	set_data_frame(1, 8, PARITY_NONE, STOP_BITS_1);
+	set_rcv_rate(31250);
+}
+
+void sc88_sub_rx_device::device_reset()
+{
+	receive_register_reset();
+}
+
+void sc88_sub_rx_device::rcv_complete()
+{
+	receive_register_extract();
+	m_byte_cb(get_received_char());
+}
+
+
+//-------------------------------------------------
+//  sub CPU
+//-------------------------------------------------
+
+sc88_sub_device::sc88_sub_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, SC88_SUB, tag, owner, clock)
+	, m_int_cb(*this)
+	, m_keys_cb(*this, 0xff)
+	, m_tx_cb(*this)
+	, m_rx(*this, "rx%u", 0U)
+{
+}
+
+void sc88_sub_device::device_add_mconfig(machine_config &config)
+{
+	SC88_SUB_RX(config, m_rx[0], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<0>));
+	SC88_SUB_RX(config, m_rx[1], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<1>));
+	SC88_SUB_RX(config, m_rx[2], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<2>));
+}
+
+void sc88_sub_device::device_start()
+{
+	m_deliver_timer = timer_alloc(FUNC(sc88_sub_device::deliver_timer), this);
+	m_tx_timer = timer_alloc(FUNC(sc88_sub_device::tx_timer), this);
+
+	save_item(NAME(m_dpram));
+	save_item(NAME(m_ipcm));
+	save_item(NAME(m_ipcer));
+	save_item(NAME(m_flags));
+	save_item(NAME(m_sem));
+	save_item(NAME(m_spcon));
+	save_item(NAME(m_pa));
+	save_item(NAME(m_pa_dir));
+	save_item(NAME(m_pb));
+	save_item(NAME(m_pb_dir));
+	save_item(NAME(m_int_state));
+	save_item(NAME(m_in_reset));
+	save_item(NAME(m_busy));
+	save_item(NAME(m_tx_rd));
+	save_item(NAME(m_tx_left));
+	save_item(NAME(m_tx_end));
+	save_item(NAME(m_tx_shift));
+	save_item(NAME(m_tx_bits));
+}
+
+void sc88_sub_device::device_reset()
+{
+	std::fill(std::begin(m_dpram), std::end(m_dpram), 0);
+	std::fill(std::begin(m_ipcm), std::end(m_ipcm), 0);
+	std::fill(std::begin(m_ipcer), std::end(m_ipcer), 0);
+	std::fill(std::begin(m_flags), std::end(m_flags), 0);
+	m_sem = 0x80; // ready: the sub CPU has finished its own initialisation
+	m_spcon = 0;
+	m_pa = m_pa_dir = m_pb = m_pb_dir = 0;
+	m_int_state = false;
+	m_int_cb(0);
+
+	for (source &s : m_src)
+		s = source();
+	m_queue.clear();
+	m_busy = false;
+	m_deliver_timer->adjust(attotime::never);
+
+	m_dpram[TX_READ_PTR] = m_dpram[TX_WRITE_PTR] = TX_RING_START;
+	m_tx_rd = TX_RING_START;
+	m_tx_left = 0;
+	m_tx_end = TX_RING_START;
+	m_tx_shift = 0;
+	m_tx_bits = 0;
+	m_tx_timer->adjust(attotime::never);
+	m_tx_cb(1);
+}
+
+
+//-------------------------------------------------
+//  system bus interface
+//-------------------------------------------------
+
+u8 sc88_sub_device::port_r()
+{
+	switch ((m_spcon >> 2) & 7)
+	{
+	case 0: return m_pa;
+	case 1: return m_pa_dir;
+	case 2: return m_pb;
+	case 3: return m_pb_dir;
+	case 4:
+	{
+		// P0 returns the switch matrix rows selected by the strobes on PB0-PB3
+		u8 keys = 0xff;
+		for (int row = 0; row < 4; row++)
+			if (BIT(m_pb, row))
+				keys &= m_keys_cb[row]();
+		return keys;
+	}
+	default: return 0xff;
+	}
+}
+
+void sc88_sub_device::port_w(u8 data)
+{
+	switch ((m_spcon >> 2) & 7)
+	{
+	case 0: m_pa = data; break;
+	case 1: m_pa_dir = data; break;
+	case 2: m_pb = data; break;
+	case 3: m_pb_dir = data; break;
+	default: break;
+	}
+}
+
+void sc88_sub_device::reset_w(int state)
+{
+	if (m_in_reset == !state)
+		return;
+	m_in_reset = !state;
+	if (m_in_reset)
+		reset();
+}
+
+u8 sc88_sub_device::read(offs_t offset)
+{
+	if (offset < 0xd8)
+	{
+		if (!machine().side_effects_disabled())
+			m_flags[offset >> 3] &= ~(1 << (offset & 7));
+		return m_dpram[offset];
+	}
+	if (offset < 0xdc)
+		return m_ipcm[offset & 3];
+	if (offset < 0xe0)
+	{
+		const u8 data = m_ipcer[offset & 3];
+		if (!machine().side_effects_disabled())
+		{
+			m_ipcer[offset & 3] = 0;
+			if (offset == 0xdc && m_int_state)
+			{
+				// the message has been taken; the next one may follow
+				m_int_state = false;
+				m_int_cb(0);
+				m_deliver_timer->adjust(attotime::from_usec(20));
+			}
+		}
+		return data;
+	}
+	if (offset < 0xfb)
+		return m_flags[offset - 0xe0];
+	if (offset == 0xfd)
+		return m_sem;
+	if (offset == 0xfe)
+		return port_r();
+	if (offset == 0xff)
+		return m_spcon;
+	return 0xff;
+}
+
+void sc88_sub_device::write(offs_t offset, u8 data)
+{
+	if (offset < 0xd8)
+	{
+		m_dpram[offset] = data;
+		m_flags[offset >> 3] |= 1 << (offset & 7);
+		if (offset == TX_WRITE_PTR && m_tx_timer->expire().is_never())
+			m_tx_timer->adjust(attotime::zero);
+		return;
+	}
+
+	if (offset < 0xdc)
+	{
+		m_ipcm[offset & 3] = data;
+		if (offset == 0xd8)
+			m_sem &= 0x7f;
+		LOG("%s: IPC mode register %d = %02x\n", machine().describe_context(), offset & 3, data);
+	}
+	else if (offset == 0xfd)
+	{
+		const u8 bit = 1 << (data & 7);
+		if (BIT(data, 7))
+			m_sem |= bit;
+		else
+			m_sem &= ~bit;
+		if (!m_busy && !m_queue.empty())
+			m_deliver_timer->adjust(attotime::from_usec(20));
+	}
+	else if (offset == 0xfe)
+		port_w(data);
+	else if (offset == 0xff)
+		m_spcon = data;
+}
+
+
+//-------------------------------------------------
+//  MIDI input parsing
+//-------------------------------------------------
+
+void sc88_sub_device::midi_byte(int src, u8 data)
+{
+	source &s = m_src[src];
+
+	if (data >= 0xf8)
+		return; // system realtime
+
+	if (data >= 0x80)
+	{
+		if (s.in_sysex)
+		{
+			if (data == 0xf7)
+			{
+				s.sysex.push_back(data);
+				send_sysex(src, s);
+			}
+			s.in_sysex = false;
+			s.sysex.clear();
+		}
+		if (data == 0xf0)
+		{
+			s.in_sysex = true;
+			s.status = 0;
+		}
+		else if (data < 0xf0)
+		{
+			s.status = data;
+			s.count = 0;
+		}
+		else
+			s.status = 0; // other system common messages cancel running status
+		return;
+	}
+
+	if (s.in_sysex)
+	{
+		if (s.sysex.size() < MAX_EXCLUSIVE + 8)
+			s.sysex.push_back(data);
+		return;
+	}
+	if (s.status == 0)
+		return;
+
+	s.data[s.count++] = data;
+	const int type = s.status >> 4;
+	const int length = (type == 0xc || type == 0xd) ? 1 : 2;
+	if (s.count < length)
+		return;
+	s.count = 0;
+
+	queue(type - 7, (s.status & 0x0f) | SOURCE_FLAGS[src], s.data[0], (length == 2) ? s.data[1] : 0);
+}
+
+// s.sysex holds the bytes after F0, ending with F7
+void sc88_sub_device::send_sysex(int src, source &s)
+{
+	const std::vector<u8> &x = s.sysex;
+	u8 code;
+	u8 chan = 0;
+	u8 request = 0;
+	if (x.size() >= 8 && x[0] == 0x41 && x[2] == 0x42 && (x[3] == 0x12 || x[3] == 0x11))
+	{
+		const exclusive_block *block = nullptr;
+		for (const exclusive_block &b : BLOCKS)
+			if (b.address == x[4] && (b.paged || (x[5] & 0xf0) == 0))
+				block = &b;
+		if (!block)
+		{
+			LOGMASKED(LOG_MSG, "exclusive address %02x %02x has no block\n", x[4], x[5]);
+			return;
+		}
+		code = block->code + (block->paged ? (x[5] >> 4) : 0);
+		chan = x[5] & 0x0f;
+		request = (x[3] == 0x11) ? 0x80 : 0x00;
+	}
+	else if (x.size() >= 5 && x[0] == 0x7e)
+		code = 0xee;
+	else if (x.size() >= 5 && x[0] == 0x7f)
+		code = 0xef;
+	else
+		return;
+
+	if (x.size() > MAX_EXCLUSIVE)
+	{
+		LOGMASKED(LOG_MSG, "exclusive message of %d bytes dropped\n", int(x.size()));
+		return;
+	}
+
+	// long messages are split into blocks the main CPU reassembles; the
+	// length counts the bytes up to the checksum, not the F7
+	const size_t total = x.size() - 1;
+	for (size_t pos = 0; pos < total; pos += BLOCK_SIZE)
+	{
+		const size_t len = std::min<size_t>(BLOCK_SIZE, total - pos);
+		const bool more = pos + len < total;
+		queue(pos ? 0xe7 : code, SOURCE_FLAGS[src] | 0x80 | (more ? 0x40 : 0) | chan,
+				u8(len) | (pos ? 0 : request), 0,
+				std::vector<u8>(x.begin() + pos, x.begin() + pos + len));
+	}
+}
+
+
+//-------------------------------------------------
+//  IPC messages to the main CPU
+//-------------------------------------------------
+
+void sc88_sub_device::queue(u8 code, u8 flags, u8 d1, u8 d2, std::vector<u8> &&block)
+{
+	m_queue.push_back(message{ code, flags, d1, d2, std::move(block) });
+	if (!m_busy)
+		deliver();
+}
+
+void sc88_sub_device::deliver()
+{
+	if (m_busy || m_queue.empty())
+		return;
+
+	message &m = m_queue.front();
+	const int src = (m.flags >> 4) & 3;
+	if (!m.block.empty())
+	{
+		// the previous block of this source must have been consumed
+		if (BIT(m_sem, src))
+		{
+			m_deliver_timer->adjust(attotime::from_usec(100));
+			return;
+		}
+		std::copy(m.block.begin(), m.block.end(), &m_dpram[0]);
+		m_sem |= 1 << src;
+	}
+
+	LOGMASKED(LOG_MSG, "message %02x %02x %02x %02x%s\n", m.code, m.flags, m.d1, m.d2, m.block.empty() ? "" : " (block)");
+	m_ipcer[0] = m.code;
+	m_ipcer[1] = m.flags;
+	m_ipcer[2] = m.d1;
+	m_ipcer[3] = m.d2;
+	m_queue.pop_front();
+	m_busy = true;
+	m_int_state = true;
+	m_int_cb(1);
+}
+
+TIMER_CALLBACK_MEMBER(sc88_sub_device::deliver_timer)
+{
+	m_busy = false;
+	deliver();
+}
+
+
+//-------------------------------------------------
+//  MIDI OUT: bytes queued by the main CPU in the dual port RAM ring
+//-------------------------------------------------
+
+u8 sc88_sub_device::ring_advance(u8 offset, u8 count)
+{
+	offset += count;
+	if (offset >= TX_RING_END)
+		offset -= TX_RING_END - TX_RING_START;
+	return offset;
+}
+
+TIMER_CALLBACK_MEMBER(sc88_sub_device::tx_timer)
+{
+	if (m_tx_bits)
+	{
+		m_tx_cb(BIT(m_tx_shift, 0));
+		m_tx_shift >>= 1;
+		m_tx_bits--;
+		m_tx_timer->adjust(attotime::from_hz(31250));
+		return;
+	}
+
+	while (!m_tx_left)
+	{
+		if (m_tx_rd == m_dpram[TX_WRITE_PTR])
+			return;
+		m_tx_left = m_dpram[m_tx_rd];
+		m_tx_end = ring_advance(m_tx_rd, (m_tx_left + 4) & ~3);
+		m_tx_rd = ring_advance(m_tx_rd, 1);
+		if (!m_tx_left)
+			m_dpram[TX_READ_PTR] = m_tx_rd = m_tx_end;
+	}
+
+	const u8 data = m_dpram[m_tx_rd];
+	LOGMASKED(LOG_TX, "MIDI OUT %02x\n", data);
+	m_tx_rd = ring_advance(m_tx_rd, 1);
+	if (!--m_tx_left)
+		m_dpram[TX_READ_PTR] = m_tx_rd = m_tx_end;
+
+	// start bit, 8 data bits, stop bit
+	m_tx_shift = (u16(data) << 1) | 0x200;
+	m_tx_bits = 10;
+	m_tx_timer->adjust(attotime::zero);
+}

--- a/src/mame/roland/sc88_sub.h
+++ b/src/mame/roland/sc88_sub.h
@@ -1,0 +1,123 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/****************************************************************************
+
+    Roland SC-88 sub CPU (M38881M2, undumped): high level emulation of its
+    system bus interface and of the MIDI protocol it speaks with the main
+    CPU.
+
+****************************************************************************/
+
+#ifndef MAME_ROLAND_SC88_SUB_H
+#define MAME_ROLAND_SC88_SUB_H
+
+#pragma once
+
+#include "diserial.h"
+
+#include <deque>
+
+
+// UART receiver, one per MIDI source
+class sc88_sub_rx_device : public device_t, public device_serial_interface
+{
+public:
+	sc88_sub_rx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	auto byte_callback() { return m_byte_cb.bind(); }
+	using device_serial_interface::rx_w;
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void rcv_complete() override;
+private:
+	devcb_write8 m_byte_cb;
+};
+
+DECLARE_DEVICE_TYPE(SC88_SUB_RX, sc88_sub_rx_device)
+
+
+class sc88_sub_device : public device_t
+{
+public:
+	sc88_sub_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	// INTR pin: raised when a message is waiting in the IPC error registers
+	auto int_callback() { return m_int_cb.bind(); }
+	// switch matrix rows selected by the strobes on PB0-PB3
+	template <unsigned N> auto keys_callback() { return m_keys_cb[N].bind(); }
+	// serial data for the MIDI OUT connector
+	auto tx_callback() { return m_tx_cb.bind(); }
+
+	// MIDI IN A (rear) and B (front), and the RS-422/RS-232 computer port
+	template <unsigned N> void rxd_w(int state) { m_rx[N]->rx_w(state); }
+
+	// /RST, driven from the main CPU's P4-0 on the SC-88VL
+	void reset_w(int state);
+
+	// system bus window (A0-A7)
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
+
+protected:
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	struct message
+	{
+		u8 code, flags, d1, d2;
+		std::vector<u8> block;
+	};
+
+	struct source
+	{
+		u8 status = 0;
+		u8 data[2]{};
+		u8 count = 0;
+		std::vector<u8> sysex;
+		bool in_sysex = false;
+	};
+
+	template <unsigned N> void rx_byte(u8 data) { midi_byte(N, data); }
+	void midi_byte(int src, u8 data);
+	void send_sysex(int src, source &s);
+	void queue(u8 code, u8 flags, u8 d1, u8 d2, std::vector<u8> &&block = {});
+	static u8 ring_advance(u8 offset, u8 count);
+	void deliver();
+	TIMER_CALLBACK_MEMBER(deliver_timer);
+	TIMER_CALLBACK_MEMBER(tx_timer);
+	u8 port_r();
+	void port_w(u8 data);
+
+	devcb_write_line m_int_cb;
+	devcb_read8::array<4> m_keys_cb;
+	devcb_write_line m_tx_cb;
+	required_device_array<sc88_sub_rx_device, 3> m_rx;
+
+	u8 m_dpram[0xd8]{};
+	u8 m_ipcm[4]{};
+	u8 m_ipcer[4]{};
+	u8 m_flags[0x1b]{};
+	u8 m_sem = 0;
+	u8 m_spcon = 0;
+	u8 m_pa = 0, m_pa_dir = 0, m_pb = 0, m_pb_dir = 0;
+	bool m_int_state = false;
+	bool m_in_reset = false;
+
+	source m_src[3];
+	std::deque<message> m_queue;
+	bool m_busy = false;
+	emu_timer *m_deliver_timer = nullptr;
+
+	u8 m_tx_rd = 0;
+	u8 m_tx_left = 0;
+	u8 m_tx_end = 0;
+	emu_timer *m_tx_timer = nullptr;
+	u16 m_tx_shift = 0;
+	int m_tx_bits = 0;
+};
+
+DECLARE_DEVICE_TYPE(SC88_SUB, sc88_sub_device)
+
+#endif // MAME_ROLAND_SC88_SUB_H

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -228,6 +228,8 @@ using util::BIT;
 #include "cpu/z80/z80dasm.h"
 #include "cpu/z8000/8000dasm.h"
 
+#include "sound/roland_xpd.h"
+
 #include "corestr.h"
 #include "ioprocs.h"
 #include "multibyte.h"
@@ -614,6 +616,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "r65c02",          le,  0, []() -> util::disasm_interface * { return new r65c02_disassembler; } },
 	{ "r65c19",          le,  0, []() -> util::disasm_interface * { return new r65c19_disassembler; } },
 	{ "r800",            le,  0, []() -> util::disasm_interface * { return new r800_disassembler; } },
+	{ "roland_xp",       be, -2, []() -> util::disasm_interface * { return new roland_xp_disassembler; } },
 	{ "romp",            be,  0, []() -> util::disasm_interface * { return new romp_disassembler; } },
 	{ "rsp",             le,  0, []() -> util::disasm_interface * { return new rsp_disassembler; } },
 	{ "rupi44",          le,  0, []() -> util::disasm_interface * { return new rupi44_disassembler; } },

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -228,6 +228,7 @@ using util::BIT;
 #include "cpu/z80/z80dasm.h"
 #include "cpu/z8000/8000dasm.h"
 
+#include "sound/roland_lspd.h"
 #include "sound/roland_xpd.h"
 
 #include "corestr.h"
@@ -616,6 +617,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "r65c02",          le,  0, []() -> util::disasm_interface * { return new r65c02_disassembler; } },
 	{ "r65c19",          le,  0, []() -> util::disasm_interface * { return new r65c19_disassembler; } },
 	{ "r800",            le,  0, []() -> util::disasm_interface * { return new r800_disassembler; } },
+	{ "roland_lsp",      be, -2, []() -> util::disasm_interface * { return new roland_lsp_disassembler; } },
 	{ "roland_xp",       be, -2, []() -> util::disasm_interface * { return new roland_xp_disassembler; } },
 	{ "romp",            be,  0, []() -> util::disasm_interface * { return new romp_disassembler; } },
 	{ "rsp",             le,  0, []() -> util::disasm_interface * { return new rsp_disassembler; } },


### PR DESCRIPTION
This PR adds support for the Roland XP custom sound chip and the Roland LSP sound DSP bringing the Sound Canvas SC-88/88Pro to working status.

This was made possible thanks to giulioz [reverse-engineering notes](https://github.com/giulioz/roland-dsps) and Roland themselves by porting XP/LSP effects directly to native x64 and therefore giving me a rosetta stone for reconstructing the ISAs.

## Machines promoted to working:
- Sound Canvas SC-88 [superctr]
- Sound Canvas SC-88Pro [superctr]

## New non-working machines
- VE-GSPro Voice Expansion Board [superctr]

## Other
- Add SC-88Pro control ROM dumps [Valley Bell]
- Reconstructed SC-88Pro wave ROM from VE-GSPro [superctr]

AI disclosure: Claude Fable 5, Claude Fable 5.1, Claude Opus 5