### PR TITLE
toshiba/rupo.cpp: Add not working word processor

### DIFF
--- a/hash/rupo_flop.xml
+++ b/hash/rupo_flop.xml
@@ -5,121 +5,37 @@ license:CC0-1.0
 
 Known undumped software releases:
 
-- [T-W003] Jong Kyo (ジャン狂)
-- [T-W004] Lode Runner (ロードランナー)
-- [T-W005] Bomberman (ボンバーマン)
-- [JWS2073B] 毛筆
-- [JWS2086C] アウトラインフォント
-- [JWS2091A] 名簿テータバンク
-- [JWS2092A] 表計算Ⅱ
-- [JWS2092C] 表計算Ⅱソフド
-- [JWS2092D] 表計算Ⅲ
-- [JWS2097C] アウトライン外字作成用ソフト
-- [JWS2931B] MS-DOS テキスト変換ユーティリティ
-- [JWS2953C] アウトラインフォント
-- [JWS2960B] ぼのぼのデザインコレクション
-- [JWS2995A] 企画書上手
-- [JW-S014] はがき上手'89
-- [JW-S016] ワープロ手帳Ⅱ
-- [JW-S031] Knight Moves (ナイトムーブス)
-- [JW-S033] はがき上手「四季」Ⅲ
-- [JW-S039] はがき上手「四季」Ⅳ
-- [PNS0120A] トラベル英会話
-- [PN-S301] Daisenryaku (大戦略)
-- [PN-S302] Mahjong Gokuu (麻雀悟空)
-- [PN-S303] Shanghai II (上海Ⅱ) (1993 Release)
-- [PN-S307] Shanghai II (上海Ⅱ) (Monochrome + Color Release)
-- [PN-S308] Trump World (トランプワールド)
-- [PN-S309] Mahjong Gokuu Tenjiku (麻雀悟空天竺) (SVGA Release)
-- [PN-S401] パーソナル情報バンク
-- [S0330] はがき上手「四季編・特選」
+- [T-W005]   Bomberman (ボンバーマン)
+- [JWS2960B] Bo no Bo no Design Collection (ぼのぼのデザインコレクション)
+- [PN-S301]  Daisenryaku (大戦略)
+- [JW-S014]  Hagaki Jouzu '89 (はがき上手'89)
+- [S0330]    Hagaki Jouzu "Shiki-hen Tokusen" (はがき上手「四季編・特選」)
+- [JW-S033]  Hagaki Jouzu "Shiki" II (はがき上手「四季」Ⅲ)
+- [JW-S039]  Hagaki Jouzu "Shiki" IV (はがき上手「四季」Ⅳ)
+- [T-W003]   Jong Kyo (ジャン狂)
+- [JWS2995A] Kikaku-sho Jouzu (企画書上手)
+- [JW-S031]  Knight Moves (ナイトムーブス)
+- [T-W004]   Lode Runner (ロードランナー)
+- [PN-S309]  Mahjong Gokuu Tenjiku (麻雀悟空天竺) (SVGA Release)
+- [PN-S302]  Mahjong Gokuu (麻雀悟空)
+- [JWS2091A] Meibo Data Bank (名簿テータバンク)
+- [JWS2073B] Mouhitsu (毛筆)
+- [JWS2931B] MS-DOS Tekisuto Henkan Utility (MS-DOS テキスト変換ユーティリティ)
+- [JWS2092D] Omotekeisan III (表計算Ⅲ)
+- [JWS2092C] Omotekeisan II Software (表計算Ⅱソフド)
+- [JWS2092A] Omotekeisan II (表計算Ⅱ)
+- [JWS2086C] Outline Font (アウトラインフォント)
+- [JWS2953C] Outline Font (アウトラインフォント)
+- [JWS2097C] Outline Gaiji Sakusei-you Software (アウトライン外字作成用ソフト)
+- [PN-S401]  Personal Jouhou Bank (パーソナル情報バンク)
+- [PN-S303]  Shanghai II (上海Ⅱ) (1993 Release)
+- [PN-S307]  Shanghai II (上海Ⅱ) (Monochrome + Color Release)
+- [PNS0120A] Travel Eikaiwa (トラベル英会話)
+- [PN-S308]  Trump World (トランプワールド)
+- [JW-S016]  Word Processor Techou II (ワープロ手帳Ⅱ)
 -->
 
 <softwarelist name="rupo_flop" description="Toshiba Rupo Personal Word Processor floppy disk images">
-
-	<software name="ishidou" supported="no">
-		<description>Ishidou - The Way Of Stones</description>
-		<year>199?</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Dumped from non-original media.
-]]></notes>
-		<info name="alt_title" value="石道"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="ishidou.mfm" size="655360" crc="d084d26c" sha1="03d695a22c19e8eeeaa7d0a1ed4e2b2bd84e190c"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shanghai" supported="no">
-		<description>Shanghai</description>
-		<year>1990</year>
-		<publisher>ASCII Corporation / Activision</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Track 78 null-filled: no flux in MFM pulse intervals.
-]]></notes>
-		<info name="alt_title" value="上海"/>
-		<info name="serial" value="JW-S018"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="jw-s018.mfm" size="655360" crc="60355d61" sha1="2b144c200b78be2c2d226bd6d039cad7d1655525"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sokoban" supported="no">
-		<description>Sokoban</description>
-		<year>1990</year>
-		<publisher>ASCII Corporation / Thinking Rabbit</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Dumped from non-original media.
-]]></notes>
-		<info name="alt_title" value="倉庫番"/>
-		<info name="serial" value="JW-S019"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="jw-s019.mfm" size="655360" crc="d56ed669" sha1="4c2f10f3cabebd2fcdc3a4539f6bb6089eccc11b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mahgokuu" supported="no">
-		<description>Mahjong Gokuu</description>
-		<year>1990</year>
-		<publisher>Chatnoir</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Dumped from non-original media.
-]]></notes>
-		<info name="alt_title" value="麻雀悟空"/>
-		<info name="serial" value="JW-S020"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="jw-s020.mfm" size="655360" crc="b4511eec" sha1="e9b825d5c9c4d001f177ee9f7cd0b8368b12965b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tetris" supported="no">
-		<description>Tetris</description>
-		<year>1990</year>
-		<publisher>ASCII Corporation / Bullet-Proof Software Inc.</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Track 78 null-filled: no flux in MFM pulse intervals.
-]]></notes>
-		<info name="alt_title" value="テトリス"/>
-		<info name="serial" value="JW-S023"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="jw-s023.mfm" size="655360" crc="7b92a698" sha1="b398e8148882e30a3e58ae9484bbb1f28003ca99"/>
-			</dataarea>
-		</part>
-	</software>
 
 	<software name="cardcon" supported="no">
 		<description>Card Connection</description>
@@ -139,53 +55,35 @@ Marked bad due to missing file data (leftover graphics from Ishidou?).
 		</part>
 	</software>
 
-	<software name="sanrioc" supported="no">
-		<description>Sanrio Carnival</description>
-		<year>1991</year>
-		<publisher>ASCII Corporation</publisher>
+	<software name="ishidou" supported="no">
+		<description>Ishidou - The Way Of Stones</description>
+		<year>199?</year>
+		<publisher>&lt;unknown&gt;</publisher>
 		<notes><![CDATA[
 256 bytes/sector, 16 sectors/track, 80 tracks/side.
 Dumped from non-original media.
 ]]></notes>
-		<info name="alt_title" value="サンリオカーニバル"/>
-		<info name="serial" value="JW-S028"/>
+		<info name="alt_title" value="石道"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="655360">
-				<rom name="jw-s028.mfm" size="655360" crc="da8f9ea1" sha1="46f7e8f627cf8a9092ac7de7a321e135c7200266"/>
+				<rom name="ishidou.mfm" size="655360" crc="d084d26c" sha1="03d695a22c19e8eeeaa7d0a1ed4e2b2bd84e190c"/>
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="tesserae" supported="no">
-		<description>Tesserae</description>
-		<year>1991</year>
-		<publisher>ASCII Corporation</publisher>
+	<software name="mahgokuu" supported="no">
+		<description>Mahjong Gokuu</description>
+		<year>1990</year>
+		<publisher>Chatnoir</publisher>
 		<notes><![CDATA[
 256 bytes/sector, 16 sectors/track, 80 tracks/side.
 Dumped from non-original media.
 ]]></notes>
-		<info name="alt_title" value="テッセラ"/>
-		<info name="serial" value="JW-S029"/>
+		<info name="alt_title" value="麻雀悟空"/>
+		<info name="serial" value="JW-S020"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="655360">
-				<rom name="jw-s029.mfm" size="655360" crc="86554a35" sha1="25d4a63b88027f78e112ef4b8e6335db6c23c6aa"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shang2" supported="no">
-		<description>Shanghai II</description>
-		<year>1991</year>
-		<publisher>ASCII Corporation / Activision</publisher>
-		<notes><![CDATA[
-256 bytes/sector, 16 sectors/track, 80 tracks/side.
-Dumped from non-original media.
-Tracks 47,48 Side 1 Sector 15 have invalid header CRCs.
-]]></notes>
-		<info name="alt_title" value="上海Ⅱ"/>
-		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="655360">
-				<rom name="shang2.mfm" size="655360" crc="4526dc82" sha1="22c683d5e5af132aa90fe09e74f70ea9eb9620f0" status="baddump"/>
+				<rom name="jw-s020.mfm" size="655360" crc="b4511eec" sha1="e9b825d5c9c4d001f177ee9f7cd0b8368b12965b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -210,6 +108,108 @@ Color Version: 512 bytes/sector, 18 sectors/track, 80 tracks/side.
 			<feature name="part_id" value="Color Version (カラー液晶対応版)"/>
 			<dataarea name="flop" size="1474560">
 				<rom name="pn-s306.color.mfm" size="1474560" crc="cf111f2e" sha1="a491225a8eeec3481da8a710e03443c097e51660"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sanrioc" supported="no">
+		<description>Sanrio Carnival</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="サンリオカーニバル"/>
+		<info name="serial" value="JW-S028"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s028.mfm" size="655360" crc="da8f9ea1" sha1="46f7e8f627cf8a9092ac7de7a321e135c7200266"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shanghai" supported="no">
+		<description>Shanghai</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Activision</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Track 78 null-filled: no flux in MFM pulse intervals.
+]]></notes>
+		<info name="alt_title" value="上海"/>
+		<info name="serial" value="JW-S018"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s018.mfm" size="655360" crc="60355d61" sha1="2b144c200b78be2c2d226bd6d039cad7d1655525"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shang2" supported="no">
+		<description>Shanghai II</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation / Activision</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+Tracks 47,48 Side 1 Sector 15 have invalid header CRCs.
+]]></notes>
+		<info name="alt_title" value="上海Ⅱ"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="shang2.mfm" size="655360" crc="4526dc82" sha1="22c683d5e5af132aa90fe09e74f70ea9eb9620f0" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sokoban" supported="no">
+		<description>Sokoban</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Thinking Rabbit</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="倉庫番"/>
+		<info name="serial" value="JW-S019"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s019.mfm" size="655360" crc="d56ed669" sha1="4c2f10f3cabebd2fcdc3a4539f6bb6089eccc11b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tesserae" supported="no">
+		<description>Tesserae</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="テッセラ"/>
+		<info name="serial" value="JW-S029"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s029.mfm" size="655360" crc="86554a35" sha1="25d4a63b88027f78e112ef4b8e6335db6c23c6aa"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tetris" supported="no">
+		<description>Tetris</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Bullet-Proof Software Inc.</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Track 78 null-filled: no flux in MFM pulse intervals.
+]]></notes>
+		<info name="alt_title" value="テトリス"/>
+		<info name="serial" value="JW-S023"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s023.mfm" size="655360" crc="7b92a698" sha1="b398e8148882e30a3e58ae9484bbb1f28003ca99"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/rupo_flop.xml
+++ b/hash/rupo_flop.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0-1.0
@@ -6,7 +6,7 @@ license:CC0-1.0
 Known undumped software releases:
 
 - [T-W005]   Bomberman (ボンバーマン)
-- [JWS2960B] Bo no Bo no Design Collection (ぼのぼのデザインコレクション)
+- [JWS2960B] Bonobono Design Collection (ぼのぼのデザインコレクション)
 - [PN-S301]  Daisenryaku (大戦略)
 - [JW-S014]  Hagaki Jouzu '89 (はがき上手'89)
 - [S0330]    Hagaki Jouzu "Shiki-hen Tokusen" (はがき上手「四季編・特選」)
@@ -16,14 +16,14 @@ Known undumped software releases:
 - [JWS2995A] Kikaku-sho Jouzu (企画書上手)
 - [JW-S031]  Knight Moves (ナイトムーブス)
 - [T-W004]   Lode Runner (ロードランナー)
-- [PN-S309]  Mahjong Gokuu Tenjiku (麻雀悟空天竺) (SVGA Release)
 - [PN-S302]  Mahjong Gokuu (麻雀悟空)
+- [PN-S309]  Mahjong Gokuu Tenjiku (麻雀悟空天竺) (SVGA Release)
 - [JWS2091A] Meibo Data Bank (名簿テータバンク)
 - [JWS2073B] Mouhitsu (毛筆)
 - [JWS2931B] MS-DOS Tekisuto Henkan Utility (MS-DOS テキスト変換ユーティリティ)
-- [JWS2092D] Omotekeisan III (表計算Ⅲ)
-- [JWS2092C] Omotekeisan II Software (表計算Ⅱソフド)
 - [JWS2092A] Omotekeisan II (表計算Ⅱ)
+- [JWS2092C] Omotekeisan II Software (表計算Ⅱソフド)
+- [JWS2092D] Omotekeisan III (表計算Ⅲ)
 - [JWS2086C] Outline Font (アウトラインフォント)
 - [JWS2953C] Outline Font (アウトラインフォント)
 - [JWS2097C] Outline Gaiji Sakusei-you Software (アウトライン外字作成用ソフト)

--- a/hash/rupo_flop.xml
+++ b/hash/rupo_flop.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+
+Known undumped software releases:
+
+- [T-W003] Jong Kyo (ジャン狂)
+- [T-W004] Lode Runner (ロードランナー)
+- [T-W005] Bomberman (ボンバーマン)
+- [JWS2073B] 毛筆
+- [JWS2086C] アウトラインフォント
+- [JWS2091A] 名簿テータバンク
+- [JWS2092A] 表計算Ⅱ
+- [JWS2092C] 表計算Ⅱソフド
+- [JWS2092D] 表計算Ⅲ
+- [JWS2097C] アウトライン外字作成用ソフト
+- [JWS2931B] MS-DOS テキスト変換ユーティリティ
+- [JWS2953C] アウトラインフォント
+- [JWS2960B] ぼのぼのデザインコレクション
+- [JWS2995A] 企画書上手
+- [JW-S014] はがき上手'89
+- [JW-S016] ワープロ手帳Ⅱ
+- [JW-S031] Knight Moves (ナイトムーブス)
+- [JW-S033] はがき上手「四季」Ⅲ
+- [JW-S039] はがき上手「四季」Ⅳ
+- [PNS0120A] トラベル英会話
+- [PN-S301] Daisenryaku (大戦略)
+- [PN-S302] Mahjong Gokuu (麻雀悟空)
+- [PN-S303] Shanghai II (上海Ⅱ) (1993 Release)
+- [PN-S307] Shanghai II (上海Ⅱ) (Monochrome + Color Release)
+- [PN-S308] Trump World (トランプワールド)
+- [PN-S309] Mahjong Gokuu Tenjiku (麻雀悟空天竺) (SVGA Release)
+- [PN-S401] パーソナル情報バンク
+- [S0330] はがき上手「四季編・特選」
+-->
+
+<softwarelist name="rupo_flop" description="Toshiba Rupo Personal Word Processor floppy disk images">
+
+	<software name="ishidou" supported="no">
+		<description>Ishidou - The Way Of Stones</description>
+		<year>199?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="石道"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="ishidou.mfm" size="655360" crc="d084d26c" sha1="03d695a22c19e8eeeaa7d0a1ed4e2b2bd84e190c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shanghai" supported="no">
+		<description>Shanghai</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Activision</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Track 78 null-filled: no flux in MFM pulse intervals.
+]]></notes>
+		<info name="alt_title" value="上海"/>
+		<info name="serial" value="JW-S018"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s018.mfm" size="655360" crc="60355d61" sha1="2b144c200b78be2c2d226bd6d039cad7d1655525"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sokoban" supported="no">
+		<description>Sokoban</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Thinking Rabbit</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="倉庫番"/>
+		<info name="serial" value="JW-S019"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s019.mfm" size="655360" crc="d56ed669" sha1="4c2f10f3cabebd2fcdc3a4539f6bb6089eccc11b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mahgokuu" supported="no">
+		<description>Mahjong Gokuu</description>
+		<year>1990</year>
+		<publisher>Chatnoir</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="麻雀悟空"/>
+		<info name="serial" value="JW-S020"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s020.mfm" size="655360" crc="b4511eec" sha1="e9b825d5c9c4d001f177ee9f7cd0b8368b12965b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tetris" supported="no">
+		<description>Tetris</description>
+		<year>1990</year>
+		<publisher>ASCII Corporation / Bullet-Proof Software Inc.</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Track 78 null-filled: no flux in MFM pulse intervals.
+]]></notes>
+		<info name="alt_title" value="テトリス"/>
+		<info name="serial" value="JW-S023"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s023.mfm" size="655360" crc="7b92a698" sha1="b398e8148882e30a3e58ae9484bbb1f28003ca99"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cardcon" supported="no">
+		<description>Card Connection</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Track 78 null-filled: all sectors have invalid header type codes.
+Marked bad due to missing file data (leftover graphics from Ishidou?).
+]]></notes>
+		<info name="alt_title" value="カードコネクション"/>
+		<info name="serial" value="JW-S025"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s025.mfm" size="655360" crc="0ba6c093" sha1="c26b198a98c5bf79efdb733d9aa0252e9fc17325" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sanrioc" supported="no">
+		<description>Sanrio Carnival</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="サンリオカーニバル"/>
+		<info name="serial" value="JW-S028"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s028.mfm" size="655360" crc="da8f9ea1" sha1="46f7e8f627cf8a9092ac7de7a321e135c7200266"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tesserae" supported="no">
+		<description>Tesserae</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+]]></notes>
+		<info name="alt_title" value="テッセラ"/>
+		<info name="serial" value="JW-S029"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="jw-s029.mfm" size="655360" crc="86554a35" sha1="25d4a63b88027f78e112ef4b8e6335db6c23c6aa"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shang2" supported="no">
+		<description>Shanghai II</description>
+		<year>1991</year>
+		<publisher>ASCII Corporation / Activision</publisher>
+		<notes><![CDATA[
+256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Dumped from non-original media.
+Tracks 47,48 Side 1 Sector 15 have invalid header CRCs.
+]]></notes>
+		<info name="alt_title" value="上海Ⅱ"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="655360">
+				<rom name="shang2.mfm" size="655360" crc="4526dc82" sha1="22c683d5e5af132aa90fe09e74f70ea9eb9620f0" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mahgoten" supported="no">
+		<description>Mahjong Gokuu Tenjiku</description>
+		<year>1995</year>
+		<publisher>Chatnoir</publisher>
+		<notes><![CDATA[
+Monochrome Version: 256 bytes/sector, 16 sectors/track, 80 tracks/side.
+Color Version: 512 bytes/sector, 18 sectors/track, 80 tracks/side.
+]]></notes>
+		<info name="alt_title" value="麻雀悟空天竺"/>
+		<info name="serial" value="PN-S306"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Monochrome Version (モノクロ液晶対応版)"/>
+			<dataarea name="flop" size="655360">
+				<rom name="pn-s306.mono.mfm" size="655360" crc="a8cc6091" sha1="52cc76be298a3d6598ba3cdaf49532aecfd9bc41"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Color Version (カラー液晶対応版)"/>
+			<dataarea name="flop" size="1474560">
+				<rom name="pn-s306.color.mfm" size="1474560" crc="cf111f2e" sha1="a491225a8eeec3481da8a710e03443c097e51660"/>
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47577,6 +47577,9 @@ pasopia
 pasopia7
 pasopia7lcd
 
+@source:toshiba/rupo.cpp
+jwv860
+
 @source:toshiba/t250.cpp
 t200
 t250

--- a/src/mame/toshiba/rupo.cpp
+++ b/src/mame/toshiba/rupo.cpp
@@ -60,6 +60,11 @@
 #include "screen.h"
 #include "softlist_dev.h"
 
+#define LOG_IO (1U << 1)
+
+//#define VERBOSE (LOG_IO)
+#include "logmacro.h"
+
 
 namespace {
 
@@ -89,11 +94,11 @@ private:
 
 	static void floppy_formats(format_registration &fr);
 
-	void jwcolor_am29k_data_map(address_map &map) ATTR_COLD;
-	void jwcolor_am29k_map(address_map &map) ATTR_COLD;
-	void jwcolor_am486_io_map(address_map &map) ATTR_COLD;
-	void jwcolor_am486_map(address_map &map) ATTR_COLD;
-	void jwcolor_palette(palette_device &palette) const ATTR_COLD;
+	void am29k_data_map(address_map &map) ATTR_COLD;
+	void am29k_prg_map(address_map &map) ATTR_COLD;
+	void am486_io_map(address_map &map) ATTR_COLD;
+	void am486_prg_map(address_map &map) ATTR_COLD;
+	void palette(palette_device &palette) const ATTR_COLD { }
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	u16 m_io_00d0;
@@ -120,50 +125,48 @@ void jwcolor_state::floppy_formats(format_registration &fr)
 	fr.add_mfm_containers();
 }
 
-void jwcolor_state::jwcolor_am29k_data_map(address_map &map)
+void jwcolor_state::am29k_data_map(address_map &map)
 {
 	map(0x00000000, 0x001fffff).rom().region("ic49", 0);
 }
 
-void jwcolor_state::jwcolor_am29k_map(address_map &map)
+void jwcolor_state::am29k_prg_map(address_map &map)
 {
 	map(0x00000000, 0x001fffff).rom().region("ic49", 0);
 }
 
-void jwcolor_state::jwcolor_am486_io_map(address_map &map)
+void jwcolor_state::am486_io_map(address_map &map)
 {
 	map(0x0398, 0x0398).lr8(
 		NAME([this]() {
-			m_io_0398 = m_io_0398 == 0 ? 0x88 : 0;
-			logerror("%s: io_0398_r = %02x\n", machine().describe_context(), m_io_0398);
+			if (!machine().side_effects_disabled()) {
+				m_io_0398 = m_io_0398 == 0 ? 0x88 : 0;
+				LOGMASKED(LOG_IO, "%s: io_0398_r = %02x\n", machine().describe_context(), m_io_0398);
+			}
 			return m_io_0398;
 		}));
 	map(0x03bd, 0x03bd).lr8(
 		NAME([this]() {
-			logerror("%s: io_03bd_r = 0\n", machine().describe_context());
+			if (!machine().side_effects_disabled()) {
+				LOGMASKED(LOG_IO, "%s: io_03bd_r = 0\n", machine().describe_context());
+			}
 			return 0;
 		}));
 	map(0x00d0, 0x00d1).lr16(
 		NAME([this](offs_t offset) {
-			m_io_00d0 += 100;
-			logerror("%s: io_00d0_r = %02x\n", machine().describe_context(), m_io_00d0);
+			if (!machine().side_effects_disabled()) {
+				m_io_00d0 += 100;
+				LOGMASKED(LOG_IO, "%s: io_00d0_r = %02x\n", machine().describe_context(), m_io_00d0);
+			}
 			return m_io_00d0;
 		}));
 }
 
-void jwcolor_state::jwcolor_am486_map(address_map &map)
+void jwcolor_state::am486_prg_map(address_map &map)
 {
 	map(0x00000000, 0x000001ff).ram();
 	map(0x00020000, 0x0002ffff).rom().region("ic19_ic21", 0x20000);
 	map(0x000ffff0, 0x000fffff).mirror(0xfff00000).rom().region("ic19_ic21", 0x100);
-}
-
-void jwcolor_state::jwcolor_palette(palette_device &palette) const
-{
-	for (size_t i = 0; i < 0xff; i++) {
-		palette.set_pen_color(i, 0xff, 0xff, 0xff);
-	}
-	palette.set_pen_color(0xff, 0x00, 0x00, 0x00);
 }
 
 u32 jwcolor_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
@@ -174,12 +177,12 @@ u32 jwcolor_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, co
 void jwcolor_state::jwcolor(machine_config &config)
 {
 	AM29000(config, m_am29k, 20_MHz_XTAL);
-	m_am29k->set_addrmap(AS_PROGRAM, &jwcolor_state::jwcolor_am29k_map);
-	m_am29k->set_addrmap(AS_DATA, &jwcolor_state::jwcolor_am29k_data_map);
+	m_am29k->set_addrmap(AS_PROGRAM, &jwcolor_state::am29k_prg_map);
+	m_am29k->set_addrmap(AS_DATA, &jwcolor_state::am29k_data_map);
 
 	I486(config, m_am486, 66_MHz_XTAL);
-	m_am486->set_addrmap(AS_PROGRAM, &jwcolor_state::jwcolor_am486_map);
-	m_am486->set_addrmap(AS_IO, &jwcolor_state::jwcolor_am486_io_map);
+	m_am486->set_addrmap(AS_PROGRAM, &jwcolor_state::am486_prg_map);
+	m_am486->set_addrmap(AS_IO, &jwcolor_state::am486_io_map);
 
 	SCREEN(config, m_screen);
 	m_screen->set_refresh_hz(60);
@@ -188,7 +191,7 @@ void jwcolor_state::jwcolor(machine_config &config)
 	m_screen->set_screen_update(FUNC(jwcolor_state::screen_update));
 	m_screen->set_palette("palette");
 
-	PALETTE(config, "palette", FUNC(jwcolor_state::jwcolor_palette), 256);
+	PALETTE(config, "palette", FUNC(jwcolor_state::palette), 256);
 
 	FLOPPY_CONNECTOR(config, m_flop, jwcolor_floppies, "35hd", jwcolor_state::floppy_formats);
 	SOFTWARE_LIST(config, "fd_list").set_original("rupo_flop");

--- a/src/mame/toshiba/rupo.cpp
+++ b/src/mame/toshiba/rupo.cpp
@@ -1,0 +1,225 @@
+// license:BSD-3-Clause
+// copyright-holders:QUFB
+/***************************************************************************
+
+    Skeleton driver for Toshiba Rupo (ルポ) Personal Word Processors.
+
+    Models list: https://dynabook.com/assistpc/rupo/page/list.htm
+
+    Hardware
+    --------
+
+    JW-V860 (JWP2860A):
+
+    Main Board Markings: KS-112 F8FHC1 B36017091014
+    - IC1: AMD Am486 DE2-66V8TYC (x86 IA-32 CPU)
+    - IC2: Toshiba TC203G14CF
+    - IC4: Toshiba TC170G35AF
+    - IC5: Toshiba SLA9092FF0B
+    - IC19: Toshiba 5GN1 KM23V32000BG (4M Mask ROM)
+    - IC21: Toshiba LHMV5GN2 (4M Mask ROM)
+    - IC24: Toshiba LHMNOPN9 (8M Mask ROM)
+    - IC26: Toshiba OPNA KM23C64000G (8M Mask ROM)
+    - IC27: Toshiba P46008004022 (4M Mask ROM)
+    - IC30,31: Fujitsu 81V16165B-60LPFTN (2 * 4M DRAM)
+    - IC34: NEC D482444GW-70 (4M-Bit Dual Port Graphics Buffer)
+    - IC35: National Semiconductor NS9718AH PC87312VF (SIO Floppy Disk Controller)
+    - IC36: Maxim MAX3241CAI (RS-232 Transceiver)
+    - IC39: Alps CBK0002ZA-PTCTS10 BC4482.1
+    - IC40: RTC3511 A777363
+    - IC43: National Semiconductor P74AB LVXC4245
+    - IC47: AMD Am29202-16KC (29k CPU)
+    - IC48: Toshiba TC170G21AF
+    - IC49: Toshiba G36460330036 M531655E-03 (2M Mask ROM)
+    - IC50: Oki M531655E-08 (2M Mask ROM)
+    - IC51: Toshiba KFW3Z2J KM23C32000AG (4M Mask ROM)
+    - IC52: Oki M514260CSL-60J (512K DRAM)
+    - IC53: NEC 42S4260-60 (512K DRAM)
+    - IC63: Sanyo LC83086M
+    - IC64: 88346B 9722 M78 (D/A Converter)
+    - IC66,67: Allegro MicroSystems A3953SLB (2 * Motor Driver)
+    - IC68: Allegro MicroSystems UDN2916LB (Motor Driver)
+    - IC69: LB1836 7P9 (Motor Driver)
+
+    Floppy Drive: Mitsumi D353T5
+    - Mitsumi NCL016 712 101B
+    - Mitsumi NCL017 702 B31G
+    - LB1813 6M4
+    - LB1838 6Z6
+
+***************************************************************************/
+
+#include "emu.h"
+
+#include "cpu/am29000/am29000.h"
+#include "cpu/i386/i386.h"
+#include "imagedev/floppy.h"
+#include "machine/ram.h"
+
+#include "emupal.h"
+#include "screen.h"
+#include "softlist_dev.h"
+
+
+namespace {
+
+class jwcolor_state : public driver_device
+{
+public:
+	jwcolor_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_am29k(*this, "am29k")
+		, m_am486(*this, "am486")
+		, m_screen(*this, "screen")
+		, m_flop(*this, "fdc")
+		, m_fd_softlist(*this, "fd_list")
+	{ }
+
+	void jwcolor(machine_config &config);
+
+protected:
+	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	required_device<cpu_device> m_am29k;
+	required_device<cpu_device> m_am486;
+	required_device<screen_device> m_screen;
+	required_device<floppy_connector> m_flop;
+	required_device<software_list_device> m_fd_softlist;
+
+	static void floppy_formats(format_registration &fr);
+
+	void jwcolor_am29k_data_map(address_map &map) ATTR_COLD;
+	void jwcolor_am29k_map(address_map &map) ATTR_COLD;
+	void jwcolor_am486_io_map(address_map &map) ATTR_COLD;
+	void jwcolor_am486_map(address_map &map) ATTR_COLD;
+	void jwcolor_palette(palette_device &palette) const ATTR_COLD;
+	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	u16 m_io_00d0;
+	u8 m_io_0398;
+};
+
+void jwcolor_state::machine_reset()
+{
+	// FIXME: Fatal error: Am29000 instruction MMU translation enabled!
+	m_am29k->set_input_line(INPUT_LINE_RESET, ASSERT_LINE);
+
+	m_io_00d0 = 0;
+	m_io_0398 = 0;
+}
+
+static void jwcolor_floppies(device_slot_interface &device)
+{
+	device.option_add("35dd", FLOPPY_35_DD);
+	device.option_add("35hd", FLOPPY_35_HD);
+}
+
+void jwcolor_state::floppy_formats(format_registration &fr)
+{
+	fr.add_mfm_containers();
+}
+
+void jwcolor_state::jwcolor_am29k_data_map(address_map &map)
+{
+	map(0x00000000, 0x001fffff).rom().region("ic49", 0);
+}
+
+void jwcolor_state::jwcolor_am29k_map(address_map &map)
+{
+	map(0x00000000, 0x001fffff).rom().region("ic49", 0);
+}
+
+void jwcolor_state::jwcolor_am486_io_map(address_map &map)
+{
+	map(0x0398, 0x0398).lr8(
+		NAME([this]() {
+			m_io_0398 = m_io_0398 == 0 ? 0x88 : 0;
+			logerror("%s: io_0398_r = %02x\n", machine().describe_context(), m_io_0398);
+			return m_io_0398;
+		}));
+	map(0x03bd, 0x03bd).lr8(
+		NAME([this]() {
+			logerror("%s: io_03bd_r = 0\n", machine().describe_context());
+			return 0;
+		}));
+	map(0x00d0, 0x00d1).lr16(
+		NAME([this](offs_t offset) {
+			m_io_00d0 += 100;
+			logerror("%s: io_00d0_r = %02x\n", machine().describe_context(), m_io_00d0);
+			return m_io_00d0;
+		}));
+}
+
+void jwcolor_state::jwcolor_am486_map(address_map &map)
+{
+	map(0x00000000, 0x000001ff).ram();
+	map(0x00020000, 0x0002ffff).rom().region("ic19_ic21", 0x20000);
+	map(0x000ffff0, 0x000fffff).mirror(0xfff00000).rom().region("ic19_ic21", 0x100);
+}
+
+void jwcolor_state::jwcolor_palette(palette_device &palette) const
+{
+	for (size_t i = 0; i < 0xff; i++) {
+		palette.set_pen_color(i, 0xff, 0xff, 0xff);
+	}
+	palette.set_pen_color(0xff, 0x00, 0x00, 0x00);
+}
+
+u32 jwcolor_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void jwcolor_state::jwcolor(machine_config &config)
+{
+	AM29000(config, m_am29k, 20_MHz_XTAL);
+	m_am29k->set_addrmap(AS_PROGRAM, &jwcolor_state::jwcolor_am29k_map);
+	m_am29k->set_addrmap(AS_DATA, &jwcolor_state::jwcolor_am29k_data_map);
+
+	I486(config, m_am486, 66_MHz_XTAL);
+	m_am486->set_addrmap(AS_PROGRAM, &jwcolor_state::jwcolor_am486_map);
+	m_am486->set_addrmap(AS_IO, &jwcolor_state::jwcolor_am486_io_map);
+
+	SCREEN(config, m_screen);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(640, 480);
+	m_screen->set_visarea_full();
+	m_screen->set_screen_update(FUNC(jwcolor_state::screen_update));
+	m_screen->set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(jwcolor_state::jwcolor_palette), 256);
+
+	FLOPPY_CONNECTOR(config, m_flop, jwcolor_floppies, "35hd", jwcolor_state::floppy_formats);
+	SOFTWARE_LIST(config, "fd_list").set_original("rupo_flop");
+}
+
+ROM_START( jwv860 )
+	ROM_REGION32_LE(0x800000, "ic19_ic21", 0)
+	ROM_LOAD32_WORD("km23v32000bg.5gn1.ic19", 0x000000, 0x400000, CRC(0961da04) SHA1(acdca402a8fdfb6b784864b9f61eb85c78d7ad64))
+	ROM_LOAD32_WORD("lhmv5gn2.ic21", 0x000002, 0x400000, CRC(6bf1d1d0) SHA1(c19f38e13931af6b137462532ebdb692f727e654))
+
+	ROM_REGION32_LE(0x800000, "ic24", 0)
+	ROM_LOAD("lhmnopn9.ic24", 0x000000, 0x800000, CRC(3083f6bb) SHA1(e938342745805f7626903244b4a04bd31455d1fe))
+
+	ROM_REGION32_LE(0x800000, "ic26", 0)
+	ROM_LOAD("km23c64000g.opna.ic26", 0x000000, 0x800000, CRC(760433fa) SHA1(a7965c90efa06e00aacfd4aaa6ef0fef66075f2e))
+
+	ROM_REGION32_LE(0x400000, "ic27", 0)
+	ROM_LOAD("p46008004022.ic27", 0x000000, 0x400000, CRC(bab3ded2) SHA1(ba25df3fe2c0ba368ee793cc160d03871495038c))
+
+	ROM_REGION32_BE(0x200000, "ic49", 0)
+	ROMX_LOAD("m531655e-03.g36460330036.ic49", 0x000000, 0x200000, CRC(8218c3d8) SHA1(0fb1a7a5fe375360f57c3b4a95612bd20d3b4004), ROM_GROUPDWORD | ROM_REVERSE)
+
+	ROM_REGION32_BE(0x200000, "ic50", 0)
+	ROMX_LOAD("m531655e-08.ic50", 0x000000, 0x200000, CRC(46f5dabf) SHA1(837d59e1c546b59ab14c5218339f14bbade72557), ROM_GROUPDWORD | ROM_REVERSE)
+
+	ROM_REGION32_BE(0x400000, "ic51", 0)
+	ROM_LOAD16_WORD_SWAP("km23c32000ag.kfw3z2j.ic51", 0x000000, 0x400000, CRC(f437bd92) SHA1(50472ed58a9385f0da08efb78147c5669f679872))
+ROM_END
+
+} // anonymous namespace
+
+
+//    YEAR   NAME       PARENT  COMPAT  MACHINE  INPUT  CLASS          INIT        COMPANY    FULLNAME                                FLAGS
+COMP( 1997,  jwv860,    0,      0,      jwcolor, 0,     jwcolor_state, empty_init, "Toshiba", "JW-V860 Rupo Personal Word Processor", MACHINE_NOT_WORKING|MACHINE_NO_SOUND )


### PR DESCRIPTION
New systems marked not working (rupo.cpp)
-----------------------------------------
Toshiba JW-V860 Rupo Personal Word Processor [QUFB]

New software list items marked not working (rupo_flop.xml)
----------------------------------------------------------
Card Connection [QUFB]
Ishidou - The Way Of Stones [QUFB]
Mahjong Gokuu [QUFB]
Mahjong Gokuu Tenjiku [QUFB]
Sanrio Carnival [QUFB]
Shanghai [QUFB]
Shanghai II [QUFB]
Sokoban [QUFB]
Tesserae [QUFB]
Tetris [QUFB]