### PR TITLE
fix(): Correct flip code for turbo force, aero fighters ( b / sonic wing ) and F-1 Grand prix

### DIFF
--- a/src/devices/video/k053936.cpp
+++ b/src/devices/video/k053936.cpp
@@ -235,6 +235,9 @@ k053936_device::k053936_device(const machine_config &mconfig, const char *tag, d
 	m_linectrl(nullptr),
 	m_xoff(0),
 	m_yoff(0),
+	m_xoff_flip(0),
+	m_yoff_flip(0),
+	m_flip(false),
 	m_wrap(false)
 {
 }
@@ -250,6 +253,7 @@ void k053936_device::device_start()
 
 	save_pointer(NAME(m_ctrl), 0x20);
 	save_pointer(NAME(m_linectrl), 0x4000);
+	save_item(NAME(m_flip));
 }
 
 //-------------------------------------------------
@@ -294,6 +298,9 @@ void k053936_device::zoom_draw_common(screen_device &screen, BitmapClass &bitmap
 	if (!tmap)
 		return;
 
+	int const xoff = m_flip ? m_xoff_flip : m_xoff;
+	int const yoff = m_flip ? m_yoff_flip : m_yoff;
+
 	if (m_ctrl[0x07] & 0x0040)
 	{
 		rectangle my_clip;
@@ -309,17 +316,17 @@ void k053936_device::zoom_draw_common(screen_device &screen, BitmapClass &bitmap
 
 		if (((m_ctrl[0x07] & 0x0002) && m_ctrl[0x09]) && (glfgreat_hack)) /* wrong, but fixes glfgreat */
 		{
-			my_clip.min_x = m_ctrl[0x08] + m_xoff + 2;
-			my_clip.max_x = m_ctrl[0x09] + m_xoff + 2 - 1;
+			my_clip.min_x = m_ctrl[0x08] + xoff + 2;
+			my_clip.max_x = m_ctrl[0x09] + xoff + 2 - 1;
 			if (my_clip.min_x < cliprect.min_x)
 				my_clip.min_x = cliprect.min_x;
 			if (my_clip.max_x > cliprect.max_x)
 				my_clip.max_x = cliprect.max_x;
 
-			y = m_ctrl[0x0a] + m_yoff - 2;
+			y = m_ctrl[0x0a] + yoff - 2;
 			if (y < cliprect.min_y)
 				y = cliprect.min_y;
-			maxy = m_ctrl[0x0b] + m_yoff - 2 - 1;
+			maxy = m_ctrl[0x0b] + yoff - 2 - 1;
 			if (maxy > cliprect.max_y)
 				maxy = cliprect.max_y;
 		}
@@ -334,7 +341,7 @@ void k053936_device::zoom_draw_common(screen_device &screen, BitmapClass &bitmap
 
 		while (y <= maxy)
 		{
-			uint16_t const *const lineaddr = m_linectrl.get() + 4 * ((y - m_yoff) & 0x1ff);
+			uint16_t const *const lineaddr = m_linectrl.get() + 4 * ((y - yoff) & 0x1ff);
 
 			my_clip.min_y = my_clip.max_y = y;
 
@@ -349,8 +356,8 @@ void k053936_device::zoom_draw_common(screen_device &screen, BitmapClass &bitmap
 			if (m_ctrl[0x06] & 0x0080)
 				incxy *= 256;
 
-			startx -= m_xoff * incxx;
-			starty -= m_xoff * incxy;
+			startx -= xoff * incxx;
+			starty -= xoff * incxy;
 
 			tmap->draw_roz(screen, bitmap, my_clip, startx << 5,starty << 5,
 					incxx << 5,incxy << 5,0,0,
@@ -381,11 +388,11 @@ void k053936_device::zoom_draw_common(screen_device &screen, BitmapClass &bitmap
 			incxy *= 256;
 		}
 
-		startx -= m_yoff * incyx;
-		starty -= m_yoff * incyy;
+		startx -= yoff * incyx;
+		starty -= yoff * incyy;
 
-		startx -= m_xoff * incxx;
-		starty -= m_xoff * incxy;
+		startx -= xoff * incxx;
+		starty -= xoff * incxy;
 
 		tmap->draw_roz(screen, bitmap, cliprect, startx << 5,starty << 5,
 				incxx << 5,incxy << 5,incyx << 5,incyy << 5,

--- a/src/devices/video/k053936.h
+++ b/src/devices/video/k053936.h
@@ -33,9 +33,7 @@ public:
 		m_xoff = x_offset;
 		m_yoff = y_offset;
 	}
-	// separate offsets for a flipped screen, activated by set_flip(): the
-	// unflipped calibration mixes raster-side and picture-side origins, which
-	// mirror differently, so a flipped game needs its own pair
+	// separate offsets for a flipped screen, enabled by set_flip()
 	void set_flip_offsets(int x_offset, int y_offset)
 	{
 		m_xoff_flip = x_offset;

--- a/src/devices/video/k053936.h
+++ b/src/devices/video/k053936.h
@@ -33,6 +33,15 @@ public:
 		m_xoff = x_offset;
 		m_yoff = y_offset;
 	}
+	// separate offsets for a flipped screen, activated by set_flip(): the
+	// unflipped calibration mixes raster-side and picture-side origins, which
+	// mirror differently, so a flipped game needs its own pair
+	void set_flip_offsets(int x_offset, int y_offset)
+	{
+		m_xoff_flip = x_offset;
+		m_yoff_flip = y_offset;
+	}
+	void set_flip(bool state) { m_flip = state; }
 
 	void ctrl_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint16_t ctrl_r(offs_t offset);
@@ -55,6 +64,8 @@ private:
 	std::unique_ptr<uint16_t[]>    m_ctrl;
 	std::unique_ptr<uint16_t[]>    m_linectrl;
 	int       m_xoff, m_yoff;
+	int       m_xoff_flip, m_yoff_flip;
+	bool      m_flip;
 	bool      m_wrap;
 };
 

--- a/src/mame/vsystem/f1gp.cpp
+++ b/src/mame/vsystem/f1gp.cpp
@@ -229,6 +229,12 @@ void f1gp_state::video_start()
 
 	m_fg_tilemap->set_transparent_pen(0xff);
 
+	// screen flip: the game compensates for the hardware mirror by offsetting
+	// its scroll registers; the flipped-side dx/dy are those offsets (measured
+	// against the unflipped attract sequence)
+	m_fg_tilemap->set_scrolldx(0, 160);
+	m_fg_tilemap->set_scrolldy(0, 10);
+
 	save_item(NAME(m_flipscreen));
 	save_item(NAME(m_gfxctrl));
 	save_item(NAME(m_scroll));
@@ -289,6 +295,12 @@ void f1gp_state::gfxctrl_w(uint8_t data)
 {
 	m_flipscreen = data & 0x20;
 	m_gfxctrl = data & 0xdf;
+
+	// only the character layer follows this bit; the ROZ layer is flipped by
+	// the game itself through the 053936 transform matrix, but the chip's
+	// calibration offsets still need their flipped-side values
+	m_fg_tilemap->set_flip(m_flipscreen ? TILEMAP_FLIPX | TILEMAP_FLIPY : 0);
+	m_k053936->set_flip(m_flipscreen != 0);
 }
 
 void f1gp2_state::rozbank_w(uint8_t data)
@@ -319,13 +331,13 @@ uint32_t f1gp_state::screen_update_f1gp(screen_device &screen, bitmap_ind16 &bit
 	// quick kludge for "continue" screen priority
 	if (m_gfxctrl == 0x00)
 	{
-		m_spr_old[0]->draw_sprites(m_sprvram[0], m_sprvram[0].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02);
-		m_spr_old[1]->draw_sprites(m_sprvram[1], m_sprvram[1].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02);
+		m_spr_old[0]->draw_sprites(m_sprvram[0], m_sprvram[0].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02, m_flipscreen);
+		m_spr_old[1]->draw_sprites(m_sprvram[1], m_sprvram[1].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02, m_flipscreen);
 	}
 	else
 	{
-		m_spr_old[0]->draw_sprites(m_sprvram[0], m_sprvram[0].bytes(), 0, bitmap, cliprect, screen.priority(), 0x00);
-		m_spr_old[1]->draw_sprites(m_sprvram[1], m_sprvram[1].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02);
+		m_spr_old[0]->draw_sprites(m_sprvram[0], m_sprvram[0].bytes(), 0, bitmap, cliprect, screen.priority(), 0x00, m_flipscreen);
+		m_spr_old[1]->draw_sprites(m_sprvram[1], m_sprvram[1].bytes(), 0, bitmap, cliprect, screen.priority(), 0x02, m_flipscreen);
 	}
 	return 0;
 }
@@ -868,14 +880,17 @@ void f1gp_state::f1gp(machine_config &config)
 	VSYSTEM_SPR2(config, m_spr_old[0], m_palette, gfx_f1gp_spr1);
 	m_spr_old[0]->set_tile_indirect_cb(FUNC(f1gp2_state::tile_callback<0>));
 	m_spr_old[0]->set_pritype(2);
+	m_spr_old[0]->set_flip_offsets(305, 232);
 
 	VSYSTEM_SPR2(config, m_spr_old[1], m_palette, gfx_f1gp_spr2);
 	m_spr_old[1]->set_tile_indirect_cb(FUNC(f1gp2_state::tile_callback<1>));
 	m_spr_old[1]->set_pritype(2);
+	m_spr_old[1]->set_flip_offsets(305, 232);
 
 	K053936(config, m_k053936);
 	m_k053936->set_wrap(1);
 	m_k053936->set_offsets(-58, -2);
+	m_k053936->set_flip_offsets(-58, -3);
 
 	// sound hardware
 	SPEAKER(config, "speaker", 2).front();
@@ -1186,9 +1201,9 @@ ROM_END
 } // anonymous namespace
 
 
-GAME( 1991, f1gp,   0,    f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 1)",            MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // censored banners, US McO'River release?
-GAME( 1991, f1gpa,  f1gp, f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 2)",            MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1991, f1gpb,  f1gp, f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 3)",            MACHINE_NOT_WORKING | MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE ) // supposed to be the earliest version dumped and only work with steering wheel
+GAME( 1991, f1gp,   0,    f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 1)",            MACHINE_SUPPORTS_SAVE ) // censored banners, US McO'River release?
+GAME( 1991, f1gpa,  f1gp, f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 2)",            MACHINE_SUPPORTS_SAVE )
+GAME( 1991, f1gpb,  f1gp, f1gp,   f1gp,  f1gp_state,  empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix (set 3)",            MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // supposed to be the earliest version dumped and only work with steering wheel
 GAME( 1991, f1gpbl, f1gp, f1gpbl, f1gp,  f1gp_state,  empty_init, ROT90, "bootleg (Playmark)", "F-1 Grand Prix (Playmark bootleg)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // PCB marked 'Super Formula II', manufactured by Playmark.
 
 GAME( 1992, f1gp2,  0,    f1gp2,  f1gp2, f1gp2_state, empty_init, ROT90, "Video System Co.",   "F-1 Grand Prix Part II",            MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/vsystem/f1gp.cpp
+++ b/src/mame/vsystem/f1gp.cpp
@@ -229,9 +229,7 @@ void f1gp_state::video_start()
 
 	m_fg_tilemap->set_transparent_pen(0xff);
 
-	// screen flip: the game compensates for the hardware mirror by offsetting
-	// its scroll registers; the flipped-side dx/dy are those offsets (measured
-	// against the unflipped attract sequence)
+	// flipped-side dx/dy measured from the game's own scroll compensation
 	m_fg_tilemap->set_scrolldx(0, 160);
 	m_fg_tilemap->set_scrolldy(0, 10);
 
@@ -296,9 +294,7 @@ void f1gp_state::gfxctrl_w(uint8_t data)
 	m_flipscreen = data & 0x20;
 	m_gfxctrl = data & 0xdf;
 
-	// only the character layer follows this bit; the ROZ layer is flipped by
-	// the game itself through the 053936 transform matrix, but the chip's
-	// calibration offsets still need their flipped-side values
+	// the ROZ layer is not flipped here: the game mirrors the 053936 matrix itself
 	m_fg_tilemap->set_flip(m_flipscreen ? TILEMAP_FLIPX | TILEMAP_FLIPY : 0);
 	m_k053936->set_flip(m_flipscreen != 0);
 }

--- a/src/mame/vsystem/pspikes.cpp
+++ b/src/mame/vsystem/pspikes.cpp
@@ -475,6 +475,14 @@ VIDEO_START_MEMBER(pspikes_base_state,turbofrc)
 	m_spritepalettebank = 0;
 	m_sprite_gfx = 2;
 
+	// screen flip: the game compensates for the hardware mirror by offsetting
+	// its scroll registers; the flipped-side dx/dy are those offsets (measured
+	// against the unflipped attract sequence) on top of the unflipped ones
+	m_tilemap[0]->set_scrolldx(0, 185);
+	m_tilemap[1]->set_scrolldx(0, 193);
+	m_tilemap[0]->set_scrolldy(0, 2);
+	m_tilemap[1]->set_scrolldy(0, 2);
+
 	register_state_globals();
 }
 
@@ -482,8 +490,8 @@ VIDEO_START_MEMBER(pspikes_base_state,aerofgtb)
 {
 	VIDEO_START_CALL_MEMBER(turbofrc);
 
-	m_tilemap[0]->set_scrolldx(1, 1);
-	m_tilemap[1]->set_scrolldx(1, 1);
+	m_tilemap[0]->set_scrolldx(1, 1 + 168);
+	m_tilemap[1]->set_scrolldx(1, 1 + 177);
 }
 
 
@@ -661,12 +669,12 @@ uint32_t pspikes_banked_sound_state::screen_update_turbofrc(screen_device &scree
 {
 	m_tilemap[0]->set_scroll_rows(512);
 	int scrolly = m_scrolly[0] + 2;
-	for (int i = 0; i < 256; i++)
+	for (int i = 0; i < 512; i++)
 //      m_tilemap[0]->set_scrollx((i + scrolly) & 0x1ff, m_rasterram[i] - 11);
-		m_tilemap[0]->set_scrollx((i + scrolly) & 0x1ff, m_rasterram[7] - 11 - (m_flip_screen ? 188 : 0));
-	m_tilemap[0]->set_scrolly(0, scrolly - (m_flip_screen ? 2 : 0));
-	m_tilemap[1]->set_scrollx(0, m_scrollx[1] - (m_flip_screen ? 185 : 7));
-	m_tilemap[1]->set_scrolly(0, m_scrolly[1] + (m_flip_screen ? 0 : 2));
+		m_tilemap[0]->set_scrollx((i + scrolly) & 0x1ff, m_rasterram[7] - 11);
+	m_tilemap[0]->set_scrolly(0, scrolly);
+	m_tilemap[1]->set_scrollx(0, m_scrollx[1] - 7);
+	m_tilemap[1]->set_scrolly(0, m_scrolly[1] + 2);
 
 	screen.priority().fill(0, cliprect);
 
@@ -2647,9 +2655,11 @@ void pspikes_banked_sound_state::turbofrc(machine_config &config)
 
 	VSYSTEM_SPR2(config, m_spr[0], m_palette, gfx_turbofrc_spr1);
 	m_spr[0]->set_tile_indirect_cb(FUNC(pspikes_banked_sound_state::pspikes_tile_callback));
+	m_spr[0]->set_flip_offsets(319, 224);
 
 	VSYSTEM_SPR2(config, m_spr[1], m_palette, gfx_turbofrc_spr2);
 	m_spr[1]->set_tile_indirect_cb(FUNC(pspikes_banked_sound_state::pspikes_tile2_callback));
+	m_spr[1]->set_flip_offsets(319, 224);
 
 	MCFG_VIDEO_START_OVERRIDE(pspikes_banked_sound_state,turbofrc)
 
@@ -2696,10 +2706,12 @@ void pspikes_banked_sound_state::aerofgtb(machine_config &config)
 	VSYSTEM_SPR2(config, m_spr[0], m_palette, gfx_turbofrc_spr1);
 	m_spr[0]->set_tile_indirect_cb(FUNC(pspikes_banked_sound_state::pspikes_tile_callback));
 	m_spr[0]->set_offsets(3, -1);
+	m_spr[0]->set_flip_offsets(311, 208);
 
 	VSYSTEM_SPR2(config, m_spr[1], m_palette, gfx_turbofrc_spr2);
 	m_spr[1]->set_tile_indirect_cb(FUNC(pspikes_banked_sound_state::pspikes_tile2_callback));
 	m_spr[1]->set_offsets(3, -1);
+	m_spr[1]->set_flip_offsets(311, 208);
 
 	MCFG_VIDEO_START_OVERRIDE(pspikes_banked_sound_state,aerofgtb)
 
@@ -4028,11 +4040,11 @@ GAME( 1991, karatblzbl, karatblz, karatblzbl, karatblz,  karatblzbl_state,      
 // according to Gamest magazine in new revision they changed the points value of the rocks in level 6 (5'000 versus 500)
 // turbofrcua gives 5'000, the others 500.
 // NOTE: turbofrcua also denotes HP rank on these rocks, getting there without any life lost (almost impossible without cheating) makes those literally indestructible.
-GAME( 1991, turbofrc,   0,        turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (World, set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // region code 4
-GAME( 1991, turbofrco,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (World, set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // region code 3
-GAME( 1991, turbofrcu,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (US, set 1)",    MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // region code 8
-GAME( 1991, turbofrcua, turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (US, set 2)",    MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // region code 7
-GAME( 1991, turbofrcj,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (Japan)",        MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // no region code, program ROMs marked with a red dot
+GAME( 1991, turbofrc,   0,        turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (World, set 1)", MACHINE_SUPPORTS_SAVE ) // region code 4
+GAME( 1991, turbofrco,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (World, set 2)", MACHINE_SUPPORTS_SAVE ) // region code 3
+GAME( 1991, turbofrcu,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (US, set 1)",    MACHINE_SUPPORTS_SAVE ) // region code 8
+GAME( 1991, turbofrcua, turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (US, set 2)",    MACHINE_SUPPORTS_SAVE ) // region code 7
+GAME( 1991, turbofrcj,  turbofrc, turbofrc,   turbofrc,  pspikes_banked_sound_state, empty_init,      ROT270, "Video System Co.",    "Turbo Force (Japan)",        MACHINE_SUPPORTS_SAVE ) // no region code, program ROMs marked with a red dot
 
 // the tiles on these also contain an alt title 'The Final War' for both the title screen and attract logo was it ever used?
 // sonicwi looks oldest set, aerofgt is slightly easier, aerofgtb/aerofgtc are noticeably harder

--- a/src/mame/vsystem/pspikes.cpp
+++ b/src/mame/vsystem/pspikes.cpp
@@ -475,9 +475,7 @@ VIDEO_START_MEMBER(pspikes_base_state,turbofrc)
 	m_spritepalettebank = 0;
 	m_sprite_gfx = 2;
 
-	// screen flip: the game compensates for the hardware mirror by offsetting
-	// its scroll registers; the flipped-side dx/dy are those offsets (measured
-	// against the unflipped attract sequence) on top of the unflipped ones
+	// flipped-side dx/dy measured from the game's own scroll compensation
 	m_tilemap[0]->set_scrolldx(0, 185);
 	m_tilemap[1]->set_scrolldx(0, 193);
 	m_tilemap[0]->set_scrolldy(0, 2);

--- a/src/mame/vsystem/vsystem_spr2.cpp
+++ b/src/mame/vsystem/vsystem_spr2.cpp
@@ -171,9 +171,7 @@ void vsystem_spr2_device::draw_sprites_common(uint16_t const *spriteram3,  int s
 
 		if (flip_screen)
 		{
-			// the chip mirrors each (zoom-scaled) cell, so the mirror point
-			// depends on the cell size: 16 - zoom/2 collapses to 0 for
-			// unzoomed sprites
+			// the mirror point depends on the zoomed cell size
 			m_curr_sprite.ox = m_flip_xoffs + 16 - m_curr_sprite.zoomx / 2 - m_curr_sprite.ox;
 			m_curr_sprite.oy = m_flip_yoffs + 16 - m_curr_sprite.zoomy / 2 - m_curr_sprite.oy;
 			fx = !fx;

--- a/src/mame/vsystem/vsystem_spr2.cpp
+++ b/src/mame/vsystem/vsystem_spr2.cpp
@@ -36,6 +36,8 @@ vsystem_spr2_device::vsystem_spr2_device(const machine_config &mconfig, const ch
 	, m_pritype(0) // hack until we have better handling
 	, m_xoffs(0)
 	, m_yoffs(0)
+	, m_flip_xoffs(308) // legacy values, correct at least for aerofgtb
+	, m_flip_yoffs(208)
 	, m_curr_sprite()
 {
 }
@@ -161,18 +163,22 @@ void vsystem_spr2_device::draw_sprites_common(uint16_t const *spriteram3,  int s
 
 		bool fx = m_curr_sprite.flipx;
 		bool fy = m_curr_sprite.flipy;
-		if (flip_screen)
-		{
-			m_curr_sprite.ox = 308 - m_curr_sprite.ox;
-			m_curr_sprite.oy = 208 - m_curr_sprite.oy;
-			fx = !fx;
-			fy = !fy;
-		}
 
 		m_curr_sprite.color += 16 * spritepalettebank;
 
 		m_curr_sprite.zoomx = 32 - m_curr_sprite.zoomx;
 		m_curr_sprite.zoomy = 32 - m_curr_sprite.zoomy;
+
+		if (flip_screen)
+		{
+			// the chip mirrors each (zoom-scaled) cell, so the mirror point
+			// depends on the cell size: 16 - zoom/2 collapses to 0 for
+			// unzoomed sprites
+			m_curr_sprite.ox = m_flip_xoffs + 16 - m_curr_sprite.zoomx / 2 - m_curr_sprite.ox;
+			m_curr_sprite.oy = m_flip_yoffs + 16 - m_curr_sprite.zoomy / 2 - m_curr_sprite.oy;
+			fx = !fx;
+			fy = !fy;
+		}
 
 		uint32_t const zx = m_curr_sprite.zoomx << 11;
 		uint32_t const zy = m_curr_sprite.zoomy << 11;

--- a/src/mame/vsystem/vsystem_spr2.h
+++ b/src/mame/vsystem/vsystem_spr2.h
@@ -32,6 +32,14 @@ public:
 		m_xoffs = xoffs;
 		m_yoffs = yoffs;
 	}
+	// coordinate mirror constants used when flip_screen is set: the sprite chip
+	// flips the screen itself, so these come from the raster geometry of the
+	// game rather than from the sprite RAM contents
+	void set_flip_offsets(int xoffs, int yoffs)
+	{
+		m_flip_xoffs = xoffs;
+		m_flip_yoffs = yoffs;
+	}
 
 	void draw_sprites(uint16_t const *spriteram3,  int spriteram3_bytes,  int spritepalettebank, bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, int pri_param, bool flip_screen = false);
 	void draw_sprites(uint16_t const *spriteram3,  int spriteram3_bytes,  int spritepalettebank, bitmap_rgb32 &bitmap, const rectangle &cliprect, bitmap_ind8 &priority_bitmap, int pri_param, bool flip_screen = false);
@@ -68,6 +76,7 @@ private:
 	vsystem_tile2_indirection_delegate m_newtilecb;
 	int m_pritype;
 	int m_xoffs, m_yoffs;
+	int m_flip_xoffs, m_flip_yoffs;
 
 	sprite_attributes m_curr_sprite;
 };

--- a/src/mame/vsystem/vsystem_spr2.h
+++ b/src/mame/vsystem/vsystem_spr2.h
@@ -32,9 +32,7 @@ public:
 		m_xoffs = xoffs;
 		m_yoffs = yoffs;
 	}
-	// coordinate mirror constants used when flip_screen is set: the sprite chip
-	// flips the screen itself, so these come from the raster geometry of the
-	// game rather than from the sprite RAM contents
+	// mirror constants for flip_screen, from the game's raster geometry
 	void set_flip_offsets(int xoffs, int yoffs)
 	{
 		m_flip_xoffs = xoffs;


### PR DESCRIPTION
I worked on some fpga cores for those games and noticed that flip screen was not functional with this implementation.
Since CRTs and those fpga systems do not have an easy way to rotate the game outside the game inner handling in tate mode, i implemented flip there and then decided to fix it here too.

What i did was eyeball the math with claude and then do some screenshot testing of pixel matching.

Turboforce and aerofighters match 100% between flipped and not flipped, while f1gp has some extra differences that i can't account for, but we are talking about 1-2% of whole pixels. mostly a slight shift of the rotation layer for the road.


Developed with AI assistance (Anthropic Claude Opus 4.6 or Claude Fable 5 (not known to be honest)), disclosed per the "Use of AI" contributing guideline.
