### PR TITLE
osd/sdl: quit on SDL_QUIT (Cmd-Q / app Quit) on macOS

### DIFF
--- a/src/osd/sdl/osdsdl.cpp
+++ b/src/osd/sdl/osdsdl.cpp
@@ -480,6 +480,14 @@ void sdl_osd_interface::process_events()
 		// handle UI events
 		switch (event.type)
 		{
+#if defined(__APPLE__) && defined(__MACH__)
+		case SDL_QUIT:
+			// macOS: Cmd-Q / app Quit arrives as SDL_QUIT, not a window close
+			// event, so this is the only way to exit in fullscreen
+			machine().schedule_exit();
+			break;
+#endif
+
 		case SDL_WINDOWEVENT:
 			process_window_event(event);
 			break;


### PR DESCRIPTION
On a modern MacBook with SDL2 the red close button works fine when running MAME in a window, but I have found that the is no easy way to close MAME when running full screen as apparently Cmd-Q sends SDL_QUIT which MAME does not handle.

This PR adds that handler.

This was done using AI (Claude Code) so the approach may be wrong or this should be done for all platforms.  If so, I'd appreciate pointers towards the correct approach and I'll try again.  

Thanks
/Thorbjørn

---





Claude word salad follows:

## What

On macOS the SDL OSD never handled `SDL_QUIT`, so Cmd-Q (and the window-manager
close gesture that emits `SDL_QUIT` rather than `SDL_WINDOWEVENT_CLOSE`) did not
exit MAME. This wires `SDL_QUIT` to a normal exit.

`SDL_WINDOWEVENT_CLOSE`-driven exit behaviour is unchanged.

## Open question for review

Upstream MAME currently handles `SDL_QUIT` on no platform. Whether this should
apply to all SDL platforms (not just macOS) is an open question — flagged for
maintainer input.
