### PR TITLE
cpu/mips3: Allocate each cache with its own configured size

### DIFF
--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -402,8 +402,8 @@ void mips3_device::device_start()
 
 	/* allocate the implementation-specific state from the full cache */
 	m_core = m_drc_cache.alloc_near<internal_mips3_state>();
-	m_icache = (uint8_t *)m_drc_cache.alloc_near(c_dcache_size, std::align_val_t(alignof(uint64_t)));
-	m_dcache = (uint8_t *)m_drc_cache.alloc_near(c_icache_size, std::align_val_t(alignof(uint64_t)));
+	m_icache = (uint8_t *)m_drc_cache.alloc_near(c_icache_size, std::align_val_t(alignof(uint64_t)));
+	m_dcache = (uint8_t *)m_drc_cache.alloc_near(c_dcache_size, std::align_val_t(alignof(uint64_t)));
 
 	/* initialize based on the config */
 	memset(m_core, 0, sizeof(internal_mips3_state));


### PR DESCRIPTION
Closes #15996.

`device_start` allocated `m_icache` with `c_dcache_size` and `m_dcache` with `c_icache_size`. This swaps them back.

## Scope

Most drivers configure both caches the same size, so the swap is invisible there. Three configure them differently:

| driver | icache | dcache | old `m_icache` got | old `m_dcache` got |
| --- | --- | --- | --- | --- |
| `itech/iteagle.cpp:176` | 16384 | 8192 | 8192 | 16384 |
| `nintendo/aleck64.cpp:1040` | 16384 | 8192 | 8192 | 16384 |
| `ice/vp101.cpp:562,582` | not set | 32768 | 32768 | 0 |

`vp101` is the clearest: it configures only a data cache, and the pointer named `m_dcache` was the one that ended up sized zero.

## What this does not change

Nothing reads `m_icache` or `m_dcache`. Grepping the tree, the only references in the mips3 implementation are the two assignments here and the two `nullptr` initialisations in `mips3com.cpp:196-197`; every other `m_icache`/`m_dcache` hit belongs to a different device (`mips1`, `r4000`, `psx`, `rsp`, `alpha`, `st2xxx`, `hd6120`, `s_smp`). So **no emulated behaviour changes today** — this is a correctness fix for the allocation and for whatever reads those buffers later.

The two allocations keep their order and their combined size, so nothing allocated afterwards from the DRC near cache shifts.

Also worth noting: `c_icache_size` and `c_dcache_size` are already used the right way round when building the Config register (`mips3com.cpp:244-260`, dcache into bits 6-8 and icache into bits 9-11). Only the allocation was affected.

## One difference from the issue text

The snippet in #15996 shows `if(c_dcache_size)` / `if(c_icache_size)` guards around the two allocations. Current master has no guards — `mips3.cpp:405-406` calls `alloc_near` unconditionally. The transposition is exactly as described; only the surrounding guards differ, so the issue snippet looks slightly stale.

## Testing

Honest about the limits here: I have not built MAME. A full build was not practical on this machine, so I have not run any driver.

What I did check is that the translation unit still compiles: `g++ -std=c++20 -fsyntax-only` on `src/devices/cpu/mips/mips3.cpp` with the tree's include paths succeeds, and produces the same single pre-existing warning (an SFINAE note from `src/emu/device.h` under g++ 16.2) before and after the change. Both arguments are `size_t`, so this is a pure argument swap with no type change.

If you would like this exercised against `iteagle`, `aleck64` or `vp101` before merging, I am happy to, but I would rather say plainly that I have not than imply a test run I did not do.

## AI disclosure

Per the contributing guidelines: Claude Code (Claude Opus 5) was used to investigate the issue and prepare this change. I reviewed the diff and ran the checks above myself.
