### PR TITLE
video/sti3400: Add preliminary MPEG video decoder

### DIFF
--- a/scripts/src/video.lua
+++ b/scripts/src/video.lua
@@ -1003,6 +1003,18 @@ end
 
 --------------------------------------------------
 --
+--@src/devices/video/mpeg_video.h,VIDEOS["MPEG_VIDEO"] = true
+--------------------------------------------------
+
+if VIDEOS["MPEG_VIDEO"] then
+	files {
+		MAME_DIR .. "src/devices/video/mpeg_video.cpp",
+		MAME_DIR .. "src/devices/video/mpeg_video.h",
+	}
+end
+
+--------------------------------------------------
+--
 --@src/devices/video/mr9735.h,VIDEOS["MR9735"] = true
 --------------------------------------------------
 

--- a/scripts/src/video.lua
+++ b/scripts/src/video.lua
@@ -1597,6 +1597,18 @@ end
 
 --------------------------------------------------
 --
+--@src/devices/video/sti3400.h,VIDEOS["STI3400"] = true
+--------------------------------------------------
+
+if VIDEOS["STI3400"] then
+	files {
+		MAME_DIR .. "src/devices/video/sti3400.cpp",
+		MAME_DIR .. "src/devices/video/sti3400.h",
+	}
+end
+
+--------------------------------------------------
+--
 --@src/devices/video/t6963c.h,VIDEOS["T6963C"] = true
 --------------------------------------------------
 

--- a/src/devices/video/mpeg_video.cpp
+++ b/src/devices/video/mpeg_video.cpp
@@ -1,0 +1,1353 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+/***************************************************************************
+
+    ISO/IEC 11172-2 MPEG-1 video support.
+
+    This is a clean-room implementation written directly from the syntax,
+    semantics and decoding process specified by the following standards.
+
+    References:
+
+      ISO/IEC 11172-2:1993
+        Information technology -- Coding of moving pictures and associated
+        audio for digital storage media at up to about 1,5 Mbit/s --
+        Part 2: Video
+
+      ISO/IEC 11172-2:1993/Cor 1:1996
+      ISO/IEC 11172-2:1993/Cor 2:1999
+      ISO/IEC 11172-2:1993/Cor 3:2003
+      ISO/IEC 11172-2:1993/Cor 4:2006
+
+    The implementation primarily follows clause 2.4 and normative Annexes
+    A and B.  Technical Corrigendum 2 supplies the corrected intra
+    quantizer-matrix rule, and Technical Corrigendum 4 updates the IDCT
+    conformance reference.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "mpeg_video.h"
+
+#include <cmath>
+#include <numbers>
+
+struct vlc_entry
+{
+	u32 code;
+	u8 bits;
+	int value;
+};
+
+struct dct_vlc_entry
+{
+	u32 code;
+	u8 bits;
+	u8 run;
+	u8 level;
+};
+
+template <typename T, std::size_t N>
+constexpr T make_vlc(const char (&text)[N], int value)
+{
+	u32 code = 0;
+	for (unsigned i = 0; i != (N - 1); i++)
+		code = (code << 1) | (text[i] == '1');
+	return T{ code, u8(N - 1), value };
+}
+
+template <std::size_t N>
+constexpr dct_vlc_entry make_dct_vlc(const char (&text)[N], unsigned run, unsigned level)
+{
+	u32 code = 0;
+	for (unsigned i = 0; i != (N - 1); i++)
+		code = (code << 1) | (text[i] == '1');
+	return dct_vlc_entry{ code, u8(N - 1), u8(run), u8(level) };
+}
+
+constexpr vlc_entry s_macroblock_address_increment[] =
+{
+	make_vlc<vlc_entry>("1", 1),
+	make_vlc<vlc_entry>("011", 2),
+	make_vlc<vlc_entry>("010", 3),
+	make_vlc<vlc_entry>("0011", 4),
+	make_vlc<vlc_entry>("0010", 5),
+	make_vlc<vlc_entry>("00011", 6),
+	make_vlc<vlc_entry>("00010", 7),
+	make_vlc<vlc_entry>("0000111", 8),
+	make_vlc<vlc_entry>("0000110", 9),
+	make_vlc<vlc_entry>("00001011", 10),
+	make_vlc<vlc_entry>("00001010", 11),
+	make_vlc<vlc_entry>("00001001", 12),
+	make_vlc<vlc_entry>("00001000", 13),
+	make_vlc<vlc_entry>("00000111", 14),
+	make_vlc<vlc_entry>("00000110", 15),
+	make_vlc<vlc_entry>("0000010111", 16),
+	make_vlc<vlc_entry>("0000010110", 17),
+	make_vlc<vlc_entry>("0000010101", 18),
+	make_vlc<vlc_entry>("0000010100", 19),
+	make_vlc<vlc_entry>("0000010011", 20),
+	make_vlc<vlc_entry>("0000010010", 21),
+	make_vlc<vlc_entry>("00000100011", 22),
+	make_vlc<vlc_entry>("00000100010", 23),
+	make_vlc<vlc_entry>("00000100001", 24),
+	make_vlc<vlc_entry>("00000100000", 25),
+	make_vlc<vlc_entry>("00000011111", 26),
+	make_vlc<vlc_entry>("00000011110", 27),
+	make_vlc<vlc_entry>("00000011101", 28),
+	make_vlc<vlc_entry>("00000011100", 29),
+	make_vlc<vlc_entry>("00000011011", 30),
+	make_vlc<vlc_entry>("00000011010", 31),
+	make_vlc<vlc_entry>("00000011001", 32),
+	make_vlc<vlc_entry>("00000011000", 33)
+};
+
+constexpr vlc_entry s_coded_block_pattern[] =
+{
+	make_vlc<vlc_entry>("111", 60),
+	make_vlc<vlc_entry>("1101", 4), make_vlc<vlc_entry>("1100", 8),
+	make_vlc<vlc_entry>("1011", 16), make_vlc<vlc_entry>("1010", 32),
+	make_vlc<vlc_entry>("10011", 12), make_vlc<vlc_entry>("10010", 48),
+	make_vlc<vlc_entry>("10001", 20), make_vlc<vlc_entry>("10000", 40),
+	make_vlc<vlc_entry>("01111", 28), make_vlc<vlc_entry>("01110", 44),
+	make_vlc<vlc_entry>("01101", 52), make_vlc<vlc_entry>("01100", 56),
+	make_vlc<vlc_entry>("01011", 1), make_vlc<vlc_entry>("01010", 61),
+	make_vlc<vlc_entry>("01001", 2), make_vlc<vlc_entry>("01000", 62),
+	make_vlc<vlc_entry>("001111", 24), make_vlc<vlc_entry>("001110", 36),
+	make_vlc<vlc_entry>("001101", 3), make_vlc<vlc_entry>("001100", 63),
+	make_vlc<vlc_entry>("0010111", 5), make_vlc<vlc_entry>("0010110", 9),
+	make_vlc<vlc_entry>("0010101", 17), make_vlc<vlc_entry>("0010100", 33),
+	make_vlc<vlc_entry>("0010011", 6), make_vlc<vlc_entry>("0010010", 10),
+	make_vlc<vlc_entry>("0010001", 18), make_vlc<vlc_entry>("0010000", 34),
+	make_vlc<vlc_entry>("00011111", 7), make_vlc<vlc_entry>("00011110", 11),
+	make_vlc<vlc_entry>("00011101", 19), make_vlc<vlc_entry>("00011100", 35),
+	make_vlc<vlc_entry>("00011011", 13), make_vlc<vlc_entry>("00011010", 49),
+	make_vlc<vlc_entry>("00011001", 21), make_vlc<vlc_entry>("00011000", 41),
+	make_vlc<vlc_entry>("00010111", 14), make_vlc<vlc_entry>("00010110", 50),
+	make_vlc<vlc_entry>("00010101", 22), make_vlc<vlc_entry>("00010100", 42),
+	make_vlc<vlc_entry>("00010011", 15), make_vlc<vlc_entry>("00010010", 51),
+	make_vlc<vlc_entry>("00010001", 23), make_vlc<vlc_entry>("00010000", 43),
+	make_vlc<vlc_entry>("00001111", 25), make_vlc<vlc_entry>("00001110", 37),
+	make_vlc<vlc_entry>("00001101", 26), make_vlc<vlc_entry>("00001100", 38),
+	make_vlc<vlc_entry>("00001011", 29), make_vlc<vlc_entry>("00001010", 45),
+	make_vlc<vlc_entry>("00001001", 53), make_vlc<vlc_entry>("00001000", 57),
+	make_vlc<vlc_entry>("00000111", 30), make_vlc<vlc_entry>("00000110", 46),
+	make_vlc<vlc_entry>("00000101", 54), make_vlc<vlc_entry>("00000100", 58),
+	make_vlc<vlc_entry>("000000111", 31), make_vlc<vlc_entry>("000000110", 47),
+	make_vlc<vlc_entry>("000000101", 55), make_vlc<vlc_entry>("000000100", 59),
+	make_vlc<vlc_entry>("000000011", 27), make_vlc<vlc_entry>("000000010", 39)
+};
+
+constexpr vlc_entry s_motion_code[] =
+{
+	make_vlc<vlc_entry>("1", 0),
+	make_vlc<vlc_entry>("011", -1), make_vlc<vlc_entry>("010", 1),
+	make_vlc<vlc_entry>("0011", -2), make_vlc<vlc_entry>("0010", 2),
+	make_vlc<vlc_entry>("00011", -3), make_vlc<vlc_entry>("00010", 3),
+	make_vlc<vlc_entry>("0000111", -4), make_vlc<vlc_entry>("0000110", 4),
+	make_vlc<vlc_entry>("00001011", -5), make_vlc<vlc_entry>("00001010", 5),
+	make_vlc<vlc_entry>("00001001", -6), make_vlc<vlc_entry>("00001000", 6),
+	make_vlc<vlc_entry>("00000111", -7), make_vlc<vlc_entry>("00000110", 7),
+	make_vlc<vlc_entry>("0000010111", -8), make_vlc<vlc_entry>("0000010110", 8),
+	make_vlc<vlc_entry>("0000010101", -9), make_vlc<vlc_entry>("0000010100", 9),
+	make_vlc<vlc_entry>("0000010011", -10), make_vlc<vlc_entry>("0000010010", 10),
+	make_vlc<vlc_entry>("00000100011", -11), make_vlc<vlc_entry>("00000100010", 11),
+	make_vlc<vlc_entry>("00000100001", -12), make_vlc<vlc_entry>("00000100000", 12),
+	make_vlc<vlc_entry>("00000011111", -13), make_vlc<vlc_entry>("00000011110", 13),
+	make_vlc<vlc_entry>("00000011101", -14), make_vlc<vlc_entry>("00000011100", 14),
+	make_vlc<vlc_entry>("00000011011", -15), make_vlc<vlc_entry>("00000011010", 15),
+	make_vlc<vlc_entry>("00000011001", -16), make_vlc<vlc_entry>("00000011000", 16)
+};
+
+constexpr dct_vlc_entry s_dct_coefficient[] =
+{
+	make_dct_vlc("011", 1, 1), make_dct_vlc("0100", 0, 2), make_dct_vlc("0101", 2, 1),
+	make_dct_vlc("00101", 0, 3), make_dct_vlc("00111", 3, 1), make_dct_vlc("00110", 4, 1),
+	make_dct_vlc("000110", 1, 2), make_dct_vlc("000111", 5, 1),
+	make_dct_vlc("000101", 6, 1), make_dct_vlc("000100", 7, 1),
+	make_dct_vlc("0000110", 0, 4), make_dct_vlc("0000100", 2, 2),
+	make_dct_vlc("0000111", 8, 1), make_dct_vlc("0000101", 9, 1),
+	make_dct_vlc("00100110", 0, 5), make_dct_vlc("00100001", 0, 6),
+	make_dct_vlc("00100101", 1, 3), make_dct_vlc("00100100", 3, 2),
+	make_dct_vlc("00100111", 10, 1), make_dct_vlc("00100011", 11, 1),
+	make_dct_vlc("00100010", 12, 1), make_dct_vlc("00100000", 13, 1),
+	make_dct_vlc("0000001010", 0, 7), make_dct_vlc("0000001100", 1, 4),
+	make_dct_vlc("0000001011", 2, 3), make_dct_vlc("0000001111", 4, 2),
+	make_dct_vlc("0000001001", 5, 2), make_dct_vlc("0000001110", 14, 1),
+	make_dct_vlc("0000001101", 15, 1), make_dct_vlc("0000001000", 16, 1),
+	make_dct_vlc("000000011101", 0, 8), make_dct_vlc("000000011000", 0, 9),
+	make_dct_vlc("000000010011", 0, 10), make_dct_vlc("000000010000", 0, 11),
+	make_dct_vlc("000000011011", 1, 5), make_dct_vlc("000000010100", 2, 4),
+	make_dct_vlc("000000011100", 3, 3), make_dct_vlc("000000010010", 4, 3),
+	make_dct_vlc("000000011110", 6, 2), make_dct_vlc("000000010101", 7, 2),
+	make_dct_vlc("000000010001", 8, 2), make_dct_vlc("000000011111", 17, 1),
+	make_dct_vlc("000000011010", 18, 1), make_dct_vlc("000000011001", 19, 1),
+	make_dct_vlc("000000010111", 20, 1), make_dct_vlc("000000010110", 21, 1),
+	make_dct_vlc("0000000011010", 0, 12), make_dct_vlc("0000000011001", 0, 13),
+	make_dct_vlc("0000000011000", 0, 14), make_dct_vlc("0000000010111", 0, 15),
+	make_dct_vlc("0000000010110", 1, 6), make_dct_vlc("0000000010101", 1, 7),
+	make_dct_vlc("0000000010100", 2, 5), make_dct_vlc("0000000010011", 3, 4),
+	make_dct_vlc("0000000010010", 5, 3), make_dct_vlc("0000000010001", 9, 2),
+	make_dct_vlc("0000000010000", 10, 2), make_dct_vlc("0000000011111", 22, 1),
+	make_dct_vlc("0000000011110", 23, 1), make_dct_vlc("0000000011101", 24, 1),
+	make_dct_vlc("0000000011100", 25, 1), make_dct_vlc("0000000011011", 26, 1),
+	make_dct_vlc("00000000011111", 0, 16), make_dct_vlc("00000000011110", 0, 17),
+	make_dct_vlc("00000000011101", 0, 18), make_dct_vlc("00000000011100", 0, 19),
+	make_dct_vlc("00000000011011", 0, 20), make_dct_vlc("00000000011010", 0, 21),
+	make_dct_vlc("00000000011001", 0, 22), make_dct_vlc("00000000011000", 0, 23),
+	make_dct_vlc("00000000010111", 0, 24), make_dct_vlc("00000000010110", 0, 25),
+	make_dct_vlc("00000000010101", 0, 26), make_dct_vlc("00000000010100", 0, 27),
+	make_dct_vlc("00000000010011", 0, 28), make_dct_vlc("00000000010010", 0, 29),
+	make_dct_vlc("00000000010001", 0, 30), make_dct_vlc("00000000010000", 0, 31),
+	make_dct_vlc("000000000011000", 0, 32), make_dct_vlc("000000000010111", 0, 33),
+	make_dct_vlc("000000000010110", 0, 34), make_dct_vlc("000000000010101", 0, 35),
+	make_dct_vlc("000000000010100", 0, 36), make_dct_vlc("000000000010011", 0, 37),
+	make_dct_vlc("000000000010010", 0, 38), make_dct_vlc("000000000010001", 0, 39),
+	make_dct_vlc("000000000010000", 0, 40), make_dct_vlc("000000000011111", 1, 8),
+	make_dct_vlc("000000000011110", 1, 9), make_dct_vlc("000000000011101", 1, 10),
+	make_dct_vlc("000000000011100", 1, 11), make_dct_vlc("000000000011011", 1, 12),
+	make_dct_vlc("000000000011010", 1, 13), make_dct_vlc("000000000011001", 1, 14),
+	make_dct_vlc("0000000000010011", 1, 15), make_dct_vlc("0000000000010010", 1, 16),
+	make_dct_vlc("0000000000010001", 1, 17), make_dct_vlc("0000000000010000", 1, 18),
+	make_dct_vlc("0000000000010100", 6, 3), make_dct_vlc("0000000000011010", 11, 2),
+	make_dct_vlc("0000000000011001", 12, 2), make_dct_vlc("0000000000011000", 13, 2),
+	make_dct_vlc("0000000000010111", 14, 2), make_dct_vlc("0000000000010110", 15, 2),
+	make_dct_vlc("0000000000010101", 16, 2), make_dct_vlc("0000000000011111", 27, 1),
+	make_dct_vlc("0000000000011110", 28, 1), make_dct_vlc("0000000000011101", 29, 1),
+	make_dct_vlc("0000000000011100", 30, 1), make_dct_vlc("0000000000011011", 31, 1)
+};
+
+constexpr u8 TYPE_QUANT = 0x01;
+constexpr u8 TYPE_FORWARD = 0x02;
+constexpr u8 TYPE_BACKWARD = 0x04;
+constexpr u8 TYPE_PATTERN = 0x08;
+constexpr u8 TYPE_INTRA = 0x10;
+
+constexpr vlc_entry s_i_macroblock_type[] =
+{
+	make_vlc<vlc_entry>("1", TYPE_INTRA),
+	make_vlc<vlc_entry>("01", TYPE_QUANT | TYPE_INTRA)
+};
+
+constexpr vlc_entry s_p_macroblock_type[] =
+{
+	make_vlc<vlc_entry>("1", TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("01", TYPE_PATTERN),
+	make_vlc<vlc_entry>("001", TYPE_FORWARD),
+	make_vlc<vlc_entry>("00011", TYPE_INTRA),
+	make_vlc<vlc_entry>("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("00001", TYPE_QUANT | TYPE_PATTERN),
+	make_vlc<vlc_entry>("000001", TYPE_QUANT | TYPE_INTRA)
+};
+
+constexpr vlc_entry s_b_macroblock_type[] =
+{
+	make_vlc<vlc_entry>("10", TYPE_FORWARD | TYPE_BACKWARD),
+	make_vlc<vlc_entry>("11", TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("010", TYPE_BACKWARD),
+	make_vlc<vlc_entry>("011", TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("0010", TYPE_FORWARD),
+	make_vlc<vlc_entry>("0011", TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("00011", TYPE_INTRA),
+	make_vlc<vlc_entry>("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("000011", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("000010", TYPE_QUANT | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc<vlc_entry>("000001", TYPE_QUANT | TYPE_INTRA)
+};
+
+constexpr vlc_entry s_d_macroblock_type[] =
+{
+	make_vlc<vlc_entry>("1", TYPE_INTRA)
+};
+
+constexpr vlc_entry s_dc_size_luminance[] =
+{
+	make_vlc<vlc_entry>("100", 0), make_vlc<vlc_entry>("00", 1),
+	make_vlc<vlc_entry>("01", 2), make_vlc<vlc_entry>("101", 3),
+	make_vlc<vlc_entry>("110", 4), make_vlc<vlc_entry>("1110", 5),
+	make_vlc<vlc_entry>("11110", 6), make_vlc<vlc_entry>("111110", 7),
+	make_vlc<vlc_entry>("1111110", 8)
+};
+
+constexpr vlc_entry s_dc_size_chrominance[] =
+{
+	make_vlc<vlc_entry>("00", 0), make_vlc<vlc_entry>("01", 1),
+	make_vlc<vlc_entry>("10", 2), make_vlc<vlc_entry>("110", 3),
+	make_vlc<vlc_entry>("1110", 4), make_vlc<vlc_entry>("11110", 5),
+	make_vlc<vlc_entry>("111110", 6), make_vlc<vlc_entry>("1111110", 7),
+	make_vlc<vlc_entry>("11111110", 8)
+};
+
+template <typename T, std::size_t N, unsigned MaxBits>
+class vlc_decoder
+{
+public:
+	struct match
+	{
+		s16 entry;
+		u8 bits;
+	};
+
+	constexpr vlc_decoder(const T (&table)[N]) :
+		m_nodes{}
+	{
+		for (node &item : m_nodes)
+			item = node{ { -1, -1 }, -1 };
+
+		s16 node_count = 1;
+		for (unsigned entry = 0; entry != N; entry++)
+		{
+			s16 current = 0;
+			for (unsigned bit = table[entry].bits; bit; bit--)
+			{
+				s16 &next = m_nodes[current].child[BIT(table[entry].code, bit - 1)];
+				if (next < 0)
+				{
+					next = node_count++;
+					m_nodes[next] = node{ { -1, -1 }, -1 };
+				}
+				current = next;
+			}
+			m_nodes[current].entry = entry;
+		}
+	}
+
+	match lookup(u32 code, unsigned bits) const
+	{
+		s16 current = 0;
+		for (unsigned consumed = 0; consumed != bits; consumed++)
+		{
+			current = m_nodes[current].child[BIT(code, bits - consumed - 1)];
+			if (current < 0)
+				break;
+			if (m_nodes[current].entry >= 0)
+				return match{ m_nodes[current].entry, u8(consumed + 1) };
+		}
+		return match{ -1, 0 };
+	}
+
+	static constexpr unsigned max_bits() { return MaxBits; }
+
+private:
+	struct node
+	{
+		s16 child[2];
+		s16 entry;
+	};
+
+	node m_nodes[N * MaxBits + 1];
+};
+
+template <unsigned MaxBits, typename T, std::size_t N>
+constexpr auto make_vlc_decoder(const T (&table)[N])
+{
+	return vlc_decoder<T, N, MaxBits>(table);
+}
+
+constexpr auto s_macroblock_address_increment_decoder = make_vlc_decoder<11>(s_macroblock_address_increment);
+constexpr auto s_coded_block_pattern_decoder = make_vlc_decoder<9>(s_coded_block_pattern);
+constexpr auto s_motion_code_decoder = make_vlc_decoder<11>(s_motion_code);
+constexpr auto s_dct_coefficient_decoder = make_vlc_decoder<16>(s_dct_coefficient);
+constexpr auto s_i_macroblock_type_decoder = make_vlc_decoder<2>(s_i_macroblock_type);
+constexpr auto s_p_macroblock_type_decoder = make_vlc_decoder<6>(s_p_macroblock_type);
+constexpr auto s_b_macroblock_type_decoder = make_vlc_decoder<6>(s_b_macroblock_type);
+constexpr auto s_d_macroblock_type_decoder = make_vlc_decoder<1>(s_d_macroblock_type);
+constexpr auto s_dc_size_luminance_decoder = make_vlc_decoder<7>(s_dc_size_luminance);
+constexpr auto s_dc_size_chrominance_decoder = make_vlc_decoder<8>(s_dc_size_chrominance);
+
+template <typename T, std::size_t N, unsigned MaxBits, typename P, typename S>
+const T *decode_vlc(const T (&table)[N], const vlc_decoder<T, N, MaxBits> &decoder,
+		int available, P &&peek, S &&skip)
+{
+	const unsigned lookahead = std::min<unsigned>(decoder.max_bits(), std::max(available, 0));
+	const auto match = decoder.lookup(peek(lookahead), lookahead);
+	if (match.entry >= 0)
+	{
+		skip(match.bits);
+		return &table[match.entry];
+	}
+
+	// Preserve streaming semantics: a truncated prefix needs more data rather than being invalid.
+	if (lookahead < decoder.max_bits())
+		peek(lookahead + 1);
+	return nullptr;
+}
+
+const u8 mpeg_video::s_default_intra_quantizer_matrix[64] =
+{
+	8, 16, 19, 22, 26, 27, 29, 34,
+	16, 16, 22, 24, 27, 29, 34, 37,
+	19, 22, 26, 27, 29, 34, 34, 38,
+	22, 22, 26, 27, 29, 34, 37, 40,
+	22, 26, 27, 29, 32, 35, 40, 48,
+	26, 27, 29, 32, 35, 40, 48, 58,
+	26, 27, 29, 34, 38, 46, 56, 69,
+	27, 29, 35, 38, 46, 56, 69, 83
+};
+
+// ISO/IEC 11172-2 Table 2.4.4.1, indexed by natural coefficient position.
+const u8 mpeg_video::s_scan[64] =
+{
+	0, 1, 5, 6, 14, 15, 27, 28,
+	2, 4, 7, 13, 16, 26, 29, 42,
+	3, 8, 12, 17, 25, 30, 41, 43,
+	9, 11, 18, 24, 31, 40, 44, 53,
+	10, 19, 23, 32, 39, 45, 52, 54,
+	20, 22, 33, 38, 46, 51, 55, 60,
+	21, 34, 37, 47, 50, 56, 59, 61,
+	35, 36, 48, 49, 57, 58, 62, 63
+};
+
+const double mpeg_video::s_picture_rates[16] =
+{
+	0.0, 24'000.0 / 1'001.0, 24.0, 25.0,
+	30'000.0 / 1'001.0, 30.0, 50.0, 60'000.0 / 1'001.0,
+	60.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+};
+
+mpeg_video::mpeg_video(const void *base, int maximum_width, int maximum_height) :
+	m_base(reinterpret_cast<const u8 *>(base)),
+	m_maximum_width(maximum_width),
+	m_maximum_height(maximum_height)
+{
+	assert(m_maximum_width > 0);
+	assert(m_maximum_height > 0);
+
+	const unsigned maximum_mb_width = (m_maximum_width + 15) / 16;
+	const unsigned maximum_mb_height = (m_maximum_height + 15) / 16;
+	const unsigned luma_size = maximum_mb_width * 16 * maximum_mb_height * 16;
+	const unsigned chroma_size = maximum_mb_width * 8 * maximum_mb_height * 8;
+	for (frame *const item : { &m_current_frame, &m_forward_reference, &m_backward_reference })
+	{
+		item->y.resize(luma_size);
+		item->cb.resize(chroma_size);
+		item->cr.resize(chroma_size);
+	}
+
+	for (int x = 0; x != 8; x++)
+	{
+		for (int u = 0; u != 8; u++)
+		{
+			// Fold the IDCT's quarter scaling and C(u) normalization into its two passes.
+			const double scale = u ? 0.5 : (0.5 / std::numbers::sqrt2);
+			m_idct_basis[x][u] = scale * std::cos((2 * x + 1) * u * std::numbers::pi / 16.0);
+		}
+	}
+
+	clear();
+}
+
+void mpeg_video::clear()
+{
+	m_current_pos = 0;
+	m_current_limit = 0;
+	m_horizontal_size = 0;
+	m_vertical_size = 0;
+	m_mb_width = 0;
+	m_mb_height = 0;
+	m_luma_pitch = 0;
+	m_chroma_pitch = 0;
+	m_frame_rate = 0.0;
+	std::copy(
+			std::begin(s_default_intra_quantizer_matrix),
+			std::end(s_default_intra_quantizer_matrix),
+			m_intra_quantizer_matrix);
+	std::fill(std::begin(m_non_intra_quantizer_matrix), std::end(m_non_intra_quantizer_matrix), 16);
+	m_picture_coding_type = 0;
+	m_full_pel_forward_vector = false;
+	m_full_pel_backward_vector = false;
+	m_forward_f = 0;
+	m_backward_f = 0;
+	m_quantizer_scale = 0;
+	m_macroblock_address = -1;
+	reset_dc_predictors();
+	m_forward_horizontal_previous = 0;
+	m_forward_vertical_previous = 0;
+	m_backward_horizontal_previous = 0;
+	m_backward_vertical_previous = 0;
+	m_previous_b_forward = false;
+	m_previous_b_backward = false;
+}
+
+void mpeg_video::register_save_state(device_t &device, int index)
+{
+	device.save_item(m_horizontal_size, "mpeg_video_horizontal_size", index);
+	device.save_item(m_vertical_size, "mpeg_video_vertical_size", index);
+	device.save_item(m_mb_width, "mpeg_video_mb_width", index);
+	device.save_item(m_mb_height, "mpeg_video_mb_height", index);
+	device.save_item(m_luma_pitch, "mpeg_video_luma_pitch", index);
+	device.save_item(m_chroma_pitch, "mpeg_video_chroma_pitch", index);
+	device.save_item(m_frame_rate, "mpeg_video_frame_rate", index);
+	device.save_item(m_intra_quantizer_matrix, "mpeg_video_intra_quantizer_matrix", index);
+	device.save_item(m_non_intra_quantizer_matrix, "mpeg_video_non_intra_quantizer_matrix", index);
+}
+
+mpeg_video::decode_result mpeg_video::decode_buffer(int &pos, int limit, const picture_buffers &buffers,
+		int &width, int &height, double &frame_rate)
+{
+	if ((limit - pos) < 32)
+		return decode_result::NEED_DATA;
+
+	int scan_position = pos;
+	for (;;)
+	{
+		m_current_pos = scan_position;
+		m_current_limit = limit;
+		int syntax_position = scan_position;
+
+		try
+		{
+			next_start_code();
+			syntax_position = m_current_pos;
+			const u32 code = peek(32);
+
+			switch (code)
+			{
+			case SEQUENCE_HEADER_CODE:
+				sequence_header();
+				break;
+
+			case GROUP_START_CODE:
+				group_of_pictures();
+				break;
+
+			case PICTURE_START_CODE:
+				picture(buffers);
+				// A sequence-end code terminates the preceding coded sequence rather than
+				// describing another decoding task.
+				if (peek(32) == SEQUENCE_END_CODE)
+					gb(32);
+				pos = m_current_pos;
+				width = m_horizontal_size;
+				height = m_vertical_size;
+				frame_rate = m_frame_rate;
+				return decode_result::PICTURE;
+
+			case SEQUENCE_END_CODE:
+				gb(32);
+				pos = m_current_pos;
+				width = m_horizontal_size;
+				height = m_vertical_size;
+				frame_rate = m_frame_rate;
+				return decode_result::SEQUENCE_END;
+
+			default:
+				// Extension, user and system data are delimited by the next start code.
+				gb(32);
+				break;
+			}
+
+			scan_position = m_current_pos;
+		}
+		catch (limit_hit const &)
+		{
+			pos = syntax_position;
+			return decode_result::NEED_DATA;
+		}
+		catch (invalid_stream const &)
+		{
+			// Skip the failed syntax element and resume at the next start code.
+			int recovery_position = std::max(syntax_position + 8, (m_current_pos + 7) & ~7);
+			while ((recovery_position + 24) <= limit)
+			{
+				const unsigned byte_position = recovery_position / 8;
+				if (!m_base[byte_position] && !m_base[byte_position + 1] && (m_base[byte_position + 2] == 1))
+					break;
+				recovery_position += 8;
+			}
+			pos = std::min(recovery_position, limit);
+			return decode_result::INVALID_DATA;
+		}
+	}
+}
+
+void mpeg_video::sequence_header()
+{
+	gb(32);
+	const int horizontal_size = gb(12);
+	const int vertical_size = gb(12);
+	gb(4); // pel aspect ratio
+	const unsigned picture_rate = gb(4);
+	gb(18); // bit rate
+	if (gb(1) != 1)
+		throw invalid_stream();
+	gb(10); // VBV buffer size
+	gb(1); // constrained parameters flag
+
+	u8 intra_quantizer_matrix[64];
+	u8 non_intra_quantizer_matrix[64];
+	std::copy(
+			std::begin(s_default_intra_quantizer_matrix),
+			std::end(s_default_intra_quantizer_matrix),
+			intra_quantizer_matrix);
+	if (gb(1))
+	{
+		for (unsigned zigzag = 0; zigzag != 64; zigzag++)
+		{
+			for (unsigned natural = 0; natural != 64; natural++)
+			{
+				if (s_scan[natural] == zigzag)
+				{
+					intra_quantizer_matrix[natural] = gb(8);
+					break;
+				}
+			}
+		}
+		// ISO/IEC 11172-2 Technical Corrigendum 2 requires this value to be eight.
+		intra_quantizer_matrix[0] = 8;
+	}
+
+	std::fill(std::begin(non_intra_quantizer_matrix), std::end(non_intra_quantizer_matrix), 16);
+	if (gb(1))
+	{
+		for (unsigned zigzag = 0; zigzag != 64; zigzag++)
+		{
+			for (unsigned natural = 0; natural != 64; natural++)
+			{
+				if (s_scan[natural] == zigzag)
+				{
+					non_intra_quantizer_matrix[natural] = gb(8);
+					break;
+				}
+			}
+		}
+	}
+
+	if (!horizontal_size || !vertical_size ||
+		(horizontal_size > m_maximum_width) || (vertical_size > m_maximum_height) ||
+		!s_picture_rates[picture_rate])
+		throw invalid_stream();
+
+	next_start_code();
+	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
+	{
+		gb(32);
+		next_start_code();
+	}
+
+	m_horizontal_size = horizontal_size;
+	m_vertical_size = vertical_size;
+	m_frame_rate = s_picture_rates[picture_rate];
+	m_mb_width = (m_horizontal_size + 15) / 16;
+	m_mb_height = (m_vertical_size + 15) / 16;
+	m_luma_pitch = m_mb_width * 16;
+	m_chroma_pitch = m_mb_width * 8;
+	std::copy(std::begin(intra_quantizer_matrix), std::end(intra_quantizer_matrix), m_intra_quantizer_matrix);
+	std::copy(std::begin(non_intra_quantizer_matrix), std::end(non_intra_quantizer_matrix), m_non_intra_quantizer_matrix);
+}
+
+void mpeg_video::group_of_pictures()
+{
+	gb(32);
+	gb(1); // drop frame flag
+	const unsigned hours = gb(5);
+	const unsigned minutes = gb(6);
+	if (gb(1) != 1) // marker bit
+		throw invalid_stream();
+	const unsigned seconds = gb(6);
+	const unsigned pictures = gb(6);
+	if ((hours > 23) || (minutes > 59) || (seconds > 59) || (pictures > 59))
+		throw invalid_stream();
+	gb(1); // closed GOP
+	gb(1); // broken link
+	next_start_code();
+
+	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
+	{
+		gb(32);
+		next_start_code();
+	}
+}
+
+void mpeg_video::picture(const picture_buffers &buffers)
+{
+	if (!m_horizontal_size || !m_vertical_size)
+		throw invalid_stream();
+
+	gb(32);
+	gb(10); // temporal reference
+	m_picture_coding_type = gb(3);
+	gb(16); // VBV delay
+
+	m_full_pel_forward_vector = false;
+	m_full_pel_backward_vector = false;
+	m_forward_f = 0;
+	m_backward_f = 0;
+	if ((m_picture_coding_type == 2) || (m_picture_coding_type == 3))
+	{
+		m_full_pel_forward_vector = gb(1);
+		const int forward_f_code = gb(3);
+		if (!forward_f_code)
+			throw invalid_stream();
+		m_forward_f = 1 << (forward_f_code - 1);
+	}
+	if (m_picture_coding_type == 3)
+	{
+		m_full_pel_backward_vector = gb(1);
+		const int backward_f_code = gb(3);
+		if (!backward_f_code)
+			throw invalid_stream();
+		m_backward_f = 1 << (backward_f_code - 1);
+	}
+	if ((m_picture_coding_type < 1) || (m_picture_coding_type > 4))
+		throw invalid_stream();
+
+	if ((m_picture_coding_type == 2) || (m_picture_coding_type == 3))
+		read_frame(m_forward_reference, buffers.forward.data, buffers.forward.bytes);
+	if (m_picture_coding_type == 3)
+		read_frame(m_backward_reference, buffers.backward.data, buffers.backward.bytes);
+
+	while (gb(1))
+		gb(8);
+	next_start_code();
+
+	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
+	{
+		gb(32);
+		next_start_code();
+	}
+
+	// Macroblocks not reconstructed by the task retain their previous contents in RFP.
+	read_frame(m_current_frame, buffers.reconstructed.data, buffers.reconstructed.bytes);
+
+	bool have_slice = false;
+	while ((peek(32) >= 0x00000101) && (peek(32) <= 0x000001af))
+	{
+		const unsigned vertical_position = peek(32) & 0xff;
+		slice(vertical_position);
+		have_slice = true;
+	}
+	if (!have_slice)
+		throw invalid_stream();
+
+	write_frame(m_current_frame, buffers.reconstructed.data, buffers.reconstructed.bytes);
+}
+
+void mpeg_video::reset_dc_predictors()
+{
+	std::fill(std::begin(m_dc_predictor), std::end(m_dc_predictor), 128 * 8);
+}
+
+void mpeg_video::slice(unsigned vertical_position)
+{
+	gb(32);
+	m_quantizer_scale = gb(5);
+	if (!m_quantizer_scale)
+		throw invalid_stream();
+	while (gb(1))
+		gb(8);
+
+	m_macroblock_address = (vertical_position - 1) * m_mb_width - 1;
+	reset_dc_predictors();
+	m_forward_horizontal_previous = 0;
+	m_forward_vertical_previous = 0;
+	m_backward_horizontal_previous = 0;
+	m_backward_vertical_previous = 0;
+	m_previous_b_forward = false;
+	m_previous_b_backward = false;
+
+	bool first_in_slice = true;
+	do
+	{
+		macroblock(first_in_slice);
+		first_in_slice = false;
+	}
+	while (peek(23) != 0);
+
+	next_start_code();
+}
+
+void mpeg_video::macroblock(bool first_in_slice)
+{
+	const int increment = macroblock_address_increment();
+	const int address = m_macroblock_address + increment;
+	if ((address < 0) || (address >= (m_mb_width * m_mb_height)))
+		throw invalid_stream();
+
+	if (!first_in_slice)
+	{
+		for (int skipped = m_macroblock_address + 1; skipped < address; skipped++)
+			skipped_macroblock(skipped);
+	}
+	m_macroblock_address = address;
+
+	const macroblock_type type = macroblock_type_code();
+	if (type.quant)
+	{
+		m_quantizer_scale = gb(5);
+		if (!m_quantizer_scale)
+			throw invalid_stream();
+	}
+
+	motion_vector forward_vector{ 0, 0 };
+	motion_vector backward_vector{ 0, 0 };
+
+	if (m_picture_coding_type == 2)
+	{
+		if (type.forward)
+			decode_motion_vector(true, forward_vector);
+		else
+		{
+			m_forward_horizontal_previous = 0;
+			m_forward_vertical_previous = 0;
+		}
+	}
+	else if (m_picture_coding_type == 3)
+	{
+		if (type.forward)
+			decode_motion_vector(true, forward_vector);
+		else
+		{
+			forward_vector.horizontal = m_forward_horizontal_previous * (m_full_pel_forward_vector ? 2 : 1);
+			forward_vector.vertical = m_forward_vertical_previous * (m_full_pel_forward_vector ? 2 : 1);
+		}
+
+		if (type.backward)
+			decode_motion_vector(false, backward_vector);
+		else
+		{
+			backward_vector.horizontal = m_backward_horizontal_previous * (m_full_pel_backward_vector ? 2 : 1);
+			backward_vector.vertical = m_backward_vertical_previous * (m_full_pel_backward_vector ? 2 : 1);
+		}
+	}
+
+	if (!type.intra)
+	{
+		reset_dc_predictors();
+		const bool predict_forward = (m_picture_coding_type == 2) || type.forward;
+		predict_macroblock(predict_forward, type.backward, forward_vector, backward_vector);
+	}
+
+	const int pattern = type.intra ? 0x3f : (type.pattern ? coded_block_pattern() : 0);
+	for (unsigned index = 0; index != 6; index++)
+	{
+		if (BIT(pattern, 5 - index))
+			block(index, type.intra);
+	}
+
+	if (m_picture_coding_type == 4)
+	{
+		if (gb(1) != 1)
+			throw invalid_stream();
+	}
+
+	if (type.intra)
+	{
+		m_forward_horizontal_previous = 0;
+		m_forward_vertical_previous = 0;
+		m_backward_horizontal_previous = 0;
+		m_backward_vertical_previous = 0;
+		m_previous_b_forward = false;
+		m_previous_b_backward = false;
+	}
+	else if (m_picture_coding_type == 3)
+	{
+		m_previous_b_forward = type.forward;
+		m_previous_b_backward = type.backward;
+	}
+}
+
+void mpeg_video::skipped_macroblock(int address)
+{
+	m_macroblock_address = address;
+	reset_dc_predictors();
+
+	if (m_picture_coding_type == 2)
+	{
+		m_forward_horizontal_previous = 0;
+		m_forward_vertical_previous = 0;
+		predict_macroblock(true, false, motion_vector{ 0, 0 }, motion_vector{ 0, 0 });
+	}
+	else if (m_picture_coding_type == 3)
+	{
+		if (!m_previous_b_forward && !m_previous_b_backward)
+			throw invalid_stream();
+		const motion_vector forward_vector
+		{
+			m_forward_horizontal_previous * (m_full_pel_forward_vector ? 2 : 1),
+			m_forward_vertical_previous * (m_full_pel_forward_vector ? 2 : 1)
+		};
+		const motion_vector backward_vector
+		{
+			m_backward_horizontal_previous * (m_full_pel_backward_vector ? 2 : 1),
+			m_backward_vertical_previous * (m_full_pel_backward_vector ? 2 : 1)
+		};
+		predict_macroblock(m_previous_b_forward, m_previous_b_backward, forward_vector, backward_vector);
+	}
+	else
+	{
+		throw invalid_stream();
+	}
+}
+
+void mpeg_video::decode_motion_vector(bool forward, motion_vector &vector)
+{
+	const int f = forward ? m_forward_f : m_backward_f;
+	const bool full_pel = forward ? m_full_pel_forward_vector : m_full_pel_backward_vector;
+	int &horizontal_previous = forward ? m_forward_horizontal_previous : m_backward_horizontal_previous;
+	int &vertical_previous = forward ? m_forward_vertical_previous : m_backward_vertical_previous;
+
+	const int horizontal_code = motion_code();
+	const int horizontal_residual = ((f != 1) && horizontal_code) ? int(gb(std::countr_zero(unsigned(f)))) : 0;
+	const int vertical_code = motion_code();
+	const int vertical_residual = ((f != 1) && vertical_code) ? int(gb(std::countr_zero(unsigned(f)))) : 0;
+
+	vector.horizontal = decode_motion_component(horizontal_code, horizontal_residual, f, horizontal_previous, full_pel);
+	vector.vertical = decode_motion_component(vertical_code, vertical_residual, f, vertical_previous, full_pel);
+}
+
+int mpeg_video::decode_motion_component(int code, int residual, int f, int &previous, bool full_pel)
+{
+	const int complement = ((f == 1) || !code) ? 0 : (f - 1 - residual);
+	int little = code * f;
+	int big = 0;
+	if (little > 0)
+	{
+		little -= complement;
+		big = little - 32 * f;
+	}
+	else if (little < 0)
+	{
+		little += complement;
+		big = little + 32 * f;
+	}
+
+	const int maximum = 16 * f - 1;
+	const int minimum = -16 * f;
+	const int candidate = previous + little;
+	previous += ((candidate >= minimum) && (candidate <= maximum)) ? little : big;
+	return previous * (full_pel ? 2 : 1);
+}
+
+void mpeg_video::predict_macroblock(
+		bool forward,
+		bool backward,
+		motion_vector forward_vector,
+		motion_vector backward_vector)
+{
+	const int macroblock_x = (m_macroblock_address % m_mb_width) * 16;
+	const int macroblock_y = (m_macroblock_address / m_mb_width) * 16;
+	bool have_prediction = false;
+
+	if (forward)
+	{
+		predict_plane(m_current_frame.y.data(), m_luma_pitch, m_forward_reference.y.data(), m_luma_pitch,
+				macroblock_x, macroblock_y, 16, 16, forward_vector, false, false);
+		predict_plane(m_current_frame.cb.data(), m_chroma_pitch, m_forward_reference.cb.data(), m_chroma_pitch,
+				macroblock_x / 2, macroblock_y / 2, 8, 8, forward_vector, true, false);
+		predict_plane(m_current_frame.cr.data(), m_chroma_pitch, m_forward_reference.cr.data(), m_chroma_pitch,
+				macroblock_x / 2, macroblock_y / 2, 8, 8, forward_vector, true, false);
+		have_prediction = true;
+	}
+
+	if (backward)
+	{
+		predict_plane(m_current_frame.y.data(), m_luma_pitch, m_backward_reference.y.data(), m_luma_pitch,
+				macroblock_x, macroblock_y, 16, 16, backward_vector, false, have_prediction);
+		predict_plane(m_current_frame.cb.data(), m_chroma_pitch, m_backward_reference.cb.data(), m_chroma_pitch,
+				macroblock_x / 2, macroblock_y / 2, 8, 8, backward_vector, true, have_prediction);
+		predict_plane(m_current_frame.cr.data(), m_chroma_pitch, m_backward_reference.cr.data(), m_chroma_pitch,
+				macroblock_x / 2, macroblock_y / 2, 8, 8, backward_vector, true, have_prediction);
+	}
+}
+
+void mpeg_video::predict_plane(u8 *destination, int destination_pitch, const u8 *reference, int reference_pitch,
+		int x, int y, int width, int height, motion_vector vector, bool chroma, bool average) const
+{
+	auto split_half_pel = [] (int value, int &whole, int &half)
+	{
+		whole = value / 2;
+		if ((value < 0) && (value % 2))
+			whole--;
+		half = value - 2 * whole;
+	};
+
+	const int horizontal_vector = chroma ? (vector.horizontal / 2) : vector.horizontal;
+	const int vertical_vector = chroma ? (vector.vertical / 2) : vector.vertical;
+	int horizontal_whole, horizontal_half;
+	int vertical_whole, vertical_half;
+	split_half_pel(horizontal_vector, horizontal_whole, horizontal_half);
+	split_half_pel(vertical_vector, vertical_whole, vertical_half);
+	const int source_x = x + horizontal_whole;
+	const int source_y = y + vertical_whole;
+	const int reference_height = m_mb_height * (chroma ? 8 : 16);
+	if ((source_x < 0) || (source_y < 0) ||
+		((source_x + width + horizontal_half) > reference_pitch) ||
+		((source_y + height + vertical_half) > reference_height))
+	{
+		throw invalid_stream();
+	}
+
+	for (int row = 0; row != height; row++)
+	{
+		for (int column = 0; column != width; column++)
+		{
+			const int reference_x = source_x + column;
+			const int reference_y = source_y + row;
+			int prediction = reference[reference_y * reference_pitch + reference_x];
+			if (horizontal_half)
+				prediction += reference[reference_y * reference_pitch + reference_x + 1];
+			if (vertical_half)
+			{
+				prediction += reference[(reference_y + 1) * reference_pitch + reference_x];
+				if (horizontal_half)
+					prediction += reference[(reference_y + 1) * reference_pitch + reference_x + 1];
+			}
+
+			const int divisor = (horizontal_half + 1) * (vertical_half + 1);
+			prediction = (prediction + divisor / 2) / divisor;
+			u8 &target = destination[(y + row) * destination_pitch + x + column];
+			target = average ? ((int(target) + prediction + 1) / 2) : prediction;
+		}
+	}
+}
+
+void mpeg_video::block(unsigned index, bool intra)
+{
+	int quantized[64]{};
+	int scan_position = intra ? 0 : -1;
+
+	if (intra)
+	{
+		const int size = dc_size(index < 4);
+		int differential = size ? int(gb(size)) : 0;
+		if (size && !(differential & (1 << (size - 1))))
+			differential = differential + 1 - (1 << size);
+		quantized[0] = differential;
+	}
+	else
+	{
+		int run, level;
+		dct_coefficient(true, run, level);
+		scan_position = run;
+		if (scan_position > 63)
+			throw invalid_stream();
+		quantized[scan_position] = level;
+	}
+
+	if (m_picture_coding_type != 4)
+	{
+		while (peek(2) != 2)
+		{
+			int run, level;
+			dct_coefficient(false, run, level);
+			scan_position += run + 1;
+			if (scan_position > 63)
+				throw invalid_stream();
+			quantized[scan_position] = level;
+		}
+		gb(2); // end of block
+	}
+
+	int coefficients[64];
+	bool dc_only = true;
+	for (unsigned natural = 0; natural != 64; natural++)
+	{
+		const int level = quantized[s_scan[natural]];
+		dc_only = dc_only && (!natural || !level);
+		const int sign = (level > 0) - (level < 0);
+		int reconstructed;
+		if (intra)
+		{
+			reconstructed = (2 * level * m_quantizer_scale * m_intra_quantizer_matrix[natural]) / 16;
+		}
+		else
+		{
+			reconstructed = ((2 * level + sign) * m_quantizer_scale * m_non_intra_quantizer_matrix[natural]) / 16;
+		}
+		if (!(reconstructed & 1))
+			reconstructed -= (reconstructed > 0) - (reconstructed < 0);
+		coefficients[natural] = std::clamp(reconstructed, -2048, 2047);
+		if (!level)
+			coefficients[natural] = 0;
+	}
+
+	if (intra)
+	{
+		const unsigned component = (index < 4) ? 0 : (index - 3);
+		m_dc_predictor[component] += quantized[0] * 8;
+		coefficients[0] = m_dc_predictor[component];
+	}
+
+	int values[64];
+	inverse_dct(coefficients, values, dc_only);
+	put_block(index, values, intra);
+}
+
+void mpeg_video::put_block(unsigned index, const int *values, bool intra)
+{
+	const int macroblock_x = (m_macroblock_address % m_mb_width) * 16;
+	const int macroblock_y = (m_macroblock_address / m_mb_width) * 16;
+	u8 *destination;
+	int pitch;
+	int x;
+	int y;
+
+	if (index < 4)
+	{
+		destination = m_current_frame.y.data();
+		pitch = m_luma_pitch;
+		x = macroblock_x + ((index & 1) * 8);
+		y = macroblock_y + ((index >> 1) * 8);
+	}
+	else
+	{
+		destination = (index == 4) ? m_current_frame.cb.data() : m_current_frame.cr.data();
+		pitch = m_chroma_pitch;
+		x = macroblock_x / 2;
+		y = macroblock_y / 2;
+	}
+
+	for (int row = 0; row != 8; row++)
+	{
+		for (int column = 0; column != 8; column++)
+		{
+			u8 &target = destination[(y + row) * pitch + x + column];
+			const int value = intra ? values[row * 8 + column] : (int(target) + values[row * 8 + column]);
+			target = std::clamp(value, 0, 255);
+		}
+	}
+}
+
+void mpeg_video::inverse_dct(const int *coefficients, int *values, bool dc_only) const
+{
+	if (dc_only)
+	{
+		// A block with no AC coefficients has the same value in every sample.
+		std::fill_n(values, 64, std::clamp<int>(std::lround(double(coefficients[0]) / 8.0), -256, 255));
+		return;
+	}
+
+	double intermediate[8][8];
+	for (int v = 0; v != 8; v++)
+	{
+		for (int x = 0; x != 8; x++)
+		{
+			double sum = 0.0;
+			for (int u = 0; u != 8; u++)
+				sum += coefficients[v * 8 + u] * m_idct_basis[x][u];
+			intermediate[v][x] = sum;
+		}
+	}
+
+	for (int y = 0; y != 8; y++)
+	{
+		for (int x = 0; x != 8; x++)
+		{
+			double sum = 0.0;
+			for (int v = 0; v != 8; v++)
+				sum += intermediate[v][x] * m_idct_basis[y][v];
+			values[y * 8 + x] = std::clamp<int>(std::lround(sum), -256, 255);
+		}
+	}
+}
+
+void mpeg_video::read_frame(frame &destination, const u8 *source, unsigned source_bytes) const
+{
+	const unsigned luma_bytes = m_luma_pitch * m_mb_height * 16;
+	const unsigned chroma_bytes = m_chroma_pitch * m_mb_height * 8;
+	if (!source || (source_bytes < (luma_bytes + 2 * chroma_bytes)))
+		throw invalid_stream();
+
+	std::copy_n(source, luma_bytes, destination.y.begin());
+	std::copy_n(source + luma_bytes, chroma_bytes, destination.cb.begin());
+	std::copy_n(source + luma_bytes + chroma_bytes, chroma_bytes, destination.cr.begin());
+}
+
+void mpeg_video::write_frame(const frame &source, u8 *output, unsigned output_bytes) const
+{
+	const unsigned luma_bytes = m_luma_pitch * m_mb_height * 16;
+	const unsigned chroma_bytes = m_chroma_pitch * m_mb_height * 8;
+	if (!output || (output_bytes < (luma_bytes + 2 * chroma_bytes)))
+		throw invalid_stream();
+
+	std::copy_n(source.y.begin(), luma_bytes, output);
+	std::copy_n(source.cb.begin(), chroma_bytes, output + luma_bytes);
+	std::copy_n(source.cr.begin(), chroma_bytes, output + luma_bytes + chroma_bytes);
+}
+
+int mpeg_video::macroblock_address_increment()
+{
+	int increment = 0;
+	while (peek(11) == 0x00f)
+		gb(11); // macroblock stuffing
+	while (peek(11) == 0x008)
+	{
+		gb(11); // macroblock escape
+		increment += 33;
+	}
+
+	const vlc_entry *const entry = decode_vlc(
+			s_macroblock_address_increment,
+			s_macroblock_address_increment_decoder,
+			m_current_limit - m_current_pos,
+			[this] (int bits) { return peek(bits); },
+			[this] (int bits) { m_current_pos += bits; });
+	if (!entry)
+		throw invalid_stream();
+	return increment + entry->value;
+}
+
+mpeg_video::macroblock_type mpeg_video::macroblock_type_code()
+{
+	const vlc_entry *entry = nullptr;
+	auto const read = [this, &entry] (auto const &table, auto const &decoder)
+	{
+		entry = decode_vlc(table, decoder, m_current_limit - m_current_pos,
+				[this] (int bits) { return peek(bits); },
+				[this] (int bits) { m_current_pos += bits; });
+	};
+
+	switch (m_picture_coding_type)
+	{
+	case 1: read(s_i_macroblock_type, s_i_macroblock_type_decoder); break;
+	case 2: read(s_p_macroblock_type, s_p_macroblock_type_decoder); break;
+	case 3: read(s_b_macroblock_type, s_b_macroblock_type_decoder); break;
+	case 4: read(s_d_macroblock_type, s_d_macroblock_type_decoder); break;
+	}
+	if (!entry)
+		throw invalid_stream();
+	const int value = entry->value;
+
+	return macroblock_type
+	{
+		bool(value & TYPE_QUANT),
+		bool(value & TYPE_FORWARD),
+		bool(value & TYPE_BACKWARD),
+		bool(value & TYPE_PATTERN),
+		bool(value & TYPE_INTRA)
+	};
+}
+
+int mpeg_video::coded_block_pattern()
+{
+	const vlc_entry *const entry = decode_vlc(
+			s_coded_block_pattern,
+			s_coded_block_pattern_decoder,
+			m_current_limit - m_current_pos,
+			[this] (int bits) { return peek(bits); },
+			[this] (int bits) { m_current_pos += bits; });
+	if (!entry)
+		throw invalid_stream();
+	return entry->value;
+}
+
+int mpeg_video::motion_code()
+{
+	const vlc_entry *const entry = decode_vlc(
+			s_motion_code,
+			s_motion_code_decoder,
+			m_current_limit - m_current_pos,
+			[this] (int bits) { return peek(bits); },
+			[this] (int bits) { m_current_pos += bits; });
+	if (!entry)
+		throw invalid_stream();
+	return entry->value;
+}
+
+int mpeg_video::dc_size(bool luminance)
+{
+	const vlc_entry *const entry = luminance
+		? decode_vlc(s_dc_size_luminance, s_dc_size_luminance_decoder,
+				m_current_limit - m_current_pos,
+				[this] (int bits) { return peek(bits); },
+				[this] (int bits) { m_current_pos += bits; })
+		: decode_vlc(s_dc_size_chrominance, s_dc_size_chrominance_decoder,
+				m_current_limit - m_current_pos,
+				[this] (int bits) { return peek(bits); },
+				[this] (int bits) { m_current_pos += bits; });
+	if (!entry)
+		throw invalid_stream();
+	return entry->value;
+}
+
+void mpeg_video::dct_coefficient(bool first, int &run, int &level)
+{
+	if (first && (peek(1) == 1))
+	{
+		gb(1);
+		run = 0;
+		level = gb(1) ? -1 : 1;
+		return;
+	}
+	if (!first && (peek(2) == 3))
+	{
+		gb(2);
+		run = 0;
+		level = gb(1) ? -1 : 1;
+		return;
+	}
+	if (peek(6) == 1)
+	{
+		gb(6);
+		run = gb(6);
+		const int level_byte = gb(8);
+		if (!level_byte)
+		{
+			const int extension = gb(8);
+			if (extension < 0x80)
+				throw invalid_stream();
+			level = extension;
+		}
+		else if (level_byte == 0x80)
+		{
+			const int extension = gb(8);
+			if (!extension || (extension > 0x80))
+				throw invalid_stream();
+			level = extension - 256;
+		}
+		else
+		{
+			level = util::sext(level_byte, 8);
+		}
+		return;
+	}
+
+	const dct_vlc_entry *const entry = decode_vlc(
+			s_dct_coefficient,
+			s_dct_coefficient_decoder,
+			m_current_limit - m_current_pos,
+			[this] (int bits) { return peek(bits); },
+			[this] (int bits) { m_current_pos += bits; });
+	if (entry)
+	{
+		run = entry->run;
+		level = gb(1) ? -entry->level : entry->level;
+		return;
+	}
+	throw invalid_stream();
+}
+
+void mpeg_video::next_start_code()
+{
+	if (m_current_pos & 7)
+	{
+		if (gb(8 - (m_current_pos & 7)))
+			throw invalid_stream();
+	}
+	while (peek(24) != START_CODE_PREFIX)
+		gb(8);
+}
+
+u32 mpeg_video::peek(int count) const
+{
+	if ((count < 0) || (count > 32) || ((m_current_pos + count) > m_current_limit))
+		throw limit_hit();
+	if (!count)
+		return 0;
+
+	const unsigned byte_position = m_current_pos / 8;
+	const unsigned bit_offset = m_current_pos & 7;
+	const unsigned bytes = (bit_offset + count + 7) / 8;
+	u64 source = 0;
+	for (unsigned byte = 0; byte != bytes; byte++)
+		source = (source << 8) | m_base[byte_position + byte];
+	return (source >> (bytes * 8 - bit_offset - count)) & make_bitmask<u32>(count);
+}
+
+u32 mpeg_video::gb(int count)
+{
+	const u32 value = peek(count);
+	m_current_pos += count;
+	return value;
+}

--- a/src/devices/video/mpeg_video.cpp
+++ b/src/devices/video/mpeg_video.cpp
@@ -47,13 +47,13 @@ struct dct_vlc_entry
 	u8 level;
 };
 
-template <typename T, std::size_t N>
-constexpr T make_vlc(const char (&text)[N], int value)
+template <std::size_t N>
+constexpr vlc_entry make_vlc(const char (&text)[N], int value)
 {
 	u32 code = 0;
 	for (unsigned i = 0; i != (N - 1); i++)
 		code = (code << 1) | (text[i] == '1');
-	return T{ code, u8(N - 1), value };
+	return vlc_entry{ code, u8(N - 1), value };
 }
 
 template <std::size_t N>
@@ -67,96 +67,96 @@ constexpr dct_vlc_entry make_dct_vlc(const char (&text)[N], unsigned run, unsign
 
 constexpr vlc_entry s_macroblock_address_increment[] =
 {
-	make_vlc<vlc_entry>("1", 1),
-	make_vlc<vlc_entry>("011", 2),
-	make_vlc<vlc_entry>("010", 3),
-	make_vlc<vlc_entry>("0011", 4),
-	make_vlc<vlc_entry>("0010", 5),
-	make_vlc<vlc_entry>("00011", 6),
-	make_vlc<vlc_entry>("00010", 7),
-	make_vlc<vlc_entry>("0000111", 8),
-	make_vlc<vlc_entry>("0000110", 9),
-	make_vlc<vlc_entry>("00001011", 10),
-	make_vlc<vlc_entry>("00001010", 11),
-	make_vlc<vlc_entry>("00001001", 12),
-	make_vlc<vlc_entry>("00001000", 13),
-	make_vlc<vlc_entry>("00000111", 14),
-	make_vlc<vlc_entry>("00000110", 15),
-	make_vlc<vlc_entry>("0000010111", 16),
-	make_vlc<vlc_entry>("0000010110", 17),
-	make_vlc<vlc_entry>("0000010101", 18),
-	make_vlc<vlc_entry>("0000010100", 19),
-	make_vlc<vlc_entry>("0000010011", 20),
-	make_vlc<vlc_entry>("0000010010", 21),
-	make_vlc<vlc_entry>("00000100011", 22),
-	make_vlc<vlc_entry>("00000100010", 23),
-	make_vlc<vlc_entry>("00000100001", 24),
-	make_vlc<vlc_entry>("00000100000", 25),
-	make_vlc<vlc_entry>("00000011111", 26),
-	make_vlc<vlc_entry>("00000011110", 27),
-	make_vlc<vlc_entry>("00000011101", 28),
-	make_vlc<vlc_entry>("00000011100", 29),
-	make_vlc<vlc_entry>("00000011011", 30),
-	make_vlc<vlc_entry>("00000011010", 31),
-	make_vlc<vlc_entry>("00000011001", 32),
-	make_vlc<vlc_entry>("00000011000", 33)
+	make_vlc("1", 1),
+	make_vlc("011", 2),
+	make_vlc("010", 3),
+	make_vlc("0011", 4),
+	make_vlc("0010", 5),
+	make_vlc("00011", 6),
+	make_vlc("00010", 7),
+	make_vlc("0000111", 8),
+	make_vlc("0000110", 9),
+	make_vlc("00001011", 10),
+	make_vlc("00001010", 11),
+	make_vlc("00001001", 12),
+	make_vlc("00001000", 13),
+	make_vlc("00000111", 14),
+	make_vlc("00000110", 15),
+	make_vlc("0000010111", 16),
+	make_vlc("0000010110", 17),
+	make_vlc("0000010101", 18),
+	make_vlc("0000010100", 19),
+	make_vlc("0000010011", 20),
+	make_vlc("0000010010", 21),
+	make_vlc("00000100011", 22),
+	make_vlc("00000100010", 23),
+	make_vlc("00000100001", 24),
+	make_vlc("00000100000", 25),
+	make_vlc("00000011111", 26),
+	make_vlc("00000011110", 27),
+	make_vlc("00000011101", 28),
+	make_vlc("00000011100", 29),
+	make_vlc("00000011011", 30),
+	make_vlc("00000011010", 31),
+	make_vlc("00000011001", 32),
+	make_vlc("00000011000", 33)
 };
 
 constexpr vlc_entry s_coded_block_pattern[] =
 {
-	make_vlc<vlc_entry>("111", 60),
-	make_vlc<vlc_entry>("1101", 4), make_vlc<vlc_entry>("1100", 8),
-	make_vlc<vlc_entry>("1011", 16), make_vlc<vlc_entry>("1010", 32),
-	make_vlc<vlc_entry>("10011", 12), make_vlc<vlc_entry>("10010", 48),
-	make_vlc<vlc_entry>("10001", 20), make_vlc<vlc_entry>("10000", 40),
-	make_vlc<vlc_entry>("01111", 28), make_vlc<vlc_entry>("01110", 44),
-	make_vlc<vlc_entry>("01101", 52), make_vlc<vlc_entry>("01100", 56),
-	make_vlc<vlc_entry>("01011", 1), make_vlc<vlc_entry>("01010", 61),
-	make_vlc<vlc_entry>("01001", 2), make_vlc<vlc_entry>("01000", 62),
-	make_vlc<vlc_entry>("001111", 24), make_vlc<vlc_entry>("001110", 36),
-	make_vlc<vlc_entry>("001101", 3), make_vlc<vlc_entry>("001100", 63),
-	make_vlc<vlc_entry>("0010111", 5), make_vlc<vlc_entry>("0010110", 9),
-	make_vlc<vlc_entry>("0010101", 17), make_vlc<vlc_entry>("0010100", 33),
-	make_vlc<vlc_entry>("0010011", 6), make_vlc<vlc_entry>("0010010", 10),
-	make_vlc<vlc_entry>("0010001", 18), make_vlc<vlc_entry>("0010000", 34),
-	make_vlc<vlc_entry>("00011111", 7), make_vlc<vlc_entry>("00011110", 11),
-	make_vlc<vlc_entry>("00011101", 19), make_vlc<vlc_entry>("00011100", 35),
-	make_vlc<vlc_entry>("00011011", 13), make_vlc<vlc_entry>("00011010", 49),
-	make_vlc<vlc_entry>("00011001", 21), make_vlc<vlc_entry>("00011000", 41),
-	make_vlc<vlc_entry>("00010111", 14), make_vlc<vlc_entry>("00010110", 50),
-	make_vlc<vlc_entry>("00010101", 22), make_vlc<vlc_entry>("00010100", 42),
-	make_vlc<vlc_entry>("00010011", 15), make_vlc<vlc_entry>("00010010", 51),
-	make_vlc<vlc_entry>("00010001", 23), make_vlc<vlc_entry>("00010000", 43),
-	make_vlc<vlc_entry>("00001111", 25), make_vlc<vlc_entry>("00001110", 37),
-	make_vlc<vlc_entry>("00001101", 26), make_vlc<vlc_entry>("00001100", 38),
-	make_vlc<vlc_entry>("00001011", 29), make_vlc<vlc_entry>("00001010", 45),
-	make_vlc<vlc_entry>("00001001", 53), make_vlc<vlc_entry>("00001000", 57),
-	make_vlc<vlc_entry>("00000111", 30), make_vlc<vlc_entry>("00000110", 46),
-	make_vlc<vlc_entry>("00000101", 54), make_vlc<vlc_entry>("00000100", 58),
-	make_vlc<vlc_entry>("000000111", 31), make_vlc<vlc_entry>("000000110", 47),
-	make_vlc<vlc_entry>("000000101", 55), make_vlc<vlc_entry>("000000100", 59),
-	make_vlc<vlc_entry>("000000011", 27), make_vlc<vlc_entry>("000000010", 39)
+	make_vlc("111", 60),
+	make_vlc("1101", 4), make_vlc("1100", 8),
+	make_vlc("1011", 16), make_vlc("1010", 32),
+	make_vlc("10011", 12), make_vlc("10010", 48),
+	make_vlc("10001", 20), make_vlc("10000", 40),
+	make_vlc("01111", 28), make_vlc("01110", 44),
+	make_vlc("01101", 52), make_vlc("01100", 56),
+	make_vlc("01011", 1), make_vlc("01010", 61),
+	make_vlc("01001", 2), make_vlc("01000", 62),
+	make_vlc("001111", 24), make_vlc("001110", 36),
+	make_vlc("001101", 3), make_vlc("001100", 63),
+	make_vlc("0010111", 5), make_vlc("0010110", 9),
+	make_vlc("0010101", 17), make_vlc("0010100", 33),
+	make_vlc("0010011", 6), make_vlc("0010010", 10),
+	make_vlc("0010001", 18), make_vlc("0010000", 34),
+	make_vlc("00011111", 7), make_vlc("00011110", 11),
+	make_vlc("00011101", 19), make_vlc("00011100", 35),
+	make_vlc("00011011", 13), make_vlc("00011010", 49),
+	make_vlc("00011001", 21), make_vlc("00011000", 41),
+	make_vlc("00010111", 14), make_vlc("00010110", 50),
+	make_vlc("00010101", 22), make_vlc("00010100", 42),
+	make_vlc("00010011", 15), make_vlc("00010010", 51),
+	make_vlc("00010001", 23), make_vlc("00010000", 43),
+	make_vlc("00001111", 25), make_vlc("00001110", 37),
+	make_vlc("00001101", 26), make_vlc("00001100", 38),
+	make_vlc("00001011", 29), make_vlc("00001010", 45),
+	make_vlc("00001001", 53), make_vlc("00001000", 57),
+	make_vlc("00000111", 30), make_vlc("00000110", 46),
+	make_vlc("00000101", 54), make_vlc("00000100", 58),
+	make_vlc("000000111", 31), make_vlc("000000110", 47),
+	make_vlc("000000101", 55), make_vlc("000000100", 59),
+	make_vlc("000000011", 27), make_vlc("000000010", 39)
 };
 
 constexpr vlc_entry s_motion_code[] =
 {
-	make_vlc<vlc_entry>("1", 0),
-	make_vlc<vlc_entry>("011", -1), make_vlc<vlc_entry>("010", 1),
-	make_vlc<vlc_entry>("0011", -2), make_vlc<vlc_entry>("0010", 2),
-	make_vlc<vlc_entry>("00011", -3), make_vlc<vlc_entry>("00010", 3),
-	make_vlc<vlc_entry>("0000111", -4), make_vlc<vlc_entry>("0000110", 4),
-	make_vlc<vlc_entry>("00001011", -5), make_vlc<vlc_entry>("00001010", 5),
-	make_vlc<vlc_entry>("00001001", -6), make_vlc<vlc_entry>("00001000", 6),
-	make_vlc<vlc_entry>("00000111", -7), make_vlc<vlc_entry>("00000110", 7),
-	make_vlc<vlc_entry>("0000010111", -8), make_vlc<vlc_entry>("0000010110", 8),
-	make_vlc<vlc_entry>("0000010101", -9), make_vlc<vlc_entry>("0000010100", 9),
-	make_vlc<vlc_entry>("0000010011", -10), make_vlc<vlc_entry>("0000010010", 10),
-	make_vlc<vlc_entry>("00000100011", -11), make_vlc<vlc_entry>("00000100010", 11),
-	make_vlc<vlc_entry>("00000100001", -12), make_vlc<vlc_entry>("00000100000", 12),
-	make_vlc<vlc_entry>("00000011111", -13), make_vlc<vlc_entry>("00000011110", 13),
-	make_vlc<vlc_entry>("00000011101", -14), make_vlc<vlc_entry>("00000011100", 14),
-	make_vlc<vlc_entry>("00000011011", -15), make_vlc<vlc_entry>("00000011010", 15),
-	make_vlc<vlc_entry>("00000011001", -16), make_vlc<vlc_entry>("00000011000", 16)
+	make_vlc("1", 0),
+	make_vlc("011", -1), make_vlc("010", 1),
+	make_vlc("0011", -2), make_vlc("0010", 2),
+	make_vlc("00011", -3), make_vlc("00010", 3),
+	make_vlc("0000111", -4), make_vlc("0000110", 4),
+	make_vlc("00001011", -5), make_vlc("00001010", 5),
+	make_vlc("00001001", -6), make_vlc("00001000", 6),
+	make_vlc("00000111", -7), make_vlc("00000110", 7),
+	make_vlc("0000010111", -8), make_vlc("0000010110", 8),
+	make_vlc("0000010101", -9), make_vlc("0000010100", 9),
+	make_vlc("0000010011", -10), make_vlc("0000010010", 10),
+	make_vlc("00000100011", -11), make_vlc("00000100010", 11),
+	make_vlc("00000100001", -12), make_vlc("00000100000", 12),
+	make_vlc("00000011111", -13), make_vlc("00000011110", 13),
+	make_vlc("00000011101", -14), make_vlc("00000011100", 14),
+	make_vlc("00000011011", -15), make_vlc("00000011010", 15),
+	make_vlc("00000011001", -16), make_vlc("00000011000", 16)
 };
 
 constexpr dct_vlc_entry s_dct_coefficient[] =
@@ -225,57 +225,57 @@ constexpr u8 TYPE_INTRA = 0x10;
 
 constexpr vlc_entry s_i_macroblock_type[] =
 {
-	make_vlc<vlc_entry>("1", TYPE_INTRA),
-	make_vlc<vlc_entry>("01", TYPE_QUANT | TYPE_INTRA)
+	make_vlc("1", TYPE_INTRA),
+	make_vlc("01", TYPE_QUANT | TYPE_INTRA)
 };
 
 constexpr vlc_entry s_p_macroblock_type[] =
 {
-	make_vlc<vlc_entry>("1", TYPE_FORWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("01", TYPE_PATTERN),
-	make_vlc<vlc_entry>("001", TYPE_FORWARD),
-	make_vlc<vlc_entry>("00011", TYPE_INTRA),
-	make_vlc<vlc_entry>("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("00001", TYPE_QUANT | TYPE_PATTERN),
-	make_vlc<vlc_entry>("000001", TYPE_QUANT | TYPE_INTRA)
+	make_vlc("1", TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc("01", TYPE_PATTERN),
+	make_vlc("001", TYPE_FORWARD),
+	make_vlc("00011", TYPE_INTRA),
+	make_vlc("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc("00001", TYPE_QUANT | TYPE_PATTERN),
+	make_vlc("000001", TYPE_QUANT | TYPE_INTRA)
 };
 
 constexpr vlc_entry s_b_macroblock_type[] =
 {
-	make_vlc<vlc_entry>("10", TYPE_FORWARD | TYPE_BACKWARD),
-	make_vlc<vlc_entry>("11", TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("010", TYPE_BACKWARD),
-	make_vlc<vlc_entry>("011", TYPE_BACKWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("0010", TYPE_FORWARD),
-	make_vlc<vlc_entry>("0011", TYPE_FORWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("00011", TYPE_INTRA),
-	make_vlc<vlc_entry>("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("000011", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("000010", TYPE_QUANT | TYPE_BACKWARD | TYPE_PATTERN),
-	make_vlc<vlc_entry>("000001", TYPE_QUANT | TYPE_INTRA)
+	make_vlc("10", TYPE_FORWARD | TYPE_BACKWARD),
+	make_vlc("11", TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc("010", TYPE_BACKWARD),
+	make_vlc("011", TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc("0010", TYPE_FORWARD),
+	make_vlc("0011", TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc("00011", TYPE_INTRA),
+	make_vlc("00010", TYPE_QUANT | TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc("000011", TYPE_QUANT | TYPE_FORWARD | TYPE_PATTERN),
+	make_vlc("000010", TYPE_QUANT | TYPE_BACKWARD | TYPE_PATTERN),
+	make_vlc("000001", TYPE_QUANT | TYPE_INTRA)
 };
 
 constexpr vlc_entry s_d_macroblock_type[] =
 {
-	make_vlc<vlc_entry>("1", TYPE_INTRA)
+	make_vlc("1", TYPE_INTRA)
 };
 
 constexpr vlc_entry s_dc_size_luminance[] =
 {
-	make_vlc<vlc_entry>("100", 0), make_vlc<vlc_entry>("00", 1),
-	make_vlc<vlc_entry>("01", 2), make_vlc<vlc_entry>("101", 3),
-	make_vlc<vlc_entry>("110", 4), make_vlc<vlc_entry>("1110", 5),
-	make_vlc<vlc_entry>("11110", 6), make_vlc<vlc_entry>("111110", 7),
-	make_vlc<vlc_entry>("1111110", 8)
+	make_vlc("100", 0), make_vlc("00", 1),
+	make_vlc("01", 2), make_vlc("101", 3),
+	make_vlc("110", 4), make_vlc("1110", 5),
+	make_vlc("11110", 6), make_vlc("111110", 7),
+	make_vlc("1111110", 8)
 };
 
 constexpr vlc_entry s_dc_size_chrominance[] =
 {
-	make_vlc<vlc_entry>("00", 0), make_vlc<vlc_entry>("01", 1),
-	make_vlc<vlc_entry>("10", 2), make_vlc<vlc_entry>("110", 3),
-	make_vlc<vlc_entry>("1110", 4), make_vlc<vlc_entry>("11110", 5),
-	make_vlc<vlc_entry>("111110", 6), make_vlc<vlc_entry>("1111110", 7),
-	make_vlc<vlc_entry>("11111110", 8)
+	make_vlc("00", 0), make_vlc("01", 1),
+	make_vlc("10", 2), make_vlc("110", 3),
+	make_vlc("1110", 4), make_vlc("11110", 5),
+	make_vlc("111110", 6), make_vlc("1111110", 7),
+	make_vlc("11111110", 8)
 };
 
 template <typename T, std::size_t N, unsigned MaxBits>

--- a/src/devices/video/mpeg_video.cpp
+++ b/src/devices/video/mpeg_video.cpp
@@ -32,14 +32,14 @@
 #include <cmath>
 #include <numbers>
 
-struct vlc_entry
+struct mpeg_video::vlc_entry
 {
 	u32 code;
 	u8 bits;
 	int value;
 };
 
-struct dct_vlc_entry
+struct mpeg_video::dct_vlc_entry
 {
 	u32 code;
 	u8 bits;
@@ -48,7 +48,7 @@ struct dct_vlc_entry
 };
 
 template <std::size_t N>
-constexpr vlc_entry make_vlc(const char (&text)[N], int value)
+constexpr mpeg_video::vlc_entry mpeg_video::make_vlc(const char (&text)[N], int value)
 {
 	u32 code = 0;
 	for (unsigned i = 0; i != (N - 1); i++)
@@ -57,7 +57,7 @@ constexpr vlc_entry make_vlc(const char (&text)[N], int value)
 }
 
 template <std::size_t N>
-constexpr dct_vlc_entry make_dct_vlc(const char (&text)[N], unsigned run, unsigned level)
+constexpr mpeg_video::dct_vlc_entry mpeg_video::make_dct_vlc(const char (&text)[N], unsigned run, unsigned level)
 {
 	u32 code = 0;
 	for (unsigned i = 0; i != (N - 1); i++)
@@ -65,7 +65,7 @@ constexpr dct_vlc_entry make_dct_vlc(const char (&text)[N], unsigned run, unsign
 	return dct_vlc_entry{ code, u8(N - 1), u8(run), u8(level) };
 }
 
-constexpr vlc_entry s_macroblock_address_increment[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_macroblock_address_increment[33] =
 {
 	make_vlc("1", 1),
 	make_vlc("011", 2),
@@ -102,7 +102,7 @@ constexpr vlc_entry s_macroblock_address_increment[] =
 	make_vlc("00000011000", 33)
 };
 
-constexpr vlc_entry s_coded_block_pattern[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_coded_block_pattern[63] =
 {
 	make_vlc("111", 60),
 	make_vlc("1101", 4), make_vlc("1100", 8),
@@ -138,7 +138,7 @@ constexpr vlc_entry s_coded_block_pattern[] =
 	make_vlc("000000011", 27), make_vlc("000000010", 39)
 };
 
-constexpr vlc_entry s_motion_code[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_motion_code[33] =
 {
 	make_vlc("1", 0),
 	make_vlc("011", -1), make_vlc("010", 1),
@@ -159,7 +159,7 @@ constexpr vlc_entry s_motion_code[] =
 	make_vlc("00000011001", -16), make_vlc("00000011000", 16)
 };
 
-constexpr dct_vlc_entry s_dct_coefficient[] =
+constexpr mpeg_video::dct_vlc_entry mpeg_video::s_dct_coefficient[110] =
 {
 	make_dct_vlc("011", 1, 1), make_dct_vlc("0100", 0, 2), make_dct_vlc("0101", 2, 1),
 	make_dct_vlc("00101", 0, 3), make_dct_vlc("00111", 3, 1), make_dct_vlc("00110", 4, 1),
@@ -217,19 +217,13 @@ constexpr dct_vlc_entry s_dct_coefficient[] =
 	make_dct_vlc("0000000000011100", 30, 1), make_dct_vlc("0000000000011011", 31, 1)
 };
 
-constexpr u8 TYPE_QUANT = 0x01;
-constexpr u8 TYPE_FORWARD = 0x02;
-constexpr u8 TYPE_BACKWARD = 0x04;
-constexpr u8 TYPE_PATTERN = 0x08;
-constexpr u8 TYPE_INTRA = 0x10;
-
-constexpr vlc_entry s_i_macroblock_type[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_i_macroblock_type[2] =
 {
 	make_vlc("1", TYPE_INTRA),
 	make_vlc("01", TYPE_QUANT | TYPE_INTRA)
 };
 
-constexpr vlc_entry s_p_macroblock_type[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_p_macroblock_type[7] =
 {
 	make_vlc("1", TYPE_FORWARD | TYPE_PATTERN),
 	make_vlc("01", TYPE_PATTERN),
@@ -240,7 +234,7 @@ constexpr vlc_entry s_p_macroblock_type[] =
 	make_vlc("000001", TYPE_QUANT | TYPE_INTRA)
 };
 
-constexpr vlc_entry s_b_macroblock_type[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_b_macroblock_type[11] =
 {
 	make_vlc("10", TYPE_FORWARD | TYPE_BACKWARD),
 	make_vlc("11", TYPE_FORWARD | TYPE_BACKWARD | TYPE_PATTERN),
@@ -255,12 +249,12 @@ constexpr vlc_entry s_b_macroblock_type[] =
 	make_vlc("000001", TYPE_QUANT | TYPE_INTRA)
 };
 
-constexpr vlc_entry s_d_macroblock_type[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_d_macroblock_type[1] =
 {
 	make_vlc("1", TYPE_INTRA)
 };
 
-constexpr vlc_entry s_dc_size_luminance[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_dc_size_luminance[9] =
 {
 	make_vlc("100", 0), make_vlc("00", 1),
 	make_vlc("01", 2), make_vlc("101", 3),
@@ -269,7 +263,7 @@ constexpr vlc_entry s_dc_size_luminance[] =
 	make_vlc("1111110", 8)
 };
 
-constexpr vlc_entry s_dc_size_chrominance[] =
+constexpr mpeg_video::vlc_entry mpeg_video::s_dc_size_chrominance[9] =
 {
 	make_vlc("00", 0), make_vlc("01", 1),
 	make_vlc("10", 2), make_vlc("110", 3),
@@ -279,7 +273,7 @@ constexpr vlc_entry s_dc_size_chrominance[] =
 };
 
 template <typename T, std::size_t N, unsigned MaxBits>
-class vlc_decoder
+class mpeg_video::vlc_decoder
 {
 public:
 	struct match
@@ -339,24 +333,24 @@ private:
 };
 
 template <unsigned MaxBits, typename T, std::size_t N>
-constexpr auto make_vlc_decoder(const T (&table)[N])
+constexpr auto mpeg_video::make_vlc_decoder(const T (&table)[N])
 {
 	return vlc_decoder<T, N, MaxBits>(table);
 }
 
-constexpr auto s_macroblock_address_increment_decoder = make_vlc_decoder<11>(s_macroblock_address_increment);
-constexpr auto s_coded_block_pattern_decoder = make_vlc_decoder<9>(s_coded_block_pattern);
-constexpr auto s_motion_code_decoder = make_vlc_decoder<11>(s_motion_code);
-constexpr auto s_dct_coefficient_decoder = make_vlc_decoder<16>(s_dct_coefficient);
-constexpr auto s_i_macroblock_type_decoder = make_vlc_decoder<2>(s_i_macroblock_type);
-constexpr auto s_p_macroblock_type_decoder = make_vlc_decoder<6>(s_p_macroblock_type);
-constexpr auto s_b_macroblock_type_decoder = make_vlc_decoder<6>(s_b_macroblock_type);
-constexpr auto s_d_macroblock_type_decoder = make_vlc_decoder<1>(s_d_macroblock_type);
-constexpr auto s_dc_size_luminance_decoder = make_vlc_decoder<7>(s_dc_size_luminance);
-constexpr auto s_dc_size_chrominance_decoder = make_vlc_decoder<8>(s_dc_size_chrominance);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 33, 11> mpeg_video::s_macroblock_address_increment_decoder = make_vlc_decoder<11>(s_macroblock_address_increment);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 63, 9> mpeg_video::s_coded_block_pattern_decoder = make_vlc_decoder<9>(s_coded_block_pattern);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 33, 11> mpeg_video::s_motion_code_decoder = make_vlc_decoder<11>(s_motion_code);
+constexpr mpeg_video::vlc_decoder<mpeg_video::dct_vlc_entry, 110, 16> mpeg_video::s_dct_coefficient_decoder = make_vlc_decoder<16>(s_dct_coefficient);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 2, 2> mpeg_video::s_i_macroblock_type_decoder = make_vlc_decoder<2>(s_i_macroblock_type);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 7, 6> mpeg_video::s_p_macroblock_type_decoder = make_vlc_decoder<6>(s_p_macroblock_type);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 11, 6> mpeg_video::s_b_macroblock_type_decoder = make_vlc_decoder<6>(s_b_macroblock_type);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 1, 1> mpeg_video::s_d_macroblock_type_decoder = make_vlc_decoder<1>(s_d_macroblock_type);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 9, 7> mpeg_video::s_dc_size_luminance_decoder = make_vlc_decoder<7>(s_dc_size_luminance);
+constexpr mpeg_video::vlc_decoder<mpeg_video::vlc_entry, 9, 8> mpeg_video::s_dc_size_chrominance_decoder = make_vlc_decoder<8>(s_dc_size_chrominance);
 
 template <typename T, std::size_t N, unsigned MaxBits, typename P, typename S>
-const T *decode_vlc(const T (&table)[N], const vlc_decoder<T, N, MaxBits> &decoder,
+const T *mpeg_video::decode_vlc(const T (&table)[N], const vlc_decoder<T, N, MaxBits> &decoder,
 		int available, P &&peek, S &&skip)
 {
 	const unsigned lookahead = std::min<unsigned>(decoder.max_bits(), std::max(available, 0));

--- a/src/devices/video/mpeg_video.cpp
+++ b/src/devices/video/mpeg_video.cpp
@@ -367,7 +367,7 @@ const T *mpeg_video::decode_vlc(const T (&table)[N], const vlc_decoder<T, N, Max
 	return nullptr;
 }
 
-const u8 mpeg_video::s_default_intra_quantizer_matrix[64] =
+constexpr u8 mpeg_video::s_default_intra_quantizer_matrix[64] =
 {
 	8, 16, 19, 22, 26, 27, 29, 34,
 	16, 16, 22, 24, 27, 29, 34, 37,
@@ -380,7 +380,7 @@ const u8 mpeg_video::s_default_intra_quantizer_matrix[64] =
 };
 
 // ISO/IEC 11172-2 Table 2.4.4.1, indexed by natural coefficient position.
-const u8 mpeg_video::s_scan[64] =
+constexpr u8 mpeg_video::s_scan[64] =
 {
 	0, 1, 5, 6, 14, 15, 27, 28,
 	2, 4, 7, 13, 16, 26, 29, 42,
@@ -392,15 +392,14 @@ const u8 mpeg_video::s_scan[64] =
 	35, 36, 48, 49, 57, 58, 62, 63
 };
 
-const double mpeg_video::s_picture_rates[16] =
+constexpr double mpeg_video::s_picture_rates[16] =
 {
 	0.0, 24'000.0 / 1'001.0, 24.0, 25.0,
 	30'000.0 / 1'001.0, 30.0, 50.0, 60'000.0 / 1'001.0,
 	60.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 };
 
-mpeg_video::mpeg_video(const void *base, int maximum_width, int maximum_height) :
-	m_base(reinterpret_cast<const u8 *>(base)),
+mpeg_video::mpeg_video(int maximum_width, int maximum_height) :
 	m_maximum_width(maximum_width),
 	m_maximum_height(maximum_height)
 {
@@ -433,8 +432,17 @@ mpeg_video::mpeg_video(const void *base, int maximum_width, int maximum_height) 
 
 void mpeg_video::clear()
 {
+	std::fill(std::begin(m_input_buffer), std::end(m_input_buffer), 0);
+	m_input_bytes = 0;
 	m_current_pos = 0;
-	m_current_limit = 0;
+	m_phase = SCAN;
+	m_in_picture = false;
+	m_have_slice = false;
+	m_first_in_slice = false;
+	m_slice_vertical_position = 0;
+	m_address_increment = 0;
+	m_input = {};
+	m_consumed = 0;
 	m_horizontal_size = 0;
 	m_vertical_size = 0;
 	m_mb_width = 0;
@@ -461,10 +469,25 @@ void mpeg_video::clear()
 	m_backward_vertical_previous = 0;
 	m_previous_b_forward = false;
 	m_previous_b_backward = false;
+	for (frame *const item : { &m_current_frame, &m_forward_reference, &m_backward_reference })
+	{
+		std::fill(item->y.begin(), item->y.end(), 0);
+		std::fill(item->cb.begin(), item->cb.end(), 0);
+		std::fill(item->cr.begin(), item->cr.end(), 0);
+	}
 }
 
 void mpeg_video::register_save_state(device_t &device, int index)
 {
+	device.save_item(m_input_buffer, "mpeg_video_input_buffer", index);
+	device.save_item(m_input_bytes, "mpeg_video_input_bytes", index);
+	device.save_item(m_current_pos, "mpeg_video_current_pos", index);
+	device.save_item(m_phase, "mpeg_video_phase", index);
+	device.save_item(m_in_picture, "mpeg_video_in_picture", index);
+	device.save_item(m_have_slice, "mpeg_video_have_slice", index);
+	device.save_item(m_first_in_slice, "mpeg_video_first_in_slice", index);
+	device.save_item(m_slice_vertical_position, "mpeg_video_slice_vertical_position", index);
+	device.save_item(m_address_increment, "mpeg_video_address_increment", index);
 	device.save_item(m_horizontal_size, "mpeg_video_horizontal_size", index);
 	device.save_item(m_vertical_size, "mpeg_video_vertical_size", index);
 	device.save_item(m_mb_width, "mpeg_video_mb_width", index);
@@ -474,90 +497,206 @@ void mpeg_video::register_save_state(device_t &device, int index)
 	device.save_item(m_frame_rate, "mpeg_video_frame_rate", index);
 	device.save_item(m_intra_quantizer_matrix, "mpeg_video_intra_quantizer_matrix", index);
 	device.save_item(m_non_intra_quantizer_matrix, "mpeg_video_non_intra_quantizer_matrix", index);
+	device.save_item(m_picture_coding_type, "mpeg_video_picture_coding_type", index);
+	device.save_item(m_full_pel_forward_vector, "mpeg_video_full_pel_forward_vector", index);
+	device.save_item(m_full_pel_backward_vector, "mpeg_video_full_pel_backward_vector", index);
+	device.save_item(m_forward_f, "mpeg_video_forward_f", index);
+	device.save_item(m_backward_f, "mpeg_video_backward_f", index);
+	device.save_item(m_quantizer_scale, "mpeg_video_quantizer_scale", index);
+	device.save_item(m_macroblock_address, "mpeg_video_macroblock_address", index);
+	device.save_item(m_dc_predictor, "mpeg_video_dc_predictor", index);
+	device.save_item(m_forward_horizontal_previous, "mpeg_video_forward_horizontal_previous", index);
+	device.save_item(m_forward_vertical_previous, "mpeg_video_forward_vertical_previous", index);
+	device.save_item(m_backward_horizontal_previous, "mpeg_video_backward_horizontal_previous", index);
+	device.save_item(m_backward_vertical_previous, "mpeg_video_backward_vertical_previous", index);
+	device.save_item(m_previous_b_forward, "mpeg_video_previous_b_forward", index);
+	device.save_item(m_previous_b_backward, "mpeg_video_previous_b_backward", index);
+	device.save_item(m_current_frame.y, "mpeg_video_current_y", index);
+	device.save_item(m_current_frame.cb, "mpeg_video_current_cb", index);
+	device.save_item(m_current_frame.cr, "mpeg_video_current_cr", index);
+	device.save_item(m_forward_reference.y, "mpeg_video_forward_y", index);
+	device.save_item(m_forward_reference.cb, "mpeg_video_forward_cb", index);
+	device.save_item(m_forward_reference.cr, "mpeg_video_forward_cr", index);
+	device.save_item(m_backward_reference.y, "mpeg_video_backward_y", index);
+	device.save_item(m_backward_reference.cb, "mpeg_video_backward_cb", index);
+	device.save_item(m_backward_reference.cr, "mpeg_video_backward_cr", index);
 }
 
-mpeg_video::decode_result mpeg_video::decode_buffer(int &pos, int limit, const picture_buffers &buffers,
+mpeg_video::decode_result mpeg_video::decode(std::span<const u8> input, std::size_t &consumed, const picture_buffers &buffers,
 		int &width, int &height, double &frame_rate)
 {
-	if ((limit - pos) < 32)
-		return decode_result::NEED_DATA;
+	m_input = input;
+	m_consumed = 0;
+	auto const finish = [this, &consumed] (decode_result result)
+	{
+		discard_consumed_bytes();
+		consumed = m_consumed;
+		m_input = {};
+		m_consumed = 0;
+		return result;
+	};
 
-	int scan_position = pos;
 	for (;;)
 	{
-		m_current_pos = scan_position;
-		m_current_limit = limit;
-		int syntax_position = scan_position;
-
+		const u32 checkpoint = m_current_pos;
 		try
 		{
-			next_start_code();
-			syntax_position = m_current_pos;
-			const u32 code = peek(32);
-
-			switch (code)
+			switch (m_phase)
 			{
-			case SEQUENCE_HEADER_CODE:
-				sequence_header();
-				break;
+			case SCAN:
+			case RECOVER:
+			{
+				if (m_current_pos & 7)
+				{
+					const u32 padding = gb(8 - (m_current_pos & 7));
+					if (padding && (m_phase != RECOVER))
+						throw invalid_stream();
+					break;
+				}
+				if (peek(24) != START_CODE_PREFIX)
+				{
+					gb(8);
+					break;
+				}
+				const u32 code = peek(32);
+				if (m_in_picture)
+				{
+					if ((code >= 0x00000101) && (code <= 0x000001af))
+					{
+						gb(32);
+						m_slice_vertical_position = code;
+						m_phase = SLICE_HEADER;
+						break;
+					}
+					if (!m_have_slice && ((code == USER_DATA_START_CODE) || (code == EXTENSION_START_CODE)))
+					{
+						gb(32);
+						break;
+					}
+					if (!m_have_slice)
+						throw invalid_stream();
+					write_frame(m_current_frame, buffers.reconstructed.data, buffers.reconstructed.bytes);
+					m_in_picture = false;
+					// A sequence-end marker completes this task, rather than starting another.
+					if (code == SEQUENCE_END_CODE)
+						gb(32);
+					width = m_horizontal_size;
+					height = m_vertical_size;
+					frame_rate = m_frame_rate;
+					return finish(decode_result::PICTURE);
+				}
 
-			case GROUP_START_CODE:
-				group_of_pictures();
-				break;
-
-			case PICTURE_START_CODE:
-				picture(buffers);
-				// A sequence-end code terminates the preceding coded sequence rather than
-				// describing another decoding task.
-				if (peek(32) == SEQUENCE_END_CODE)
-					gb(32);
-				pos = m_current_pos;
-				width = m_horizontal_size;
-				height = m_vertical_size;
-				frame_rate = m_frame_rate;
-				return decode_result::PICTURE;
-
-			case SEQUENCE_END_CODE:
 				gb(32);
-				pos = m_current_pos;
-				width = m_horizontal_size;
-				height = m_vertical_size;
-				frame_rate = m_frame_rate;
-				return decode_result::SEQUENCE_END;
-
-			default:
-				// Extension, user and system data are delimited by the next start code.
-				gb(32);
+				m_phase = SCAN;
+				switch (code)
+				{
+				case SEQUENCE_HEADER_CODE: m_phase = SEQUENCE_HEADER; break;
+				case GROUP_START_CODE: m_phase = GROUP_HEADER; break;
+				case PICTURE_START_CODE: m_phase = PICTURE_HEADER; break;
+				case SEQUENCE_END_CODE:
+					width = m_horizontal_size;
+					height = m_vertical_size;
+					frame_rate = m_frame_rate;
+					return finish(decode_result::SEQUENCE_END);
+				}
 				break;
 			}
 
-			scan_position = m_current_pos;
+			case SEQUENCE_HEADER:
+				sequence_header();
+				m_phase = SCAN;
+				break;
+
+			case GROUP_HEADER:
+				group_of_pictures();
+				m_phase = SCAN;
+				break;
+
+			case PICTURE_HEADER:
+				picture_header(buffers);
+				m_in_picture = true;
+				m_have_slice = false;
+				m_phase = PICTURE_EXTRA;
+				break;
+
+			case PICTURE_EXTRA:
+			case SLICE_EXTRA:
+				if (gb(1))
+					gb(8);
+				else
+					m_phase = (m_phase == PICTURE_EXTRA) ? SCAN : MACROBLOCK_ADDRESS;
+				break;
+
+			case SLICE_HEADER:
+				slice_header();
+				m_have_slice = true;
+				m_phase = SLICE_EXTRA;
+				break;
+
+			case MACROBLOCK_ADDRESS:
+				// Consume stuffing and escapes separately, so even long runs do not
+				// require unbounded input retention or replay.
+				if (peek(11) == 0x00f)
+				{
+					gb(11);
+					break;
+				}
+				if (peek(11) == 0x008)
+				{
+					gb(11);
+					m_address_increment += 33;
+					if ((m_macroblock_address + m_address_increment) >= (m_mb_width * m_mb_height))
+						throw invalid_stream();
+					break;
+				}
+				{
+					const int address = m_macroblock_address + m_address_increment + macroblock_address_increment();
+					if ((address < 0) || (address >= (m_mb_width * m_mb_height)))
+						throw invalid_stream();
+					if (!m_first_in_slice)
+					{
+						for (int skipped = m_macroblock_address + 1; skipped < address; skipped++)
+							skipped_macroblock(skipped);
+					}
+					m_macroblock_address = address;
+					m_address_increment = 0;
+					m_phase = MACROBLOCK;
+				}
+				break;
+
+			case MACROBLOCK:
+				macroblock();
+				m_first_in_slice = false;
+				m_phase = MACROBLOCK_END;
+				break;
+
+			case MACROBLOCK_END:
+				m_phase = (peek(23) == 0) ? SCAN : MACROBLOCK_ADDRESS;
+				break;
+			}
+			discard_consumed_bytes();
 		}
 		catch (limit_hit const &)
 		{
-			pos = syntax_position;
-			return decode_result::NEED_DATA;
+			m_current_pos = checkpoint;
+			return finish(decode_result::NEED_DATA);
 		}
 		catch (invalid_stream const &)
 		{
-			// Skip the failed syntax element and resume at the next start code.
-			int recovery_position = std::max(syntax_position + 8, (m_current_pos + 7) & ~7);
-			while ((recovery_position + 24) <= limit)
-			{
-				const unsigned byte_position = recovery_position / 8;
-				if (!m_base[byte_position] && !m_base[byte_position + 1] && (m_base[byte_position + 2] == 1))
-					break;
-				recovery_position += 8;
-			}
-			pos = std::min(recovery_position, limit);
-			return decode_result::INVALID_DATA;
+			// Discard the partial picture, then search forward at byte boundaries.
+			// Scanning itself can stop on any input byte and retains prefix lookahead.
+			m_in_picture = false;
+			m_have_slice = false;
+			m_phase = RECOVER;
+			if (m_current_pos == checkpoint)
+				m_current_pos = std::min(m_current_pos + 8, m_input_bytes * 8);
+			return finish(decode_result::INVALID_DATA);
 		}
 	}
 }
 
 void mpeg_video::sequence_header()
 {
-	gb(32);
 	const int horizontal_size = gb(12);
 	const int vertical_size = gb(12);
 	gb(4); // pel aspect ratio
@@ -612,13 +751,6 @@ void mpeg_video::sequence_header()
 		!s_picture_rates[picture_rate])
 		throw invalid_stream();
 
-	next_start_code();
-	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
-	{
-		gb(32);
-		next_start_code();
-	}
-
 	m_horizontal_size = horizontal_size;
 	m_vertical_size = vertical_size;
 	m_frame_rate = s_picture_rates[picture_rate];
@@ -632,7 +764,6 @@ void mpeg_video::sequence_header()
 
 void mpeg_video::group_of_pictures()
 {
-	gb(32);
 	gb(1); // drop frame flag
 	const unsigned hours = gb(5);
 	const unsigned minutes = gb(6);
@@ -644,77 +775,52 @@ void mpeg_video::group_of_pictures()
 		throw invalid_stream();
 	gb(1); // closed GOP
 	gb(1); // broken link
-	next_start_code();
-
-	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
-	{
-		gb(32);
-		next_start_code();
-	}
 }
 
-void mpeg_video::picture(const picture_buffers &buffers)
+void mpeg_video::picture_header(const picture_buffers &buffers)
 {
 	if (!m_horizontal_size || !m_vertical_size)
 		throw invalid_stream();
 
-	gb(32);
 	gb(10); // temporal reference
-	m_picture_coding_type = gb(3);
+	const int picture_coding_type = gb(3);
 	gb(16); // VBV delay
 
-	m_full_pel_forward_vector = false;
-	m_full_pel_backward_vector = false;
-	m_forward_f = 0;
-	m_backward_f = 0;
-	if ((m_picture_coding_type == 2) || (m_picture_coding_type == 3))
+	bool full_pel_forward_vector = false;
+	bool full_pel_backward_vector = false;
+	int forward_f = 0;
+	int backward_f = 0;
+	if ((picture_coding_type == 2) || (picture_coding_type == 3))
 	{
-		m_full_pel_forward_vector = gb(1);
+		full_pel_forward_vector = gb(1);
 		const int forward_f_code = gb(3);
 		if (!forward_f_code)
 			throw invalid_stream();
-		m_forward_f = 1 << (forward_f_code - 1);
+		forward_f = 1 << (forward_f_code - 1);
 	}
-	if (m_picture_coding_type == 3)
+	if (picture_coding_type == 3)
 	{
-		m_full_pel_backward_vector = gb(1);
+		full_pel_backward_vector = gb(1);
 		const int backward_f_code = gb(3);
 		if (!backward_f_code)
 			throw invalid_stream();
-		m_backward_f = 1 << (backward_f_code - 1);
+		backward_f = 1 << (backward_f_code - 1);
 	}
-	if ((m_picture_coding_type < 1) || (m_picture_coding_type > 4))
+	if ((picture_coding_type < 1) || (picture_coding_type > 4))
 		throw invalid_stream();
 
+	m_picture_coding_type = picture_coding_type;
+	m_full_pel_forward_vector = full_pel_forward_vector;
+	m_full_pel_backward_vector = full_pel_backward_vector;
+	m_forward_f = forward_f;
+	m_backward_f = backward_f;
 	if ((m_picture_coding_type == 2) || (m_picture_coding_type == 3))
 		read_frame(m_forward_reference, buffers.forward.data, buffers.forward.bytes);
 	if (m_picture_coding_type == 3)
 		read_frame(m_backward_reference, buffers.backward.data, buffers.backward.bytes);
 
-	while (gb(1))
-		gb(8);
-	next_start_code();
-
-	while ((peek(32) == EXTENSION_START_CODE) || (peek(32) == USER_DATA_START_CODE))
-	{
-		gb(32);
-		next_start_code();
-	}
-
 	// Macroblocks not reconstructed by the task retain their previous contents in RFP.
 	read_frame(m_current_frame, buffers.reconstructed.data, buffers.reconstructed.bytes);
-
-	bool have_slice = false;
-	while ((peek(32) >= 0x00000101) && (peek(32) <= 0x000001af))
-	{
-		const unsigned vertical_position = peek(32) & 0xff;
-		slice(vertical_position);
-		have_slice = true;
-	}
-	if (!have_slice)
-		throw invalid_stream();
-
-	write_frame(m_current_frame, buffers.reconstructed.data, buffers.reconstructed.bytes);
 }
 
 void mpeg_video::reset_dc_predictors()
@@ -722,16 +828,14 @@ void mpeg_video::reset_dc_predictors()
 	std::fill(std::begin(m_dc_predictor), std::end(m_dc_predictor), 128 * 8);
 }
 
-void mpeg_video::slice(unsigned vertical_position)
+void mpeg_video::slice_header()
 {
-	gb(32);
-	m_quantizer_scale = gb(5);
-	if (!m_quantizer_scale)
+	const int quantizer_scale = gb(5);
+	if (!quantizer_scale)
 		throw invalid_stream();
-	while (gb(1))
-		gb(8);
 
-	m_macroblock_address = (vertical_position - 1) * m_mb_width - 1;
+	m_quantizer_scale = quantizer_scale;
+	m_macroblock_address = (m_slice_vertical_position - 1) * m_mb_width - 1;
 	reset_dc_predictors();
 	m_forward_horizontal_previous = 0;
 	m_forward_vertical_previous = 0;
@@ -740,69 +844,84 @@ void mpeg_video::slice(unsigned vertical_position)
 	m_previous_b_forward = false;
 	m_previous_b_backward = false;
 
-	bool first_in_slice = true;
-	do
-	{
-		macroblock(first_in_slice);
-		first_in_slice = false;
-	}
-	while (peek(23) != 0);
-
-	next_start_code();
+	m_first_in_slice = true;
+	m_address_increment = 0;
 }
 
-void mpeg_video::macroblock(bool first_in_slice)
+void mpeg_video::macroblock()
 {
-	const int increment = macroblock_address_increment();
-	const int address = m_macroblock_address + increment;
-	if ((address < 0) || (address >= (m_mb_width * m_mb_height)))
-		throw invalid_stream();
-
-	if (!first_in_slice)
+	const int quantizer_scale = m_quantizer_scale;
+	const int previous[4] =
 	{
-		for (int skipped = m_macroblock_address + 1; skipped < address; skipped++)
-			skipped_macroblock(skipped);
-	}
-	m_macroblock_address = address;
-
-	const macroblock_type type = macroblock_type_code();
-	if (type.quant)
-	{
-		m_quantizer_scale = gb(5);
-		if (!m_quantizer_scale)
-			throw invalid_stream();
-	}
-
+		m_forward_horizontal_previous, m_forward_vertical_previous,
+		m_backward_horizontal_previous, m_backward_vertical_previous
+	};
+	macroblock_type type;
 	motion_vector forward_vector{ 0, 0 };
 	motion_vector backward_vector{ 0, 0 };
+	int pattern;
+	int quantized[6][64]{};
 
-	if (m_picture_coding_type == 2)
+	// Input may stop inside any VLC or coefficient escape.  Stage a single
+	// macroblock before modifying pixels or DC predictors, so only its bounded
+	// syntax is retried and completed macroblocks are never reconstructed twice.
+	try
 	{
-		if (type.forward)
-			decode_motion_vector(true, forward_vector);
-		else
+		type = macroblock_type_code();
+		if (type.quant)
 		{
-			m_forward_horizontal_previous = 0;
-			m_forward_vertical_previous = 0;
+			m_quantizer_scale = gb(5);
+			if (!m_quantizer_scale)
+				throw invalid_stream();
 		}
+
+		if (m_picture_coding_type == 2)
+		{
+			if (type.forward)
+				decode_motion_vector(true, forward_vector);
+			else
+			{
+				m_forward_horizontal_previous = 0;
+				m_forward_vertical_previous = 0;
+			}
+		}
+		else if (m_picture_coding_type == 3)
+		{
+			if (type.forward)
+				decode_motion_vector(true, forward_vector);
+			else
+			{
+				forward_vector.horizontal = m_forward_horizontal_previous * (m_full_pel_forward_vector ? 2 : 1);
+				forward_vector.vertical = m_forward_vertical_previous * (m_full_pel_forward_vector ? 2 : 1);
+			}
+
+			if (type.backward)
+				decode_motion_vector(false, backward_vector);
+			else
+			{
+				backward_vector.horizontal = m_backward_horizontal_previous * (m_full_pel_backward_vector ? 2 : 1);
+				backward_vector.vertical = m_backward_vertical_previous * (m_full_pel_backward_vector ? 2 : 1);
+			}
+		}
+
+		pattern = type.intra ? 0x3f : (type.pattern ? coded_block_pattern() : 0);
+		for (unsigned index = 0; index != 6; index++)
+		{
+			if (BIT(pattern, 5 - index))
+				block(index, type.intra, quantized[index]);
+		}
+
+		if ((m_picture_coding_type == 4) && (gb(1) != 1))
+			throw invalid_stream();
 	}
-	else if (m_picture_coding_type == 3)
+	catch (limit_hit const &)
 	{
-		if (type.forward)
-			decode_motion_vector(true, forward_vector);
-		else
-		{
-			forward_vector.horizontal = m_forward_horizontal_previous * (m_full_pel_forward_vector ? 2 : 1);
-			forward_vector.vertical = m_forward_vertical_previous * (m_full_pel_forward_vector ? 2 : 1);
-		}
-
-		if (type.backward)
-			decode_motion_vector(false, backward_vector);
-		else
-		{
-			backward_vector.horizontal = m_backward_horizontal_previous * (m_full_pel_backward_vector ? 2 : 1);
-			backward_vector.vertical = m_backward_vertical_previous * (m_full_pel_backward_vector ? 2 : 1);
-		}
+		m_quantizer_scale = quantizer_scale;
+		m_forward_horizontal_previous = previous[0];
+		m_forward_vertical_previous = previous[1];
+		m_backward_horizontal_previous = previous[2];
+		m_backward_vertical_previous = previous[3];
+		throw;
 	}
 
 	if (!type.intra)
@@ -811,18 +930,10 @@ void mpeg_video::macroblock(bool first_in_slice)
 		const bool predict_forward = (m_picture_coding_type == 2) || type.forward;
 		predict_macroblock(predict_forward, type.backward, forward_vector, backward_vector);
 	}
-
-	const int pattern = type.intra ? 0x3f : (type.pattern ? coded_block_pattern() : 0);
 	for (unsigned index = 0; index != 6; index++)
 	{
 		if (BIT(pattern, 5 - index))
-			block(index, type.intra);
-	}
-
-	if (m_picture_coding_type == 4)
-	{
-		if (gb(1) != 1)
-			throw invalid_stream();
+			reconstruct_block(index, type.intra, quantized[index]);
 	}
 
 	if (type.intra)
@@ -996,9 +1107,8 @@ void mpeg_video::predict_plane(u8 *destination, int destination_pitch, const u8 
 	}
 }
 
-void mpeg_video::block(unsigned index, bool intra)
+void mpeg_video::block(unsigned index, bool intra, int *quantized)
 {
-	int quantized[64]{};
 	int scan_position = intra ? 0 : -1;
 
 	if (intra)
@@ -1032,7 +1142,10 @@ void mpeg_video::block(unsigned index, bool intra)
 		}
 		gb(2); // end of block
 	}
+}
 
+void mpeg_video::reconstruct_block(unsigned index, bool intra, const int *quantized)
+{
 	int coefficients[64];
 	bool dc_only = true;
 	for (unsigned natural = 0; natural != 64; natural++)
@@ -1162,24 +1275,15 @@ void mpeg_video::write_frame(const frame &source, u8 *output, unsigned output_by
 
 int mpeg_video::macroblock_address_increment()
 {
-	int increment = 0;
-	while (peek(11) == 0x00f)
-		gb(11); // macroblock stuffing
-	while (peek(11) == 0x008)
-	{
-		gb(11); // macroblock escape
-		increment += 33;
-	}
-
 	const vlc_entry *const entry = decode_vlc(
 			s_macroblock_address_increment,
 			s_macroblock_address_increment_decoder,
-			m_current_limit - m_current_pos,
+			available_bits(),
 			[this] (int bits) { return peek(bits); },
 			[this] (int bits) { m_current_pos += bits; });
 	if (!entry)
 		throw invalid_stream();
-	return increment + entry->value;
+	return entry->value;
 }
 
 mpeg_video::macroblock_type mpeg_video::macroblock_type_code()
@@ -1187,7 +1291,7 @@ mpeg_video::macroblock_type mpeg_video::macroblock_type_code()
 	const vlc_entry *entry = nullptr;
 	auto const read = [this, &entry] (auto const &table, auto const &decoder)
 	{
-		entry = decode_vlc(table, decoder, m_current_limit - m_current_pos,
+		entry = decode_vlc(table, decoder, available_bits(),
 				[this] (int bits) { return peek(bits); },
 				[this] (int bits) { m_current_pos += bits; });
 	};
@@ -1218,7 +1322,7 @@ int mpeg_video::coded_block_pattern()
 	const vlc_entry *const entry = decode_vlc(
 			s_coded_block_pattern,
 			s_coded_block_pattern_decoder,
-			m_current_limit - m_current_pos,
+			available_bits(),
 			[this] (int bits) { return peek(bits); },
 			[this] (int bits) { m_current_pos += bits; });
 	if (!entry)
@@ -1231,7 +1335,7 @@ int mpeg_video::motion_code()
 	const vlc_entry *const entry = decode_vlc(
 			s_motion_code,
 			s_motion_code_decoder,
-			m_current_limit - m_current_pos,
+			available_bits(),
 			[this] (int bits) { return peek(bits); },
 			[this] (int bits) { m_current_pos += bits; });
 	if (!entry)
@@ -1243,11 +1347,11 @@ int mpeg_video::dc_size(bool luminance)
 {
 	const vlc_entry *const entry = luminance
 		? decode_vlc(s_dc_size_luminance, s_dc_size_luminance_decoder,
-				m_current_limit - m_current_pos,
+				available_bits(),
 				[this] (int bits) { return peek(bits); },
 				[this] (int bits) { m_current_pos += bits; })
 		: decode_vlc(s_dc_size_chrominance, s_dc_size_chrominance_decoder,
-				m_current_limit - m_current_pos,
+				available_bits(),
 				[this] (int bits) { return peek(bits); },
 				[this] (int bits) { m_current_pos += bits; });
 	if (!entry)
@@ -1300,7 +1404,7 @@ void mpeg_video::dct_coefficient(bool first, int &run, int &level)
 	const dct_vlc_entry *const entry = decode_vlc(
 			s_dct_coefficient,
 			s_dct_coefficient_decoder,
-			m_current_limit - m_current_pos,
+			available_bits(),
 			[this] (int bits) { return peek(bits); },
 			[this] (int bits) { m_current_pos += bits; });
 	if (entry)
@@ -1312,30 +1416,42 @@ void mpeg_video::dct_coefficient(bool first, int &run, int &level)
 	throw invalid_stream();
 }
 
-void mpeg_video::next_start_code()
+void mpeg_video::discard_consumed_bytes()
 {
-	if (m_current_pos & 7)
+	const unsigned bytes = m_current_pos / 8;
+	if (bytes)
 	{
-		if (gb(8 - (m_current_pos & 7)))
-			throw invalid_stream();
+		std::move(m_input_buffer + bytes, m_input_buffer + m_input_bytes, m_input_buffer);
+		m_input_bytes -= bytes;
+		m_current_pos &= 7;
 	}
-	while (peek(24) != START_CODE_PREFIX)
-		gb(8);
 }
 
-u32 mpeg_video::peek(int count) const
+int mpeg_video::available_bits() const
 {
-	if ((count < 0) || (count > 32) || ((m_current_pos + count) > m_current_limit))
-		throw limit_hit();
+	return m_input_bytes * 8 - m_current_pos + std::min<std::size_t>(m_input.size() - m_consumed, 4) * 8;
+}
+
+u32 mpeg_video::peek(int count)
+{
+	assert((count >= 0) && (count <= 32));
 	if (!count)
 		return 0;
+	while ((m_current_pos + count) > (m_input_bytes * 8))
+	{
+		if (m_consumed == m_input.size())
+			throw limit_hit();
+		if (m_input_bytes == INPUT_BUFFER_BYTES)
+			throw invalid_stream();
+		m_input_buffer[m_input_bytes++] = m_input[m_consumed++];
+	}
 
 	const unsigned byte_position = m_current_pos / 8;
 	const unsigned bit_offset = m_current_pos & 7;
 	const unsigned bytes = (bit_offset + count + 7) / 8;
 	u64 source = 0;
 	for (unsigned byte = 0; byte != bytes; byte++)
-		source = (source << 8) | m_base[byte_position + byte];
+		source = (source << 8) | m_input_buffer[byte_position + byte];
 	return (source >> (bytes * 8 - bit_offset - count)) & make_bitmask<u32>(count);
 }
 

--- a/src/devices/video/mpeg_video.h
+++ b/src/devices/video/mpeg_video.h
@@ -1,0 +1,175 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+/***************************************************************************
+
+    ISO/IEC 11172-2 MPEG-1 video support.
+
+    Clean-room implementation derived directly from ISO/IEC 11172-2:1993
+    and its technical corrigenda.
+
+***************************************************************************/
+
+#ifndef MAME_VIDEO_MPEG_VIDEO_H
+#define MAME_VIDEO_MPEG_VIDEO_H
+
+#pragma once
+
+class device_t;
+
+class mpeg_video
+{
+public:
+	enum class decode_result
+	{
+		PICTURE,
+		SEQUENCE_END,
+		NEED_DATA,
+		INVALID_DATA
+	};
+
+	struct picture_buffer
+	{
+		u8 *data;
+		unsigned bytes;
+	};
+
+	struct picture_buffers
+	{
+		picture_buffer reconstructed;
+		picture_buffer forward;
+		picture_buffer backward;
+	};
+
+	// base = start of the MPEG video data block
+
+	mpeg_video(const void *base, int maximum_width, int maximum_height);
+
+	// Decode one MPEG coded picture or sequence-end marker.
+	// pos          = position in bits relative to base
+	// limit        = maximum accepted position in bits
+	// buffers      = reconstructed, forward and backward YCbCr picture buffers
+	// width        = width of a completed output picture
+	// height       = height of a completed output picture
+	// frame_rate   = sequence picture rate
+	//
+	// returns PICTURE if a complete coded picture was reconstructed,
+	// SEQUENCE_END if a standalone sequence-end marker was consumed, NEED_DATA
+	// if more input is required, or INVALID_DATA if invalid syntax was skipped.
+	// pos is updated to the first unconsumed bit.
+
+	decode_result decode_buffer(int &pos, int limit, const picture_buffers &buffers,
+						int &width, int &height, double &frame_rate);
+
+	// Clear persistent decoding state.
+	void clear();
+
+	// Register persistent decoding state with an owning device.
+	void register_save_state(device_t &device, int index = 0);
+
+private:
+	struct limit_hit { };
+
+	struct invalid_stream { };
+
+	struct frame
+	{
+		std::vector<u8> y;
+		std::vector<u8> cb;
+		std::vector<u8> cr;
+	};
+
+	struct macroblock_type
+	{
+		bool quant;
+		bool forward;
+		bool backward;
+		bool pattern;
+		bool intra;
+	};
+
+	struct motion_vector
+	{
+		int horizontal;
+		int vertical;
+	};
+
+	static constexpr u32 PICTURE_START_CODE = 0x00000100;
+	static constexpr u32 USER_DATA_START_CODE = 0x000001b2;
+	static constexpr u32 SEQUENCE_HEADER_CODE = 0x000001b3;
+	static constexpr u32 EXTENSION_START_CODE = 0x000001b5;
+	static constexpr u32 SEQUENCE_END_CODE = 0x000001b7;
+	static constexpr u32 GROUP_START_CODE = 0x000001b8;
+	static constexpr u32 START_CODE_PREFIX = 0x000001;
+
+	static const u8 s_default_intra_quantizer_matrix[64];
+	static const u8 s_scan[64];
+	static const double s_picture_rates[16];
+
+	const u8 *m_base;
+	int m_maximum_width;
+	int m_maximum_height;
+	int m_current_pos;
+	int m_current_limit;
+
+	s32 m_horizontal_size;
+	s32 m_vertical_size;
+	s32 m_mb_width;
+	s32 m_mb_height;
+	s32 m_luma_pitch;
+	s32 m_chroma_pitch;
+	double m_frame_rate;
+	u8 m_intra_quantizer_matrix[64];
+	u8 m_non_intra_quantizer_matrix[64];
+
+	int m_picture_coding_type;
+	bool m_full_pel_forward_vector;
+	bool m_full_pel_backward_vector;
+	int m_forward_f;
+	int m_backward_f;
+	int m_quantizer_scale;
+	int m_macroblock_address;
+	int m_dc_predictor[3];
+	int m_forward_horizontal_previous;
+	int m_forward_vertical_previous;
+	int m_backward_horizontal_previous;
+	int m_backward_vertical_previous;
+	bool m_previous_b_forward;
+	bool m_previous_b_backward;
+
+	frame m_current_frame;
+	frame m_forward_reference;
+	frame m_backward_reference;
+	double m_idct_basis[8][8];
+
+	void sequence_header();
+	void group_of_pictures();
+	void picture(const picture_buffers &buffers);
+	void slice(unsigned vertical_position);
+	void macroblock(bool first_in_slice);
+	void skipped_macroblock(int address);
+	void block(unsigned index, bool intra);
+
+	void reset_dc_predictors();
+	void decode_motion_vector(bool forward, motion_vector &vector);
+	static int decode_motion_component(int code, int residual, int f, int &previous, bool full_pel);
+	void predict_macroblock(bool forward, bool backward, motion_vector forward_vector, motion_vector backward_vector);
+	void predict_plane(u8 *destination, int destination_pitch, const u8 *reference, int reference_pitch,
+					int x, int y, int width, int height, motion_vector vector, bool chroma, bool average) const;
+	void put_block(unsigned index, const int *values, bool intra);
+	void inverse_dct(const int *coefficients, int *values, bool dc_only) const;
+	void read_frame(frame &destination, const u8 *source, unsigned source_bytes) const;
+	void write_frame(const frame &source, u8 *output, unsigned output_bytes) const;
+
+	int macroblock_address_increment();
+	macroblock_type macroblock_type_code();
+	int coded_block_pattern();
+	int motion_code();
+	int dc_size(bool luminance);
+	void dct_coefficient(bool first, int &run, int &level);
+
+	void next_start_code();
+	u32 peek(int count) const;
+	u32 gb(int count);
+};
+
+#endif // MAME_VIDEO_MPEG_VIDEO_H

--- a/src/devices/video/mpeg_video.h
+++ b/src/devices/video/mpeg_video.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <span>
+
 class device_t;
 
 class mpeg_video
@@ -40,13 +42,11 @@ public:
 		picture_buffer backward;
 	};
 
-	// base = start of the MPEG video data block
-
-	mpeg_video(const void *base, int maximum_width, int maximum_height);
+	mpeg_video(int maximum_width, int maximum_height) ATTR_COLD;
 
 	// Decode one MPEG coded picture or sequence-end marker.
-	// pos          = position in bits relative to base
-	// limit        = maximum accepted position in bits
+	// input        = next bytes of the elementary video stream
+	// consumed     = bytes accepted from input, which the caller may discard
 	// buffers      = reconstructed, forward and backward YCbCr picture buffers
 	// width        = width of a completed output picture
 	// height       = height of a completed output picture
@@ -55,16 +55,20 @@ public:
 	// returns PICTURE if a complete coded picture was reconstructed,
 	// SEQUENCE_END if a standalone sequence-end marker was consumed, NEED_DATA
 	// if more input is required, or INVALID_DATA if invalid syntax was skipped.
-	// pos is updated to the first unconsumed bit.
+	// Partial syntax and any accepted lookahead are retained across calls.
+	// NEED_DATA accepts all supplied bytes.  An event can consume zero bytes
+	// when its syntax was retained by a preceding call.  Keep picture buffer
+	// bindings unchanged across NEED_DATA; the references and previous
+	// reconstructed contents are sampled at the picture header.
 
-	decode_result decode_buffer(int &pos, int limit, const picture_buffers &buffers,
+	decode_result decode(std::span<const u8> input, std::size_t &consumed, const picture_buffers &buffers,
 						int &width, int &height, double &frame_rate);
 
 	// Clear persistent decoding state.
-	void clear();
+	void clear() ATTR_COLD;
 
 	// Register persistent decoding state with an owning device.
-	void register_save_state(device_t &device, int index = 0);
+	void register_save_state(device_t &device, int index = 0) ATTR_COLD;
 
 private:
 	struct vlc_entry;
@@ -74,6 +78,21 @@ private:
 	struct limit_hit { };
 
 	struct invalid_stream { };
+
+	enum : u8
+	{
+		SCAN,
+		SEQUENCE_HEADER,
+		GROUP_HEADER,
+		PICTURE_HEADER,
+		PICTURE_EXTRA,
+		SLICE_HEADER,
+		SLICE_EXTRA,
+		MACROBLOCK_ADDRESS,
+		MACROBLOCK,
+		MACROBLOCK_END,
+		RECOVER
+	};
 
 	struct frame
 	{
@@ -137,11 +156,22 @@ private:
 	static const u8 s_scan[64];
 	static const double s_picture_rates[16];
 
-	const u8 *m_base;
+	// A macroblock contains at most six blocks of 64 coefficients, with at
+	// most 28 bits per escape-coded coefficient, plus header and motion bits.
+	static constexpr unsigned INPUT_BUFFER_BYTES = (6 * 64 * 28 + 128) / 8;
+	u8 m_input_buffer[INPUT_BUFFER_BYTES];
+	u32 m_input_bytes;
+	u32 m_current_pos;
+	u8 m_phase;
+	bool m_in_picture;
+	bool m_have_slice;
+	bool m_first_in_slice;
+	u8 m_slice_vertical_position;
+	s32 m_address_increment;
+	std::span<const u8> m_input;
+	std::size_t m_consumed;
 	int m_maximum_width;
 	int m_maximum_height;
-	int m_current_pos;
-	int m_current_limit;
 
 	s32 m_horizontal_size;
 	s32 m_vertical_size;
@@ -153,18 +183,18 @@ private:
 	u8 m_intra_quantizer_matrix[64];
 	u8 m_non_intra_quantizer_matrix[64];
 
-	int m_picture_coding_type;
+	s32 m_picture_coding_type;
 	bool m_full_pel_forward_vector;
 	bool m_full_pel_backward_vector;
-	int m_forward_f;
-	int m_backward_f;
-	int m_quantizer_scale;
-	int m_macroblock_address;
-	int m_dc_predictor[3];
-	int m_forward_horizontal_previous;
-	int m_forward_vertical_previous;
-	int m_backward_horizontal_previous;
-	int m_backward_vertical_previous;
+	s32 m_forward_f;
+	s32 m_backward_f;
+	s32 m_quantizer_scale;
+	s32 m_macroblock_address;
+	s32 m_dc_predictor[3];
+	s32 m_forward_horizontal_previous;
+	s32 m_forward_vertical_previous;
+	s32 m_backward_horizontal_previous;
+	s32 m_backward_vertical_previous;
 	bool m_previous_b_forward;
 	bool m_previous_b_backward;
 
@@ -175,11 +205,12 @@ private:
 
 	void sequence_header();
 	void group_of_pictures();
-	void picture(const picture_buffers &buffers);
-	void slice(unsigned vertical_position);
-	void macroblock(bool first_in_slice);
+	void picture_header(const picture_buffers &buffers);
+	void slice_header();
+	void macroblock();
 	void skipped_macroblock(int address);
-	void block(unsigned index, bool intra);
+	void block(unsigned index, bool intra, int *quantized);
+	void reconstruct_block(unsigned index, bool intra, const int *quantized);
 
 	void reset_dc_predictors();
 	void decode_motion_vector(bool forward, motion_vector &vector);
@@ -206,8 +237,9 @@ private:
 	int dc_size(bool luminance);
 	void dct_coefficient(bool first, int &run, int &level);
 
-	void next_start_code();
-	u32 peek(int count) const;
+	void discard_consumed_bytes();
+	int available_bits() const;
+	u32 peek(int count);
 	u32 gb(int count);
 };
 

--- a/src/devices/video/mpeg_video.h
+++ b/src/devices/video/mpeg_video.h
@@ -67,6 +67,10 @@ public:
 	void register_save_state(device_t &device, int index = 0);
 
 private:
+	struct vlc_entry;
+	struct dct_vlc_entry;
+	template <typename T, std::size_t N, unsigned MaxBits> class vlc_decoder;
+
 	struct limit_hit { };
 
 	struct invalid_stream { };
@@ -100,6 +104,34 @@ private:
 	static constexpr u32 SEQUENCE_END_CODE = 0x000001b7;
 	static constexpr u32 GROUP_START_CODE = 0x000001b8;
 	static constexpr u32 START_CODE_PREFIX = 0x000001;
+
+	static constexpr u8 TYPE_QUANT = 0x01;
+	static constexpr u8 TYPE_FORWARD = 0x02;
+	static constexpr u8 TYPE_BACKWARD = 0x04;
+	static constexpr u8 TYPE_PATTERN = 0x08;
+	static constexpr u8 TYPE_INTRA = 0x10;
+
+	static const vlc_entry s_macroblock_address_increment[33];
+	static const vlc_entry s_coded_block_pattern[63];
+	static const vlc_entry s_motion_code[33];
+	static const dct_vlc_entry s_dct_coefficient[110];
+	static const vlc_entry s_i_macroblock_type[2];
+	static const vlc_entry s_p_macroblock_type[7];
+	static const vlc_entry s_b_macroblock_type[11];
+	static const vlc_entry s_d_macroblock_type[1];
+	static const vlc_entry s_dc_size_luminance[9];
+	static const vlc_entry s_dc_size_chrominance[9];
+
+	static const vlc_decoder<vlc_entry, 33, 11> s_macroblock_address_increment_decoder;
+	static const vlc_decoder<vlc_entry, 63, 9> s_coded_block_pattern_decoder;
+	static const vlc_decoder<vlc_entry, 33, 11> s_motion_code_decoder;
+	static const vlc_decoder<dct_vlc_entry, 110, 16> s_dct_coefficient_decoder;
+	static const vlc_decoder<vlc_entry, 2, 2> s_i_macroblock_type_decoder;
+	static const vlc_decoder<vlc_entry, 7, 6> s_p_macroblock_type_decoder;
+	static const vlc_decoder<vlc_entry, 11, 6> s_b_macroblock_type_decoder;
+	static const vlc_decoder<vlc_entry, 1, 1> s_d_macroblock_type_decoder;
+	static const vlc_decoder<vlc_entry, 9, 7> s_dc_size_luminance_decoder;
+	static const vlc_decoder<vlc_entry, 9, 8> s_dc_size_chrominance_decoder;
 
 	static const u8 s_default_intra_quantizer_matrix[64];
 	static const u8 s_scan[64];
@@ -159,6 +191,13 @@ private:
 	void inverse_dct(const int *coefficients, int *values, bool dc_only) const;
 	void read_frame(frame &destination, const u8 *source, unsigned source_bytes) const;
 	void write_frame(const frame &source, u8 *output, unsigned output_bytes) const;
+
+	template <std::size_t N> static constexpr vlc_entry make_vlc(const char (&text)[N], int value);
+	template <std::size_t N> static constexpr dct_vlc_entry make_dct_vlc(const char (&text)[N], unsigned run, unsigned level);
+	template <unsigned MaxBits, typename T, std::size_t N> static constexpr auto make_vlc_decoder(const T (&table)[N]);
+	template <typename T, std::size_t N, unsigned MaxBits, typename P, typename S>
+	static const T *decode_vlc(const T (&table)[N], const vlc_decoder<T, N, MaxBits> &decoder,
+			int available, P &&peek, S &&skip);
 
 	int macroblock_address_increment();
 	macroblock_type macroblock_type_code();

--- a/src/devices/video/sti3400.cpp
+++ b/src/devices/video/sti3400.cpp
@@ -1,0 +1,563 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+
+/*
+ * SGS-Thomson STi3400 MPEG-1 video decoder (preliminary)
+ *
+ * The host interface, start-code detector and MPEG-1 picture reconstruction
+ * are implemented sufficiently for Cobra 3 software.
+ */
+
+#include "emu.h"
+#include "sti3400.h"
+
+#define LOG_START_CODES (1U << 1)
+#define LOG_INVALID_DATA (1U << 2)
+
+#define VERBOSE (0)
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(STI3400, sti3400_device, "sti3400", "SGS-Thomson STi3400 MPEG-1 Video Decoder")
+
+sti3400_device::sti3400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, STI3400, tag, owner, clock)
+	, m_irq_cb(*this)
+{
+}
+
+void sti3400_device::device_start()
+{
+	if (!m_dram_size || !std::has_single_bit(m_dram_size) || (m_dram_size % BIT_BUFFER_LEVEL_UNIT_BYTES))
+		fatalerror("%s: picture DRAM size must be a power-of-two multiple of 256 bytes\n", tag());
+
+	m_decode_timer = timer_alloc(FUNC(sti3400_device::decode_tick), this);
+	m_fifo = std::make_unique<u8[]>(COMPRESSED_DATA_BUFFER_BYTES);
+	m_input = std::make_unique<u8[]>(COMPRESSED_DATA_BUFFER_BYTES);
+	m_dram = std::make_unique<u8[]>(m_dram_size);
+	m_overwrite_display = std::make_unique<u8[]>(m_dram_size);
+	m_picture_valid = std::make_unique<u8[]>(m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES);
+	m_decoder = std::make_unique<mpeg_video>(m_input.get(), MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
+	m_decoder->register_save_state(*this);
+
+	save_item(NAME(m_registers));
+	save_pointer(NAME(m_fifo), COMPRESSED_DATA_BUFFER_BYTES);
+	save_item(NAME(m_event_position));
+	save_item(NAME(m_event_code));
+	save_item(NAME(m_fifo_write));
+	save_item(NAME(m_fifo_read));
+	save_item(NAME(m_decode_position));
+	save_item(NAME(m_start_code_shift));
+	save_item(NAME(m_event_head));
+	save_item(NAME(m_event_tail));
+	save_item(NAME(m_event_count));
+	save_item(NAME(m_interrupt_status));
+	save_item(NAME(m_event_active));
+	save_pointer(NAME(m_input), COMPRESSED_DATA_BUFFER_BYTES);
+	save_pointer(NAME(m_dram), m_dram_size);
+	save_pointer(NAME(m_overwrite_display), m_dram_size);
+	save_pointer(NAME(m_picture_valid), m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES);
+	save_item(NAME(m_input_bytes));
+	save_item(NAME(m_input_bit_position));
+	save_item(NAME(m_display_pointer));
+	save_item(NAME(m_presented_pointer));
+	save_item(NAME(m_reconstructed_pointer));
+	save_item(NAME(m_forward_pointer));
+	save_item(NAME(m_backward_pointer));
+	save_item(NAME(m_width));
+	save_item(NAME(m_height));
+	save_item(NAME(m_decoded_width));
+	save_item(NAME(m_decoded_height));
+	save_item(NAME(m_frame_rate));
+	save_item(NAME(m_task_active));
+	save_item(NAME(m_repeat_pending));
+	save_item(NAME(m_overwrite_display_active));
+}
+
+void sti3400_device::device_reset()
+{
+	std::fill(std::begin(m_registers), std::end(m_registers), 0);
+	m_interrupt_status = 0;
+	m_status = STA_RESET;
+	m_irq_state = false;
+	reset_decoder();
+	m_irq_cb(CLEAR_LINE);
+}
+
+void sti3400_device::device_post_load()
+{
+	m_status = decoder_status();
+	m_irq_state = bool(m_interrupt_status & m_registers[REG_ITM]);
+	m_irq_cb(m_irq_state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+void sti3400_device::reset_decoder()
+{
+	m_fifo_write = 0;
+	m_fifo_read = 0;
+	m_decode_position = 0;
+	m_start_code_shift = MPEG_START_CODE_SHIFT_RESET;
+	m_event_head = 0;
+	m_event_tail = 0;
+	m_event_count = 0;
+	m_event_active = false;
+	std::fill_n(m_picture_valid.get(), m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES, 0);
+	m_input_bytes = 0;
+	m_input_bit_position = 0;
+	m_display_pointer = 0;
+	m_presented_pointer = 0;
+	m_reconstructed_pointer = 0;
+	m_forward_pointer = 0;
+	m_backward_pointer = 0;
+	m_width = 0;
+	m_height = 0;
+	m_decoded_width = 0;
+	m_decoded_height = 0;
+	m_frame_rate = FALLBACK_FRAME_RATE;
+	m_task_active = false;
+	m_repeat_pending = false;
+	m_overwrite_display_active = false;
+	m_decoder->clear();
+	m_decode_timer->adjust(attotime::never);
+}
+
+void sti3400_device::decoder_soft_reset()
+{
+	reset_decoder();
+	update_status();
+}
+
+bool sti3400_device::execute_task()
+{
+	auto const picture_buffer = [this] (u16 pointer)
+	{
+		const u32 base = (u32(pointer) * BIT_BUFFER_LEVEL_UNIT_BYTES) & (m_dram_size - 1);
+		return mpeg_video::picture_buffer{ m_dram.get() + base, m_dram_size - base };
+	};
+	const mpeg_video::picture_buffers buffers
+	{
+		picture_buffer(m_reconstructed_pointer),
+		picture_buffer(m_forward_pointer),
+		picture_buffer(m_backward_pointer)
+	};
+
+	for (;;)
+	{
+		int position = m_input_bit_position;
+		int width = m_decoded_width;
+		int height = m_decoded_height;
+		double frame_rate = m_frame_rate;
+		const u64 stream_position = m_decode_position + (position / 8);
+		const mpeg_video::decode_result result = m_decoder->decode_buffer(
+				position,
+				m_input_bytes * 8,
+				buffers,
+				width,
+				height,
+				frame_rate);
+
+		if (result == mpeg_video::decode_result::PICTURE)
+		{
+			m_decoded_width = width;
+			m_decoded_height = height;
+			m_frame_rate = frame_rate;
+			const u32 picture = m_reconstructed_pointer & ((m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES) - 1);
+			m_picture_valid[picture] = 1;
+		}
+		else if (result == mpeg_video::decode_result::INVALID_DATA)
+		{
+			LOGMASKED(LOG_INVALID_DATA, "%s: skipped invalid MPEG video data at byte %08x\n",
+				machine().describe_context(), u32(stream_position));
+		}
+
+		const u32 bytes_consumed = position / 8;
+		if (bytes_consumed)
+		{
+			std::move(m_input.get() + bytes_consumed, m_input.get() + m_input_bytes, m_input.get());
+			m_input_bytes -= bytes_consumed;
+			m_decode_position += bytes_consumed;
+		}
+		m_input_bit_position = position & 7;
+
+		if (result != mpeg_video::decode_result::INVALID_DATA)
+			return result != mpeg_video::decode_result::NEED_DATA;
+	}
+}
+
+TIMER_CALLBACK_MEMBER(sti3400_device::decode_tick)
+{
+	if (m_task_active && execute_task())
+		m_task_active = false;
+
+	update_status();
+	activate_event();
+}
+
+void sti3400_device::vblank_w(int state)
+{
+	if (!state)
+		return;
+
+	// DFP is double-buffered by the hardware and becomes active at VSYNC.  The
+	// physical pipeline can display a buffer while reconstruction finishes;
+	// retain the preceding complete picture until the whole-picture backend
+	// finishes an active task targeting the newly selected buffer.
+	m_display_pointer = m_registers[REG_DFP] & PICTURE_POINTER_MASK;
+	if (!m_task_active || (m_display_pointer != m_reconstructed_pointer))
+	{
+		m_overwrite_display_active = false;
+		m_presented_pointer = m_display_pointer;
+	}
+	m_width = m_decoded_width;
+	m_height = m_decoded_height;
+
+	// A VSYNC-generated DSYNC starts the next task and restarts automatic start-code detection.
+	if (m_repeat_pending)
+	{
+		m_repeat_pending = false;
+	}
+	else if ((m_registers[REG_CTL] & CTL_EDC) && !(m_registers[REG_CTL] & CTL_DVS) &&
+		!(m_registers[REG_INS] & INS_WAIT) && m_event_active && !m_task_active)
+	{
+		m_reconstructed_pointer = m_registers[REG_RFP] & PICTURE_POINTER_MASK;
+		m_forward_pointer = m_registers[REG_FFP] & PICTURE_POINTER_MASK;
+		m_backward_pointer = m_registers[REG_BFP] & PICTURE_POINTER_MASK;
+		if ((m_registers[REG_INS] & INS_OVW) && (m_reconstructed_pointer == m_display_pointer))
+		{
+			// The hardware keeps reconstruction behind the display scan in overwrite mode.
+			// Preserve the current field because MAME renders it as a single operation.
+			std::copy_n(m_dram.get(), m_dram_size, m_overwrite_display.get());
+			m_overwrite_display_active = true;
+		}
+		m_task_active = true;
+		m_repeat_pending = bool(m_registers[REG_INS] & INS_RPT);
+		finish_event();
+		// PSD is a three-clock status pulse at DSYNC.  As primary-clock timing is
+		// not modelled, latch its interrupt-visible rising edge directly.
+		m_interrupt_status |= STA_PSD;
+		update_irq();
+		m_decode_timer->adjust(attotime::zero);
+	}
+}
+
+void sti3400_device::stream_byte_w(u8 data)
+{
+	if (m_input_bytes == COMPRESSED_DATA_BUFFER_BYTES)
+	{
+		logerror("%s: compressed-video input overflow\n", machine().describe_context());
+		return;
+	}
+	m_input[m_input_bytes++] = data;
+
+	m_fifo[m_fifo_write & (COMPRESSED_DATA_BUFFER_BYTES - 1)] = data;
+	m_fifo_write++;
+	m_start_code_shift = (m_start_code_shift << 8) | data;
+
+	if ((m_start_code_shift & MPEG_START_CODE_MASK) == MPEG_START_CODE_PREFIX)
+	{
+		const u8 code = m_start_code_shift;
+
+		// In MPEG mode the detector recognises every start code except slice codes 01-AF.
+		if ((code == MPEG_PICTURE_START_CODE) || (code >= MPEG_NON_SLICE_CODE_MIN))
+		{
+			LOGMASKED(LOG_START_CODES, "start code %02x at %08x\n", code, u32(m_fifo_write - 1));
+			queue_start_code(m_fifo_write - 1, code);
+		}
+	}
+
+	update_status();
+	activate_event();
+
+	// Resume a parked picture task at the modelled picture cadence once CDF input returns.
+	if (m_task_active && !m_decode_timer->enabled())
+		m_decode_timer->adjust(attotime::from_hz(m_frame_rate));
+}
+
+bool sti3400_device::video_valid() const
+{
+	const u32 picture = m_presented_pointer & ((m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES) - 1);
+	return m_picture_valid[picture];
+}
+
+u16 sti3400_device::video_width() const
+{
+	return m_width;
+}
+
+u16 sti3400_device::video_height() const
+{
+	return m_height;
+}
+
+void sti3400_device::video_line(u32 y, u32 x, u32 width, u32 *destination) const
+{
+	assert(video_valid());
+	assert(y < m_height);
+	assert(x <= m_width);
+	assert(width <= (m_width - x));
+
+	const u32 mask = m_dram_size - 1;
+	const u32 base = (u32(m_presented_pointer) * BIT_BUFFER_LEVEL_UNIT_BYTES) & mask;
+	const u32 luma_pitch = (m_width + 15) & ~15;
+	const u32 luma_rows = (m_height + 15) & ~15;
+	const u32 luma_bytes = luma_pitch * luma_rows;
+	const u32 chroma_pitch = luma_pitch / 2;
+	const u32 chroma_bytes = chroma_pitch * luma_rows / 2;
+	const u32 luma = base + y * luma_pitch + x;
+	const u32 cb_plane = base + luma_bytes + (y / 2) * chroma_pitch;
+	const u32 cr_plane = cb_plane + chroma_bytes;
+	const u8 *const picture = m_overwrite_display_active ? m_overwrite_display.get() : m_dram.get();
+
+	for (u32 column = 0; column != width; column++)
+	{
+		const int luminance = picture[(luma + column) & mask];
+		const u32 chroma_x = (x + column) / 2;
+		const int cb = picture[(cb_plane + chroma_x) & mask] - 128;
+		const int cr = picture[(cr_plane + chroma_x) & mask] - 128;
+		const int scaled_luminance = 298 * (luminance - 16);
+		const u8 red = rgb_t::clamp((scaled_luminance + 409 * cr + 128) >> 8);
+		const u8 green = rgb_t::clamp((scaled_luminance - 100 * cb - 208 * cr + 128) >> 8);
+		const u8 blue = rgb_t::clamp((scaled_luminance + 516 * cb + 128) >> 8);
+		destination[column] = rgb_t(red, green, blue);
+	}
+}
+
+void sti3400_device::queue_start_code(u64 position, u8 code)
+{
+	if (m_event_count == START_CODE_EVENT_COUNT)
+	{
+		logerror("%s: start-code event queue overflow\n", machine().describe_context());
+		return;
+	}
+
+	m_event_position[m_event_tail] = position;
+	m_event_code[m_event_tail] = code;
+	m_event_tail = (m_event_tail + 1) & (START_CODE_EVENT_COUNT - 1);
+	m_event_count++;
+	activate_event();
+}
+
+void sti3400_device::activate_event()
+{
+	if (!m_event_active && m_event_count)
+	{
+		const u64 position = m_event_position[m_event_head];
+		const u8 code = m_event_code[m_event_head];
+		if (code == MPEG_SEQUENCE_END_CODE)
+		{
+			if (m_decode_position <= position)
+				return;
+		}
+		else if ((m_fifo_write - position) < HEADER_FIFO_BYTES)
+		{
+			// The software detector runs on CDF writes; defer the hit until HDF can supply a hardware-sized window.
+			return;
+		}
+
+		m_event_active = true;
+		m_fifo_read = position;
+		update_status();
+	}
+}
+
+void sti3400_device::finish_event()
+{
+	if (m_event_active)
+	{
+		m_event_head = (m_event_head + 1) & (START_CODE_EVENT_COUNT - 1);
+		m_event_count--;
+		m_event_active = false;
+	}
+
+	update_status();
+	activate_event();
+}
+
+u16 sti3400_device::bit_buffer_level() const
+{
+	const u64 bytes_available = (m_fifo_write > m_decode_position) ? (m_fifo_write - m_decode_position) : 0;
+
+	// BBL excludes the first 64 bytes and reports the remainder in 256-byte units.
+	return std::min<u64>((bytes_available > BIT_BUFFER_LEVEL_BIAS_BYTES)
+		? ((bytes_available - BIT_BUFFER_LEVEL_BIAS_BYTES) / BIT_BUFFER_LEVEL_UNIT_BYTES)
+		: 0, BIT_BUFFER_LEVEL_MASK);
+}
+
+u16 sti3400_device::decoder_status() const
+{
+	const u16 level = bit_buffer_level();
+	u16 status = 0;
+
+	if (!m_task_active)
+		status |= STA_PID;
+	if (!level || (level < (m_registers[REG_BBB] & BIT_BUFFER_LEVEL_MASK)))
+		status |= STA_BBE;
+	if (level > (m_registers[REG_BBT] & BIT_BUFFER_LEVEL_MASK))
+		status |= STA_BBF;
+	if (!m_event_active || (m_fifo_read >= m_fifo_write))
+		status |= STA_HFE;
+	if (m_event_active && ((m_fifo_write - m_fifo_read) >= HEADER_FIFO_BYTES))
+		status |= STA_HFF;
+	if (m_event_active && (m_fifo_read == m_event_position[m_event_head]))
+		status |= STA_SCH;
+
+	return status;
+}
+
+void sti3400_device::update_status()
+{
+	const u16 status = decoder_status();
+	m_interrupt_status |= status & ~m_status;
+	m_status = status;
+	update_irq();
+}
+
+void sti3400_device::update_irq()
+{
+	const u16 mask = m_registers[REG_ITM];
+	const bool state = bool(m_interrupt_status & mask);
+	if (state != m_irq_state)
+	{
+		m_irq_state = state;
+		m_irq_cb(state ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+u8 sti3400_device::stream_byte(u64 position) const
+{
+	if (position >= m_fifo_write)
+		return 0;
+
+	return m_fifo[position & (COMPRESSED_DATA_BUFFER_BYTES - 1)];
+}
+
+u16 sti3400_device::register_r(offs_t offset)
+{
+	return m_registers[offset];
+}
+
+void sti3400_device::register_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_registers[offset]);
+}
+
+void sti3400_device::compressed_data_w(offs_t, u16 data, u16 mem_mask)
+{
+	if (ACCESSING_BITS_8_15)
+		stream_byte_w(data >> 8);
+	if (ACCESSING_BITS_0_7)
+		stream_byte_w(data);
+}
+
+u16 sti3400_device::header_data_r()
+{
+	const u16 result = (stream_byte(m_fifo_read) << 8) | stream_byte(m_fifo_read + 1);
+	if (!machine().side_effects_disabled())
+	{
+		m_fifo_read = std::min(m_fifo_read + 2, m_fifo_write);
+		update_status();
+	}
+	return result;
+}
+
+u16 sti3400_device::header_position_r()
+{
+	return 0;
+}
+
+u16 sti3400_device::status_r()
+{
+	return m_status;
+}
+
+u16 sti3400_device::interrupt_status_r(offs_t, u16 mem_mask)
+{
+	const u16 result = m_interrupt_status;
+	if (!machine().side_effects_disabled())
+	{
+		if (ACCESSING_BITS_8_15)
+			m_interrupt_status &= 0x00ff;
+		if (ACCESSING_BITS_0_7)
+			m_interrupt_status &= 0xff00;
+		update_irq();
+	}
+	return result;
+}
+
+u16 sti3400_device::display_pointer_r()
+{
+	return m_display_pointer;
+}
+
+u16 sti3400_device::reconstructed_pointer_r()
+{
+	return m_reconstructed_pointer;
+}
+
+u16 sti3400_device::forward_pointer_r()
+{
+	return m_forward_pointer;
+}
+
+u16 sti3400_device::backward_pointer_r()
+{
+	return m_backward_pointer;
+}
+
+u16 sti3400_device::bit_buffer_level_r()
+{
+	return bit_buffer_level();
+}
+
+void sti3400_device::control_w(offs_t, u16 data, u16 mem_mask)
+{
+	const u16 old_data = m_registers[REG_CTL];
+	COMBINE_DATA(&m_registers[REG_CTL]);
+	if ((old_data & CTL_SRS) && !(m_registers[REG_CTL] & CTL_SRS))
+		decoder_soft_reset();
+	else
+		update_status();
+}
+
+void sti3400_device::interrupt_mask_w(offs_t, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_registers[REG_ITM]);
+	update_irq();
+}
+
+void sti3400_device::header_search_w(offs_t, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_registers[REG_HDS]);
+	finish_event();
+}
+
+void sti3400_device::bit_buffer_bottom_w(offs_t, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_registers[REG_BBB]);
+	update_status();
+}
+
+void sti3400_device::bit_buffer_top_w(offs_t, u16 data, u16 mem_mask)
+{
+	COMBINE_DATA(&m_registers[REG_BBT]);
+	update_status();
+}
+
+void sti3400_device::map(address_map &map)
+{
+	map(0x00, 0x7f).rw(FUNC(sti3400_device::register_r), FUNC(sti3400_device::register_w));
+	map(0x00, 0x01).w(FUNC(sti3400_device::compressed_data_w));
+	map(0x04, 0x05).r(FUNC(sti3400_device::header_data_r));
+	map(0x08, 0x09).r(FUNC(sti3400_device::header_position_r));
+	map(0x10, 0x11).r(FUNC(sti3400_device::status_r));
+	map(0x14, 0x15).w(FUNC(sti3400_device::control_w));
+	map(0x1c, 0x1d).w(FUNC(sti3400_device::interrupt_mask_w));
+	map(0x20, 0x21).r(FUNC(sti3400_device::interrupt_status_r));
+	map(0x24, 0x25).w(FUNC(sti3400_device::header_search_w));
+	map(0x2c, 0x2d).w(FUNC(sti3400_device::bit_buffer_bottom_w));
+	map(0x30, 0x31).r(FUNC(sti3400_device::display_pointer_r));
+	map(0x34, 0x35).r(FUNC(sti3400_device::reconstructed_pointer_r));
+	map(0x38, 0x39).r(FUNC(sti3400_device::forward_pointer_r));
+	map(0x3c, 0x3d).r(FUNC(sti3400_device::backward_pointer_r));
+	map(0x44, 0x45).r(FUNC(sti3400_device::bit_buffer_level_r));
+	map(0x64, 0x65).w(FUNC(sti3400_device::bit_buffer_top_w));
+}

--- a/src/devices/video/sti3400.cpp
+++ b/src/devices/video/sti3400.cpp
@@ -32,12 +32,11 @@ void sti3400_device::device_start()
 
 	m_decode_timer = timer_alloc(FUNC(sti3400_device::decode_tick), this);
 	m_fifo = std::make_unique<u8[]>(COMPRESSED_DATA_BUFFER_BYTES);
-	m_input = std::make_unique<u8[]>(COMPRESSED_DATA_BUFFER_BYTES);
 	m_dram = std::make_unique<u8[]>(m_dram_size);
 	m_overwrite_display = std::make_unique<u8[]>(m_dram_size);
 	m_picture_valid = std::make_unique<u8[]>(m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES);
 	m_video_bitmap.allocate(MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
-	m_decoder = std::make_unique<mpeg_video>(m_input.get(), MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
+	m_decoder = std::make_unique<mpeg_video>(MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
 	m_decoder->register_save_state(*this);
 
 	save_item(NAME(m_registers));
@@ -53,12 +52,9 @@ void sti3400_device::device_start()
 	save_item(NAME(m_event_count));
 	save_item(NAME(m_interrupt_status));
 	save_item(NAME(m_event_active));
-	save_pointer(NAME(m_input), COMPRESSED_DATA_BUFFER_BYTES);
 	save_pointer(NAME(m_dram), m_dram_size);
 	save_pointer(NAME(m_overwrite_display), m_dram_size);
 	save_pointer(NAME(m_picture_valid), m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES);
-	save_item(NAME(m_input_bytes));
-	save_item(NAME(m_input_bit_position));
 	save_item(NAME(m_display_pointer));
 	save_item(NAME(m_presented_pointer));
 	save_item(NAME(m_reconstructed_pointer));
@@ -80,6 +76,20 @@ void sti3400_device::device_reset()
 	m_interrupt_status = 0;
 	m_status = STA_RESET;
 	m_irq_state = false;
+	std::fill_n(m_picture_valid.get(), m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES, 0);
+	m_display_pointer = 0;
+	m_presented_pointer = 0;
+	m_reconstructed_pointer = 0;
+	m_forward_pointer = 0;
+	m_backward_pointer = 0;
+	m_width = 0;
+	m_height = 0;
+	m_decoded_width = 0;
+	m_decoded_height = 0;
+	m_video_bitmap.resize(0, 0);
+	m_video_bitmap_dirty = false;
+	m_frame_rate = FALLBACK_FRAME_RATE;
+	m_overwrite_display_active = false;
 	reset_decoder();
 	m_irq_cb(CLEAR_LINE);
 }
@@ -102,30 +112,15 @@ void sti3400_device::reset_decoder()
 	m_event_tail = 0;
 	m_event_count = 0;
 	m_event_active = false;
-	std::fill_n(m_picture_valid.get(), m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES, 0);
-	m_input_bytes = 0;
-	m_input_bit_position = 0;
-	m_display_pointer = 0;
-	m_presented_pointer = 0;
-	m_reconstructed_pointer = 0;
-	m_forward_pointer = 0;
-	m_backward_pointer = 0;
-	m_width = 0;
-	m_height = 0;
-	m_decoded_width = 0;
-	m_decoded_height = 0;
-	m_video_bitmap.resize(0, 0);
-	m_video_bitmap_dirty = false;
-	m_frame_rate = FALLBACK_FRAME_RATE;
 	m_task_active = false;
 	m_repeat_pending = false;
-	m_overwrite_display_active = false;
 	m_decoder->clear();
 	m_decode_timer->adjust(attotime::never);
 }
 
 void sti3400_device::decoder_soft_reset()
 {
+	// SRS discards compressed data and decoding work without disturbing display.
 	reset_decoder();
 	update_status();
 }
@@ -146,18 +141,21 @@ bool sti3400_device::execute_task()
 
 	for (;;)
 	{
-		int position = m_input_bit_position;
+		const u32 offset = m_decode_position & (COMPRESSED_DATA_BUFFER_BYTES - 1);
+		const u32 available = std::min<u64>(m_fifo_write - m_decode_position, COMPRESSED_DATA_BUFFER_BYTES - offset);
+		std::size_t consumed = 0;
 		int width = m_decoded_width;
 		int height = m_decoded_height;
 		double frame_rate = m_frame_rate;
-		const u64 stream_position = m_decode_position + (position / 8);
-		const mpeg_video::decode_result result = m_decoder->decode_buffer(
-				position,
-				m_input_bytes * 8,
+		const u64 stream_position = m_decode_position;
+		const mpeg_video::decode_result result = m_decoder->decode(
+				std::span<const u8>(m_fifo.get() + offset, available),
+				consumed,
 				buffers,
 				width,
 				height,
 				frame_rate);
+		assert(consumed <= available);
 
 		if (result == mpeg_video::decode_result::PICTURE)
 		{
@@ -174,14 +172,10 @@ bool sti3400_device::execute_task()
 				machine().describe_context(), u32(stream_position));
 		}
 
-		const u32 bytes_consumed = position / 8;
-		if (bytes_consumed)
-		{
-			std::move(m_input.get() + bytes_consumed, m_input.get() + m_input_bytes, m_input.get());
-			m_input_bytes -= bytes_consumed;
-			m_decode_position += bytes_consumed;
-		}
-		m_input_bit_position = position & 7;
+		m_decode_position += consumed;
+		// A contiguous span can end at the ring boundary while more input is available.
+		if ((result == mpeg_video::decode_result::NEED_DATA) && (consumed == available) && (m_decode_position < m_fifo_write))
+			continue;
 
 		if (result != mpeg_video::decode_result::INVALID_DATA)
 			return result != mpeg_video::decode_result::NEED_DATA;
@@ -210,8 +204,8 @@ void sti3400_device::vblank_w(int state)
 
 	// DFP is double-buffered by the hardware and becomes active at VSYNC.  The
 	// physical pipeline can display a buffer while reconstruction finishes;
-	// retain the preceding complete picture until the whole-picture backend
-	// finishes an active task targeting the newly selected buffer.
+	// retain the preceding complete picture until the decoder publishes the
+	// result of an active task targeting the newly selected buffer.
 	m_display_pointer = m_registers[REG_DFP] & PICTURE_POINTER_MASK;
 	if (!m_task_active || (m_display_pointer != m_reconstructed_pointer))
 	{
@@ -259,13 +253,11 @@ void sti3400_device::vblank_w(int state)
 
 void sti3400_device::stream_byte_w(u8 data)
 {
-	if (m_input_bytes == COMPRESSED_DATA_BUFFER_BYTES)
+	if ((m_fifo_write - m_decode_position) == COMPRESSED_DATA_BUFFER_BYTES)
 	{
 		logerror("%s: compressed-video input overflow\n", machine().describe_context());
 		return;
 	}
-	m_input[m_input_bytes++] = data;
-
 	m_fifo[m_fifo_write & (COMPRESSED_DATA_BUFFER_BYTES - 1)] = data;
 	m_fifo_write++;
 	m_start_code_shift = (m_start_code_shift << 8) | data;
@@ -369,9 +361,9 @@ void sti3400_device::activate_event()
 			if (m_decode_position <= position)
 				return;
 		}
-		else if ((m_fifo_write - position) < HEADER_FIFO_BYTES)
+		else if ((m_fifo_write - position) < HEADER_FIFO_READY_BYTES)
 		{
-			// The software detector runs on CDF writes; defer the hit until HDF can supply a hardware-sized window.
+			// The software detector runs on CDF writes; defer the hit until HDF reaches the HFF threshold.
 			return;
 		}
 
@@ -417,7 +409,7 @@ u16 sti3400_device::decoder_status() const
 		status |= STA_BBF;
 	if (!m_event_active || (m_fifo_read >= m_fifo_write))
 		status |= STA_HFE;
-	if (m_event_active && ((m_fifo_write - m_fifo_read) >= HEADER_FIFO_BYTES))
+	if (m_event_active && ((m_fifo_write - m_fifo_read) >= HEADER_FIFO_READY_BYTES))
 		status |= STA_HFF;
 	if (m_event_active && (m_fifo_read == m_event_position[m_event_head]))
 		status |= STA_SCH;

--- a/src/devices/video/sti3400.cpp
+++ b/src/devices/video/sti3400.cpp
@@ -36,6 +36,7 @@ void sti3400_device::device_start()
 	m_dram = std::make_unique<u8[]>(m_dram_size);
 	m_overwrite_display = std::make_unique<u8[]>(m_dram_size);
 	m_picture_valid = std::make_unique<u8[]>(m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES);
+	m_video_bitmap.allocate(MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
 	m_decoder = std::make_unique<mpeg_video>(m_input.get(), MAX_VIDEO_WIDTH, MAX_VIDEO_HEIGHT);
 	m_decoder->register_save_state(*this);
 
@@ -88,6 +89,7 @@ void sti3400_device::device_post_load()
 	m_status = decoder_status();
 	m_irq_state = bool(m_interrupt_status & m_registers[REG_ITM]);
 	m_irq_cb(m_irq_state ? ASSERT_LINE : CLEAR_LINE);
+	update_video_bitmap();
 }
 
 void sti3400_device::reset_decoder()
@@ -112,6 +114,8 @@ void sti3400_device::reset_decoder()
 	m_height = 0;
 	m_decoded_width = 0;
 	m_decoded_height = 0;
+	m_video_bitmap.resize(0, 0);
+	m_video_bitmap_dirty = false;
 	m_frame_rate = FALLBACK_FRAME_RATE;
 	m_task_active = false;
 	m_repeat_pending = false;
@@ -162,6 +166,7 @@ bool sti3400_device::execute_task()
 			m_frame_rate = frame_rate;
 			const u32 picture = m_reconstructed_pointer & ((m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES) - 1);
 			m_picture_valid[picture] = 1;
+			m_video_bitmap_dirty = true;
 		}
 		else if (result == mpeg_video::decode_result::INVALID_DATA)
 		{
@@ -196,6 +201,12 @@ void sti3400_device::vblank_w(int state)
 {
 	if (!state)
 		return;
+
+	const u16 previous_pointer = m_presented_pointer;
+	const u16 previous_width = m_width;
+	const u16 previous_height = m_height;
+	const bool previous_overwrite = m_overwrite_display_active;
+	const bool previous_valid = presented_picture_valid();
 
 	// DFP is double-buffered by the hardware and becomes active at VSYNC.  The
 	// physical pipeline can display a buffer while reconstruction finishes;
@@ -237,6 +248,13 @@ void sti3400_device::vblank_w(int state)
 		update_irq();
 		m_decode_timer->adjust(attotime::zero);
 	}
+
+	if (m_video_bitmap_dirty || (m_presented_pointer != previous_pointer) ||
+		(m_width != previous_width) || (m_height != previous_height) ||
+		(m_overwrite_display_active != previous_overwrite) || (presented_picture_valid() != previous_valid))
+	{
+		update_video_bitmap();
+	}
 }
 
 void sti3400_device::stream_byte_w(u8 data)
@@ -274,26 +292,25 @@ void sti3400_device::stream_byte_w(u8 data)
 
 bool sti3400_device::video_valid() const
 {
+	return m_video_bitmap.width() && m_video_bitmap.height();
+}
+
+bool sti3400_device::presented_picture_valid() const
+{
 	const u32 picture = m_presented_pointer & ((m_dram_size / BIT_BUFFER_LEVEL_UNIT_BYTES) - 1);
-	return m_picture_valid[picture];
+	return m_width && m_height && m_picture_valid[picture];
 }
 
-u16 sti3400_device::video_width() const
+void sti3400_device::update_video_bitmap()
 {
-	return m_width;
-}
+	m_video_bitmap_dirty = false;
+	if (!presented_picture_valid())
+	{
+		m_video_bitmap.resize(0, 0);
+		return;
+	}
 
-u16 sti3400_device::video_height() const
-{
-	return m_height;
-}
-
-void sti3400_device::video_line(u32 y, u32 x, u32 width, u32 *destination) const
-{
-	assert(video_valid());
-	assert(y < m_height);
-	assert(x <= m_width);
-	assert(width <= (m_width - x));
+	m_video_bitmap.resize(m_width, m_height);
 
 	const u32 mask = m_dram_size - 1;
 	const u32 base = (u32(m_presented_pointer) * BIT_BUFFER_LEVEL_UNIT_BYTES) & mask;
@@ -302,22 +319,27 @@ void sti3400_device::video_line(u32 y, u32 x, u32 width, u32 *destination) const
 	const u32 luma_bytes = luma_pitch * luma_rows;
 	const u32 chroma_pitch = luma_pitch / 2;
 	const u32 chroma_bytes = chroma_pitch * luma_rows / 2;
-	const u32 luma = base + y * luma_pitch + x;
-	const u32 cb_plane = base + luma_bytes + (y / 2) * chroma_pitch;
+	const u32 cb_plane = base + luma_bytes;
 	const u32 cr_plane = cb_plane + chroma_bytes;
 	const u8 *const picture = m_overwrite_display_active ? m_overwrite_display.get() : m_dram.get();
 
-	for (u32 column = 0; column != width; column++)
+	for (u32 y = 0; y != m_height; y++)
 	{
-		const int luminance = picture[(luma + column) & mask];
-		const u32 chroma_x = (x + column) / 2;
-		const int cb = picture[(cb_plane + chroma_x) & mask] - 128;
-		const int cr = picture[(cr_plane + chroma_x) & mask] - 128;
-		const int scaled_luminance = 298 * (luminance - 16);
-		const u8 red = rgb_t::clamp((scaled_luminance + 409 * cr + 128) >> 8);
-		const u8 green = rgb_t::clamp((scaled_luminance - 100 * cb - 208 * cr + 128) >> 8);
-		const u8 blue = rgb_t::clamp((scaled_luminance + 516 * cb + 128) >> 8);
-		destination[column] = rgb_t(red, green, blue);
+		const u32 luma = base + y * luma_pitch;
+		const u32 chroma = (y / 2) * chroma_pitch;
+		u32 *const destination = &m_video_bitmap.pix(y);
+		for (u32 x = 0; x != m_width; x++)
+		{
+			const int luminance = picture[(luma + x) & mask];
+			const u32 chroma_x = chroma + x / 2;
+			const int cb = picture[(cb_plane + chroma_x) & mask] - 128;
+			const int cr = picture[(cr_plane + chroma_x) & mask] - 128;
+			const int scaled_luminance = 298 * (luminance - 16);
+			const u8 red = rgb_t::clamp((scaled_luminance + 409 * cr + 128) >> 8);
+			const u8 green = rgb_t::clamp((scaled_luminance - 100 * cb - 208 * cr + 128) >> 8);
+			const u8 blue = rgb_t::clamp((scaled_luminance + 516 * cb + 128) >> 8);
+			destination[x] = rgb_t(red, green, blue);
+		}
 	}
 }
 

--- a/src/devices/video/sti3400.h
+++ b/src/devices/video/sti3400.h
@@ -1,0 +1,182 @@
+// license:BSD-3-Clause
+// copyright-holders:MagikalUnicorn
+
+#ifndef MAME_VIDEO_STI3400_H
+#define MAME_VIDEO_STI3400_H
+
+#pragma once
+
+#include "mpeg_video.h"
+
+class sti3400_device : public device_t
+{
+public:
+	static constexpr feature_type imperfect_features() { return feature::TIMING; }
+
+	sti3400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
+
+	void set_dram_size(u32 bytes) { m_dram_size = bytes; }
+
+	auto irq() { return m_irq_cb.bind(); }
+
+	void map(address_map &map) ATTR_COLD;
+	void vblank_w(int state);
+
+	bool video_valid() const;
+	u16 video_width() const;
+	u16 video_height() const;
+	void video_line(u32 y, u32 x, u32 width, u32 *destination) const;
+
+protected:
+	void device_start() override ATTR_COLD;
+	void device_reset() override ATTR_COLD;
+	void device_post_load() override ATTR_COLD;
+
+private:
+	// STi3400 host-interface register addresses from the data sheet.
+	static constexpr offs_t REG_CDF = 0x00; // compressed data FIFO
+	static constexpr offs_t REG_HDF = 0x02; // header data FIFO
+	static constexpr offs_t REG_HDP = 0x04; // header data position
+	static constexpr offs_t REG_STA = 0x08; // decoder status
+	static constexpr offs_t REG_CTL = 0x0a; // decoder control
+	static constexpr offs_t REG_ITM = 0x0e; // interrupt mask
+	static constexpr offs_t REG_ITS = 0x10; // interrupt status
+	static constexpr offs_t REG_HDS = 0x12; // header data search command
+	static constexpr offs_t REG_INS = 0x14; // next decoding instruction
+	static constexpr offs_t REG_BBB = 0x16; // bit-buffer bottom threshold
+	static constexpr offs_t REG_DFP = 0x18; // displayed picture pointer
+	static constexpr offs_t REG_RFP = 0x1a; // reconstructed picture pointer
+	static constexpr offs_t REG_FFP = 0x1c; // forward prediction picture pointer
+	static constexpr offs_t REG_BFP = 0x1e; // backward prediction picture pointer
+	static constexpr offs_t REG_BBL = 0x22; // current bit-buffer level
+	static constexpr offs_t REG_BBT = 0x32; // bit-buffer top threshold
+
+	static constexpr u16 STA_SCH = 0x0001; // start-code hit
+	static constexpr u16 STA_HFE = 0x0004; // header FIFO empty
+	static constexpr u16 STA_BBF = 0x0008; // bit buffer nearly full
+	static constexpr u16 STA_BBE = 0x0010; // bit buffer nearly empty
+	static constexpr u16 STA_PSD = 0x0040; // pipeline starting to decode
+	static constexpr u16 STA_PID = 0x0200; // decoding pipeline idle
+	static constexpr u16 STA_HFF = 0x1000; // header FIFO full
+	static constexpr u16 STA_RESET = STA_PID | STA_BBE | STA_HFE; // hard-reset status
+
+	static constexpr u16 CTL_EDC = 0x0001; // enable decoding
+	static constexpr u16 CTL_SRS = 0x0002; // soft reset
+	static constexpr u16 CTL_DVS = 0x0080; // disable VSYNC-triggered task start
+	static constexpr u16 INS_RPT = 0x0002; // repeat picture for a second VSYNC period
+	static constexpr u16 INS_WAIT = 0x0004; // inhibit DSYNC, decoding and header search
+	static constexpr u16 INS_OVW = 0x8000; // reconstruct into the displayed picture buffer
+
+	// Bit-buffer levels and thresholds are 14-bit counts of 256-byte units.
+	static constexpr u16 BIT_BUFFER_LEVEL_MASK = 0x3fff;
+	static constexpr u32 BIT_BUFFER_LEVEL_UNIT_BYTES = 0x100;
+	static constexpr u32 BIT_BUFFER_LEVEL_BIAS_BYTES = 0x40;
+	static constexpr u16 PICTURE_POINTER_MASK = 0x3fff;
+
+	// The hardware header FIFO is 256 bits wide.
+	static constexpr u32 HEADER_FIFO_BYTES = 0x20;
+	// Software buffers cover the maximum amount representable by BBL.
+	static constexpr u32 COMPRESSED_DATA_BUFFER_BYTES = 4U * 1024 * 1024;
+	// This software queue holds start codes pending host service; 256 covers the
+	// observed backlog and permits masked ring wrap.
+	static constexpr u32 START_CODE_EVENT_COUNT = 256;
+	static_assert(std::has_single_bit(COMPRESSED_DATA_BUFFER_BYTES));
+	static_assert(std::has_single_bit(START_CODE_EVENT_COUNT));
+
+	static constexpr u32 MPEG_START_CODE_SHIFT_RESET = ~u32(0);
+	static constexpr u32 MPEG_START_CODE_MASK = 0xffffff00U;
+	static constexpr u32 MPEG_START_CODE_PREFIX = 0x00000100U;
+	static constexpr u8 MPEG_PICTURE_START_CODE = 0x00;
+	static constexpr u8 MPEG_NON_SLICE_CODE_MIN = 0xb0;
+	static constexpr u8 MPEG_SEQUENCE_END_CODE = 0xb7;
+	// Maximum constrained-parameters MPEG-1 dimensions.
+	static constexpr u32 MAX_VIDEO_WIDTH = 768;
+	static constexpr u32 MAX_VIDEO_HEIGHT = 576;
+	// Used until an MPEG sequence header supplies the picture rate.
+	static constexpr u32 FALLBACK_FRAME_RATE = 25;
+
+	void reset_decoder();
+	void decoder_soft_reset();
+	bool execute_task();
+	TIMER_CALLBACK_MEMBER(decode_tick);
+
+	void stream_byte_w(u8 data);
+	void queue_start_code(u64 position, u8 code);
+	void activate_event();
+	void finish_event();
+	u16 bit_buffer_level() const;
+	u16 decoder_status() const;
+	void update_status();
+	void update_irq();
+	u8 stream_byte(u64 position) const;
+
+	u16 register_r(offs_t offset);
+	void register_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void compressed_data_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	u16 header_data_r();
+	u16 header_position_r();
+	u16 status_r();
+	u16 interrupt_status_r(offs_t offset, u16 mem_mask = ~0);
+	u16 display_pointer_r();
+	u16 reconstructed_pointer_r();
+	u16 forward_pointer_r();
+	u16 backward_pointer_r();
+	u16 bit_buffer_level_r();
+	void control_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void interrupt_mask_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void header_search_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void bit_buffer_bottom_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void bit_buffer_top_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+
+	// Configuration and callbacks
+	devcb_write_line m_irq_cb;
+	u32 m_dram_size = 0;
+
+	// Host interface
+	u16 m_registers[0x40];
+	u16 m_interrupt_status = 0;
+	u16 m_status = 0;
+	bool m_irq_state = false;
+
+	// Compressed-data FIFO and start-code queue
+	std::unique_ptr<u8[]> m_fifo;
+	u64 m_event_position[START_CODE_EVENT_COUNT];
+	u8 m_event_code[START_CODE_EVENT_COUNT];
+	u64 m_fifo_write = 0;
+	u64 m_fifo_read = 0;
+	u32 m_start_code_shift = 0;
+	u16 m_event_head = 0;
+	u16 m_event_tail = 0;
+	u16 m_event_count = 0;
+	bool m_event_active = false;
+
+	// Decoder input and scheduling
+	emu_timer *m_decode_timer = nullptr;
+	std::unique_ptr<u8[]> m_input;
+	std::unique_ptr<mpeg_video> m_decoder;
+	u64 m_decode_position = 0;
+	u32 m_input_bytes = 0;
+	u32 m_input_bit_position = 0;
+	u16 m_decoded_width = 0;
+	u16 m_decoded_height = 0;
+	double m_frame_rate = FALLBACK_FRAME_RATE;
+	bool m_task_active = false;
+	bool m_repeat_pending = false;
+
+	// Picture DRAM and video output
+	std::unique_ptr<u8[]> m_dram;
+	std::unique_ptr<u8[]> m_overwrite_display;
+	std::unique_ptr<u8[]> m_picture_valid;
+	u16 m_display_pointer = 0;
+	u16 m_presented_pointer = 0;
+	u16 m_reconstructed_pointer = 0;
+	u16 m_forward_pointer = 0;
+	u16 m_backward_pointer = 0;
+	u16 m_width = 0;
+	u16 m_height = 0;
+	bool m_overwrite_display_active = false;
+};
+
+DECLARE_DEVICE_TYPE(STI3400, sti3400_device)
+
+#endif // MAME_VIDEO_STI3400_H

--- a/src/devices/video/sti3400.h
+++ b/src/devices/video/sti3400.h
@@ -23,9 +23,7 @@ public:
 	void vblank_w(int state);
 
 	bool video_valid() const;
-	u16 video_width() const;
-	u16 video_height() const;
-	void video_line(u32 y, u32 x, u32 width, u32 *destination) const;
+	bitmap_rgb32 const &bitmap() const { return m_video_bitmap; }
 
 protected:
 	void device_start() override ATTR_COLD;
@@ -98,6 +96,8 @@ private:
 	void reset_decoder();
 	void decoder_soft_reset();
 	bool execute_task();
+	bool presented_picture_valid() const;
+	void update_video_bitmap();
 	TIMER_CALLBACK_MEMBER(decode_tick);
 
 	void stream_byte_w(u8 data);
@@ -167,6 +167,7 @@ private:
 	std::unique_ptr<u8[]> m_dram;
 	std::unique_ptr<u8[]> m_overwrite_display;
 	std::unique_ptr<u8[]> m_picture_valid;
+	bitmap_rgb32 m_video_bitmap;
 	u16 m_display_pointer = 0;
 	u16 m_presented_pointer = 0;
 	u16 m_reconstructed_pointer = 0;
@@ -175,6 +176,7 @@ private:
 	u16 m_width = 0;
 	u16 m_height = 0;
 	bool m_overwrite_display_active = false;
+	bool m_video_bitmap_dirty = false;
 };
 
 DECLARE_DEVICE_TYPE(STI3400, sti3400_device)

--- a/src/devices/video/sti3400.h
+++ b/src/devices/video/sti3400.h
@@ -15,7 +15,7 @@ public:
 
 	sti3400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0) ATTR_COLD;
 
-	void set_dram_size(u32 bytes) { m_dram_size = bytes; }
+	void set_dram_size(u32 bytes) ATTR_COLD { m_dram_size = bytes; }
 
 	auto irq() { return m_irq_cb.bind(); }
 
@@ -60,7 +60,7 @@ private:
 
 	static constexpr u16 CTL_EDC = 0x0001; // enable decoding
 	static constexpr u16 CTL_SRS = 0x0002; // soft reset
-	static constexpr u16 CTL_DVS = 0x0080; // disable VSYNC-triggered task start
+	static constexpr u16 CTL_DVS = 0x0100; // disable VSYNC-triggered task start
 	static constexpr u16 INS_RPT = 0x0002; // repeat picture for a second VSYNC period
 	static constexpr u16 INS_WAIT = 0x0004; // inhibit DSYNC, decoding and header search
 	static constexpr u16 INS_OVW = 0x8000; // reconstruct into the displayed picture buffer
@@ -71,9 +71,9 @@ private:
 	static constexpr u32 BIT_BUFFER_LEVEL_BIAS_BYTES = 0x40;
 	static constexpr u16 PICTURE_POINTER_MASK = 0x3fff;
 
-	// The hardware header FIFO is 256 bits wide.
-	static constexpr u32 HEADER_FIFO_BYTES = 0x20;
-	// Software buffers cover the maximum amount representable by BBL.
+	// HFF asserts at 16 words (32 bytes) in the 32-word hardware header FIFO.
+	static constexpr u32 HEADER_FIFO_READY_BYTES = 0x20;
+	// The software buffer covers the maximum amount representable by BBL.
 	static constexpr u32 COMPRESSED_DATA_BUFFER_BYTES = 4U * 1024 * 1024;
 	// This software queue holds start codes pending host service; 256 covers the
 	// observed backlog and permits masked ring wrap.
@@ -93,8 +93,8 @@ private:
 	// Used until an MPEG sequence header supplies the picture rate.
 	static constexpr u32 FALLBACK_FRAME_RATE = 25;
 
-	void reset_decoder();
-	void decoder_soft_reset();
+	void reset_decoder() ATTR_COLD;
+	void decoder_soft_reset() ATTR_COLD;
 	bool execute_task();
 	bool presented_picture_valid() const;
 	void update_video_bitmap();
@@ -140,8 +140,8 @@ private:
 
 	// Compressed-data FIFO and start-code queue
 	std::unique_ptr<u8[]> m_fifo;
-	u64 m_event_position[START_CODE_EVENT_COUNT];
-	u8 m_event_code[START_CODE_EVENT_COUNT];
+	u64 m_event_position[START_CODE_EVENT_COUNT]{};
+	u8 m_event_code[START_CODE_EVENT_COUNT]{};
 	u64 m_fifo_write = 0;
 	u64 m_fifo_read = 0;
 	u32 m_start_code_shift = 0;
@@ -152,11 +152,8 @@ private:
 
 	// Decoder input and scheduling
 	emu_timer *m_decode_timer = nullptr;
-	std::unique_ptr<u8[]> m_input;
 	std::unique_ptr<mpeg_video> m_decoder;
 	u64 m_decode_position = 0;
-	u32 m_input_bytes = 0;
-	u32 m_input_bit_position = 0;
 	u16 m_decoded_width = 0;
 	u16 m_decoded_height = 0;
 	double m_frame_rate = FALLBACK_FRAME_RATE;

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -3,9 +3,6 @@
 
 /* Bellfruit SWP (Skill With Prizes) Video hardware
     aka Cobra 3
-
-   MPEG audio decoding is preliminary.
-   TODO: MPEG video decoding is not implemented.
 */
 
 
@@ -24,6 +21,7 @@
 #include "sound/tms320av110.h"
 #include "sound/ymz280b.h"
 #include "video/ramdac.h"
+#include "video/sti3400.h"
 
 #include "screen.h"
 #include "speaker.h"
@@ -41,9 +39,11 @@ public:
 		m_nvram(*this, "nvram"),
 		m_av110(*this, "av110"),
 		m_ymz(*this, "ymz280b"),
+		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
 		m_ramdac(*this, "ramdac"),
 		m_scc66470(*this, "scc66470"),
+		m_sti3400(*this, "sti3400"),
 		m_strobein(*this, "STROBE%u", 0),
 		m_meters(*this, "meters"),
 		m_lamps(*this, "lamp%u", 0U),
@@ -61,9 +61,11 @@ protected:
 	required_device<nvram_device> m_nvram;
 	required_device<tms320av110_device> m_av110;
 	required_device<ymz280b_device> m_ymz;
+	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	required_device<ramdac_device> m_ramdac;
 	required_device<scc66470_device> m_scc66470;
+	required_device<sti3400_device> m_sti3400;
 	required_ioport_array<5> m_strobein;
 	optional_device<meters_device> m_meters;
 	output_finder<256> m_lamps;
@@ -72,6 +74,8 @@ protected:
 	required_device<watchdog_timer_device> m_watchdog;
 
 	std::unique_ptr<uint16_t[]> m_mainram;
+	std::unique_ptr<u8[]> m_scc_line_buffer;
+	std::unique_ptr<u32[]> m_sti_line_buffer;
 
 	uint8_t m_active_strobe;
 	uint8_t m_triac_latch;
@@ -319,6 +323,7 @@ void bfm_cobra3_state::bfm_cobra3_map(address_map &map)
 {
 	map(0x00000000, 0xffffffff).rw(FUNC(bfm_cobra3_state::mem_r), FUNC(bfm_cobra3_state::mem_w));
 	map(0x00800000, 0x009fffff).m(m_scc66470, FUNC(scc66470_device::map)).cswidth(16);
+	map(0x00a40000, 0x00a4007f).m(m_sti3400, FUNC(sti3400_device::map));
 	map(0x00a80000, 0x00a80001).w(FUNC(bfm_cobra3_state::av110_reset_strobe_w)).umask16(0x00ff);
 	map(0x00a81000, 0x00a810ff).m(m_av110, FUNC(tms320av110_device::map)).umask16(0x00ff);
 }
@@ -395,6 +400,8 @@ void bfm_cobra3_state::machine_start()
 	m_volume = 0;
 	m_mainram = make_unique_clear<uint16_t[]>((1024 * 16) / 2);
 	m_nvram->set_base(m_mainram.get(), 1024 * 16);
+	m_scc_line_buffer = std::make_unique<u8[]>(m_screen->visible_area().width());
+	m_sti_line_buffer = std::make_unique<u32[]>(m_screen->visible_area().width());
 
 	save_item(NAME(m_vol_clock));
 	save_item(NAME(m_volume));
@@ -408,62 +415,56 @@ void bfm_cobra3_state::scc66470_irq(int state)
 
 uint32_t bfm_cobra3_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	if (m_scc66470->display_enabled())
+	bitmap.fill(0, cliprect);
+
+	rectangle const &visible = screen.visible_area();
+
+	if (m_sti3400->video_valid())
 	{
-		if (cliprect.min_y == cliprect.max_y)
+		int const source_width = m_sti3400->video_width();
+		int const source_height = m_sti3400->video_height();
+		if (source_width && source_height)
 		{
-			uint32_t *dest = &bitmap.pix(cliprect.min_y);
-			uint8_t buffer[768];
-			uint8_t *src = buffer;
-			m_scc66470->line(cliprect.min_y, buffer, sizeof(buffer));
+			rectangle video(visible);
+			video.set_size(std::min(source_width * 2, visible.width()), std::min(source_height, visible.height()));
+			video.set_origin(visible.left() + (visible.width() - video.width()) / 2, visible.top() + (visible.height() - video.height()) / 2);
 
-			src = buffer;
-
-			if (*src == 254)
+			rectangle const draw = video & cliprect;
+			int const source_left = ((source_width * 2 - video.width()) / 2 + draw.left() - video.left()) / 2;
+			int const source_right = ((source_width * 2 - video.width()) / 2 + draw.right() - video.left()) / 2;
+			for (int y = draw.top(); y <= draw.bottom(); y++)
 			{
-				// Other implementations suggest leaving transparency / MPEG border colour here to ease blending
-				src += 32;
-			}
-			else
-			{
-				dest = std::fill_n(dest, 32, m_palette->pen(*src));
-				src += 32;
-			}
-
-			/* mpeg video has significant overscan, 4 lines either side.
-
-			Just crop it out to fit, presume the chip does this IRL */
-
-			for (int x = 0 ; x < 352 ; x++)
-			{
-				if (*src == 254)
+				u32 *const line = &bitmap.pix(y);
+				int const source_y = (source_height - video.height()) / 2 + y - video.top();
+				m_sti3400->video_line(source_y, source_left, source_right - source_left + 1, m_sti_line_buffer.get());
+				for (int x = draw.left(); x <= draw.right(); x++)
 				{
-					*dest++ = 0; // Will allow MPEG to be drawn i.e. transparent
-					src++;
+					// SCC66470 8-bit output repeats each stored pixel twice horizontally.
+					int const source_x = ((source_width * 2 - video.width()) / 2 + x - video.left()) / 2;
+					line[x] = m_sti_line_buffer[source_x - source_left];
 				}
-				else
-				{
-					*dest++ = m_palette->pen(*src++);
-				}
-
-				if (*src == 254)
-				{
-					*dest++ = 0; // This should be mpeg video pixel i.e. transparent
-					src++;
-				}
-				else
-				{
-					*dest++ = m_palette->pen(*src++);
-				}
-			}
-			// TODO: MPEG image will write a border of 32 pixels of mpeg border colour here when it's mixed in, see above.
-
-			if (*src != 254)
-			{
-				std::fill_n(dest, 32, m_palette->pen(*src));
 			}
 		}
 	}
+
+	if (m_scc66470->display_enabled())
+	{
+		rectangle const draw = visible & cliprect;
+		for (int y = draw.top(); y <= draw.bottom(); y++)
+		{
+			u32 *const line = &bitmap.pix(y);
+			m_scc66470->line(y, m_scc_line_buffer.get(), visible.width());
+
+			for (int x = draw.left(); x <= draw.right(); x++)
+			{
+				u8 const pen = m_scc_line_buffer[x - visible.left()];
+				// The Cobra mixer selects external MPEG video for palette index 0xfe.
+				if (pen != 0xfe)
+					line[x] = m_palette->pen(pen);
+			}
+		}
+	}
+
 	return 0;
 }
 
@@ -476,9 +477,12 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
 	screen_device &screen(SCREEN(config, "screen"));
-	screen.set_raw(15000000, 960, 0, 768, 312, 32, 312);
+	// The SCC66470 produces a pixel clock at half its oscillator frequency.
+	// Cobra uses its 768-pixel, 280-visible-line mode in a 312-line field.
+	screen.set_raw(30_MHz_XTAL / 2, 960, 0, 768, 312, 32, 312);
 	screen.set_video_attributes(VIDEO_UPDATE_SCANLINE);
 	screen.set_screen_update(FUNC(bfm_cobra3_state::screen_update));
+	screen.screen_vblank().set(m_sti3400, FUNC(sti3400_device::vblank_w));
 
 	PALETTE(config, m_palette).set_entries(256);
 
@@ -501,10 +505,14 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	m_av110->add_route(0, "lspeaker", 1.0);
 	m_av110->add_route(1, "rspeaker", 1.0);
 
-	SCC66470(config,m_scc66470,30000000);
+	SCC66470(config,m_scc66470,30_MHz_XTAL);
 	m_scc66470->set_addrmap(0, &bfm_cobra3_state::scc66470_map);
 	m_scc66470->set_screen("screen");
 	m_scc66470->irq().set(FUNC(bfm_cobra3_state::scc66470_irq));
+
+	STI3400(config, m_sti3400, 0); // decoder clock and external-memory cycle timing are not modelled
+	m_sti3400->set_dram_size(1024 * 1024); // Cobra's buffer pointers cover a 1 MiB address space
+	m_sti3400->irq().set_inputline(m_maincpu, 6);
 
 	auto &scsi(NSCSI_BUS(config, m_scsibus));
 	auto &cdrom(NSCSI_CDROM(config, "cdrom"));

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -17,6 +17,7 @@
 #include "machine/nvram.h"
 #include "machine/rescap.h"
 #include "machine/scc66470.h"
+#include "machine/timer.h"
 #include "machine/watchdog.h"
 #include "sound/tms320av110.h"
 #include "sound/ymz280b.h"
@@ -75,7 +76,7 @@ protected:
 
 	std::unique_ptr<uint16_t[]> m_mainram;
 	std::unique_ptr<u8[]> m_scc_line_buffer;
-	std::unique_ptr<u32[]> m_sti_line_buffer;
+	bitmap_rgb32 m_scc_bitmap;
 
 	uint8_t m_active_strobe;
 	uint8_t m_triac_latch;
@@ -83,6 +84,8 @@ protected:
 	uint8_t m_volume;
 
 	virtual void machine_start() override ATTR_COLD;
+	virtual void video_start() override ATTR_COLD;
+	virtual void video_reset() override ATTR_COLD;
 
 	void volume_control(uint8_t direction, uint8_t clock);
 	void av110_reset_strobe_w(u8 data);
@@ -90,6 +93,7 @@ protected:
 	void mem_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	TIMER_DEVICE_CALLBACK_MEMBER(scc_scanline);
 
 	void scc66470_irq(int state);
 
@@ -400,17 +404,58 @@ void bfm_cobra3_state::machine_start()
 	m_volume = 0;
 	m_mainram = make_unique_clear<uint16_t[]>((1024 * 16) / 2);
 	m_nvram->set_base(m_mainram.get(), 1024 * 16);
-	m_scc_line_buffer = std::make_unique<u8[]>(m_screen->visible_area().width());
-	m_sti_line_buffer = std::make_unique<u32[]>(m_screen->visible_area().width());
 
 	save_item(NAME(m_vol_clock));
 	save_item(NAME(m_volume));
+}
+
+void bfm_cobra3_state::video_start()
+{
+	m_scc_bitmap.allocate(m_screen->width(), m_screen->height());
+	m_scc_line_buffer = std::make_unique<u8[]>(m_screen->visible_area().width());
+	m_scc_bitmap.fill(rgb_t::transparent());
+
+	// Earlier scanlines cannot be reconstructed from the restored SCC state.
+	save_item(NAME(m_scc_bitmap));
+}
+
+void bfm_cobra3_state::video_reset()
+{
+	m_scc_bitmap.fill(rgb_t::transparent());
 }
 
 
 void bfm_cobra3_state::scc66470_irq(int state)
 {
 	m_maincpu->set_input_line(5, state);
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(bfm_cobra3_state::scc_scanline)
+{
+	rectangle const &visible = m_screen->visible_area();
+	if ((param < visible.top()) || (param > visible.bottom()))
+		return;
+
+	u32 *const destination = &m_scc_bitmap.pix(param, visible.left());
+
+	if (m_scc66470->display_enabled())
+	{
+		m_scc66470->line(param, m_scc_line_buffer.get(), visible.width());
+		pen_t const *const pens = m_palette->pens();
+		for (int x = 0; x != visible.width(); x++)
+		{
+			u8 const pen = m_scc_line_buffer[x];
+			// The Cobra mixer selects external MPEG video for palette index 0xfe.
+			if (pen == 0xfe)
+				destination[x] = rgb_t::transparent();
+			else
+				destination[x] = pens[pen];
+		}
+	}
+	else
+	{
+		std::fill_n(destination, visible.width(), rgb_t::transparent());
+	}
 }
 
 uint32_t bfm_cobra3_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
@@ -421,49 +466,18 @@ uint32_t bfm_cobra3_state::screen_update(screen_device &screen, bitmap_rgb32 &bi
 
 	if (m_sti3400->video_valid())
 	{
-		int const source_width = m_sti3400->video_width();
-		int const source_height = m_sti3400->video_height();
-		if (source_width && source_height)
-		{
-			rectangle video(visible);
-			video.set_size(std::min(source_width * 2, visible.width()), std::min(source_height, visible.height()));
-			video.set_origin(visible.left() + (visible.width() - video.width()) / 2, visible.top() + (visible.height() - video.height()) / 2);
+		bitmap_rgb32 const &source = m_sti3400->bitmap();
+		rectangle video(visible);
+		video.set_size(std::min(source.width() * 2, visible.width()), std::min(source.height(), visible.height()));
+		video.set_origin(visible.left() + (visible.width() - video.width()) / 2, visible.top() + (visible.height() - video.height()) / 2);
 
-			rectangle const draw = video & cliprect;
-			int const source_left = ((source_width * 2 - video.width()) / 2 + draw.left() - video.left()) / 2;
-			int const source_right = ((source_width * 2 - video.width()) / 2 + draw.right() - video.left()) / 2;
-			for (int y = draw.top(); y <= draw.bottom(); y++)
-			{
-				u32 *const line = &bitmap.pix(y);
-				int const source_y = (source_height - video.height()) / 2 + y - video.top();
-				m_sti3400->video_line(source_y, source_left, source_right - source_left + 1, m_sti_line_buffer.get());
-				for (int x = draw.left(); x <= draw.right(); x++)
-				{
-					// SCC66470 8-bit output repeats each stored pixel twice horizontally.
-					int const source_x = ((source_width * 2 - video.width()) / 2 + x - video.left()) / 2;
-					line[x] = m_sti_line_buffer[source_x - source_left];
-				}
-			}
-		}
+		// SCC66470 8-bit output repeats each stored pixel twice horizontally.
+		s32 const startx = (((source.width() * 2 - video.width()) / 2) - video.left()) * 0x8000;
+		s32 const starty = (((source.height() - video.height()) / 2) - video.top()) * 0x10000;
+		copyrozbitmap(bitmap, video & cliprect, source, startx, starty, 0x8000, 0, 0, 0x10000, false);
 	}
 
-	if (m_scc66470->display_enabled())
-	{
-		rectangle const draw = visible & cliprect;
-		for (int y = draw.top(); y <= draw.bottom(); y++)
-		{
-			u32 *const line = &bitmap.pix(y);
-			m_scc66470->line(y, m_scc_line_buffer.get(), visible.width());
-
-			for (int x = draw.left(); x <= draw.right(); x++)
-			{
-				u8 const pen = m_scc_line_buffer[x - visible.left()];
-				// The Cobra mixer selects external MPEG video for palette index 0xfe.
-				if (pen != 0xfe)
-					line[x] = m_palette->pen(pen);
-			}
-		}
-	}
+	copybitmap_transalpha(bitmap, m_scc_bitmap, 0, 0, 0, 0, visible & cliprect);
 
 	return 0;
 }
@@ -480,7 +494,6 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	// The SCC66470 produces a pixel clock at half its oscillator frequency.
 	// Cobra uses its 768-pixel, 280-visible-line mode in a 312-line field.
 	screen.set_raw(30_MHz_XTAL / 2, 960, 0, 768, 312, 32, 312);
-	screen.set_video_attributes(VIDEO_UPDATE_SCANLINE);
 	screen.set_screen_update(FUNC(bfm_cobra3_state::screen_update));
 	screen.screen_vblank().set(m_sti3400, FUNC(sti3400_device::vblank_w));
 
@@ -509,6 +522,7 @@ void bfm_cobra3_state::bfm_cobra3(machine_config &config)
 	m_scc66470->set_addrmap(0, &bfm_cobra3_state::scc66470_map);
 	m_scc66470->set_screen("screen");
 	m_scc66470->irq().set(FUNC(bfm_cobra3_state::scc66470_irq));
+	TIMER(config, "scc_scanline").configure_scanline(FUNC(bfm_cobra3_state::scc_scanline), m_screen, 0, 1);
 
 	STI3400(config, m_sti3400, 0); // decoder clock and external-memory cycle timing are not modelled
 	m_sti3400->set_dram_size(1024 * 1024); // Cobra's buffer pointers cover a 1 MiB address space

--- a/src/mame/bfm/bfm_cobra3.cpp
+++ b/src/mame/bfm/bfm_cobra3.cpp
@@ -405,6 +405,8 @@ void bfm_cobra3_state::machine_start()
 	m_mainram = make_unique_clear<uint16_t[]>((1024 * 16) / 2);
 	m_nvram->set_base(m_mainram.get(), 1024 * 16);
 
+	save_pointer(NAME(m_mainram), (1024 * 16) / 2);
+	save_item(NAME(m_active_strobe));
 	save_item(NAME(m_vol_clock));
 	save_item(NAME(m_volume));
 }


### PR DESCRIPTION
## 3/4 for Telly Addicts, Radio Times, Top of the Pops, and the Phrase that Pays on the Bellfruit Cobra 3

This is the third of a series of changes intended to get all titles (previously just Telly Addicts) on the Bellfruit Cobra 3 through to working.

The planned dependency order is:

1. MC68340 DMA, interrupt handling, and Cobra 3 board-level integration - merged in #15896
2. TMS320AV110 MPEG audio - merged in #15907
3. **MPEG-1 video and STi3400 support - this change**
4. All titles' controls, lamps, layout, and serial interfaces, cash-handling hardware and their meters.

The now complete development version can be viewed here:
https://github.com/MagikalUnicorn/mame/commits/cobra3

## This change

This adds a reusable MPEG-1 video decoder, emulation of the implemented portions of the STMicroelectronics STi3400 MPEG video decoder, and the corresponding Cobra 3 integration.

The generic MPEG-1 decoder supports:

- MPEG-1 video elementary streams;
- sequence, group, picture and slice parsing;
- I, P and B picture reconstruction;
- forward, backward and bidirectional motion compensation;
- full-pixel and half-pixel motion vectors;
- skipped macroblocks;
- intra and non-intra inverse quantisation, including custom quantiser matrices;
- inverse DCT;
- caller-owned YCbCr 4:2:0 picture buffers;
- distinct results for completed pictures, sequence ends, incomplete input and invalid data; and
- save-state support for decoding parameters, predictors and reference-picture history.

It was implemented directly from [ISO/IEC 11172-2:1993](https://www.iso.org/standard/22411.html) and its technical corrigenda.

The STi3400 implementation covers the functionality currently exercised by the available Cobra 3 software:

- the host register interface;
- compressed-data input and bit-buffer level reporting;
- the 256-bit header FIFO;
- MPEG start-code searching and header-position reporting;
- decoder status, interrupt status and interrupt masking;
- vertical-sync and decode-task handling;
- reconstructed, forward-reference, backward-reference and displayed-picture pointers;
- external picture DRAM;
- repeat-picture and overwrite-display operations;
- complete-picture presentation; and
- save-state support for the host interface, buffers, picture memory, decoder state and pending tasks.

The generic MPEG-1 decoder performs picture reconstruction, while the STi3400 device owns the hardware-facing registers, buffering, scheduling and external picture memory. Pictures are reconstructed into the configured external DRAM and presented through the STi3400 display-picture mechanism, ensuring that only complete pictures become visible.

The Cobra 3 driver maps the STi3400 host interface, connects its interrupt and vertical-blank signals, and configures its 1 MiB picture memory. Decoded video is composited beneath the SCC66470 output using the external-video palette selection made by the board.

The STi3400 behaviour was implemented from its [data sheet](https://www.datasheetarchive.com/?q=sti3400).

H.261 decoding, exact internal pipeline and external-memory timing, and functionality not exercised by the available Cobra 3 software remain outside the implemented scope. The device therefore reports imperfect timing.

## Validation

A targeted release build completed successfully, and MAME validation passed.

Finite unthrottled smoke tests completed without errors for:

- `c3_telly`
- `c3_tellyns`
- `c3_rtime`
- `c3_totp`
- `c3_ppays`

Frame ordering was also compared against extracted MPEG streams for the Top of the Pops opening sequence and The Phrase That Pays attract sequence. This included I, P and B picture ordering, repeated playback, complete-picture presentation, and save/load during active video playback.

## AI assistance disclosure

I used OpenAI Codex (GPT-5) to carry out the investigations and the majority of the implementation, code reviews, clean-history reconstruction and testing. The generic MPEG-1 decoder backend was produced entirely with Codex assistance from the ISO standard under my direction.

I reviewed the resulting code and test results, extensively tested the implementation myself, and directed its design, scope, hardware integration and change structure towards what I considered the cleanest and most MAME-like approach.

I take responsibility for the submitted changes and will disclose the extent of AI assistance separately for each subsequent submission.