### PR TITLE
cdrom: Reject negative track numbers

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -971,7 +971,7 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 		}
 
 		if (tracknum <= 0 || tracknum > MAX_TRACKS)
-  			return chd_file::error::INVALID_DATA;
+			return chd_file::error::INVALID_DATA;
 
 		track = &toc.tracks[tracknum - 1];
 

--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -939,15 +939,12 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 		// fetch the metadata for this track
 		if (!chd->read_metadata(CDROM_TRACK_METADATA_TAG, toc.numtrks, metadata, metaindex))
 		{
-			if (sscanf(metadata.c_str(), "TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d",
-					&tracknum, type, subtype, &frames) != 4)
+			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA_FORMAT, &tracknum, type, subtype, &frames) != 4)
 				return chd_file::error::INVALID_DATA;
 		}
 		else if (!chd->read_metadata(CDROM_TRACK_METADATA2_TAG, toc.numtrks, metadata, metaindex))
 		{
-			if (sscanf(metadata.c_str(),
-					"TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d PREGAP:%d PGTYPE:%15s PGSUB:%15s POSTGAP:%d",
-					&tracknum, type, subtype, &frames, &pregap, pgtype, pgsub, &postgap) != 8)
+			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA2_FORMAT, &tracknum, type, subtype, &frames, &pregap, pgtype, pgsub, &postgap) != 8)
 				return chd_file::error::INVALID_DATA;
 		}
 		else
@@ -962,9 +959,7 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 			if (err)
 				break;
 
-			if (sscanf(metadata.c_str(),
-					"TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d PAD:%d PREGAP:%d PGTYPE:%15s PGSUB:%15s POSTGAP:%d",
-					&tracknum, type, subtype, &frames, &padframes, &pregap, pgtype, pgsub, &postgap) != 9)
+			if (sscanf(metadata.c_str(), GDROM_TRACK_METADATA_FORMAT, &tracknum, type, subtype, &frames, &padframes, &pregap, pgtype, pgsub, &postgap) != 9)
 				return chd_file::error::INVALID_DATA;
 
 			toc.flags |= CD_FLAG_GDROM;

--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -939,12 +939,15 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 		// fetch the metadata for this track
 		if (!chd->read_metadata(CDROM_TRACK_METADATA_TAG, toc.numtrks, metadata, metaindex))
 		{
-			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA_FORMAT, &tracknum, type, subtype, &frames) != 4)
+			if (sscanf(metadata.c_str(), "TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d",
+					&tracknum, type, subtype, &frames) != 4)
 				return chd_file::error::INVALID_DATA;
 		}
 		else if (!chd->read_metadata(CDROM_TRACK_METADATA2_TAG, toc.numtrks, metadata, metaindex))
 		{
-			if (sscanf(metadata.c_str(), CDROM_TRACK_METADATA2_FORMAT, &tracknum, type, subtype, &frames, &pregap, pgtype, pgsub, &postgap) != 8)
+			if (sscanf(metadata.c_str(),
+					"TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d PREGAP:%d PGTYPE:%15s PGSUB:%15s POSTGAP:%d",
+					&tracknum, type, subtype, &frames, &pregap, pgtype, pgsub, &postgap) != 8)
 				return chd_file::error::INVALID_DATA;
 		}
 		else
@@ -959,14 +962,16 @@ std::error_condition cdrom_file::parse_metadata(chd_file *chd, toc &toc)
 			if (err)
 				break;
 
-			if (sscanf(metadata.c_str(), GDROM_TRACK_METADATA_FORMAT, &tracknum, type, subtype, &frames, &padframes, &pregap, pgtype, pgsub, &postgap) != 9)
+			if (sscanf(metadata.c_str(),
+					"TRACK:%d TYPE:%15s SUBTYPE:%15s FRAMES:%d PAD:%d PREGAP:%d PGTYPE:%15s PGSUB:%15s POSTGAP:%d",
+					&tracknum, type, subtype, &frames, &padframes, &pregap, pgtype, pgsub, &postgap) != 9)
 				return chd_file::error::INVALID_DATA;
 
 			toc.flags |= CD_FLAG_GDROM;
 		}
 
-		if (tracknum == 0 || tracknum > MAX_TRACKS)
-			return chd_file::error::INVALID_DATA;
+		if (tracknum <= 0 || tracknum > MAX_TRACKS)
+  			return chd_file::error::INVALID_DATA;
 
 		track = &toc.tracks[tracknum - 1];
 


### PR DESCRIPTION
Track numbers in CHD CD/GD-ROM metadata are parsed as signed integers, but the existing validation only rejects zero and values above MAX_TRACKS.

A negative track number can therefore reach toc.tracks[tracknum - 1], resulting in an out-of-bounds access.

Reject non-positive track numbers before indexing the track array.

AI Disclosure: ChatGPT used for analysis and drafting.