### PR TITLE
umc/supracan.cpp: Correct main CPU clock divider

### DIFF
--- a/src/mame/umc/supracan.cpp
+++ b/src/mame/umc/supracan.cpp
@@ -104,6 +104,9 @@ namespace {
 
 // NOTE: same as sega/segac2.cpp XL2
 static constexpr XTAL U13_CLOCK = XTAL(53'693'175);
+static constexpr XTAL MAIN_CPU_CLOCK = U13_CLOCK / 5;
+// Keep the existing FRC timing independent of the corrected main CPU clock.
+static constexpr XTAL FRC_REFERENCE_CLOCK = U13_CLOCK / 6;
 // TODO: bump to 4 after conversion of video_r/_w to um6618_map
 static constexpr int ROZ_LAYER_NUMBER = 3;
 
@@ -1711,7 +1714,7 @@ void supracan_state::update_frc_state()
 		// - causes a crash at boot if too fast;
 		// - takes roughly 6 seconds for a title screen individual kanji to move right-to-left;
 		case 1:
-			m_frc_timer->adjust(m_maincpu->cycles_to_attotime(1024 * period), 0);
+			m_frc_timer->adjust(attotime::from_ticks(u64(1024) * period, FRC_REFERENCE_CLOCK), 0);
 			break;
 
 		// gamblord: sets 0xa20f normally, plays with frequency register a lot.
@@ -1719,7 +1722,7 @@ void supracan_state::update_frc_state()
 		// - takes ~1 second for character screen to switch;
 		// - during gameplay sometimes switches to 0xa200 / 0xffff;
 		case 0xf:
-			m_frc_timer->adjust(m_maincpu->cycles_to_attotime(8192 * period), 0);
+			m_frc_timer->adjust(attotime::from_ticks(u64(8192) * period, FRC_REFERENCE_CLOCK), 0);
 			break;
 
 		default:
@@ -2417,7 +2420,7 @@ static void superacan_cart_types(device_slot_interface &device)
 void supracan_state::supracan(machine_config &config)
 {
 	// M68000P10
-	M68000(config, m_maincpu, U13_CLOCK / 6);
+	M68000(config, m_maincpu, MAIN_CPU_CLOCK);
 	m_maincpu->set_addrmap(AS_PROGRAM, &supracan_state::main_map);
 
 	// TODO: Verify type and actual clock


### PR DESCRIPTION
# Summary  - Correct the Super A'Can M68000 clock from `U13 / 6` (8.9488625 MHz) to `U13 / 5` (10.738635 MHz). -

Keep the existing provisional FRC timing explicitly referenced to `U13 / 6`, so the CPU correction does not silently retime the FRC.  # Basis  The `/5` divider restores the CPU rate used before the 2024 shared-crystal cleanup and agrees with timing comparisons against original hardware across the available commercial-title test set. One concrete comparison is the opening of *Son of Evil* ([original-hardware capture](https://www.youtube.com/watch?v=RWUgKnMy7Qs)): at `U13 / 6` it runs visibly too slowly, while `U13 / 5` aligns with the capture timing. Direct measurement at the M68000 clock pin is still pending, so this first change is deliberately limited to the CPU divider and preservation of the current FRC rate.  # Testing  - Windows UCRT64 GCC 16.2.0 A'Can-only Release build - Windows UCRT64 GCC 16.2.0 A'Can-only Debug build - `acan.exe -validate` and `acand.exe -validate` - `-verifyroms supracan` - Eight-second headless boot smoke tests in full MAME, A'Can-only Release, and A'Can-only Debug for all 12 available titles: `formduel`, `sangofgt`, `sonevil`, `speedyd`, `staiwbbl`, `boomzoo`, `gamblord`, `jttlaugh`, `magipool`, `monopoly`, `rebelst`, and `slghtsag` (36/36 passed) - Full MAME strict Release build on submission base `b94935ef5bf28eb2e27016afe9c3b87568124a2e`  # AI assistance disclosure

This pull request was prepared with assistance from OpenAI Codex (GPT-5, Codex desktop, August-September 2026). AI assistance was used for English translation and editing of pull-request comments, driver inspection, preparation of the code and test instrumentation, and organization of trace analysis.

The reported builds, traces, and timing results came from actual runs. I am responsible for the submission and will state when a point cannot be independently explained or verified. No direct hardware clock measurement is claimed; the proposed divider remains an inference from the available evidence.