### PR TITLE
current Plug+Play / Handhelds PR (5 working sets, 29 not working sets, 6 not working clones + various softlist additions)

### DIFF
--- a/hash/leapfrog_leappad_cart.xml
+++ b/hash/leapfrog_leappad_cart.xml
@@ -246,6 +246,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- also found as UBL 500-10916 - Monsters, Inc with identical ROM -->
 	<software name="monsters" supported="no">
 		<description>Leap 2 - Reading - Disney/Pixar Monsters, Inc. (UK)</description>
 		<year>2001</year>
@@ -292,7 +293,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="thomasrue" supported="no">
-		<description>Pre Reading - Thomas the Really Useful Engine (UK)</description>
+		<description>Thomas the Really Useful Engine (UK, Pre Reading, set 1)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-00531"/>
@@ -300,6 +301,21 @@ license:CC0-1.0
 			<feature name="u1" value="MR27V1602E"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-00531 - Pre Reading - Thomas the Really Useful Engine.bin" size="0x200000" crc="8122325d" sha1="f76b2e6c4d56fd8616c90bf86d720f267724723e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- also seen as UBL 500-10903 - Thomas and Friends - The Really Useful Engine with identical ROM -->
+	<software name="thomasruea" cloneof="thomasrue" supported="no">
+		<description>Thomas the Really Useful Engine (UK, Pre Reading, set 2)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="xxx"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="ASY-310-00087-FAB-300-00087-A"/>
+			<feature name="u1" value="LeapFrog 2000 16M DIE ROM"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-00550 - Pre Reading - Thomas the Really Useful Engine.bin" size="0x200000" crc="595e2045" sha1="2846efa96efbc9754e85ae773faf7d598edd0952" />
 			</dataarea>
 		</part>
 	</software>
@@ -451,7 +467,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="lionking" supported="no">
-		<description>Leap Start - Pre Reading Storybook - Disney's The Lion King (UK)</description>
+		<description>Disney's The Lion King (UK, Leap Start - Pre Reading Storybook, set 1)</description>
 		<year>2002</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-01354"/>
@@ -461,6 +477,20 @@ license:CC0-1.0
 			<feature name="u1" value="Matronix 16M"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
 			<dataarea name="rom" size="0x200000">
 				<rom name="500-01354 - Leap Start - Pre Reading Storybook - The Lion King.bin" size="0x200000" crc="66126bc1" sha1="36f51db4669f29ee1cb8e12b1c13d9e1738e458f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lionkinga" cloneof="lionking" supported="no">
+		<description>Disney's The Lion King (UK, Leap Start - Pre Reading Storybook, set 2)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-01025"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="000-835040-101002V2"/>
+			<feature name="u1" value="MR27V3202E"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-01025 - Pre Reading - Storybook - The Lion King.bin" size="0x400000" crc="126f277e" sha1="049e7c860272f319f1a940d5087646b842a0455d" />
 			</dataarea>
 		</part>
 	</software>
@@ -480,6 +510,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- also found as UBL 500-10904-B - Finding Nemo with identical ROM -->
 	<software name="findnemoa" supported="no">
 		<description>Leap 1 - Reading - Disney/Pixar Finding Nemo (UK)</description>
 		<year>2003</year>
@@ -526,7 +557,7 @@ license:CC0-1.0
 	</software>
 
 	<software name="lostdino" supported="no">
-		<description>Leap and the lost Dinosaur (UK)</description>
+		<description>Leap and the lost Dinosaur (UK, set 1)</description>
 		<year>2004</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10136"/>
@@ -536,6 +567,21 @@ license:CC0-1.0
 			<feature name="u1" value="OKi 32m"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-10136 - Leap and the lost Dinosaur.bin" size="0x400000" crc="eb3b01c7" sha1="bdc3791199e8b04942459c09047202b048ef27dc" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lostdinoa" cloneof="lostdino" supported="no">
+		<description>Leap and the lost Dinosaur (UK, set 2)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-11430"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="02172-003-7124"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 32M VER:J"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-11430 - Leap and the lost Dinosaur.bin" size="0x400000" crc="69de4c79" sha1="3a4aed688f54ba87f4a2fa56721600fb299c3818" />
 			</dataarea>
 		</part>
 	</software>
@@ -617,13 +663,13 @@ license:CC0-1.0
 		<description>Disney/Pixar Toy Story 2 (UK)</description>
 		<year>2003</year>
 		<publisher>LeapFrog</publisher>
-		<info name="serial" value="500-10497 UBL"/>
+		<info name="serial" value="UBL 500-10497-C"/>
 		<part name="cart" interface="leapfrog_leappad_cart">
 			<feature name="pcb" value="57000-003-2911"/>
 			<feature name="pcb_rev" value="REV.01"/>
 			<feature name="u1" value="Sunplus32m"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
 			<dataarea name="rom" size="0x400000">
-				<rom name="500-10497 UBL - Toy Story 2.bin" size="0x400000" crc="a5e841e2" sha1="7dbb0f053cbf8e9459a964bec43a5013d84ae87b" />
+				<rom name="UBL 500-10497-C - Toy Story 2.bin" size="0x400000" crc="a5e841e2" sha1="7dbb0f053cbf8e9459a964bec43a5013d84ae87b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1211,6 +1257,259 @@ license:CC0-1.0
 			<feature name="u1" value="JS28F320"/>
 			<dataarea name="rom" size="0x400000">
 				<rom name="500-13044 UBL - Sed de Saber - English as a Second Language Edition - Book 6 - How do you say... .bin" size="0x400000" crc="5ed699f6" sha1="902c70e0437525de94a8febab794e46b8a55f5c1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="braintw" supported="no">
+		<description>Brain Twisters - Search the City! (Leap 3)</description>
+		<year>2001</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-00091"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="ASY-310-00087-FAB-300-00087-A"/>
+			<feature name="u1" value="LeapFrog 2000 16M DIE ROM"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-00091 - Brain Twisters - Search the City.bin" size="0x200000" crc="807c99d9" sha1="9ff255a1ded10b62e8c721833c10064250af4c04" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pooh" supported="no">
+		<description>Disney Winnie the Pooh - Lots and Lots of Honey Pots (UK, Mar 05 2002, Pre Math)</description> <!-- Honeypots is without a space on the cart label -->
+		<year>2001</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-00413"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-7210"/>
+			<feature name="pcb_rev" value="REV.00"/>
+			<feature name="u1" value="OKi 16M"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-00413 - Pre Math - Lots  and Lots of Honeypots.bin" size="0x200000" crc="c6686b03" sha1="4488a1117ceca218746e010a4134fa2c042ebcfe" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pooha" cloneof="pooh" supported="no">
+		<description>Disney Winnie the Pooh - Lots and Lots of Honey Pots (UK, Apr 15 2002)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-10914"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-7211"/>
+			<feature name="pcb_rev" value="REV.01"/>
+			<feature name="u1" value="OKi 16M(F)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="UBL 500-10914 - Lots and Lots of Honey Pots.bin" size="0x200000" crc="99f7d00d" sha1="41c9da7e8cc07b53448eae7c1f3ce36e780e5236" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scoobhnt" supported="no">
+		<description>Scooby Doo! and the Haunted Castle (Leap 2, Reading)</description>
+		<year>2002</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-00537"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-3317"/>
+			<feature name="pcb_rev" value="REV.03"/>
+			<feature name="u1" value="HY23V16202"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-00537 - Reading - Scooby Doo and the Haunted Castle.bin" size="0x200000" crc="fb1e17b5" sha1="49dc4670dcc889ced6e2e580a8043713bdf04322" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- also seen as 500-10961 UBL - The Incredibles (US, 2nd Grade) with identical ROM to UK Ages 6-8 version -->
+	<software name="incred" supported="no">
+		<description>The Incredibles (UK/USA)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-11422"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000+003+7223"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 32(J)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-11422 - The Incredibles (Ages 6-8).bin" size="0x400000" crc="0b6c9a94" sha1="bc592aa72d3418e346384183f776aef708d913fb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bratz" supported="no">
+		<description>Bratz - Election Perfection! (UK)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11588"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="335-13845-40"/>
+			<feature name="u1" value="MR27V1602E"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-11588 - Bratz - Election Perfection.bin" size="0x200000" crc="9c81785e" sha1="a947a7277597a487e1eb7ccc7f37923b2c0dd517" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cars" supported="no">
+		<description>Disney/Pixar Cars (UK)</description>
+		<year>2005</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11686"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000+003+7211"/>
+			<feature name="pcb_rev" value="REV.00"/>
+			<feature name="u1" value="OKi 16M(F)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-11686 - Cars.bin" size="0x200000" crc="95dca7ca" sha1="863904681486afe5fde8f549f7eeaf5b6180b426" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dprnmmm" supported="no">
+		<description>Disney Princess - Maths, Mazes and More (UK)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11687"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000+003+7211"/>
+			<feature name="pcb_rev" value="REV.00"/>
+			<feature name="u1" value="OKi 16M(F)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-11687 - Disney Princess - Maths, Mazes and More.bin" size="0x200000" crc="f92280fa" sha1="ec1809bbe98602c248db7f21e3577f1b81f824ad" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- no serial printed anywhere -->
+	<software name="leapaz" supported="no">
+		<description>Leap's Friends from A to Z</description>
+		<year>200?</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-7030"/>
+			<feature name="pcb_rev" value="REV.02"/>
+			<feature name="u1" value="Matronix 8m"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x100000">
+				<rom name="Leap's Friends from A to Z.bin" size="0x100000" crc="19ca9cd4" sha1="5acd30955ac7e31f62a44027b2a49dba2aa946d9" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- no serial printed anywhere -->
+	<software name="wrldgeog" supported="no">
+		<description>LeapPadPro Interactive Geography - World Geography</description>
+		<year>200?</year>
+		<publisher>LeapFrog</publisher>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="ASY-310-00087-FAB-300-00087-A"/>
+			<feature name="u1" value="LeapFrog 2000 16M DIE ROM"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="LeapPad Pro - Interactive Geography - World Geography.bin" size="0x200000" crc="d25cb770" sha1="e58973365e5e96222e27f11ba3d897b3acf8a3c0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sbobsss" supported="no">
+		<description>Spongebob Squarepants - Salty Sea Stories (UK)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-10496 "/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-7011"/>
+			<feature name="pcb_rev" value="REV.01"/>
+			<feature name="u1" value="Matronix 16M"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="UBL 500-10496 - Spongebob Squarepants - Salty Sea Stories.bin" size="0x200000" crc="95f9072a" sha1="f92d6c7f0f6c951cabf4f8f31832cb96cf182a4e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cathat" supported="no">
+		<description>The Cat in the Hat</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-10532"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="335-13845-00"/>
+			<feature name="u1" value="MX23L3211B"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-10532 - The Cat in the Hat.bin" size="0x400000" crc="48369518" sha1="45d16a39fe0c8f0288b80093c89d74071df03cdb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="scoobzom" supported="no">
+		<description>Scooby-Doo! and the Zombie's Treasure (UK)</description>
+		<year>2001</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-11427"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="335-13845-00"/>
+			<feature name="u1" value="MX23L1611B"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-11427 - Scooby-Doo and the Zombie's Treasure.bin" size="0x400000" crc="d48ec54a" sha1="dfcacf1db04d65579e4ecabe24cbbae8643e92ee" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="madagas" supported="no">
+		<description>Madagascar (UK)</description>
+		<year>2005</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-11819"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-7211"/>
+			<feature name="pcb_rev" value="REV.01"/>
+			<feature name="u1" value="OKi 16M(F)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-11819 - Madagascar.bin" size="0x400000" crc="966dfdf7" sha1="4ccca7ced2cc8bb4c9653e699d79257b658fd2c2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Plus Writing cartridges -->
+
+	<software name="mathmagi" supported="no">
+		<description>Maths Magic (LeapPad Plus Writing)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11281 UBL"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000+003+7223"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 32(J)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-11281 UBL - Maths Magic.bin" size="0x400000" crc="f7580e7b" sha1="17f5b1b9b2dc87b4c54a74ad403c0aaf90e376b7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wildword" supported="no">
+		<description>Wild Word Games (LeapPad Plus Writing)</description>
+		<year>2005</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="UBL 500-11688"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="57000-003-2911"/>
+			<feature name="pcb_rev" value="REV.01"/>
+			<feature name="u1" value="Sunplus32m"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-11688 - Wild Word Games.bin" size="0x400000" crc="04c195c0" sha1="eb2f87a41ae97c952b5302174f75337ec7bc2576" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rwmath" supported="no">
+		<description>Reading, Writing and Maths (LeapPad Plus Writing)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11030 UBL"/>
+		<part name="cart" interface="leapfrog_leappad_cart">
+			<feature name="pcb" value="30056+003+7124"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 32M VER:J"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-11030 UBL - Reading, Writing and Maths.bin" size="0x400000" crc="e0fed406" sha1="80e9d3c3a97ca09be1f77725a7b683822537d7d0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/leapfrog_ltleappad_cart.xml
+++ b/hash/leapfrog_ltleappad_cart.xml
@@ -5,6 +5,34 @@ license:CC0-1.0
 -->
 <softwarelist name="leapfrog_ltleappad_cart" description="LeapFrog Little Touch LeapPad cartridges">
 
+	<software name="animalwl" supported="no">
+		<description>Animal World (UK)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11706"/>
+		<part name="cart" interface="leapfrog_ltleappad_cart">
+			<feature name="pcb" value="CT225V5"/>
+			<feature name="u1" value="Macronix 16MBit ROM: MS23L1610HC"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="UBL 500-11706 - Animal World (UK).bin" size="0x200000" crc="c5973571" sha1="661e35da784b371d094895736b7a095c4a54c8ab" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="animalda" supported="no">
+		<description>Animal Dance (UK)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-10244"/>
+		<part name="cart" interface="leapfrog_ltleappad_cart">
+			<feature name="pcb" value="CT337V0"/>
+			<feature name="u1" value="Sunplus ROM: MX23L3210HC"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-10244 - Animal Dance (UK).bin" size="0x400000" crc="65ed100c" sha1="20287a62d88f7d4da9342e016e09fb202e93335a" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Will be clone of "Baby Animals" once found and dumped -->
 	<software name="babyanimlsg" supported="no">
 		<description>Tierbabys (Germany)</description>
@@ -37,8 +65,22 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="bearbed" supported="no">
+		<description>One Bear in the Bedroom (UK)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-10243"/>
+		<part name="cart" interface="leapfrog_ltleappad_cart">
+			<feature name="pcb" value="CT337V0"/>
+			<feature name="u1" value="Sunplus ROM: MX23L3210HC"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-10243 - One Bear in the Bedroom (UK).bin" size="0x400000" crc="87e648cf" sha1="1dfa9f18ffec51072a9bca6cea788a2351d4f76e" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="babyfwords" supported="no">
-		<description>Baby's First Words (USA)</description>
+		<description>Baby's First Words (UK/USA)</description>
 		<year>2003</year>
 		<publisher>LeapFrog</publisher>
 		<info name="serial" value="500-10247"/>

--- a/hash/leapfrog_mfleappad_cart.xml
+++ b/hash/leapfrog_mfleappad_cart.xml
@@ -55,7 +55,22 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="dorafr" supported="no">
+	<software name="dora" supported="no">
+		<description>Dora the Explorer - To the Rescue (UK)</description>
+		<year>2003</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-10301"/>
+		<part name="cart" interface="leapfrog_mfleappad_cart">
+			<feature name="pcb" value="57000+003+7223"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="Oki 32(J)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="UBL 500-10301 - Dora the Explorer - To the Rescue.bin" size="0x400000" crc="f54026a8" sha1="b8eae12f6b4800e58b97527571a5353955ddc2ad" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dorafr" cloneof="dora" supported="no">
 		<description>Dora the Explorer - À la rescousse (France)</description>
 		<year>2003</year>
 		<publisher>LeapFrog</publisher>
@@ -85,7 +100,37 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="carss" supported="no">
+	<software name="wiggles" supported="no">
+		<description>The Wiggles - Learn, Dance and Sing with The Wiggles! (UK)</description>
+		<year>2004</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-12288"/>
+		<part name="cart" interface="leapfrog_mfleappad_cart">
+			<feature name="pcb" value="57000+003+7223"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 32(J)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x400000">
+				<rom name="500-12288 - The Wiggles - Learn, Dance and Sing with The Wiggles.bin" size="0x400000" crc="febe7467" sha1="e35c7e3a1093e6e5b90f836acde4c39ad00addf0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cars" supported="no">
+		<description>Disney/Pixar Cars (UK)</description>
+		<year>2005</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-11460"/>
+		<part name="cart" interface="leapfrog_mfleappad_cart">
+			<feature name="pcb" value="57000+003+7211"/>
+			<feature name="pcb_rev" value="REV:00"/>
+			<feature name="u1" value="OKI 16M(F)"/> <!-- ROM on epoxy blob, but type silkscreened on the PCB -->
+			<dataarea name="rom" size="0x200000">
+				<rom name="500-11460 - Cars.bin" size="0x200000" crc="833797c7" sha1="96a8c5aea32bbd9a2242a6f4757c56b7bf7059e2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="carss" cloneof="cars" supported="no">
 		<description>Disney/Pixar Cars (Spain)</description>
 		<year>2005</year>
 		<publisher>LeapFrog</publisher>
@@ -100,7 +145,7 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="carsfr" cloneof="carss" supported="no">
+	<software name="carsfr" cloneof="cars" supported="no">
 		<description>Disney/Pixar Cars (France)</description>
 		<year>2005</year>
 		<publisher>LeapFrog</publisher>

--- a/hash/leapster.xml
+++ b/hash/leapster.xml
@@ -112,7 +112,7 @@ Known games listed by part-no, (*) denotes undumped, (**) denotes acquired but n
 | 500-12718-A |ENG| Go Diego Go! - Animal Rescuer                             | LEAPSTER       | YES    |
 | 500-12719-A |ENG| SpongeBob SquarePants - Through The Wormhole              | LEAPSTER       | YES    |
 | 500-12738-A |GER| Ratatouille                                               | LEAPSTER       | YES    |
-| 500-12798-A |UK | Noddy - Rainbow Adventures                                | LEAPSTER       | NO     |
+| 500-12798-A |UK | Noddy - Rainbow Adventures                                | LEAPSTER       | YeS    |
 | 500-12799-A |FRA| Oui-Oui - Aventures Au Pays Des Jouet                     | LEAPSTER       | YES    |
 | 500-12800-A |FRA| Lapin Malin - Danse Avec Les Mots                         | LEAPSTER       | YES    |
 | 500-12824-A |SPA| Perrito Club - ¡Adopta Un Nuevo Amiguito Y Aprende!       | LEAPSTER       | YES    |
@@ -1051,7 +1051,19 @@ Entries are ordered by title of the parent, clones are list after the parent, Le
 		</part>
 	</software>
 
-	<software name="noddyf" supported="no">
+	<software name="noddy" supported="no">
+		<description>Noddy - Rainbow Adventure (UK)</description>
+		<year>2007</year>
+		<publisher>LeapFrog</publisher>
+		<info name="serial" value="500-12798-A" />
+		<part name="cart" interface="leapster_cart">
+			<dataarea name="rom" size="0x800000">
+				<rom name="500-12798-A - Noddy - Rainbow Adventure.bin" size="0x800000" crc="dd80e783" sha1="854451718bb14c567daace1cd4394b99f3ce2844" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="noddyf" cloneof="noddy" supported="no">
 		<description>Oui-Oui - Aventures Au Pays Des Jouets (France)</description>
 		<year>2007</year>
 		<publisher>LeapFrog</publisher>

--- a/hash/mobigo_cart.xml
+++ b/hash/mobigo_cart.xml
@@ -5,13 +5,81 @@ license:CC0-1.0
 -->
 <softwarelist name="mobigo_cart" description="VTech MobiGo cartridges">
 
-	<!-- This list is ordered by game description -->
+	<!-- known software
+
+	80-2500xx - Shrek - Forever After
+	80-2501xx - Disney/Pixar Toy Story 3
+	80-2502xx - Mr.Men Little Miss - Adventures in Dillydale
+	80-2503xx - DreamWorks/Nickelodeon The Penguins of Madagascar - Mission Madness
+	80-2504xx - Marvel Super Hero Squad - Sport Heroes
+	80-2505xx - Mickey Mouse - Clubhouse
+	80-2506xx - Ben 10 - Ultimate Alien Mind Mine
+	80-2507xx - Touch & Learn - Game Pack / MobiGo 2 pack-in cart (ROMless, at least for US and Germany carts, see note below)
+	80-2508xx - Nickelodeon Dora the Explorer - Twins' Day
+	80-2509xx - Disney Fairies Explore Your Talents
+	80-2510xx - NASCAR Champion's Touch **
+	80-2511xx - Disney Princess
+	80-2512xx - Disney/Pixar Cars Toon
+	80-2513xx - ?
+	80-2514xx - Sesame Street - Elmo and Abby - Nature Explorers
+	80-2515xx - SpongeBob SquarePants - Defending the Secret Formula
+	80-2516xx - Scooby-Doo! - Mystery Town
+	80-2517xx - Rapunzel - From the Disney film Tangled
+	80-2518xx - Chuggington
+	80-2519xx - Disney/Pixar Cars 2
+	80-2520xx - DreamWorks Kung Fu Panda 2
+	80-2521xx - DreamWorks Madagascar 3 **
+	80-2522xx - ?
+	80-2523xx - Dino Train
+	80-2524xx - Hello Kitty - Hello Kitty Birthday Party!
+	80-2525xx - Team Umizoomi - The Great Umicar Rescue
+	80-2526xx - Disney/Pixar Brave
+	80-2527xx - Thomas & Friends - Really Useful Engines
+	80-2528xx - Disney Jake and the Neverland Pirates
+	80-2529xx - Disney Minnie Mouse
+	80-2530xx - Disney Planes
+	80-2531xx - Disney/Pixar Monsters University **
+	80-2532xx - Sofia the First
+	80-2533xx - Doc McStuffins
+	80-2534xx - Bubble Guppies **
+	80-2535xx - ?
+	80-2536xx - Marvel Ultimate Spider-Man
+	(any more?)
+
+	x is region
+	00 = USA
+	01 = ? (not seen)
+	02 = ? (not seen)
+	03 = UK
+	04 = Germany
+	05 = France
+	06 = ? (not seen)
+	07 = Italy
+	..
+	22 = Spain
+	23 = Netherlands
+
+	** = no versions in software list
+
+	-->
 
 	<!-- Dummy carts (just a jumper PCB, without ROM) that enable internal games in the BIOS:
 	    80-250700 - Touch & Learn - Game Pack (US)
 	    80-250704 - MobiGo 2 (GE) -->
 
-	<software name="ben10g" supported="no">
+	<software name="ben10" supported="no">
+		<description>Ben 10 - Ultimate Alien Mind Mine (UK)</description>
+		<year>2011</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250603(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250603 - Ben 10 - Ultimate Alien Mind Mine (UK).bin" size="0x1000000" crc="96b0a733" sha1="dd7e0e9e8be159c5df8e4defd6af84ea18abd81e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ben10g" cloneof="ben10" supported="no">
 		<description>Ben 10 - UltimateAlien - Mine der Gedanken (Germany)</description>
 		<year>2011</year>
 		<publisher>VTech</publisher>
@@ -59,8 +127,20 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<!-- offset 0x12 is '0x02' is this a version number? cartridge was still only marked as 80-251900(US) -->
 	<software name="cars2" supported="no">
+		<description>Disney/Pixar Cars 2 (UK)</description>
+		<year>2011</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-251903-103(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-251903-103 - Cars 2 (UK).bin" size="0x1000000" crc="4f6e5cb0" sha1="0708e44eb2f2da5798a76564dd6417cc2d76e194"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- offset 0x12 is '0x02' is this a version number? cartridge was still only marked as 80-251900(US) -->
+	<software name="cars2u" cloneof="cars2" supported="no">
 		<description>Disney/Pixar Cars 2 (USA, rev 2?)</description>
 		<year>2011</year>
 		<publisher>VTech</publisher>
@@ -120,7 +200,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="chuggg" supported="no">
+	<software name="chugg" supported="no">
+		<description>Chuggington (US)</description>
+		<year>201?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-251800(US)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-251800 - Chuggington (US).bin" size="0x1000000" crc="1060dc78" sha1="58846f152a19a9ac2eb36f4c941d8e9de3879715"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="chuggg" cloneof="chugg" supported="no">
 		<description>Chuggington (Germany)</description>
 		<year>201?</year>
 		<publisher>VTech</publisher>
@@ -228,7 +320,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="dorag" supported="no">
+	<software name="dora" supported="no">
+		<description>Nickelodeon Dora the Explorer - Twins' Day (UK)</description>
+		<year>2010</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250803(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250803 - Dora the Explorer - Twins' Day (UK).bin" size="0x1000000" crc="f3f7c553" sha1="f9575d9c63817a6b6b4d19ca1bea46fb4322370c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dorag" cloneof="dora" supported="no">
 		<description>Nickelodeon Dora - Tag des Zwillings (Germany)</description>
 		<year>2010</year>
 		<publisher>VTech</publisher>
@@ -240,7 +344,31 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="hkittyg" supported="no">
+	<software name="doraf" cloneof="dora" supported="no">
+		<description>Nickelodeon Dora L' Exploratrice - Dora et Babouche a la fete des jumeaux (France)</description>
+		<year>2010</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250805(FR)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250805 - Dora L' Exploratrice - Dora et Babouche a la fete des jumeaux (France).bin" size="0x1000000" crc="79a36bd2" sha1="9cf46eb3d5504fd2920a50dcfbd1cbe5ae9c1508"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hkitty" supported="no">
+		<description>Hello Kitty - Hello Kitty Birthday Party! (UK)</description>
+		<year>2012</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-252403(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-252403 - Hello Kitty - Hello Kitty Birthday Party (UK).bin" size="0x1000000" crc="f3a17458" sha1="34728ef4f1ce9ed555c2e13c5f8ec821680bb118"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hkittyg" cloneof="hkitty" supported="no">
 		<description>Hello Kitty - Hello Kitty feiert Geburtstag! (Germany)</description>
 		<year>2012</year>
 		<publisher>VTech</publisher>
@@ -248,6 +376,18 @@ license:CC0-1.0
 		<part name="cart" interface="mobigo_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="80-252404 - Hello Kitty - Hello Kitty feiert Geburtstag (GER).bin" size="0x1000000" crc="f47d475b" sha1="ba84cf8f919881856a8a367bc9dea2b04486ba50"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hkittyf" cloneof="hkitty" supported="no">
+		<description>Hello Kitty - La fete d'anniversaire (France)</description>
+		<year>2012</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-252405(FR)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-252405 - Hello Kitty - La fete d'anniversaire (France).bin" size="0x1000000" crc="aec2a761" sha1="ddbbe4416139520908b7be7006eb7c434466b8a3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -288,7 +428,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="kfpand2g" supported="no">
+	<software name="kfpand2" supported="no">
+		<description>DreamWorks Kung Fu Panda 2 (UK)</description>
+		<year>201?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-252003(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-252003 - Kung Fu Panda 2 (UK).bin" size="0x1000000" crc="f944d48e" sha1="9a42116474889236221f4f40f74d5886dfe619d6"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kfpand2g" cloneof="kfpand2" supported="no">
 		<description>DreamWorks Kung Fu Panda 2 (Germany)</description>
 		<year>201?</year>
 		<publisher>VTech</publisher>
@@ -296,41 +448,6 @@ license:CC0-1.0
 		<part name="cart" interface="mobigo_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="80-252004 - kung fu panda 2 (ger).bin" size="0x1000000" crc="88b0b148" sha1="a2ce8915c8acf3a9c7741cae7fcc51aa59895de9"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mickey" supported="no"> <!-- part #? full title? region? -->
-		<description>Mickey Mouse</description>
-		<year>201?</year>
-		<publisher>VTech</publisher>
-		<part name="cart" interface="mobigo_cart">
-			<dataarea name="rom" size="0x1000000">
-				<rom name="mobigomickey.bin" size="0x1000000" crc="51671cd0" sha1="73a2d1a0a8701d3a5daaa98972af545b4b448bf2"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mickeyg" cloneof="mickey" supported="no"> <!-- By now, cloneof "mickey" -->
-		<description>Disney Micky Maus - Wunderhaus (Germany)</description>
-		<year>2010</year>
-		<publisher>VTech</publisher>
-		<info name="serial" value="80-250504(GER)"/>
-		<part name="cart" interface="mobigo_cart">
-			<dataarea name="rom" size="0x1000000">
-				<rom name="80-250504 - micky maus - wunderhaus (ger).bin" size="0x1000000" crc="90467973" sha1="7abcf0064ad961b6a22f43cf78158a8e37905800"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mickeys" cloneof="mickey" supported="no"> <!-- By now, cloneof "mickey" -->
-		<description>Disney La Casa de Mickey Mouse (Spain)</description>
-		<year>2011</year>
-		<publisher>VTech</publisher>
-		<info name="serial" value="80-250522(SP)"/>
-		<part name="cart" interface="mobigo_cart">
-			<dataarea name="rom" size="0x1000000">
-				<rom name="mobigo_250522.bin" size="0x1000000" crc="40b659c4" sha1="8e864ed29c3e3f4d5f1904082e920e92ceeb37fd"/>
 			</dataarea>
 		</part>
 	</software>
@@ -343,6 +460,18 @@ license:CC0-1.0
 		<part name="cart" interface="mobigo_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="80-252904 - Minnie (GER).bin" size="0x1000000" crc="fef9a9a5" sha1="a3d2afda48defc8520129453e4a3475907746761"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="minnief" cloneof="minnieg" supported="no">
+		<description>La Boutique de Minnie (France)</description>
+		<year>2013</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-252905(FR)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-252905 - La Boutique de Minnie (France).bin" size="0x1000000" crc="32c1578d" sha1="c3122b012c04ec11c0699b49df39323333722d45"/>
 			</dataarea>
 		</part>
 	</software>
@@ -403,18 +532,6 @@ license:CC0-1.0
 		<part name="cart" interface="mobigo_cart">
 			<dataarea name="rom" size="0x1000000">
 				<rom name="80-253005 - Disney Planes (France).bin" size="0x1000000" crc="e370c31c" sha1="51b66ad8230d376d6ae3f23055216245c7f27826"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rapunzelg" supported="no">
-		<description>Disney Rapunzel - Neu verföhnt (Germany)</description>
-		<year>2011</year>
-		<publisher>VTech</publisher>
-		<info name="serial" value="80-251704(GER)"/>
-		<part name="cart" interface="mobigo_cart">
-			<dataarea name="rom" size="0x1000000">
-				<rom name="80-251704 - rapunzel - neu verfohnt (ger).bin" size="0x1000000" crc="23cd9cd4" sha1="ef9ee2f21ff741668d65ea343f4b47e4472fada7"/>
 			</dataarea>
 		</part>
 	</software>
@@ -539,13 +656,14 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="tangled" supported="no"> <!-- part #? full title? region? -->
-		<description>Tangled</description>
+	<software name="tangled" supported="no">
+		<description>Rapunzel - From the Disney film Tangled (UK)</description>
 		<year>201?</year>
 		<publisher>VTech</publisher>
+		<info name="serial" value="80-251703(UK)"/>
 		<part name="cart" interface="mobigo_cart">
 			<dataarea name="rom" size="0x1000000">
-				<rom name="mobigotangled.bin" size="0x1000000" crc="8883ecf6" sha1="b51cff0333644e758a4cc7ef26b2365e9a58877c"/>
+				<rom name="80-251703 - Rapunzel - From the Disney film Tangled (UK).bin" size="0x1000000" crc="8883ecf6" sha1="b51cff0333644e758a4cc7ef26b2365e9a58877c"/>
 			</dataarea>
 		</part>
 	</software>
@@ -562,7 +680,32 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="teamumizg" supported="no">
+	<software name="tangledg" cloneof="tangled" supported="no">
+		<description>Disney Rapunzel - Neu verföhnt (Germany)</description>
+		<year>2011</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-251704(GER)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-251704 - rapunzel - neu verfohnt (ger).bin" size="0x1000000" crc="23cd9cd4" sha1="ef9ee2f21ff741668d65ea343f4b47e4472fada7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="teamumiz" supported="no">
+		<description>Team Umizoomi - The Great Umicar Rescue (US)</description>
+		<year>2012</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-252500(US)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-252500 - Team Umizoomi - The Great Umicar Rescue (US).bin" size="0x1000000" crc="36834e00" sha1="ccf12c5954667195590bb583833ef7a6d5210f12"/>
+			</dataarea>
+		</part>
+	</software>
+
+
+	<software name="teamumizg" cloneof="teamumiz" supported="no">
 		<description>Nickelodeon Team Umizoomi - Die große Umiauto Rettung (Germany)</description>
 		<year>2012</year>
 		<publisher>VTech</publisher>
@@ -648,8 +791,9 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<!-- identical ROM found on 80-250103(UK) cart -->
 	<software name="tstory3" supported="no">
-		<description>Disney/Pixar Toy Story 3 (USA)</description>
+		<description>Disney/Pixar Toy Story 3 (USA/UK)</description>
 		<year>2010</year>
 		<publisher>VTech</publisher>
 		<info name="serial" value="80-250100(US)"/>
@@ -684,7 +828,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="mrmenf" supported="no">
+	<software name="mrmen" supported="no">
+		<description>Mr.Men Little Miss - Adventures in Dillydale (UK)</description>
+		<year>201?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250203(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250203 - Mr.Men Little Miss - Adventures in Dillydale (UK).bin" size="0x1000000" crc="e4350f50" sha1="7baa7827b2da2cb8208131e832f4f3a45d09964c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mrmenf" cloneof="mrmen" supported="no">
 		<description>Les Monsieur Madame - Aventures a Jolieville (France)</description>
 		<year>201?</year>
 		<publisher>VTech</publisher>
@@ -696,7 +852,19 @@ license:CC0-1.0
 		</part>
 	</software>
 
-	<software name="mmclubf" supported="no">
+	<software name="mmclub" supported="no">
+		<description>Mickey Mouse - Clubhouse (UK)</description>
+		<year>201?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250503(UK)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250503 - Mickey Mouse - Clubhouse (UK).bin" size="0x1000000" crc="282b8e08" sha1="f9dc340551c02c5a2dc79190a985229bea5205e3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mmclubf" cloneof="mmclub" supported="no">
 		<description>La Maison de Mickey - La Balle de Pluto (France)</description>
 		<year>201?</year>
 		<publisher>VTech</publisher>
@@ -708,6 +876,40 @@ license:CC0-1.0
 		</part>
 	</software>
 
+	<software name="mmclubg" cloneof="mmclub" supported="no">
+		<description>Disney Micky Maus - Wunderhaus (Germany)</description>
+		<year>2010</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250504(GER)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="80-250504 - micky maus - wunderhaus (ger).bin" size="0x1000000" crc="90467973" sha1="7abcf0064ad961b6a22f43cf78158a8e37905800"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mmclubs" cloneof="mmclub" supported="no">
+		<description>Disney La Casa de Mickey Mouse (Spain)</description>
+		<year>2011</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-250522(SP)"/>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mobigo_250522.bin" size="0x1000000" crc="40b659c4" sha1="8e864ed29c3e3f4d5f1904082e920e92ceeb37fd"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mickey" cloneof="mmclub" supported="no"> <!-- part #? full title? region? -->
+		<description>Mickey Mouse</description>
+		<year>201?</year>
+		<publisher>VTech</publisher>
+		<part name="cart" interface="mobigo_cart">
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mobigomickey.bin" size="0x1000000" crc="51671cd0" sha1="73a2d1a0a8701d3a5daaa98972af545b4b448bf2"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<!-- this is from a special large scale Kiosk unit, which should also have a unique BIOS.
 	         Maybe move into driver as a hardcodd cart once BIOS is dumped rather than having it here? -->

--- a/hash/vsmile_cart.xml
+++ b/hash/vsmile_cart.xml
@@ -97,7 +97,7 @@ Regular game cartridges
 |        | 80-090140(US)     | <Unknown> (Should be My Pet Puppy)                                                             |
 |        | 80-090142(NL)     | Mijn Puppy!                                                                                    |
 |   XX   | 80-090144(GE)     | Mein erster Hund                                                                               |
-|        | 80-090145(FR)     | Mon Toutou Tout Fou!                                                                           |
+|   XX   | 80-090145(FR)     | Mon Toutou Tout Fou!                                                                           |
 |   XX   | 80-090147(SP)     | Dakota y su mascota (EAN 3417766901475, 52-090147(SP) on back label)                           |
 |        |          (DK)     | Min hundehvalp                                                                                 |
 |   XX   | 80-090154(SE)     | Min hundvalp                                                                                   |
@@ -418,7 +418,7 @@ Regular game cartridges
 |   XX   | 80-092467(SP)     | Barrio Sésamo - El Mundo Fantástico de Epi y Blas (no # on front label, 52-92467(SP) on back label)
 +========+===================+================================================================================================+
 |        | 80-092480(US)     | The Batman - Gotham City Rescue                                                                |
-|        |          (IT)     | The Batman - Il Salvataggio di Gotham City (80-092492??, GPZ06629)                             |
+|   XX   |          (IT)     | The Batman - Il Salvataggio di Gotham City (80-092492??, GPZ06629)                             |
 |   XX   | 80-092482(NL)     | The Batman - De Redding van Gotham City (52-92482(NL) on back label)                           |
 |   XX   | 80-092483(UK)     | The Batman - Gotham City Rescue                                                                |
 |        | 80-092484(GE)     | The Batman - Rettung von Gotham City                                                           |
@@ -482,7 +482,7 @@ Regular game cartridges
 +========+===================+================================================================================================+
 |   XX   | 80-092660(US)     | Cars - Rev It Up In Radiator Springs                                                           |
 |   XX   | 80-092660-201(US) | Cars - Rev It Up In Radiator Springs (rev. 201)                                                |
-|        |          (IT)     | Cars - Motori Ruggenti (gpz06755)                                                              |
+|   XX?  |          (IT)     | Cars - Motori Ruggenti (gpz06755)                                                              |
 |        | 80-092662(NL)     | Cars - Spektakel in Radiator Springs                                                           |
 |   XX   | 80-092663(UK)     | Cars - Rev It Up In Radiator Springs                                                           |
 |   XX   | 80-092663(UK)     | Cars - Rev It Up In Radiator Springs (alt)                                                     |
@@ -1100,6 +1100,19 @@ V.Smile Smartbook Smartidges (need a Smartbook touch tablet connected to a regul
 		</part>
 	</software>
 
+	<software name="batmanit" cloneof="batmanuk">
+		<description>The Batman - Il Salvataggio di Gotham City (Italy)</description>
+		<year>2006</year> <!-- (s06) -->
+		<publisher>VTech</publisher>
+		<part name="cart" interface="vsmile_cart">
+			<feature name="slot" value="vsmile_rom" />
+			<feature name="cart_type" value="lilac" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="The Batman - Il Salvataggio di Gotham City (Italy).bin" size="0x800000" crc="d6835b03" sha1="40e849b04fcb9d232fd5d512ba8a321fe25bafa1" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="batmannl" cloneof="batmanuk">
 		<description>The Batman - De redding van Gotham City (Netherlands)</description>
 		<year>2006</year> <!-- (s06) -->
@@ -1594,6 +1607,22 @@ V.Smile Smartbook Smartidges (need a Smartbook touch tablet connected to a regul
 			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
 			<dataarea name="rom" size="0x800000">
 				<rom name="C92674-1.u1" size="0x800000" crc="69b535f2" sha1="7785e4e92a0edbb90fd0e0a4f2de3afafae5e957" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- this fails to boot with 'vsmile' but runs with 'vsmilem' despite not being a motion cart, is it failing a checksum that 'vsmilem' doesn't perform?
+	     reads were consistent but ROM may be bad -->
+	<software name="carsit" cloneof="carsr201" supported="no">
+		<description>Disney-Pixar Cars - Motori Ruggenti a Radiator Springs (Italy)</description>
+		<year>2006?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="80-092671(IT)" />
+		<part name="cart" interface="vsmile_cart">
+			<feature name="slot" value="vsmile_rom" />
+			<feature name="cart_type" value="translucent blue" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="Disney-Pixar Cars - Motori Ruggenti (Italy).bin" size="0x800000" crc="74a7fb79" sha1="7003d465a59a4627fb5307719d59e4bb3206087d" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3009,6 +3038,19 @@ V.Smile Smartbook Smartidges (need a Smartbook touch tablet connected to a regul
 			<feature name="u1" value="" /> <!-- EPOXY BLOB ROM -->
 			<dataarea name="rom" size="0x800000">
 				<rom name="90144 OK.u1" size="0x800000" crc="501a4c33" sha1="ebd3e8acd9e1e53409544b847cf508d75a8a0012" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mypuppyfr" cloneof="mypuppyge">
+		<description>Mon Toutou tout fou! (France)</description>
+		<year>200?</year>
+		<publisher>VTech</publisher>
+		<info name="serial" value="52-090145(FR)" />
+		<part name="cart" interface="vsmile_cart">
+			<feature name="slot" value="vsmile_rom" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="52-090145 - Mon Toutou tout fou (France).bin" size="0x800000" crc="124b11c1" sha1="7b8b612b3f610e22ca4c7054fc612fd30695cc7c" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/machine/spg2xx_video.cpp
+++ b/src/devices/machine/spg2xx_video.cpp
@@ -350,9 +350,10 @@ void spg2xx_video_device::video_w(offs_t offset, uint16_t data)
 	case 0x37: // IRQ pos H
 		m_video_regs[offset] = data & 0x01ff;
 		LOGMASKED(LOG_IRQS, "video_w: Video IRQ Position: %04x,%04x (%04x)\n", m_video_regs[0x37], m_video_regs[0x36], 0x2800 | offset);
-		// TODO: some smartvad games set the scanline IRQ to 240 and need it to trigger to progress.
+		// Some smartvad games, stvscri, and some smartcyc games set the scanline IRQ to 240 and need it to trigger to progress.
 		// should that be treated as valid, or is it intentionally disabling it for some other reason?
-		if (m_video_regs[0x37] < 160 && m_video_regs[0x36] < 240)
+		// documentation suggests that 0-239 is the valid range, but could be incorrect
+		if (m_video_regs[0x37] < 160 && m_video_regs[0x36] <= 240)
 			m_screenpos_timer->adjust(m_screen->time_until_pos(m_video_regs[0x36], m_video_regs[0x37] << 1));
 		else
 			m_screenpos_timer->adjust(attotime::never);

--- a/src/mame/handheld/gc71_nes_bootleg.cpp
+++ b/src/mame/handheld/gc71_nes_bootleg.cpp
@@ -1,0 +1,80 @@
+// license:BSD-3-Clause
+// copyright-holders:
+
+/*
+bootleg handheld with standard NES game library
+probably emulation based as the games have a brief animated loading graphic
+and the game data appears to be compressed in the ROM
+
+SoC / CPU is an unmarked 48-pin chip, architecture unknown, there is what looks like native code
+at 0x4000
+
+has T1FF signature at the start of the ROM
+ 
+other similar devices are S+Core, but the code in the ROM doesn't appear to disassemble as such
+*/
+
+#include "emu.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+namespace {
+
+class gc71_nes_bootleg_state : public driver_device
+{
+public:
+	gc71_nes_bootleg_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_screen(*this, "screen")
+	{
+	}
+
+	void gc71hh(machine_config &config) ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	required_device<screen_device> m_screen;
+};
+
+u32 gc71_nes_bootleg_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void gc71_nes_bootleg_state::machine_start()
+{
+}
+
+static INPUT_PORTS_START(gc71hh)
+INPUT_PORTS_END
+
+
+void gc71_nes_bootleg_state::gc71hh(machine_config &config)
+{
+	// unknown CPU
+
+	SCREEN(config, m_screen).set_lcd();
+	m_screen->set_refresh_hz(60);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
+	m_screen->set_size(640, 480);
+	m_screen->set_visarea(0, 640 - 1, 0, 480 - 1);
+	m_screen->set_screen_update(FUNC(gc71_nes_bootleg_state::screen_update));
+
+	SPEAKER(config, "speaker").front_center();
+}
+
+ROM_START( gc71hh )
+	ROM_REGION( 0x800000, "maincpu", 0 )
+	ROM_LOAD( "p25q64sh.u6", 0x000000, 0x800000, CRC(465ccc0a) SHA1(b2dd18fbad05f9011f53c54173c8956771bf616f) )
+ROM_END
+
+} // anonymous namespace
+
+// GC71D-TYPE-C-250819-V3 on PCB, no manufacturer information present on box or unit
+GAME( 2025, gc71hh, 0, gc71hh, gc71hh, gc71_nes_bootleg_state, empty_init, ROT0, "<unknown>", "Mini Handled Game Console GC71", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/handheld/generalplus_gpce4.cpp
+++ b/src/mame/handheld/generalplus_gpce4.cpp
@@ -475,6 +475,13 @@ ROM_START( siddr )
 	ROM_LOAD16_WORD_SWAP( "ddr-toy.bin", 0x0000, 0x400000, CRC(873cbcc8) SHA1(bdd3d12adb1284991a3f8aaa8e451e3a55931267) )
 ROM_END
 
+ROM_START( l2lelmo )
+	ROM_REGION16_BE( 0x20000, "maincpu:internal", ROMREGION_ERASEFF )
+	ROM_LOAD16_WORD_SWAP( "mcu_otp_love2learnelmo.bin", 0x000000, 0x20000, CRC(6726a044) SHA1(15e821c99932cb1d176fca5441c778fb7738d84d) )
+
+	ROM_REGION16_BE( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_LOAD16_WORD_SWAP( "spi_love2learnelmo.bin", 0x000000, 0x800000, CRC(dbe692cc) SHA1(8363992c9fa6ca32fdd900f8f1a53250249e1668) )
+ROM_END
 
 } // anonymous namespace
 
@@ -492,6 +499,8 @@ CONS( 2017, parcade,       0,       0,      generalplus_gpce4,   generalplus_gpc
 CONS( 2019, taturtf,       0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Teenage Mutant Ninja Turtles - Turtle Fighter (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 CONS( 2022, digicolr,   0,         0,      digicolr,            digicolr,          generalplus_gpce4_digicolr_state, empty_init, "Bandai", "Digimon Color", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+
+CONS( 2016, l2lelmo,    0,         0,      generalplus_gpce4,    generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Hasbro", "Love2Learn Elmo", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 // Probably not identical hardware, but still not direct mapped SPI.  External ROM after 0x3000 is encrypted (maybe decrypted in software) seems to have jumps to internal ROM
 CONS( 2021, siddr,         0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, init_siddr, "Super Impulse", "Dance Dance Revolution - Broadwalk Arcade", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/handheld/generalplus_gpl162xx_lcdtype.cpp
+++ b/src/mame/handheld/generalplus_gpl162xx_lcdtype.cpp
@@ -59,6 +59,8 @@ public:
 
 	void gpl162xx_lcdtype(machine_config &config);
 
+	void init_pink218();
+
 private:
 	virtual void machine_start() override ATTR_COLD;
 	virtual void machine_reset() override ATTR_COLD;

--- a/src/mame/handheld/generalplus_gpl951xx.cpp
+++ b/src/mame/handheld/generalplus_gpl951xx.cpp
@@ -32,13 +32,16 @@ public:
 	void fixitflx(machine_config &config) ATTR_COLD;
 	void wiwcs(machine_config &config) ATTR_COLD;
 	void poke(machine_config &config) ATTR_COLD;
+	void pixlstar(machine_config &config) ATTR_COLD;
 	void flufflav(machine_config &config) ATTR_COLD;
 	void puni(machine_config &config) ATTR_COLD;
 	void bubltea(machine_config &config) ATTR_COLD;
 	void dsgnpal(machine_config &config) ATTR_COLD;
 	void bftetris(machine_config &config) ATTR_COLD;
+	void pink218(machine_config &config) ATTR_COLD;
 
 	void init_fif() ATTR_COLD;
+	void init_pink218() ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -395,6 +398,14 @@ void generalplus_gpl951xx_game_state::poke(machine_config &config)
 	m_genspi->set_jedec_capacity(0x19);
 }
 
+void generalplus_gpl951xx_game_state::pixlstar(machine_config &config)
+{
+	gpl951xx(config);
+	m_genspi->set_jedec_manufacturer(0xc2);
+	m_genspi->set_jedec_memtype(0x20);
+	m_genspi->set_jedec_capacity(0x18);
+}
+
 void generalplus_gpl951xx_game_state::flufflav(machine_config &config)
 {
 	gpl951xx(config);
@@ -438,6 +449,16 @@ void generalplus_gpl951xx_game_state::bftetris(machine_config &config)
 	m_screen->set_size(320, 262);
 	m_screen->set_visarea(0, 320-1, 0, 240-1);
 	m_screen->set_screen_update(FUNC(generalplus_gpl951xx_game_state::bftetris_screen_update));
+}
+
+void generalplus_gpl951xx_game_state::pink218(machine_config &config)
+{
+	bftetris(config);
+
+	// check!
+	m_genspi->set_jedec_manufacturer(0xc2);
+	m_genspi->set_jedec_memtype(0x20);
+	m_genspi->set_jedec_capacity(0x17);
 }
 
 
@@ -519,6 +540,31 @@ ROM_END
 ROM_START( punistar )
 	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
 	ROM_LOAD16_WORD_SWAP( "xm25qh64c.ic3", 0x0000, 0x800000, CRC(72f54f23) SHA1(902955764d0b61decc057eb3afaf2960cf2134c6) )
+ROM_END
+
+ROM_START( pixlstar )
+	ROM_REGION16_BE(0x1000000, "spi", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP( "pixel_stars.bin", 0x0000, 0x1000000, CRC(24787fa9) SHA1(104791a1e5783e6d657c6c3b37c2120db8e6f4eb) )
+ROM_END
+
+ROM_START( kenshino )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP( "kenshi no michi.bin", 0x0000, 0x800000, CRC(259c8393) SHA1(5a1aa31127a188cdce1efb87d48016b49aebfd61) )
+ROM_END
+
+ROM_START( tamasmrt )
+	ROM_REGION16_BE(0x1000000, "spi", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP( "tamasmart_mb_spi.bin", 0x0000, 0x1000000, CRC(d1bce309) SHA1(b17f245e1c5919584cd84e8708ed7aba25c3aced) )
+ROM_END
+
+ROM_START( tamasmrta )
+	ROM_REGION16_BE(0x1000000, "spi", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP( "tamasmart_s_spi.bin", 0x0000, 0x1000000, CRC(da7296dc) SHA1(92b5f92fc06274ee886d4ce3c11dae9e40c1f219) )
+ROM_END
+
+ROM_START( teriermn )
+	ROM_REGION16_BE(0x1000000, "spi", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP( "spi_terriermon.bin", 0x0000, 0x1000000, CRC(02073b42) SHA1(8d4a947cf60463e9896f941d7647359a7eac1c1e) )
 ROM_END
 
 ROM_START( flufflav )
@@ -616,6 +662,23 @@ ROM_START( bubltea )
 	ROM_LOAD16_WORD_SWAP( "gpr25l64.ic2", 0x0000, 0x800000, CRC(56549fa7) SHA1(4a03b4c69035baa48b146ecee3912a3b0672b845) )
 ROM_END
 
+ROM_START( pink218 )
+	ROM_REGION( 0x800000, "spi", ROMREGION_ERASEFF )
+	ROM_LOAD( "p25q64h.u2", 0x000000, 0x800000, CRC(7209e7bf) SHA1(1cc0a0b74d3f373dae18b52b3f7014d56f0d9b51) )
+ROM_END
+
+ROM_START( smkfrnd )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "gpr25l6403.u3", 0x0000, 0x800000, CRC(1a865cc2) SHA1(c7abee0b625c713f22c0ffbc923e0938e503ce55) )
+ROM_END
+
+ROM_START( chiikawa )
+	ROM_REGION16_BE(0x800000, "spi", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "chiikawa_to_issho.bin", 0x0000, 0x800000, CRC(cb65a0f6) SHA1(2c8fa2c52fbb7968c4cebfd4b7bdf9b97f31f2f3) )
+ROM_END
+
+
+
 void generalplus_gpl951xx_game_state::init_fif()
 {
 	u16 *spirom16 = (u16*)memregion("spi")->base();
@@ -625,6 +688,20 @@ void generalplus_gpl951xx_game_state::init_fif()
 			3, 1, 11, 9, 6, 14, 0, 2, 8, 7, 13, 15, 4, 5, 12, 10);
 	}
 }
+
+
+void generalplus_gpl951xx_game_state::init_pink218()
+{
+	u16 *romdata = (u16*)memregion("spi")->base();
+	int romsize = memregion("spi")->bytes();
+
+	for (offs_t i = 0; i < romsize / 2; i++)
+	{
+		romdata[i] = romdata[i] ^ 0xc8a9;
+		romdata[i] = bitswap<16>(romdata[i], 3,1,11,9,  6,14,0,2,  8,7,13,15,  4,5,12,10);
+	}
+}
+
 
 } // anonymous namespace
 
@@ -657,6 +734,16 @@ CONS(2021, punij2pk, punirune, 0, puni, puni, generalplus_gpl951xx_game_state, e
 CONS(2021, punifrnd, 0,        0, puni, puni, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes Punitomo Tsuushin (hot pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 CONS(2021, punistar, 0,        0, puni, base, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Punirunes Punistarz (pink, Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
+CONS(2020, pixlstar, 0,        0, pixlstar, base, generalplus_gpl951xx_game_state, empty_init, "Skyrocket Toys", "Pixel Stars Dreamhouse", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
+CONS(2022, kenshino, 0,        0, puni, base, generalplus_gpl951xx_game_state, empty_init, "Takara Tomy", "Kenshi No Michi (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
+CONS(2021, tamasmrt,  0,        0, puni, base, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Tamagotchi Smart (Japan, set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2021, tamasmrta, tamasmrt, 0, puni, base, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Tamagotchi Smart (Japan, set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
+CONS(2021, teriermn,  0,        0, puni, base, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Terriermon (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
 
 // 'Poo' emoji shaped item, comes in multiple colours, has a solder pad which might change between units
 // this was dumped from the 'Lavender' unit
@@ -707,3 +794,11 @@ CONS( 2020, segapet3a, segapet3, 0, puni, base, generalplus_gpl951xx_game_state,
 
 // まぜまぜミックス！ぷにタピちゃん
 CONS( 201?, bubltea,   0,        0, bubltea, bubltea, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Mazemaze Mix! Puni Tapi-chan (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+
+// this one has 2 checksums in service mode (like the generalplus_gp3x_unknown.cpp sets) but one is 00000000 and there is only a single ROM
+// BL-519-V1.2 20220822 on PCB
+CONS( 2022, pink218,      0,       0,      pink218,   bfspyhnt, generalplus_gpl951xx_game_state, init_pink218, "<unknown>", "218-in-1 Handheld Game (pink)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+
+CONS( 2022, smkfrnd,      0,       0,      puni,   segapet2, generalplus_gpl951xx_game_state, empty_init, "Tomy", "Sumikko Gurashi: Sumikko Friend", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
+
+CONS( 2022, chiikawa,     0,       0,      puni,   segapet2, generalplus_gpl951xx_game_state, empty_init, "Bandai", "Chiikawa to Issho (Japan)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )

--- a/src/mame/handheld/hh_mediatek_mt6260a.cpp
+++ b/src/mame/handheld/hh_mediatek_mt6260a.cpp
@@ -243,5 +243,5 @@ CONS( 2022, atw_pepa, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "A
 // red PCB
 CONS( 2022, atw_swst, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Star Wars: Stormtrooper (Accutime, STM4353PH)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 CONS( 2022, atw_swy,  0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Star Wars: The Mandalorian (Accutime, MNL4023PH)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2022, atw_blue, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Bluey (Accutime)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2022, atw_blue, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Bluey (Accutime, BLY4070)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 

--- a/src/mame/handheld/hh_mediatek_mt6260a.cpp
+++ b/src/mame/handheld/hh_mediatek_mt6260a.cpp
@@ -192,6 +192,11 @@ ROM_START( atw_swy )
 	ROM_LOAD( "w25q128jwiq.bin", 0x000000, 0x1000000, CRC(ab3128fd) SHA1(4bc3bf6946b6fbd7c0d783ab48eff5d37828a876) )
 ROM_END
 
+ROM_START( atw_blue )
+	ROM_REGION( 0x1000000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "25lq128c.bin", 0x000000, 0x1000000, CRC(8ddb5514) SHA1(f7e86b49df08ae88c9fb120b0ff9ec7e14bfbec7) )
+ROM_END
+
 ROM_START( atw_toys )
 	ROM_REGION( 0x1000000, "maincpu", ROMREGION_ERASEFF )
 	ROM_LOAD( "w25q128jwiq.bin", 0x000000, 0x1000000, CRC(a748c0f4) SHA1(fa21e16f85cc73109d2ac16286bc345d654e5b94) )
@@ -238,4 +243,5 @@ CONS( 2022, atw_pepa, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "A
 // red PCB
 CONS( 2022, atw_swst, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Star Wars: Stormtrooper (Accutime, STM4353PH)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 CONS( 2022, atw_swy,  0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Star Wars: The Mandalorian (Accutime, MNL4023PH)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2022, atw_blue, 0, 0, atw, atw, accutime_smart_watch_state, empty_init, "Accutime", "Kids Smart Watch: Bluey (Accutime)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 

--- a/src/mame/handheld/sfc_nes_bootleg.cpp
+++ b/src/mame/handheld/sfc_nes_bootleg.cpp
@@ -13,6 +13,7 @@
 #include "screen.h"
 #include "speaker.h"
 
+#include "cpu/arm7/arm7.h"
 
 namespace {
 
@@ -21,6 +22,7 @@ class sfc_nes_bootleg : public driver_device
 public:
 	sfc_nes_bootleg(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen")
 	{
 	}
@@ -33,6 +35,9 @@ protected:
 private:
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
+	void arm_map(address_map &map);
+
+	required_device<cpu_device> m_maincpu;
 	required_device<screen_device> m_screen;
 };
 
@@ -49,9 +54,14 @@ static INPUT_PORTS_START(sfcnes)
 INPUT_PORTS_END
 
 
+void sfc_nes_bootleg::arm_map(address_map &map)
+{
+}
+
 void sfc_nes_bootleg::sfcnes(machine_config &config)
 {
-	// unknown CPU
+	ARM7(config, m_maincpu, 100000000); // unknown ARM
+	m_maincpu->set_addrmap(AS_PROGRAM, &sfc_nes_bootleg::arm_map);
 
 	SCREEN(config, m_screen).set_lcd();
 	m_screen->set_refresh_hz(60);

--- a/src/mame/handheld/sfc_nes_bootleg.cpp
+++ b/src/mame/handheld/sfc_nes_bootleg.cpp
@@ -1,0 +1,77 @@
+// license:BSD-3-Clause
+// copyright-holders:
+
+// SFC-style shell, with bootleg NES games
+// seems to be emulation based as there's an ARM ROM
+
+// main SoC is marked MPK3B18.00 1852
+// PCB is marked SFC-36-H4 20181116 on front
+//               LCX-136P2N4502B1 on back
+
+#include "emu.h"
+
+#include "screen.h"
+#include "speaker.h"
+
+
+namespace {
+
+class sfc_nes_bootleg : public driver_device
+{
+public:
+	sfc_nes_bootleg(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_screen(*this, "screen")
+	{
+	}
+
+	void sfcnes(machine_config &config) ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+
+private:
+	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	required_device<screen_device> m_screen;
+};
+
+u32 sfc_nes_bootleg::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void sfc_nes_bootleg::machine_start()
+{
+}
+
+static INPUT_PORTS_START(sfcnes)
+INPUT_PORTS_END
+
+
+void sfc_nes_bootleg::sfcnes(machine_config &config)
+{
+	// unknown CPU
+
+	SCREEN(config, m_screen).set_lcd();
+	m_screen->set_refresh_hz(60);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
+	m_screen->set_size(640, 480);
+	m_screen->set_visarea(0, 640 - 1, 0, 480 - 1);
+	m_screen->set_screen_update(FUNC(sfc_nes_bootleg::screen_update));
+
+	SPEAKER(config, "speaker").front_center();
+}
+
+ROM_START( sfcnes )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "at25f512.u6", 0x000000, 0x10000, CRC(5d10a597) SHA1(37d7d43b86d66507264b28bd3f26e06a62384041) )
+
+	ROM_REGION( 0x4000000, "maincpu2", 0 )
+	ROM_LOAD( "s29gl512n11tfi02.u3", 0x000000, 0x4000000, CRC(206405a4) SHA1(f3280ef5b5dc95d222c856ce907293e18498a77d) )
+ROM_END
+
+} // anonymous namespace
+
+// there are 600, 620 and 621 game versions at least, unsure which this is
+GAME( 2018, sfcnes, 0, sfcnes, sfcnes, sfc_nes_bootleg, empty_init, ROT0, "<unknown>", "Super Mini SFC (NES/Famicom bootleg)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/handheld/st2302u_bbl_spi.cpp
+++ b/src/mame/handheld/st2302u_bbl_spi.cpp
@@ -447,6 +447,13 @@ ROM_START(qpet)
 	ROM_LOAD("t25s16.bin", 0x000000, 0x200000, CRC(78a9c285) SHA1(73b0ebe1c88af79fae3357ab3cb4920d685a14f4) )
 ROM_END
 
+ROM_START(tchib158)
+	ROM_REGION(0x2000, "maincpu", ROMREGION_ERASEFF)
+	ROM_LOAD("st2x_internal_tchib158.bin", 0x0000, 0x2000, NO_DUMP )
+
+	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_LOAD("p25d32sh.u2", 0x000000, 0x400000, CRC(274a25ff) SHA1(4c0560ee6cb2d31edd4afdf99adf04ce8d69c6bf) )
+ROM_END
 
 } // anonymous namespace
 
@@ -489,6 +496,10 @@ CONS( 201?, ppg118,        0,       0,      bbl380_24mhz,   bbl380_prot, bbl380_
 // it is unclear if dphh8633 refers to the case style, rather than the software, as the dphh8630 set was also noted as previously being found in an 8633 unit
 CONS( 201?, dphh8633,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 268-in-1 - Model 8633", MACHINE_NOT_WORKING )
 CONS( 2016, dphh8661,      0,       0,      bbl380_24mhz,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 268-in-1 - Model 8661", MACHINE_NOT_WORKING ) // from PCP? (logo on back of console) 2016 date on PCB
+
+// yet another internal ROM? (doesn't seem to boot with the ones we have)
+
+CONS( 2022, tchib158,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Tchibo GmbH", "Tchibo 158-in-1 Retro Game", MACHINE_NOT_WORKING )
 
 // also has the 0xE4 XOR, also doesn't currently boot, could be yet another internal ROM
 CONS( 2021, toumapet,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-550)", MACHINE_NOT_WORKING )

--- a/src/mame/leapfrog/leappad.cpp
+++ b/src/mame/leapfrog/leappad.cpp
@@ -232,6 +232,16 @@ ROM_START( leappad )
 	ROM_LOAD( "fs80a363.u4", 0x0000, 0x8000, NO_DUMP )
 ROM_END
 
+ROM_START( leappadw )
+	ROM_REGION( 0x200000, "maincpu", ROMREGION_ERASEFF )
+	ROM_DEFAULT_BIOS("uk")
+	ROM_SYSTEM_BIOS( 0, "uk",  "United Kingdom" )
+	ROMX_LOAD( "lpwriting.u5",       0x000000, 0x200000, CRC(78fb0f39) SHA1(b3faa8f24b9fae9911c3c088cbc8bd8919a2dfaa), ROM_BIOS(0) ) // "ToolPad V2.3.6 LeapPad FullBase V1.1.7 W2K-L0314" "Jun 24 2004 10:49:50 152-10774 2MB UK LPPW Full Base ROM: UK Library"
+
+	ROM_REGION( 0x8000, "bootloader", 0) // Main MCU (LeapFrog FS80A363) internal ROM (exact size unknown)
+	ROM_LOAD( "fs80a363.u4", 0x0000, 0x8000, NO_DUMP )
+ROM_END
+
 ROM_START( mfleappad )
 	ROM_REGION( 0x400000, "maincpu", ROMREGION_ERASEFF )
 	ROM_DEFAULT_BIOS("internat_v1.3")
@@ -276,6 +286,13 @@ ROM_END
 
 //    year, name,       parent, compat, machine,            input,            class,                  init,       company,    fullname,                  flags
 CONS( 2001, leappad,    0,      0,      leapfrog_leappad,   leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "LeapPad",                 MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2002, mfleappad,  0,      0,      leapfrog_mfleappad, leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "My First LeapPad",        MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2004, leappadw,   0,      0,      leapfrog_leappad,   leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "LeapPad Plus Writing",    MACHINE_NO_SOUND | MACHINE_NOT_WORKING ) // Compatible with regular LeapPad carts, but also has system specific carts
 CONS( 2004, leappadmic, 0,      0,      leapfrog_leappad,   leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "LeapPad Plus Microphone", MACHINE_NO_SOUND | MACHINE_NOT_WORKING ) // Compatible with regular LeapPad carts
+// "LeapPad Read Aloud" (alt name for LeapPad Plus Microphone?)
+// "LeapPad Plus Writing & Microphone"
+// "QuantumPad" (has unique carts)
+
+// a 'Microphone Upgrade Kit' cartridge exists (gives regular units Microphone support?)
+
+CONS( 2002, mfleappad,  0,      0,      leapfrog_mfleappad, leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "My First LeapPad",        MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 CONS( 2005, ltleappad,  0,      0,      leapfrog_ltleappad, leapfrog_leappad, leapfrog_leappad_state, empty_init, "LeapFrog", "Little Touch LeapPad",    MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20203,6 +20203,7 @@ retro150a
 rhhc152
 supreme
 table108
+tchib158
 throwbck
 touma560
 touma568
@@ -20236,6 +20237,7 @@ gp3x788
 
 @source:handheld/generalplus_gpce4.cpp
 digicolr
+l2lelmo
 mapacman
 parcade
 siddr
@@ -20247,12 +20249,12 @@ taturtf
 tamameet
 
 @source:handheld/generalplus_gpl162xx_lcdtype.cpp
+bkid218
 pcp8718
 pcp8728
-bkid218
 
 @source:handheld/generalplus_gpl951xx.cpp
-fixitflx
+chiikawa
 bfdigdug
 bfgalaga
 bfmpac
@@ -20261,7 +20263,11 @@ bfspyhnt
 bftetris
 bubltea
 dsgnpal
+fixitflx
 flufflav
+kenshino
+pink218
+pixlstar
 pockrmsr
 pokebala
 pokeissh
@@ -20282,10 +20288,17 @@ segapet3
 segapet3a
 segaptdx
 smkcatch
+smkfrnd
 smkgacha
 smkguras
 smkgurasa
+tamasmrt
+tamasmrta
+teriermn
 wiwcs
+
+@source:handheld/gc71_nes_bootleg.cpp
+gc71hh
 
 @source:handheld/gmaster.cpp
 gmaster
@@ -20402,6 +20415,7 @@ tmbaskb
 atw_avbp
 atw_barb
 atw_batm
+atw_blue
 atw_dp
 atw_enc
 atw_fz
@@ -20831,6 +20845,9 @@ rztoshden
 
 @source:handheld/scrablex.cpp
 scrablex
+
+@source:handheld/sfc_nes_bootleg.cpp
+sfcnes
 
 @source:handheld/talkingbb.cpp
 talkingbb
@@ -26851,6 +26868,7 @@ turboex
 @source:leapfrog/leappad.cpp
 leappad
 leappadmic
+leappadw
 mfleappad
 ltleappad
 
@@ -35767,6 +35785,7 @@ zudugo
 @source:nintendo/nes_vt09.cpp
 cybar120
 dturbogt
+gampow50
 gujtv108
 joypad65
 lxplasma
@@ -35780,6 +35799,7 @@ msimm2
 msinamco
 msisinv
 msifrog
+pckarc50
 pumpactv
 rcapnp
 senario25
@@ -35822,14 +35842,20 @@ orb300
 retror30
 rminitv
 tvkunio1
+tvkunio2
+tvkunio3
 typo240
 
 @source:nintendo/nes_vt369_vtunknown.cpp
-36pcase
+100burgr
 168pcase
+200in1fn
 240in1ar
+36pcase
+500in1gf
 500in1hh
 a6plus
+asthh
 d12power
 d9_500
 denv150
@@ -35840,6 +35866,7 @@ dgun2593
 dvnimbus
 egame150
 f5_620
+fined200
 gb50_150
 gbox2020
 gcs2mgp
@@ -35855,6 +35882,7 @@ hkb502a
 jl1810gr
 jl2050
 jl2377
+jl2950
 lexi30
 lpgm240
 lxcap
@@ -35928,6 +35956,7 @@ unkra200
 urban240
 vibes240
 vibes240a
+vibes240e
 zl383
 zonefusn
 
@@ -35945,6 +35974,7 @@ gbox2022
 gprnrs1
 gprnrs16
 hhgc319
+jjfun365
 mc_7x6ss
 mc_8x6ss
 mc_9x6sa
@@ -40822,6 +40852,7 @@ twinktmb
 
 @source:sega/megadriv_firecore.cpp
 atgame40
+bfmk
 dcat16
 mahg156
 matet
@@ -47766,6 +47797,7 @@ tsbuzz
 
 @source:tvgames/generalplus_gp327902.cpp
 chikawac
+dswitch
 fairicam
 smksagas
 smksagasa
@@ -47779,9 +47811,13 @@ tomyeggb
 mobigo
 mobigof
 mobigos
+mobigouk
+mobigouka
+mobigoukb
 
 @source:tvgames/generalplus_gpl16250_mobigo2.cpp
 mobigo2
+mobigo2g
 
 @source:tvgames/generalplus_gpl16250_nand.cpp
 beambox
@@ -47825,6 +47861,7 @@ myac220
 smartfp
 smartfpf
 smartfps
+tfmat
 tkmag220
 typo176
 
@@ -47974,6 +48011,7 @@ zonefamf
 
 @source:tvgames/spg29x_lexibook_jg7425.cpp
 dancef2p
+dbldance
 fundr200
 lx_aven
 lx_frozen
@@ -48005,6 +48043,7 @@ doraphonf
 doyousud
 dreamlss
 drumsups
+dvlaptop
 epo_tetr
 fordrace
 genitvp
@@ -48025,9 +48064,11 @@ lpetshop
 lxairjet
 lxspidaj
 mattelcs
+mgarage
 mpntball
 mpntbalt
 mylpony
+nvpoker
 ordentv
 pballpup
 pdcj
@@ -48042,6 +48083,7 @@ senspeed
 senwfit
 smartcyc
 spidm2
+stvscri
 swclone
 tiktokmm
 tmntbftc
@@ -48157,6 +48199,7 @@ disppal
 lexiseal
 lexizeus
 pokermor
+pokmax20
 vgcaplet
 vgcap35
 vsplus
@@ -48203,6 +48246,7 @@ cdlyoko
 dnv200fs
 m505neo
 m521neo
+movesyst
 mywicodx
 mywicogt
 oplayer

--- a/src/mame/nintendo/nes_vt09.cpp
+++ b/src/mame/nintendo/nes_vt09.cpp
@@ -488,6 +488,16 @@ ROM_START( lxplasma )
 	ROM_LOAD( "ig810.u2", 0x00000, 0x800000, CRC(e2cf5fe7) SHA1(1f75c723b1ab456e322c81c1d3080b9dd1f80fec) )
 ROM_END
 
+ROM_START( gampow50 )
+    ROM_REGION( 0x400000, "mainrom", 0 )
+    ROM_LOAD( "mx29lv320bt.u2", 0x00000, 0x400000, CRC(65ede8ed) SHA1(a7dc43a6d47a3f486e5af24cdd730dcd479fa8bb) )
+ROM_END
+
+ROM_START( pckarc50 )
+    ROM_REGION( 0x400000, "mainrom", 0 )
+    ROM_LOAD( "mx29lv320bt.u1", 0x00000, 0x400000, CRC(a38f0c89) SHA1(28e8c428394e71bcd2b19d26e271df8eb2634b2a) )
+ROM_END
+
 ROM_START( vgtablet )
 	ROM_REGION( 0x400000, "mainrom", 0 )
 	ROM_LOAD( "vgtablet.bin", 0x00000, 0x400000, CRC(99ef3978) SHA1(0074445708d66a04ab02b4993069ce1ae0514c2f) )
@@ -588,7 +598,9 @@ CONS( 200?, vgpmini,   0,  0,  nes_vt09_4mb, nes_vt09, nes_vt09_state, empty_ini
 // VG Pocket Max (VG-3000) (white case, 75 games) (does the game selection differ, or only the case?)
 CONS( 2006, vgtablet,  0, 0,  nes_vt09_4mb_rasterhack,  nes_vt09, nes_vt09_state, empty_init, "Performance Designed Products (licensed by Konami) / JungleTac", "VG Pocket Tablet (VG-4000)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // raster timing for Frogger needs a hack
 // VG Pocket Caplet is SunPlus hardware instead, see spg2xx_lexibook.cpp
-CONS( 2005, lxplasma,  0,  0,  nes_vt09_8mb, nes_vt09, nes_vt09_state, empty_init, "Lexibook / JungleTac", "Plasma Console (IG810, 60-in-1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 2005, lxplasma,  0,  0,  nes_vt09_8mb, nes_vt09, nes_vt09_state, empty_init, "Lexibook / JungleTac",  "Plasma Console (IG810, 60-in-1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 2005, gampow50,  0,  0,  nes_vt09_4mb, nes_vt09, nes_vt09_state, empty_init, "Logic 3 / JungleTac",   "GamesPower 50 Games", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 2005, pckarc50,  0,  0,  nes_vt09_4mb, nes_vt09, nes_vt09_state, empty_init, "<unknown> / JungleTac", "Pocket Arcade 50-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 CONS( 200?, timetp25,   0,  0,  nes_vt09_cart, nes_vt09, nes_vt09_cart_state, empty_init, "Timetop", "Super Game 25-in-1 (GM-228)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 

--- a/src/mame/nintendo/nes_vt32.cpp
+++ b/src/mame/nintendo/nes_vt32.cpp
@@ -484,9 +484,19 @@ ROM_START( micac250 )
 	ROM_LOAD( "250in1microarcade.u2", 0x000000, 0x1000000, CRC(3bb2a65c) SHA1(294eb2165466981a79e1d4ec535038e73fbca4de) )
 ROM_END
 
-ROM_START( tvkunio1 )
+ROM_START( tvkunio1 ) // yellow unit
 	ROM_REGION( 0x200000, "mainrom", 0 )
 	ROM_LOAD( "mx29lv160dt.u3", 0x00000, 0x200000, CRC(4f502bff) SHA1(5c91c46c8b3b837cf98a5519d71117164c23a721) )
+ROM_END
+
+ROM_START( tvkunio2 ) // pink unit
+	ROM_REGION( 0x200000, "mainrom", 0 )
+	ROM_LOAD( "mx29lv160dt.u3", 0x00000, 0x200000, CRC(e39d4b78) SHA1(8496efddfef97662ffb707651361a588a39efde1) )
+ROM_END
+
+ROM_START( tvkunio3 ) // blue unit
+	ROM_REGION( 0x200000, "mainrom", 0 )
+	ROM_LOAD( "mx29lv160bt.u3", 0x00000, 0x200000, CRC(dcc4f44f) SHA1(18439fbaaf392664c506d41d5e2ec17fb5cbaa11) )
 ROM_END
 
 ROM_START( fingerd )
@@ -571,6 +581,8 @@ CONS( 201?, k10_2l,    0, 0,  nes_vt32_16mb, nes_vt32, nes_vt32_unk_state, empty
 
 // びっくり熱血新記録！はるかなる金メダル
 CONS( 2022, tvkunio1,  0, 0,  nes_vt32_2mb,  nes_vt32, nes_vt32_unk_state, empty_init, "Arc System Works", "Kunio-kun TV! Bikkuri Nekketsu Shin Kiroku! Harukanaru Kin Medal (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // yellow unit
+CONS( 2022, tvkunio2,  0, 0,  nes_vt32_2mb,  nes_vt32, nes_vt32_unk_state, empty_init, "Arc System Works", "Kunio-kun TV! Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // pink unit
+CONS( 2022, tvkunio3,  0, 0,  nes_vt32_2mb,  nes_vt32, nes_vt32_unk_state, empty_init, "Arc System Works", "Kunio-kun TV! Nekketsu Koukou Dodgeball Bu (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // blue unit
 
 CONS( 202?, micac250,  0, 0,  nes_vt32_16mb, nes_vt32, nes_vt32_unk_state, empty_init, "<unknown>", "Micro Arcade 250-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -2044,7 +2044,7 @@ CONS( 201?, tiger108,  0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_i
 
 CONS( 201?, gon100,    0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "Game On 100-in-1", MACHINE_IMPERFECT_GRAPHICS )
 // very similar to gon100, but menu is at a different resolution
-CONS( 201?, 100burgr,  0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "100-in-1 Handheld Game (burger shape)", MACHINE_IMPERFECT_GRAPHICS )
+CONS( 201?, 100burgr,  0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "Tiger Retail / Zebra A/S", "100-in-1 Handheld Game (burger shape)", MACHINE_IMPERFECT_GRAPHICS )
 
 CONS( 201?, d12power,  0,        0,  vt36x_16mb, vt369, vt36x_state, empty_init, "SZDiiER", "Power - Charging and playing games (D12) (416-in-1)", MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/nintendo/nes_vt369_vtunknown.cpp
+++ b/src/mame/nintendo/nes_vt369_vtunknown.cpp
@@ -173,8 +173,10 @@ public:
 	void vt4ffx_32mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_h12p1000(machine_config &config) ATTR_COLD;
 
+	void vt4ffx_vibesswap_1mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_vibesswap_8mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_vibesswap_16mb(machine_config &config) ATTR_COLD;
+	void vt4ffx_gbox2020_4mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_gbox2020_8mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_gbox2020_16mb(machine_config &config) ATTR_COLD;
 	void vt4ffx_s10swap_8mb(machine_config &config) ATTR_COLD;
@@ -667,6 +669,12 @@ void vt4ffx_state::vt4ffx_vibesswap_8mb(machine_config &config)
 	m_soc->set_addrmap(AS_PROGRAM, &vt4ffx_state::vt_external_space_map_8mbyte);
 }
 
+void vt4ffx_state::vt4ffx_vibesswap_1mb(machine_config &config)
+{
+	vt4ffx_vibesswap_16mb(config);
+	m_soc->set_addrmap(AS_PROGRAM, &vt4ffx_state::vt_external_space_map_1mbyte);
+}
+
 void vt4ffx_state::vt4ffx_gbox2020_8mb(machine_config &config)
 {
 	VT4FFX_SOC_GBOX2020(config, m_soc, NTSC_APU_CLOCK);
@@ -680,6 +688,12 @@ void vt4ffx_state::vt4ffx_gbox2020_16mb(machine_config &config)
 {
 	vt4ffx_gbox2020_8mb(config);
 	m_soc->set_addrmap(AS_PROGRAM, &vt4ffx_state::vt_external_space_map_16mbyte);
+}
+
+void vt4ffx_state::vt4ffx_gbox2020_4mb(machine_config &config)
+{
+	vt4ffx_gbox2020_8mb(config);
+	m_soc->set_addrmap(AS_PROGRAM, &vt4ffx_state::vt_external_space_map_4mbyte);
 }
 
 void vt4ffx_state::vt4ffx_s10swap_8mb(machine_config &config)
@@ -942,6 +956,12 @@ ROM_START( urban240 )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
 	ROM_LOAD( "urban240.u3", 0x00000, 0x8000000, CRC(73d03f0d) SHA1(a1615dba39e9114ace7a8ad68f46195da655bf35) )
 ROM_END
+
+ROM_START( jl2950 )
+	ROM_REGION( 0x8000000, "mainrom", 0 )
+	ROM_LOAD( "jl2950.u3", 0x00000, 0x8000000, CRC(91aed900) SHA1(a2dfce489a66120237e68908319841440e5e7b60) )
+ROM_END
+
 
 ROM_START( rtvgc300 )
 	ROM_REGION( 0x8000000, "mainrom", 0 )
@@ -1408,16 +1428,31 @@ ROM_START( gbox2020 )
 	ROM_LOAD( "fgb2020.bin", 0x00000, 0x1000000, CRC(a685d943) SHA1(9b272daccd8fe244c910f031466a4fedd83d5236) ) // flash ROM
 ROM_END
 
-ROM_START( vibes240 )
+ROM_START( fined200 )
+	ROM_REGION( 0x400000, "mainrom", 0 )
+	ROM_LOAD( "29lv320.u1", 0x00000, 0x400000, CRC(45cefe71) SHA1(0dd5a5eed1fbdd109e831fa52eb5826ffef030d5) )
+ROM_END
+
+ROM_START( vibes240 ) // from a unit with translucent blue case
+	ROM_REGION( 0x1000000, "mainrom", 0 )
+	ROM_LOAD( "s29gl128n10tfi01.u2", 0x000000, 0x1000000, CRC(2b0a26f1) SHA1(0bd6465fc7f1c9c73069245ab6fcd1bdbe3a82d8) )
+ROM_END
+
+ROM_START( vibes240a ) // might just be a bad dump of the same revision as vibes240
 	ROM_REGION( 0x1000000, "mainrom", 0 )
 	// wouldn't read consistently
 	ROM_LOAD( "s29gl128p11tfi01.bin", 0x000000, 0x1000000, BAD_DUMP CRC(c04c5527) SHA1(58737084e1b1a2862f50f07feeab79593ca13862) )
 ROM_END
 
-ROM_START( vibes240a )
+ROM_START( vibes240e )
 	ROM_REGION( 0x1000000, "mainrom", 0 )
 	// wouldn't read consistently
 	ROM_LOAD( "vibes.u2", 0x000000, 0x1000000, BAD_DUMP CRC(a747971a) SHA1(2399d4f32d0054a06397bead069b498e634dbe37) )
+ROM_END
+
+ROM_START( asthh )
+	ROM_REGION( 0x100000, "mainrom", 0 )
+	ROM_LOAD( "29dl800ba.u2", 0x000000, 0x100000, CRC(1fbad073) SHA1(e358d24e2e383a71b41fc4e0cbf9d8a7d09c4d9d) )
 ROM_END
 
 ROM_START( retro620 )
@@ -1604,6 +1639,11 @@ ROM_START( gon100 )
 	ROM_LOAD( "p25d32sh.bin", 0x00000, 0x400000, CRC(6d852ab0) SHA1(4e90054d4632581f15aafff9e950f80d6bbcb1d5) )
 ROM_END
 
+ROM_START( 100burgr )
+    ROM_REGION( 0x800000, "mainrom", 0 )
+    ROM_LOAD( "p25d32sh.bin", 0x00000, 0x400000, CRC(db65f960) SHA1(60a9a716f83033cb0387124611c08e8c6975aa9a) )
+ROM_END
+
 ROM_START( d12power )
 	ROM_REGION( 0x1000000, "mainrom", 0 )
 	ROM_LOAD( "25q128.u2", 0x00000, 0x1000000, CRC(02650ad4) SHA1(ca346409e11732d97b892c356fc5da61dc16ab01) )
@@ -1681,6 +1721,16 @@ ROM_START( rsps300 )
 	ROM_LOAD( "s29gl128p10tfi01.u2", 0x00000, 0x1000000, CRC(77c0a7fc) SHA1(dde5f24596d34e0a1305df92ba267a868bd386d4) )
 ROM_END
 
+ROM_START( 500in1gf )
+	ROM_REGION( 0x2000000, "mainrom", 0 )
+	ROM_LOAD( "s29gl256n10tfi01.u2", 0x00000, 0x2000000, CRC(1c7012aa) SHA1(9513b07ed1eb0f19619bd9c9199d261c6e9348bd) )
+ROM_END
+
+ROM_START( 200in1fn )
+	ROM_REGION( 0x1000000, "mainrom", 0 )
+	ROM_LOAD( "200in1.u3", 0x000000, 0x1000000, CRC(9db30eac) SHA1(32cf7db7fc6a3facf59739b3fbe66c8bf1615ea3) )
+ROM_END
+
 void vt369_state::init_lxcmcypp()
 {
 	int size = memregion("mainrom")->bytes()/2;
@@ -1748,6 +1798,8 @@ void vt369_state::init_tui240()
 // First half of games don't work, probably bad dump
 CONS( 201?, dvnimbus,   0,        0,  vt369_unk_16mb, vt369, vt36x_state, empty_init, "<unknown>", "DVTech Nimbus 176 in 1", MACHINE_NOT_WORKING )
 
+// BL-901-V2.0, 20190611 on PCB
+CONS( 2019, 200in1fn, 0,  0,  vt36x_altswap_16mb, vt369, vt36x_state, empty_init, "<unknown>", "200 in 1 Handheld Console (with bad menu font)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 /****************************************************************************************************************
 
@@ -1843,6 +1895,8 @@ CONS( 201?, red5mam,  0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_st
 CONS( 2016, dgun2593,  0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_state, empty_init, "dreamGEAR", "My Arcade Retro Arcade Machine - 300 Handheld Video Games (DGUN-2593)", MACHINE_NOT_WORKING )
 
 CONS( 201?, urban240,  0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_state, empty_init, "Urban Outfitters", "Mini Arcade Machine 240-in-1 (translucent case)", MACHINE_NOT_WORKING )
+// same style menu as urban240, but more games (45 Sports, 112 Arcade, 75 Puzzle, 68 Shooting) 
+CONS( 201?, jl2950,    0,  0,  vt36x_altswap_32mb_4banks_red5mam, vt369, vt36x_state, empty_init, "Lexibook", "Cyber Arcade 300-in-1 (JL2950)", MACHINE_NOT_WORKING )
 
 // Not the same as the other 240-in-1 machine from Thumbs Up below (tup240) This one makes greater use of newer VT features with most games having sampled music, not APU sound.
 // Several of the games contained in here are buggy / broken on real hardware (see https://www.youtube.com/watch?v=-mgGNaDQ1HE )
@@ -1867,11 +1921,19 @@ CONS( 2020, gbox2020, gbox2019, 0, vt4ffx_gbox2020_16mb, vt369, vt4ffx_state, em
 // GB-40-36V1.2 and 20180825 on PCB, assuming to be from Sup although unit wasn't branded
 CONS( 2018, rsps300,  0,        0,  vt4ffx_rsps300swap_16mb, vt369, vt4ffx_state, empty_init,   "Sup", "Retro Station Pocket System GB-40 300 in 1",  MACHINE_NOT_WORKING )
 
+// HKDSUP Ver.2.0 2024.09.05 on PCB
+CONS( 2024, fined200, 0,        0, vt4ffx_gbox2020_4mb, vt369, vt4ffx_state, empty_init, "Sup", "Fine & Dandy 200 in 1", MACHINE_NOT_WORKING )
+
 // unknown tech, probably from 2021, probably VT369, ROM wouldn't read consistently
-// several games don't work (eg. Curly Monkey 2, maybe due to bad dump?)
+// several games don't work (eg. Curly Monkey 2) but the parent set should be a good dump
 CONS( 202?, vibes240, 0,        0,  vt4ffx_vibesswap_16mb, vt369, vt4ffx_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (set 1)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+// bad dump
+CONS( 202?, vibes240a,vibes240, 0,  vt4ffx_vibesswap_16mb, vt369, vt4ffx_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 // also a bad dump, different encryption, but Curly Monkey 2 works here, only first 2 opcodes are encrypted
-CONS( 202?, vibes240a,vibes240, 0,  vt4ffx_gbox2020_16mb,  vt369, vt4ffx_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (set 2)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 202?, vibes240e,vibes240, 0,  vt4ffx_gbox2020_16mb,  vt369, vt4ffx_state, empty_init, "<unknown>", "Vibes Retro Pocket Gamer 240-in-1 (alt encryption)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+
+// uses unsupported screen mode
+CONS( 202?, asthh,    0,        0,  vt4ffx_vibesswap_1mb, vt369, vt4ffx_state, empty_init, "<unknown>", "Asteroids: Classic Arcade Game", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 // has TUI (holiday company) logo on packaging, no other manufacturer details
 CONS( 201?, tui240,   0,        0,  vt4ffx_gbox2020_8mb,   vt369, vt4ffx_state, init_tui240, "<unknown>",  "TUI 240-in-1", MACHINE_NOT_WORKING )
@@ -1893,6 +1955,8 @@ CONS( 202?, s10_520,   0,  0,  vt4ffx_gbox2020_16mb, vt369, vt4ffx_state, empty_
 CONS( 202?, s5_520,    0,  0,  vt4ffx_16mb,          vt369, vt4ffx_state, empty_init, "<unknown>", "S5 Game Box (520-in-1)",  MACHINE_NOT_WORKING )
 // fewer games, but does have the scramble
 CONS( 202?, 500in1hh,  0,  0,  vt4ffx_gbox2020_16mb, vt369, vt4ffx_state, empty_init, "<unknown>", "500-in-1 Handheld Game",  MACHINE_NOT_WORKING )
+// needs banking? (32MByte ROM, but doesn't expect plain mapping)
+CONS( 202?, 500in1gf,  0,  0,  vt4ffx_gbox2020_16mb, vt369, vt4ffx_state, init_s10fake, "<unknown>", "500-in-1 Handheld Game (German / French / English / Chinese menu)",  MACHINE_NOT_WORKING )
 
 // there were also 'F1' units, shaped like a car, ROM may or may not be the same
 CONS( 202?, f5_620,    0,  0,  vt4ffx_16mb,        vt369, vt4ffx_state, init_f5_620,   "<unknown>", "F5 Handheld Game Console (620-in-1)",  MACHINE_NOT_WORKING )
@@ -1979,6 +2043,8 @@ CONS( 201?, supr200,    0,        0,  vt36x_swap_8mb, vt369, vt36x_state, empty_
 CONS( 201?, tiger108,  0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "Zebra AS / Tiger Retail", "Spillekonsol Game console - 108-in-1", MACHINE_IMPERFECT_GRAPHICS )
 
 CONS( 201?, gon100,    0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "Game On 100-in-1", MACHINE_IMPERFECT_GRAPHICS )
+// very similar to gon100, but menu is at a different resolution
+CONS( 201?, 100burgr,  0,        0,  vt36x_swap_4mb, vt369, vt36x_state, empty_init, "<unknown>", "100-in-1 Handheld Game (burger shape)", MACHINE_IMPERFECT_GRAPHICS )
 
 CONS( 201?, d12power,  0,        0,  vt36x_16mb, vt369, vt36x_state, empty_init, "SZDiiER", "Power - Charging and playing games (D12) (416-in-1)", MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/nintendo/nes_vt42xx.cpp
+++ b/src/mame/nintendo/nes_vt42xx.cpp
@@ -88,6 +88,7 @@ public:
 	void init_g9_666();
 	void init_hhgc319();
 	void init_bl339();
+	void init_jjfun365();
 
 protected:
 	uint8_t vt_rom_banked_r(offs_t offset);
@@ -511,6 +512,11 @@ ROM_START( g3_800 )
 	ROM_LOAD( "g3_800in1.bin", 0x00000, 0x4000000, CRC(df326924) SHA1(38c26ea96fbf3ba80526072d07209f19b04812e9) )
 ROM_END
 
+ROM_START( jjfun365 )
+	ROM_REGION( 0x1000000, "mainrom", 0 )
+	ROM_LOAD( "s29gl128p10tfi01.u1", 0x00000, 0x1000000, CRC(d2744949) SHA1(72af5d644d700ebfbabd37c862a81058c4c9c2f3) )
+ROM_END
+
 void nes_vt42xx_state::init_rfcp168()
 {
 	uint8_t *romdata = memregion("mainrom")->base();
@@ -571,11 +577,26 @@ void nes_vt42xx_state::init_bl339()
 		put_u16le(&romdata[i], bitswap<16>(get_u16le(&romdata[i]), 15, 7, 13, 4, 3, 10, 2, 1, 14, 6, 5, 12, 11, 9, 8, 0));
 }
 
+void nes_vt42xx_state::init_jjfun365()
+{
+	init_g9_666();
+	init_rfcp168();
+
+	uint8_t *romdata = memregion("mainrom")->base();
+	for (offs_t i = 0; i < 0x800000; i += 0x20000)
+	{
+		// Swap A16 with A23
+		std::swap_ranges(&romdata[i + 0x10000], &romdata[i + 0x20000], &romdata[i + 0x800000]);
+	}
+}
+
 } // anonymous namespace
 
 
 CONS( 201?, rfcp168,  0,  0,  nes_vt42xx_16mb, nes_vt42xx, nes_vt42xx_state, init_rfcp168, "<unknown>", "Retro FC Plus 168 in 1 Handheld", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // "RETRO_FC_V3.5"
 
+// 060-91011011V8.0 SUPER-FC280 on PCB
+CONS( 2022, jjfun365, 0,  0,  nes_vt42xx_16mb, nes_vt42xx, nes_vt42xx_state, init_jjfun365,   "JJFun", "Retro FC Game Box 365-in-1",  MACHINE_NOT_WORKING )
 
 // these share the same bitswap, many duplicates, real game counts to be confirmed, graphical issues in some games
 CONS( 201?, g5_500,   0,  0,  nes_vt42xx_16mb, nes_vt42xx, nes_vt42xx_state, init_g9_666, "<unknown>", "G5 500 in 1 Handheld", MACHINE_NOT_WORKING )

--- a/src/mame/sega/megadriv_firecore.cpp
+++ b/src/mame/sega/megadriv_firecore.cpp
@@ -382,6 +382,11 @@ ROM_START( msi_sf2 )
 	ROM_LOAD16_WORD_SWAP( "29lv320.bin", 0x000000, 0x400000, CRC(465b12f0) SHA1(7a058f6feb4f08f56ae0f7369c2ca9a9fe2ed40e) )
 ROM_END
 
+ROM_START( bfmk )
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD16_WORD_SWAP( "s29gl032.u2", 0x000000, 0x400000, CRC(d5346d32) SHA1(7aec036436e9941050ae33be3ac7d734cedf2de7) )
+ROM_END
+
 ROM_START( reactmd )
 	ROM_REGION( 0x2000000, "maincpu", ROMREGION_ERASE00 ) // this contains the MD games and main boot menu
 	ROM_LOAD16_WORD_SWAP( "reactormd.bin", 0x0000, 0x2000000, CRC(fe9664a4) SHA1(d475b524f576c9d1d90aed20c7467cc652396baf) )
@@ -500,6 +505,9 @@ CONS( 201?, mdhh100,   0,        0, megadriv_firecore_3button_ntsc,  firecore_3b
 
 // From a European unit but NTSC? - code is hacked from original USA Genesis game with region check still intact? (does the clone hardware always identify as such? or does the bypassed boot code skip the check?)
 CONS( 2018, msi_sf2,   0,        0, megadriv_firecore_6button_ntsc,  msi_6button,      megadriv_firecore_state, init_megadriv, "MSI / Capcom / Sega", "Street Fighter II: Special Champion Edition (MSI Plug & Play) (Europe)", 0)
+
+// the Firecore video mode part doesn't work correctly, game can boot if you skip over it
+CONS( 2019, bfmk,      0,        0, megadriv_firecore_6button_ntsc,  msi_6button,      megadriv_firecore_state, init_megadriv, "Basic Fun", "Mortal Kombat: Arcade Classics", MACHINE_NOT_WORKING)
 
 // Two systems in one unit - Firecore Genesis and SunPlus
 CONS( 2009, reactmd,   0,        0, megadriv_firecore_3button_pal,   firecore_3button, megadriv_firecore_state, init_reactmd,  "AtGames / Sega / Waixing", "Reactor MD (Firecore/SunPlus hybrid, PAL)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/tvgames/generalplus_gp327902.cpp
+++ b/src/mame/tvgames/generalplus_gp327902.cpp
@@ -206,6 +206,11 @@ ROM_START( fairicam )
 ROM_END
 
 
+ROM_START( dswitch )
+	ROM_REGION( 0x200000, "spi", ROMREGION_ERASEFF )
+	ROM_LOAD( "gpr25l1603.u3", 0x00000, 0x200000, CRC(7998db0b) SHA1(04861b9f88cd5c6d0a80a2de9b2737d0198ab4af) )
+ROM_END
+
 } // anonymous namespace
 
 // Tomy / San-X devices
@@ -240,3 +245,8 @@ CONS( 2021, chikawac, 0, 0, gp327902, gp327902, generalplus_gp327902_game_state,
 
 // リルリルフェアリル　フェアリルカメラ
 CONS( 2016, fairicam, 0, 0, gp327902, gp327902, generalplus_gp327902_game_state, init_spi, "Sega Toys", "Rilu Rilu Fairilu Camera (Japan)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+
+// has a VT24001 which might be the main SoC or a peripheral chip in this case, although there was another glob (ROM has GPNV header like gp327902 games though)
+// device is a storybook video projector
+CONS( 2017, dswitch, 0, 0, gp327902, gp327902, generalplus_gp327902_game_state, init_spi, "Sega Toys", "Dream Switch", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo.cpp
@@ -88,18 +88,56 @@ void mobigo_state::init_mobigo()
 	m_sdram.resize(0x400000); // 0x400000 bytes, 0x800000 words (needs verifying)
 }
 
-ROM_START( mobigo )
+// MobiOURS0.1 versions
+
+ROM_START( mobigo ) // with additional built-in game
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	// MobiOURS0.1  2010-01-02
 	ROM_LOAD16_WORD_SWAP("mobigo.bin", 0x0000, 0x800000, CRC(49479bad) SHA1(4ee82c7ba13072cf25a34893cf6272f2da5d8928) )
 ROM_END
 
+ROM_START( mobigouk ) // no built in game
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	// MobiOURS0.1  2010-01-02
+	ROM_LOAD16_WORD_SWAP("mobiours0.1_2010-01-02_uk.u3", 0x0000, 0x200000, CRC(5dfe21b0) SHA1(bdbf75909c96c6cd3636ac8be6fde4646b83ca6b) )
+
+	ROM_REGION( 0x800000, "i2mem", ROMREGION_ERASE00) // for settings
+	ROM_LOAD("k24c08c.u7", 0x000, 0x400, CRC(dea8dad3) SHA1(81409019a262a6e410d7ac2cbdc99680e73ba1a9) )
+ROM_END
+
+// MobiOURS1.0 versions
+
 ROM_START( mobigos )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
-	ROM_LOAD16_WORD_SWAP("mobigospanish.bin", 0x0000, 0x200000, CRC(462b4f9d) SHA1(1541152f1a359bc18de4d4f3d5038a954c9a3ad4))
+	// MobiOURS1.0  2010-07-21
+	ROM_LOAD16_WORD_SWAP("mobigospanish.bin", 0x0000, 0x200000, CRC(462b4f9d) SHA1(1541152f1a359bc18de4d4f3d5038a954c9a3ad4) )
+
+	ROM_REGION( 0x800000, "spi", ROMREGION_ERASE00) // for built-in games and/or downloads? (not a boot ROM)
+	ROM_LOAD16_WORD_SWAP("mx25l1606e.u3", 0x0000, 0x200000, NO_DUMP ) // assume the 1.0 sets should have this
+ROM_END
+
+ROM_START( mobigouka )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	// MobiOURS1.0  2010-07-21
+	ROM_LOAD16_WORD_SWAP("mobigo_uk.u5", 0x0000, 0x200000, CRC(efd27779) SHA1(b8f99a5c05d0fc8bbaf22996f9e699e0ea9ab4da) )
+
+	ROM_REGION( 0x800000, "spi", ROMREGION_ERASE00) // for built-in games and/or downloads? (not a boot ROM)
+	ROM_LOAD16_WORD_SWAP("mx25l1606e.u3", 0x0000, 0x200000, CRC(94a1b745) SHA1(a99ef67a6cbf93dd33ee2756627fe96abfe8690e) )
+ROM_END
+
+ROM_START( mobigoukb )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	// MobiOURS1.0  2010-07-21
+	ROM_LOAD16_WORD_SWAP("mobigo_uk.u5", 0x0000, 0x200000, CRC(efd27779) SHA1(b8f99a5c05d0fc8bbaf22996f9e699e0ea9ab4da) )
+
+	ROM_REGION( 0x800000, "spi", ROMREGION_ERASE00) // for built-in games and/or downloads? (not a boot ROM)
+	// only this differs from mobigouk  TODO: check if there's anything important stored on either
+	ROM_LOAD16_WORD_SWAP("mx25l1606e.u3", 0x0000, 0x200000, CRC(15fa384f) SHA1(0fb5115ad19dcc8a190fcef476775aaca4591aad) )
 ROM_END
 
 ROM_START( mobigof )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00)
+	// MobiOURS1.0  2010-07-21
 	ROM_LOAD16_WORD_SWAP("mobigo_fr.u5", 0x0000, 0x200000, CRC(61d739aa) SHA1(d23d4c806f1b60058c57ea9b339a7c5e3124bafa))
 
 	ROM_REGION( 0x800000, "spi", ROMREGION_ERASE00) // for built-in games and/or downloads? (not a boot ROM)
@@ -114,6 +152,12 @@ ROM_END
 // could be GPL16230A, GPL16240A or GPL16250A
 // ----------------------------------------------------
 
-CONS( 2010, mobigo,  0,      0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (USA)",    MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2011, mobigos, mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (Spain)",  MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
-CONS( 2011, mobigof, mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (France)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+// MobiOURS0.1 versions (released in 2010, only has SEEPROM for settings, no downloads)
+CONS( 2010, mobigo,    0,      0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (USA, version 0.1)",    MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2010, mobigouk,  mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (UK, version 0.1)",     MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+
+// MobiOURS1.0 versions (released in 2011, with SPI ROM for settings/downloads)
+CONS( 2011, mobigouka, mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (UK, version 1.0, set 1)",     MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2011, mobigoukb, mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (UK, version 1.0, set 2)",     MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2011, mobigos,   mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (Spain, version 1.0)",  MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2011, mobigof,   mobigo, 0, mobigo, mobigo, mobigo_state, init_mobigo, "VTech", "MobiGo (France, version 1.0)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_mobigo2.cpp
@@ -70,13 +70,22 @@ void generalplus_mobigo2_state::mobigo2(machine_config &config)
 }
 
 
-ROM_START( mobigo2 )
+ROM_START( mobigo2g )
 	ROM_REGION( 0x200000, "maincpu", ROMREGION_ERASE00) // appears to be the boot ROM, has GPspispi header
 	ROM_LOAD16_WORD_SWAP( "n25s16.u3", 0x00000, 0x200000, CRC(dfbf5029) SHA1(2a079ddd8a13c5f3d8f40fa6d6c3de2dc1573449) )
 
 	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 ) // no GPnandnand header so not a boot device
 	ROM_LOAD( "mobigo2_bios_ger.bin", 0x00000, 0x8400000, CRC(d5ab613d) SHA1(6fb104057dc3484fa958e2cb20c5dd0c19589f75) ) // SPANSION S34ML01G100TF100
 ROM_END
+
+ROM_START( mobigo2 )
+	ROM_REGION( 0x200000, "maincpu", ROMREGION_ERASE00) // appears to be the boot ROM, has GPspispi header
+	ROM_LOAD16_WORD_SWAP( "mx25l1606e.u3", 0x00000, 0x200000, CRC(cd456167) SHA1(096c1f883956558893554056cb66f1877dc39105) )
+
+	ROM_REGION( 0x8400000, "nandrom", ROMREGION_ERASE00 ) // no GPnandnand header so not a boot device
+	ROM_LOAD( "tc58dvg02d5ta00.u5", 0x00000, 0x8400000, CRC(88d07d1d) SHA1(a64f4965c78e00d61e7b45d1117dc83fe12902d6) )
+ROM_END
+
 
 } // anonymous namespace
 
@@ -86,4 +95,5 @@ ROM_END
 // could be GPL16230A, GPL16240A or GPL16250A
 // ----------------------------------------------------
 
-CONS( 2013, mobigo2, 0, 0, mobigo2, mobigo2, generalplus_mobigo2_state, init_spi, "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2012, mobigo2,  0,       0, mobigo2, mobigo2, generalplus_mobigo2_state, init_spi, "VTech", "MobiGo 2 (UK)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2013, mobigo2g, mobigo2, 0, mobigo2, mobigo2, generalplus_mobigo2_state, init_spi, "VTech", "MobiGo 2 (Germany)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/generalplus_gpl16250_rom.cpp
+++ b/src/mame/tvgames/generalplus_gpl16250_rom.cpp
@@ -625,6 +625,10 @@ ROM_START( dressmtv )
 	ROM_CONTINUE(0x600000,0x200000)
 ROM_END
 
+ROM_START( tfmat )
+	ROM_REGION( 0x2000000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD16_WORD_SWAP( "trackfield.u9", 0x000000, 0x2000000, CRC(d2f3e7f9) SHA1(41fd22e4353fcec471e2a4b43d076e32c6ab26d8) )
+ROM_END
 
 void tkmag220_game_state::tkmag220(machine_config &config)
 {
@@ -935,6 +939,10 @@ CONS( 2013, gormiti, 0, 0, base, gormiti, gpl162xx_rom_base_state, empty_init, "
 CONS( 201?, gameu50,  0, 0, gameu, gameu, gameu_handheld_game_state, init_gameu50,  "YSN", "Play Portable Color GameU+ (50-in-1) (Japan)",  MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 CONS( 201?, gameu90,  0, 0, gameu, gameu, gameu_handheld_game_state, init_gameu,    "YSN", "Play Portable Color GameU+ (90-in-1) (Japan)",  MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 CONS( 201?, gameu108, 0, 0, gameu, gameu, gameu_handheld_game_state, init_gameu108, "YSN", "Play Portable Color GameU+ (108-in-1) (Japan)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
+
+// despite using the Track & Field name this isn't a licensed Konami product
+// TODO: inputs, banking (sets 8Mbyte CS space, ROM is 32Mbyte)
+CONS( 202?, tfmat,    0, 0, base,  base,  gpl162xx_rom_base_state,   empty_init,    "The Source Wholesale", "Track & Field Game Mat - 25 Games Included", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND )
 
 // ----------------------------------------------------
 // these set SP to 3fff / only use RAM below that, so must be 'GPL162xx A' type

--- a/src/mame/tvgames/spg29x_lexibook_jg7425.cpp
+++ b/src/mame/tvgames/spg29x_lexibook_jg7425.cpp
@@ -226,6 +226,17 @@ ROM_START( dancef2p )
 	ROM_LOAD32_DWORD("internal.rom", 0x000000, 0x008000, NO_DUMP)
 ROM_END
 
+ROM_START( dbldance )
+	ROM_REGION(  0x100000, "extrom", ROMREGION_ERASE00 )
+	ROM_LOAD( "sy25q80.bin", 0x0000, 0x100000, CRC(eca3cc26) SHA1(7f4b811677fe0da27cfa7eb5827a59c023bfc984) )
+
+	DISK_REGION( "sdcard" ) // 512MB SD Card
+	DISK_IMAGE( "dbldance", 0, SHA1(5edd10c70a1c1c6cd53bbc49e825784f76cfb622) )
+
+	ROM_REGION( 0x008000, "spg290", ROMREGION_32BIT | ROMREGION_LE )
+	ROM_LOAD32_DWORD("internal.rom", 0x000000, 0x008000, NO_DUMP)
+ROM_END
+
 
 } // anonymous namespace
 
@@ -238,6 +249,7 @@ CONS( 2016, lx_frozen, 0, 0, lexibook_jg7425, lexibook_jg7425, lexibook_jg7425_s
 COMP( 201?, zone3d,    0, 0, lexibook_jg7425, lexibook_jg7425, lexibook_jg7425_state, empty_init, "Zone", "Zone 3D", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
 
 CONS( 202?, dancef2p,  0, 0, lexibook_jg7425, lexibook_jg7425, lexibook_jg7425_state, empty_init, "<unknown>", "Dance Factory 2 Player Dance Mat", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+CONS( 2021, dbldance,  0, 0, lexibook_jg7425, lexibook_jg7425, lexibook_jg7425_state, empty_init, "<unknown>", "Double Dance Mat", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
 
 // Unknown hardware, HDMI dongle with wireless pads.
 // Uses standard chips, not globs, but surface details on CPU/SoC have been erased.

--- a/src/mame/tvgames/spg2xx.cpp
+++ b/src/mame/tvgames/spg2xx.cpp
@@ -966,6 +966,21 @@ static INPUT_PORTS_START( doyousud )
 INPUT_PORTS_END
 
 
+static INPUT_PORTS_START( mgarage )
+	PORT_INCLUDE( spg2xx )
+
+	PORT_MODIFY("P2")
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("Brake")
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("Select Left")
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_NAME("Enter")
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_NAME("Back")
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Accelerate")
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON6 ) PORT_NAME("Select Right")
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT )
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT )
+INPUT_PORTS_END
+
+
 ioport_value spg2xx_game_fordrace_state::wheel_r()
 {
 	return ioport("WHEEL_REAL")->read() >> 1;
@@ -1737,6 +1752,20 @@ static INPUT_PORTS_START( prail )
 
 	PORT_MODIFY("P3")
 	PORT_BIT( 0x0003, 0x0000, IPT_POSITIONAL_V ) PORT_POSITIONS(3) PORT_REMAP_TABLE(handle_table) PORT_SENSITIVITY(15) PORT_KEYDELTA(1) PORT_CENTERDELTA(0) PORT_PLAYER(2)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( dvlaptop )
+	PORT_INCLUDE( spg2xx )
+
+	PORT_MODIFY("P1")
+	PORT_DIPNAME( 0x0040, 0x0000, "Show Display 1" ) // might be a button
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
+	PORT_DIPSETTING(      0x0040, DEF_STR( Off ) )
+
+	PORT_MODIFY("P3")
+	PORT_DIPNAME( 0x0020, 0x0000, "Show Display 2" ) // might be a button
+	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
+	PORT_DIPSETTING(      0x0020, DEF_STR( Off ) )
 INPUT_PORTS_END
 
 void spg2xx_game_state::machine_start()
@@ -2969,6 +2998,11 @@ ROM_START( lexiart )
 	ROM_LOAD16_WORD_SWAP( "lexibookartstudio.u3", 0x000000, 0x800000, CRC(fc417abb) SHA1(c0a18a2cf11c47086722f0ec88410614fed7c6f7) )
 ROM_END
 
+ROM_START( stvscri )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "scrivi_disegna.bin", 0x000000, 0x800000, CRC(44392a74) SHA1(ed59d7a2218c047aab3fa151e8fa781b81b59250) )
+ROM_END
+
 ROM_START( lexibds )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "barbiedrawingstudio.u3", 0x000000, 0x400000, CRC(16b5b52e) SHA1(e3719523d92d1302883f0b0c2d4b3fabedc34319) ) // no chip markings, dumped as 29LV320
@@ -3128,6 +3162,24 @@ ROM_END
 ROM_START( dinothun )
 	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "dinothunder.bin", 0x000000, 0x400000, CRC(03e82604) SHA1(c39d72aa8a0750ee38ab01b317e77a46e1d6004e) )
+ROM_END
+
+ROM_START( dvlaptop )
+	ROM_REGION( 0x1000000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "u3-main.u3-1", 0x000000, 0x800000, CRC(0457c902) SHA1(a0f49627e1e099262b92c2655d42090f32fb1d21) )
+	// 2nd bank? (or to drive the LCD?)  It's a SunPlus SPG2xx program like above
+	ROM_LOAD16_WORD_SWAP( "u8-slave.u8-1", 0x800000, 0x800000, CRC(d0627571) SHA1(029cb3b5d8b9e565c822c0705782770715b4fb53) )
+ROM_END
+
+
+ROM_START( nvpoker )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "poker.bin", 0x000000, 0x400000, CRC(0efbe6a7) SHA1(f266fac7a35535d37557604c782091222830d3d7) )
+ROM_END
+
+ROM_START( mgarage )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "monstergarage.bin", 0x000000, 0x400000, CRC(3a69ca21) SHA1(fc04d40d895db4a66cbb2c573d08041278cd2e2e) )
 ROM_END
 
 ROM_START( pdcj )
@@ -3321,6 +3373,8 @@ CONS( 200?, wfcentro,   wfart,    0, wfcentro,   spg2xx,     spg2xx_game_wfcentr
 
 CONS( 200?, lexiart,    0,        0, lexiart,    lexiart,    spg2xx_game_lexiart_state,       empty_init,    "Lexibook", "Lexibook Junior My 1st Drawing Studio", MACHINE_NOT_WORKING )
 
+CONS( 200?, stvscri,    0,        0, lexiart,    lexiart,    spg2xx_game_lexiart_state,       empty_init,    "Sapientino", "Smart TV Scrivi & Disegna (Italy)", MACHINE_NOT_WORKING )
+
 CONS( 200?, lexibds,    0,        0, spg2xx,     spg2xx,     spg2xx_game_state,               empty_init,    "Lexibook", "Lexibook Junior Barbie Drawing Board / Barbie Drawing Studio", MACHINE_NOT_WORKING )
 
 // set 2862 to 0003 (irq enable) when it stalls on boot to show something (doesn't turn on IRQs again otherwise?) needs camera emulating
@@ -3380,5 +3434,12 @@ CONS( 2004, spidm2,     0,        0, spg2xx,     spidm2,     spg2xx_game_state, 
 
 CONS( 2004, dinothun,   0,        0, spg2xx,     spg2xx,     spg2xx_game_state,               empty_init,    "N-Vision / Toy Quest", "Power Rangers Dino Thunder: Thunder Action", MACHINE_NOT_WORKING )
 
+CONS( 2004, nvpoker,    0,        0, spg2xx,     spg2xx,     spg2xx_game_state,               init_crc,      "N-Vision / Toy Quest", "Texas Hold'em Poker: World Poker Challenge - Las Vegas Edition", MACHINE_NOT_WORKING )
+
+CONS( 2004, mgarage,    0,        0, spg2xx,     mgarage,    spg2xx_game_state,               empty_init,    "N-Vision / Toy Quest", "Monster Garage", MACHINE_SUPPORTS_SAVE )
+
 // this Japan version uses different banking to spg2xx_pdc.cpp so is in here instead
 CONS( 2006, pdcj,       0,        0, pdcj,       pdcj,       spg2xx_game_pdcj_state,          empty_init,    "Conny / Takara", "PDC - Pocket Dream Console (Japan)", MACHINE_IMPERFECT_SOUND )
+
+// has an monochrome LCD display (that part might not be dumped if it's done entirely by one of the globs) but can also connect to the TV
+CONS( 200?, dvlaptop,   0,        0, spg2xx,     dvlaptop,   spg2xx_game_state,               empty_init,    "VTech", "Double Vision Laptop (Germany)", MACHINE_NOT_WORKING )

--- a/src/mame/tvgames/spg2xx_lexibook.cpp
+++ b/src/mame/tvgames/spg2xx_lexibook.cpp
@@ -423,6 +423,11 @@ ROM_START( arcade3d )
 	ROM_LOAD16_WORD_SWAP( "arcade3d.u3", 0x0000, 0x800000, CRC(130843a5) SHA1(f6494a34d162e702121cf71d384a4e57e0113498) )
 ROM_END
 
+ROM_START( pokmax20 )
+	ROM_REGION( 0x800000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "pocketmax20.u2", 0x0000, 0x800000, CRC(2013fcef) SHA1(2885ffd18c077756c1a1470f44f8d8d7657515e2) )
+ROM_END
+
 ROM_START( vsplus )
 	ROM_REGION( 0x1000000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD16_WORD_SWAP( "vsplus.bin", 0x0000, 0x1000000, CRC(2b13d2cc) SHA1(accae7606d83a313b8ec0232d2d67b63c9c617af) )
@@ -532,6 +537,8 @@ ROM_END
 CONS( 200?, lexizeus, 0, 0, lexizeus, lexizeus, spg2xx_lexizeus_game_state, init_zeus,     "Lexibook / JungleTac", "Zeus IG900 20-in-1 (US?)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS ) // bad sound and some corrupt bg tilemap entries in Tiger Rescue, verify ROM data (same game runs in Zone 60 without issue)
 
 CONS( 200?, arcade3d, 0, 0, lexizeus, lexiseal, spg2xx_lexizeus_game_state, init_zeus,     "Millennium 2000 GmbH / JungleTac", "Millennium Arcade 3D 15-in-1", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+
+CONS( 200?, pokmax20, 0, 0, lexizeus, lexiseal, spg2xx_lexizeus_game_state, init_zeus,     "<unknown> / JungleTac", "Pocket Max 20-in-1", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // 2007.08.02 Rev 05 on PCB
 CONS( 2007, pokermor, 0, 0, lexizeus, pokermor, spg2xx_lexizeus_game_state, init_zeus,     "SA.BI.NE trend", "Poker & More 18-in-1 (Germany)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/tvgames/spg2xx_senca.cpp
+++ b/src/mame/tvgames/spg2xx_senca.cpp
@@ -932,6 +932,10 @@ ROM_START( m521neo )
 	ROM_CONTINUE(0x07800000, 0x800000)
 ROM_END
 
+ROM_START( movesyst ) // CPU glob marked SPG200
+	ROM_REGION( 0x4000000, "maincpu", ROMREGION_ERASE00 )
+	ROM_LOAD16_WORD_SWAP( "movesystem.u2", 0x0000, 0x4000000, CRC(e314bce7) SHA1(3903dcb0325c7d6760e03d1bc84b22e2e90a9d02) )
+ROM_END
 
 void oplayer_100in1_state::init_oplayer()
 {
@@ -1077,3 +1081,6 @@ DENMARK
 */
 
 CONS( 200?, dnv200fs, 0, 0, zon32bit_bat, oplayer,  denver_200in1_state,  init_denver,  "Denver / Senca", "Denver (GMP-270CMK2) (Family Sport 200-in-1)", MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+
+// seems similar to the other sets in here, with both upper and lower banks, but might be unique
+CONS( 200?, movesyst, 0, 0, zon32bit,     zon32bit, mywicodx_state,       empty_init,   "<unknown>",      "Move System",  MACHINE_NOT_WORKING )


### PR DESCRIPTION
rebased / squashed continuation of https://github.com/mamedev/mame/pull/16042

new WORKING machines
-----------

Monster Garage [Team Europe, David Haywood]
GamesPower 50 Games [Team Europe, David Haywood]
Pocket Arcade 50-in-1 [Team Europe, David Haywood]
100-in-1 Handheld Game (burger shape) [Team Europe, David Haywood]
Pocket Max 20-in-1 [Team Europe, David Haywood]

new NOT WORKING machines
----------------

Texas Hold'em Poker: World Poker Challenge - Las Vegas Edition [Team Europe, David Haywood]
500-in-1 Handheld Game (German / French / English / Chinese menu) [Team Europe, David Haywood]
Smart TV Scrivi & Disegna (Italy) [Team Europe]
LeapPad Plus Writing [Team Europe, David Haywood]
Tchibo 158-in-1 Retro Game [Team Europe, David Haywood]
Asteroids: Classic Arcade Game [Team Europe]
218-in-1 Handheld Game (pink) [Team Europe, David Haywood]
Retro FC Game Box 365-in-1 [Team Europe, David Haywood]
Mortal Kombat: Arcade Classics [Team Europe]
Cyber Arcade 300-in-1 (JL2950) [Team Europe, David Haywood]
Track & Field Game Mat - 25 Games Included [Team Europe, David Haywood]
Kunio-kun TV! Downtown Special - Kunio-kun no Jidaigeki Da yo Zenin Shuugou! (Japan) [Team Europe]
Kunio-kun TV! Nekketsu Koukou Dodgeball Bu (Japan) [Team Europe]
Fine & Dandy 200 in 1 [Team Europe, David Haywood]
200 in 1 Handheld Console (with bad menu font) [Team Europe, David Haywood]
Sumikko Gurashi: Sumikko Friend [Team Europe]
Dream Switch [Team Europe, David Haywood]
Double Dance Mat [Team Europe, David Haywood]
Mini Handled Game Console GC71 [Team Europe, David Haywood]
Move System [Team Europe]
Double Vision Laptop (Germany) [Team Europe]
Pixel Stars Dreamhouse [cyanic]
Kenshi No Michi (Japan) [cyanic]
Kids Smart Watch: Bluey (Accutime, BLY4070) [Team Europe]
Chiikawa to Issho (Japan) [cyanic]
Terriermon (Japan) [cyanic]
Love2Learn Elmo [cyanic]
Tamagotchi Smart (Japan, set 1) [cyanic]
Super Mini SFC (NES/Famicom bootleg) [Team Europe, David Haywood]

new NOT WORKING clones
-----------

Vibes Retro Pocket Gamer 240-in-1 (set 1) [Team Europe, David Haywood]
MobiGo (UK, version 0.1) [Team Europe, David Haywood]
MobiGo (UK, version 1.0, set 1) [Team Europe, David Haywood]
MobiGo (UK, version 1.0, set 2) [Team Europe, David Haywood]
MobiGO 2 (UK) [Team Europe, David Haywood]
Tamagotchi Smart (Japan, set 2) [cyanic]


new NOT WORKING software list entries
-----------

mobigo_cart.xml:
Mr.Men Little Miss - Adventures in Dillydale (UK) [Team Europe, David Haywood]
Mickey Mouse - Clubhouse (UK) [Team Europe, David Haywood]
Ben 10 - Ultimate Alien Mind Mine (UK) [Team Europe, David Haywood]
Nickelodeon Dora the Explorer - Twins' Day (UK) [Team Europe, David Haywood]
Nickelodeon Dora L' Exploratrice - Dora et Babouche a la fete des jumeaux (France) [Team Europe]
Chuggington (US) [Team Europe, David Haywood]
Disney/Pixar Cars 2 (UK) [Team Europe, David Haywood]
DreamWorks Kung Fu Panda 2 (UK) [Team Europe, David Haywood]
Hello Kitty - Hello Kitty Birthday Party! (UK) [Team Europe, David Haywood]
Hello Kitty - La fete d'anniversaire (France) [Team Europe]
Team Umizoomi - The Great Umicar Rescue (US) [Team Europe, David Haywood]
La Boutique de Minnie (France) [Team Europe]

leapfrog_mfleappad_cart.xml:
Dora the Explorer - To the Rescue (UK) [Team Europe, David Haywood]
Disney/Pixar Cars (UK) [Team Europe, David Haywood]
The Wiggles - Learn, Dance and Sing with The Wiggles! (UK) [Team Europe, David Haywood]

leapfrog_ltleappad_cart.xml:
One Bear in the Bedroom (UK) [Team Europe, David Haywood]
Animal World (UK) [Team Europe, David Haywood]
Animal Dance (UK) [Team Europe, David Haywood]

leapster.xml:
Noddy - Rainbow Adventure (UK) [Team Europe, David Haywood]

leapfrog_leappad_cart.xml:
Thomas the Really Useful Engine (UK, Pre Reading, set 2) [Team Europe, David Haywood]
Disney's The Lion King (UK, Leap Start - Pre Reading Storybook, set 2) [Team Europe, David Haywood]
Leap and the lost Dinosaur (UK, set 2) [Team Europe, David Haywood]
Brain Twisters - Search the City! (Leap 3) [Team Europe, David Haywood]
Disney Winnie the Pooh - Lots and Lots of Honey Pots (UK, Mar 05 2002, Pre Math) [Team Europe, David Haywood]
Disney Winnie the Pooh - Lots and Lots of Honey Pots (UK, Apr 15 2002) [Team Europe, David Haywood]
Scooby Doo! and the Haunted Castle (Leap 2, Reading) [Team Europe, David Haywood]
The Incredibles (UK/USA) [Team Europe, David Haywood]
Bratz - Election Perfection! (UK) [Team Europe, David Haywood]
Disney/Pixar Cars (UK) [Team Europe, David Haywood]
Disney Princess - Maths, Mazes and More (UK) [Team Europe, David Haywood]
Leap's Friends from A to Z [Team Europe, David Haywood]
LeapPadPro Interactive Geography - World Geography [Team Europe, David Haywood]
Spongebob Squarepants - Salty Sea Stories (UK) [Team Europe, David Haywood]
The Cat in the Hat [Team Europe, David Haywood]
Scooby-Doo! and the Zombie's Treasure (UK) [Team Europe, David Haywood]
Madagascar (UK) [Team Europe, David Haywood]
Maths Magic (LeapPad Plus Writing) [Team Europe, David Haywood]
Wild Word Games (LeapPad Plus Writing) [Team Europe, David Haywood]
Reading, Writing and Maths (LeapPad Plus Writing) [Team Europe, David Haywood]

vsmile_cart.xml:
Disney-Pixar Cars - Motori Ruggenti a Radiator Springs (Italy) [Team Europe]
Mon Toutou tout fou! (France) [Team Europe]
The Batman - Il Salvataggio di Gotham City (Italy) [Team Europe]