### PR TITLE
williams/midzeus, video/zeus2: Fix Cruis'n Exotica game speed and depth clear

### DIFF
--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -851,12 +851,10 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 				}
 				if (logit)
 					logerror(" -- Clearing buffer: numPixels: %08X addr: %08X reg51: %08X", numPixels, addr, m_zeusbase[0x51]);
-				uint32_t fillColor = m_fill_color;
-				int32_t clearDepth = m_fill_depth;
 				for (int count = 0; count < numPixels; count++) {
 					// Crusn wraps the frame buffer during fill so need to mask address
-					m_frameColor[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = fillColor;
-					m_frameDepth[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = clearDepth;
+					m_frameColor[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = m_fill_color;
+					m_frameDepth[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = m_fill_depth;
 				}
 			}
 			break;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -144,7 +144,7 @@ void zeus2_device::device_reset()
 	texel_width = 256;
 	zeus_fifo_words = 0;
 	m_fill_color = 0;
-	m_fill_depth = 0;
+	m_fill_depth = 0xffffff;
 	m_texmodeReg = 0;
 	zeus_trans[3] = 0.0f;
 	m_useZOffset = false;
@@ -815,11 +815,18 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 						logerror("zeus2_register_update: Warning! Mask Register not equal to 0xffffffff\n");
 				}
 				if (m_zeusbase[0x51] == 0x00400000) {
-					// SGRAM Color Register
-					m_fill_color = m_zeusbase[0x58] & 0xffffff;
-					m_fill_depth = ((m_zeusbase[0x5a] & 0xffff) << 8) | (m_zeusbase[0x58] >> 24);
-					//m_fill_depth = -1;
-					if (m_zeusbase[0x58] != m_zeusbase[0x59])
+					// SGRAM Color Register.  R5E bit 5 packs 24 bit color with 24 bit depth,
+					// otherwise it is 32 bit color with 16 bit depth.
+					bool mode24 = m_zeusbase[0x5e] & 0x20;
+					if (mode24) {
+						m_fill_color = m_zeusbase[0x58] & 0xffffff;
+						m_fill_depth = ((m_zeusbase[0x59] & 0xffff) << 8) | (m_zeusbase[0x58] >> 24);
+					}
+					else {
+						m_fill_color = m_zeusbase[0x58];
+						m_fill_depth = (m_zeusbase[0x5a] & 0xffff) << 8;
+					}
+					if (m_zeusbase[0x58] != m_zeusbase[mode24 ? 0x5a : 0x59])
 						logerror("zeus2_register_update: Warning! Different fill colors are set.\n");
 					if (logit)
 						logerror(" -- Setting fill color = %06X depth = %06X ", m_fill_color, m_fill_depth);
@@ -844,11 +851,11 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 				}
 				if (logit)
 					logerror(" -- Clearing buffer: numPixels: %08X addr: %08X reg51: %08X", numPixels, addr, m_zeusbase[0x51]);
-				// A depth clear of 0 (nearest) rejects all later depth-tested geometry; reset to far instead.
-				int32_t clearDepth = (m_fill_depth == 0) ? 0xffffff : m_fill_depth;
+				uint32_t fillColor = m_fill_color;
+				int32_t clearDepth = m_fill_depth;
 				for (int count = 0; count < numPixels; count++) {
 					// Crusn wraps the frame buffer during fill so need to mask address
-					m_frameColor[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = m_fill_color;
+					m_frameColor[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = fillColor;
 					m_frameDepth[(addr + count) & (WAVERAM1_WIDTH * WAVERAM1_HEIGHT * 2 - 1)] = clearDepth;
 				}
 			}

--- a/src/mame/williams/midzeus.cpp
+++ b/src/mame/williams/midzeus.cpp
@@ -621,10 +621,11 @@ uint32_t midzeus_state::tms320c32_control_r(offs_t offset)
 	// watch for accesses to the timers
 	if (offset == 0x24 || offset == 0x34)
 	{
-		// timer is clocked at 100ns
+		// CLKSRC in the timer's control register selects the internal clock, H1/2 = CLKIN/4;
+		// the external TCLK rate is unknown, so keep the 100ns the driver has always assumed
 		int const which = (offset >> 4) & 1;
-		int32_t const result = (m_timer[which]->elapsed() * 10000000).as_double();
-		return result;
+		uint32_t const rate = BIT(m_tms320c32_control[offset - 4], 9) ? m_maincpu->unscaled_clock() / 4 : 10000000;
+		return m_timer[which]->elapsed().as_ticks(rate);
 	}
 
 	// log anything else except the memory control register


### PR DESCRIPTION
This PR fixes two Cruis'n Exotica issues:

**1. Add TMS320C32 timer CLKSRC selection**
The existing driver fakes the C32 timers and hardcoded both counters at 10MHz, but the games set the CLKSRC bit, which selects an internal clock of H1/2. H1 is CLKIN/2, so this is XTAL/4 = 60MHz/4 = 15MHz. The external TCLK case keeps the old rate. See [TMS320C3x User’s Guide](https://www.ti.com/lit/ug/spru031f/spru031f.pdf) section 12.1.3.

This fixes Cruis'n Exotica running in slow motion.

**2. Decode the SGRAM fill per reg 5E bit 5**
Zeus2 register 5E bit 5 picks between 32 bit color with 16 bit depth and 24 bit color with 24 bit depth. The existing driver had a wrong combined layout, so with the bit set it read color bytes as depth, leaving the clear near enough to reject the terrain drawn against it. This also drops the workaround from #15723 for this bug.

This fixes the dark band covering the background during races.

Master:
<img width="375" alt="0053 5s_old" src="https://github.com/user-attachments/assets/273f2ec9-e622-44d0-9432-fb74a3c19c73" /> <img width="375" alt="0085 5s_old" src="https://github.com/user-attachments/assets/db0b06a1-44d3-4b05-ab19-f632c3ee6048" />

This PR:
<img width="375"  alt="0053 5s_new" src="https://github.com/user-attachments/assets/b1066857-e47d-40ac-9cd3-5439c9034028" /> <img width="375" alt="0085 5s_new" src="https://github.com/user-attachments/assets/1dad35e5-0482-420f-8573-c0079d3feff6" />

Assisted by Claude Opus 5. Human polished and regression tested on The Grid and Skins Game, MK4 and Invasion.