### PR TITLE
segas32_v.cpp per line clipping - titlef, jpark, ga2

### DIFF
--- a/src/mame/sega/segas32.h
+++ b/src/mame/sega/segas32.h
@@ -87,7 +87,7 @@ protected:
 	struct extents_list
 	{
 		uint8_t                   scan_extent[256]{};
-		uint16_t                  extent[32][16]{};
+		uint16_t                  extent[256][16]{};
 	};
 
 

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -601,10 +601,18 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 		sorted[i] = i;
 	}
 
-	// bubble sort them by min_x
-	for (int i = 0; i < 5; i++)
-		for (int j = i + 1; j < 5; j++)
-			if (clips[sorted[i]].min_x > clips[sorted[j]].min_x) { int temp = sorted[i]; sorted[i] = sorted[j]; sorted[j] = temp; }
+	// insertion sort them by min_x
+	for (int i = 1; i < 5; i++)
+	{
+		int j = i - 1;
+
+		while (j >= 0 && clips[sorted[j]].min_x > clips[sorted[i]].min_x)
+		{
+			sorted[j + 1] = sorted[j];
+			j--;
+		}
+		sorted[j + 1] = sorted[i];
+	}
 
 	// create all valid extent combinations
 	for (int i = 1; i < 32; i++)
@@ -740,14 +748,17 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			{
 				uint16_t *extent = &list->extent[32 + y][0];
 
-				for (int i = 0; i < 5; i++)
-					for (int j = i + 1; j < 5; j++)
-						if (lineclips[linesorted[i]].min_x > lineclips[linesorted[j]].min_x)
-						{
-							int temp = linesorted[i];
-							linesorted[i] = linesorted[j];
-							linesorted[j] = temp;
-						}
+				for (int i = 1; i < 5; i++)
+				{
+					int j = i - 1;
+
+					while (j >= 0 && lineclips[linesorted[j]].min_x > lineclips[linesorted[i]].min_x)
+					{
+						linesorted[j + 1] = linesorted[j];
+						j--;
+					}
+					linesorted[j + 1] = linesorted[i];
+				}
 
 				*extent++ = tempclip.min_x;
 

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -23,12 +23,6 @@
     - Sonic while globally flipped via the service menu, fails to flip
       the "SEGA" and "SEGASONIC" sprite based logos on the title screen.
 
-    - titlef NBG0 and NBG2 layers are currently hidden during gameplay.
-      It sets $31ff02 with either $7be0 and $2960 (and $31ff8e is $c00).
-      Game actually uses the "rowscroll/rowselect" tables for a line window
-      effect to draw the boxing ring over NBG0.
-      Same deal for ga2 when in stage 2 cave a wall torch is lit.
-
     - Wrong priority cases (parenthesis for the level setup):
       dbzvrvs: draws text layer ($e) behind sprite-based gauges ($f).
       dbzvrvs: Sheng-Long speech balloon during Piccoro ending (fixme: check levels).
@@ -564,7 +558,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 	const bool flip = BIT(m_videoram[0x1ff00 / 2], 9);
 	rectangle tempclip;
 
-	// expand our cliprect to exclude the bottom-right
+	// expand our cliprect to include the bottom-right
 	tempclip = cliprect;
 	tempclip.max_x++;
 	tempclip.max_y++;
@@ -580,7 +574,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 		return 1;
 	}
 
-	// extract the from videoram into locals, and apply the cliprect
+	// extract the clips from videoram into locals, and apply the cliprect
 	rectangle clips[5];
 	int sorted[5];
 	for (int i = 0; i < 5; i++)
@@ -656,7 +650,136 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 		for (int i = 0; i < 5; i++)
 			if ((BIT(clipmask , i)) && y >= clips[i].min_y && y < clips[i].max_y)
 				sect |= 1 << i;
-		list->scan_extent[y] = sect;
+
+		/*
+		 * $1FF04 bits 4/5 enable per-line clip windows.
+		 *
+		 * clip 2:
+		 *   +000 = min X
+		 *   +200 = max X
+		 *
+		 * clip 3:
+		 *   +100 = min X
+		 *   +300 = max X
+		 */
+		if (BIT(m_videoram[0x1ff04 / 2], 4) || BIT(m_videoram[0x1ff04 / 2], 5))
+		{
+			rectangle lineclips[5];
+			int linesorted[5];
+			const rectangle &visarea = screen.visible_area();
+			int line = flip ? visarea.max_y - y : y;
+			uint16_t *table = &m_videoram[(m_videoram[0x1ff04/2] >> 10) * 0x400];
+
+			for (i = 0; i < 5; i++)
+			{
+				lineclips[i] = clips[i];
+				linesorted[i] = i;
+			}
+
+			// clip window 2
+			if (BIT(m_videoram[0x1ff04 / 2], 4) && BIT(clipmask, 2))
+			{
+				uint16_t minx = table[0x000 + line];
+				uint16_t maxx = table[0x200 + line];
+
+				if (minx == 0xffff || maxx == 0xffff)
+				{
+					sect &= ~(1 << 2);
+				}
+				else if (!flip)
+				{
+					lineclips[2].min_x = minx & 0x1ff;
+					lineclips[2].max_x = (maxx & 0x1ff) + 1;
+				}
+				else
+				{
+					lineclips[2].min_x = tempclip.max_x - ((maxx & 0x1ff) + 1);
+					lineclips[2].max_x = tempclip.max_x - (minx & 0x1ff);
+				}
+
+				lineclips[2] &= tempclip;
+
+				if (lineclips[2].min_x >= lineclips[2].max_x)
+					sect &= ~(1 << 2);
+			}
+
+			// clip window 3
+			if (BIT(m_videoram[0x1ff04 / 2], 5) && BIT(clipmask, 3))
+			{
+				uint16_t minx = table[0x100 + line];
+				uint16_t maxx = table[0x300 + line];
+
+				if (minx == 0xffff || maxx == 0xffff)
+				{
+					sect &= ~(1 << 3);
+				}
+				else if (!flip)
+				{
+					lineclips[3].min_x = minx & 0x1ff;
+					lineclips[3].max_x = (maxx & 0x1ff) + 1;
+				}
+				else
+				{
+					lineclips[3].min_x = tempclip.max_x - ((maxx & 0x1ff) + 1);
+					lineclips[3].max_x = tempclip.max_x - (minx & 0x1ff);
+				}
+
+				lineclips[3] &= tempclip;
+
+				if (lineclips[3].min_x >= lineclips[3].max_x)
+					sect &= ~(1 << 3);
+			}
+
+			/*
+			 * Build the extent for this individual scanline.
+			 * 0-31 remain the normal combinations.
+			 * 32+y is the per-line extent.
+			 */
+			{
+				uint16_t *extent = &list->extent[32 + y][0];
+
+				for (i = 0; i < 5; i++)
+					linesorted[i] = i;
+
+				for (i = 0; i < 5; i++)
+					for (j = i + 1; j < 5; j++)
+						if (lineclips[linesorted[i]].min_x > lineclips[linesorted[j]].min_x)
+						{
+							int temp = linesorted[i];
+							linesorted[i] = linesorted[j];
+							linesorted[j] = temp;
+						}
+
+				*extent++ = tempclip.min_x;
+
+				for (j = 0; j < 5; j++)
+				{
+					if (BIT(sect, linesorted[j]))
+					{
+						const rectangle *cur = &lineclips[linesorted[j]];
+
+						if (extent != &list->extent[32 + y][1] && cur->min_x <= extent[-1])
+						{
+							if (cur->max_x > extent[-1])
+								extent[-1] = cur->max_x;
+						}
+						else
+						{
+							*extent++ = cur->min_x;
+							*extent++ = cur->max_x;
+						}
+					}
+				}
+
+				*extent++ = tempclip.max_x;
+			}
+
+			list->scan_extent[y] = 32 + y;
+		}
+		else
+		{
+			list->scan_extent[y] = sect;
+		}
 	}
 
 	return clipout;
@@ -1127,9 +1250,12 @@ void segas32_state::update_background(segas32_state::layer_info &layer, const re
 {
 	bitmap_ind16 &bitmap = layer.bitmap;
 
+	// determine if we're flipped
+	bool flip = BIT(m_videoram[0x1ff00 / 2], 9);
+
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		uint16_t *const dst = &bitmap.pix(y);
+		uint16_t *const dst = &bitmap.pix(flip ? cliprect->max_y - y : y);
 		int color;
 
 		/* determine the color */

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -556,6 +556,8 @@ TILE_GET_INFO_MEMBER(segas32_state::get_text_tile_info)
 bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable, bool clipout, int clipmask, const rectangle &cliprect, extents_list *list)
 {
 	const bool flip = BIT(m_videoram[0x1ff00 / 2], 9);
+	const bool perlineclip2 = BIT(m_videoram[0x1ff04 / 2], 4);
+	const bool perlineclip3 = BIT(m_videoram[0x1ff04 / 2], 5);
 	rectangle tempclip;
 
 	// expand our cliprect to include the bottom-right
@@ -662,7 +664,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 		 *   +100 = min X
 		 *   +300 = max X
 		 */
-		if (BIT(m_videoram[0x1ff04 / 2], 4) || BIT(m_videoram[0x1ff04 / 2], 5))
+		if (perlineclip2 || perlineclip3)
 		{
 			rectangle lineclips[5];
 			int linesorted[5];
@@ -677,7 +679,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			}
 
 			// clip window 2
-			if (BIT(m_videoram[0x1ff04 / 2], 4) && BIT(clipmask, 2))
+			if (perlineclip2 && BIT(clipmask, 2))
 			{
 				uint16_t minx = table[0x000 + line];
 				uint16_t maxx = table[0x200 + line];
@@ -704,7 +706,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			}
 
 			// clip window 3
-			if (BIT(m_videoram[0x1ff04 / 2], 5) && BIT(clipmask, 3))
+			if (perlineclip3 && BIT(clipmask, 3))
 			{
 				uint16_t minx = table[0x100 + line];
 				uint16_t maxx = table[0x300 + line];
@@ -737,9 +739,6 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			 */
 			{
 				uint16_t *extent = &list->extent[32 + y][0];
-
-				for (int i = 0; i < 5; i++)
-					linesorted[i] = i;
 
 				for (int i = 0; i < 5; i++)
 					for (int j = i + 1; j < 5; j++)

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -670,7 +670,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			int line = flip ? visarea.max_y - y : y;
 			uint16_t *table = &m_videoram[(m_videoram[0x1ff04/2] >> 10) * 0x400];
 
-			for (i = 0; i < 5; i++)
+			for (int i = 0; i < 5; i++)
 			{
 				lineclips[i] = clips[i];
 				linesorted[i] = i;
@@ -738,11 +738,11 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 			{
 				uint16_t *extent = &list->extent[32 + y][0];
 
-				for (i = 0; i < 5; i++)
+				for (int i = 0; i < 5; i++)
 					linesorted[i] = i;
 
-				for (i = 0; i < 5; i++)
-					for (j = i + 1; j < 5; j++)
+				for (int i = 0; i < 5; i++)
+					for (int j = i + 1; j < 5; j++)
 						if (lineclips[linesorted[i]].min_x > lineclips[linesorted[j]].min_x)
 						{
 							int temp = linesorted[i];
@@ -752,7 +752,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 
 				*extent++ = tempclip.min_x;
 
-				for (j = 0; j < 5; j++)
+				for (int j = 0; j < 5; j++)
 				{
 					if (BIT(sect, linesorted[j]))
 					{

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -695,8 +695,8 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 				}
 				else
 				{
-					lineclips[2].min_x = tempclip.max_x - ((maxx & 0x1ff) + 1);
-					lineclips[2].max_x = tempclip.max_x - (minx & 0x1ff);
+					lineclips[2].min_x = (visarea.max_x + 1) - ((maxx & 0x1ff) + 1);
+					lineclips[2].max_x = (visarea.max_x + 1) - (minx & 0x1ff);
 				}
 
 				lineclips[2] &= tempclip;
@@ -722,8 +722,8 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 				}
 				else
 				{
-					lineclips[3].min_x = tempclip.max_x - ((maxx & 0x1ff) + 1);
-					lineclips[3].max_x = tempclip.max_x - (minx & 0x1ff);
+					lineclips[3].min_x = (visarea.max_x + 1) - ((maxx & 0x1ff) + 1);
+					lineclips[3].max_x = (visarea.max_x + 1) - (minx & 0x1ff);
 				}
 
 				lineclips[3] &= tempclip;

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -1255,7 +1255,7 @@ void segas32_state::update_background(segas32_state::layer_info &layer, const re
 
 	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
-		uint16_t *const dst = &bitmap.pix(flip ? cliprect->max_y - y : y);
+		uint16_t *const dst = &bitmap.pix(flip ? cliprect.max_y - y : y);
 		int color;
 
 		/* determine the color */

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -756,7 +756,7 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 				{
 					if (BIT(sect, linesorted[j]))
 					{
-						const rectangle *cur = &lineclips[linesorted[j]];
+						const rectangle &cur = lineclips[linesorted[j]];
 
 						if (extent != &list->extent[32 + y][1] && cur.min_x <= extent[-1])
 						{

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -758,15 +758,15 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 					{
 						const rectangle *cur = &lineclips[linesorted[j]];
 
-						if (extent != &list->extent[32 + y][1] && cur->min_x <= extent[-1])
+						if (extent != &list->extent[32 + y][1] && cur.min_x <= extent[-1])
 						{
-							if (cur->max_x > extent[-1])
-								extent[-1] = cur->max_x;
+							if (cur.max_x > extent[-1])
+								extent[-1] = cur.max_x;
 						}
 						else
 						{
-							*extent++ = cur->min_x;
-							*extent++ = cur->max_x;
+							*extent++ = cur.min_x;
+							*extent++ = cur.max_x;
 						}
 					}
 				}

--- a/src/mame/sega/segas32_v.cpp
+++ b/src/mame/sega/segas32_v.cpp
@@ -605,13 +605,14 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 	for (int i = 1; i < 5; i++)
 	{
 		int j = i - 1;
+		int key = sorted[i];
 
-		while (j >= 0 && clips[sorted[j]].min_x > clips[sorted[i]].min_x)
+		while (j >= 0 && clips[sorted[j]].min_x > clips[key].min_x)
 		{
 			sorted[j + 1] = sorted[j];
 			j--;
 		}
-		sorted[j + 1] = sorted[i];
+		sorted[j + 1] = key;
 	}
 
 	// create all valid extent combinations
@@ -751,13 +752,14 @@ bool segas32_state::compute_clipping_extents(screen_device &screen, bool enable,
 				for (int i = 1; i < 5; i++)
 				{
 					int j = i - 1;
+					int key = linesorted[i];
 
-					while (j >= 0 && lineclips[linesorted[j]].min_x > lineclips[linesorted[i]].min_x)
+					while (j >= 0 && lineclips[linesorted[j]].min_x > lineclips[key].min_x)
 					{
 						linesorted[j + 1] = linesorted[j];
 						j--;
 					}
-					linesorted[j + 1] = linesorted[i];
+					linesorted[j + 1] = key;
 				}
 
 				*extent++ = tempclip.min_x;


### PR DESCRIPTION
- Independent per line clipping
- background layer flipping
- original clipping combinations retained unless a line mode is active
- insertion sort

<img width="1080" height="810" alt="titlef-260901-160242" src="https://github.com/user-attachments/assets/35a4ef8b-3c2a-4582-ad9b-6aa5ce5d518c" />
<img width="1080" height="810" alt="jpark-260901-160156" src="https://github.com/user-attachments/assets/376ec921-1c72-49ee-a052-1ffe5fa8a3f2" />
<img width="1080" height="810" alt="ga2-260917-122538" src="https://github.com/user-attachments/assets/6557e2dc-9415-487f-9324-734d517a2da7" />
<img width="1080" height="810" alt="ga2-260901-154821" src="https://github.com/user-attachments/assets/e9c38aad-31ff-497a-9482-6851ad20cd56" />
<img width="1080" height="810" alt="sonic-260916-031334" src="https://github.com/user-attachments/assets/5eb55308-f53e-4aa1-addd-1924bc2c8490" />

