### PR TITLE
video/zeus2:: mwskins dotclk, XOffset and Vcounter

### DIFF
--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -444,12 +444,14 @@ void zeus2_device::zeus2_register_update(offs_t offset, uint32_t oldval, int log
 			m_yScale = (((m_zeusbase[0x39] >> 16) & 0xfff) < 0x100) ? 0 : 1;
 			int hor = ((m_zeusbase[0x34] & 0xffff) - (m_zeusbase[0x33] >> 16)) << m_yScale;
 			int ver = ((m_zeusbase[0x35] & 0xffff) + 1) << m_yScale;
-			popmessage("reg[30]: %08X Screen: %dH X %dV yScale: %d", m_zeusbase[0x30], hor, ver, m_yScale);
 			int vtotal = (m_zeusbase[0x37] & 0xffff) << m_yScale;
 			int htotal = (m_zeusbase[0x34] >> 16) << m_yScale;
 			//rectangle visarea((m_zeusbase[0x33] >> 16) << m_yScale, htotal - 1, 0, (m_zeusbase[0x35] & 0xffff) << m_yScale);
 			rectangle visarea(0, hor - 1, 0, ver - 1);
-			screen().configure(htotal, vtotal, visarea, attotime::from_ticks(htotal * vtotal, ZEUS2_VIDEO_CLOCK / 4.0));
+			// Dot clock is the PLL's 100MHz VCO (video clock x3/2) over reg 0x31's divider, held less one
+			// Interlaced mode doubles both totals (2x*2y), so x4 to scan both fields in one std-res field time
+			const XTAL dotclk = ZEUS2_VIDEO_CLOCK * 3 / 2 / (((m_zeusbase[0x31] >> 16) & 0xff) + 1) * (m_yScale ? 4 : 1);
+			screen().configure(htotal, vtotal, visarea, attotime::from_ticks(htotal * vtotal, dotclk));
 			zeus_cliprect = visarea;
 			zeus_cliprect.max_x -= zeus_cliprect.min_x;
 			zeus_cliprect.min_x = 0;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1758,6 +1758,8 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 
 	extra.ucode_src = m_state->m_curUCodeSrc;
 	extra.tex_src = m_state->zeus_texbase;
+	extra.frame_base = m_state->frame_addr_from_xy(0, 0, true);
+	extra.frame_shift = m_state->frame_row_shift();
 	int texmode = texdata & 0xffff;
 	extra.texwidth = 0x20 << ((texmode >> 2) & 3);
 	extra.solidcolor = m_state->m_zeusbase[0x00] & 0x7fff;
@@ -1858,7 +1860,7 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 	uint32_t solidColor = ((object.solidcolor & 0x7c00) << 9) | ((object.solidcolor & 0x3e0) << 6) | ((object.solidcolor & 0x1f) << 3);
 	int x;
 
-	uint32_t addr = m_state->frame_addr_from_xy(0, scanline, true);
+	uint32_t addr = object.frame_base + (scanline << object.frame_shift);
 	int32_t *depthptr = &m_state->m_frameDepth[addr];
 	uint32_t *colorptr = &m_state->m_frameColor[addr];
 	int32_t curDepthVal;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -332,9 +332,8 @@ uint32_t zeus2_device::zeus2_r(offs_t offset)
 			break;
 
 		case 0x54:
-			// VCOUNT upper 16 bits
-			//result = (screen().vpos() << 16) | screen().vpos();
-			result = (screen().vpos() << 16);
+			// VCOUNT is in unscaled lines. Scale the count back in MAME's fake interlaced mode
+			result = ((screen().vpos() >> m_yScale) << 16);
 			break;
 	}
 

--- a/src/devices/video/zeus2.h
+++ b/src/devices/video/zeus2.h
@@ -50,6 +50,9 @@ struct zeus2_poly_extra_data
 	uint32_t          ctrl_word;
 	uint32_t          ucode_src;
 	uint32_t          tex_src;
+	// Render window latched here because rendering is deferred and mwskins moves it mid-frame
+	uint32_t          frame_base;
+	uint32_t          frame_shift;
 	bool            texture_alpha;
 	bool            texture_rgb555;
 	bool            solid_enable;
@@ -234,12 +237,14 @@ public:
 			return tms320c3x_device::fp_to_float(val);
 	}
 
+	inline uint32_t frame_row_shift() const { return 9 + m_yScale; }
+
 	inline uint32_t frame_addr_from_xy(uint32_t x, uint32_t y, bool render)
 	{
 		uint32_t addr;
 		if (render) {
-			// Rendering is y location
-			addr = m_renderRegs[0x4] << (9 + m_yScale);
+			// Rend XOffset/YOffset place the render window in the frame buffer
+			addr = (m_renderRegs[0x4] << frame_row_shift()) + m_renderRegs[0x3];
 		}
 		else {
 			// y.16:x.16 row/col
@@ -248,7 +253,7 @@ public:
 		}
 		//uint32_t addr = render ? frame_addr_from_phys_addr(m_renderRegs[0x4] << (15 + m_yScale))
 		//  : frame_addr_from_phys_addr((m_zeusbase[0x38] >> 1) << (m_yScale << 1));
-		addr += (y << (9 + m_yScale)) + x;
+		addr += (y << frame_row_shift()) + x;
 		return addr;
 	}
 


### PR DESCRIPTION
This PR corrects the following Zeus 2 video behavior, as required by Skins Game:

**1. Derive the dot clock from the divider in reg 0x31**

Dot clock was hardcoded to video clock / 4. mwskins switches resolutions, so in its other modes that scaled to 94Hz and 113Hz. It is now derived as the PLL's 100MHz VCO (video clock x3/2) over reg 0x31's divider, held less one. Interlaced mode doubles lines and columns in mwskins, so the clock is scaled x4 to scan both fields in one std-res field time. VCOUNT (reg 0x54) is unscaled the same way, so the game's VBlank Start compare lands on the right line in both modes.

This fixes The Skins Game's video timing (checkable in the "System Information" dialog).

**2. Hook up render XOffset**

Render XOffset (R03) is the render window's column, the companion to Render YOffset (R04), and was never added to the address. Both are now added, and latched with the quad rather than read at rasterisation time, as rendering is deferred and mwskins moves the window several times a frame. Only mwskins programs a non-zero R03.

This fixes the course map, the header bar and the stroke count in The Skins Game.

Master:
<img width="375" alt="master-mwskins-swing" src="https://github.com/user-attachments/assets/e8845c61-4538-4098-8557-71450b5135a0" /> <img width="375" alt="master-mwskins-tee" src="https://github.com/user-attachments/assets/052b5ba7-837c-494b-bd5b-73cf966d5aab" />

This PR:
<img width="375" alt="pr-mwskins-swing" src="https://github.com/user-attachments/assets/de5f0eba-eae7-469b-a4d7-215748953be8" /> <img width="375" alt="pr-mwskins-tee" src="https://github.com/user-attachments/assets/018b239b-4865-44d5-8e0a-40674b2ce072" />

Assisted by Claude Opus 5. Human polished and regression tested on Cruis'n Exotica and The Grid.
