### PR TITLE
Creating a `manager.warnings_enabled` property exposed to LUA

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -2436,6 +2436,9 @@ void lua_engine::initialize()
 	mame_manager_type["ui"] = sol::property(&mame_machine_manager::ui);
 	mame_manager_type["options"] = sol::property(&mame_machine_manager::options);
 	mame_manager_type["plugins"] = sol::property([] (mame_machine_manager &m) { return plugin_options_plugins(m.plugins()); });
+	mame_manager_type["warnings_enabled"] = sol::property(
+		[]() { return mame_machine_manager::instance()->warnings_enabled(); },
+		[](bool enabled) { mame_machine_manager::instance()->set_warnings_enabled(enabled); });
 	sol()["manager"] = std::ref(*mame_machine_manager::instance());
 	sol()["mame_manager"] = std::ref(*mame_machine_manager::instance());
 

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -63,6 +63,7 @@ mame_machine_manager::mame_machine_manager(emu_options &options,osd_interface &o
 	m_lua(std::make_unique<lua_engine>()),
 	m_new_driver_pending(nullptr),
 	m_firstrun(true),
+	m_warnings_enabled(true),
 	m_autoboot_timer(nullptr)
 {
 }
@@ -362,7 +363,7 @@ void mame_machine_manager::ui_initialize(running_machine& machine)
 	m_ui->initialize(machine);
 
 	// display the startup screens
-	m_ui->display_startup_screens(m_firstrun);
+	m_ui->display_startup_screens(m_firstrun, m_warnings_enabled);
 }
 
 void mame_machine_manager::before_load_settings(running_machine& machine)

--- a/src/frontend/mame/mame.h
+++ b/src/frontend/mame/mame.h
@@ -71,6 +71,9 @@ public:
 	inifile_manager &inifile() const { assert(m_inifile != nullptr); return *m_inifile; }
 	favorite_manager &favorite() const { assert(m_favorite != nullptr); return *m_favorite; }
 
+	bool warnings_enabled() const { return m_warnings_enabled; }
+	void set_warnings_enabled(bool enabled) { m_warnings_enabled = enabled; }
+
 private:
 	// construction
 	mame_machine_manager(emu_options &options, osd_interface &osd);
@@ -84,6 +87,7 @@ private:
 
 	const game_driver *     m_new_driver_pending;           // pointer to the next pending driver
 	bool                    m_firstrun;
+	bool                    m_warnings_enabled;
 
 	emu_timer *                        m_autoboot_timer;    // auto-boot timer
 	std::unique_ptr<sol::load_result>  m_autoboot_script;   // auto-boot script

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -656,12 +656,12 @@ static void output_joined_collection(const TColl &collection, TEmitMemberFunc em
 //  various startup screens
 //-------------------------------------------------
 
-void mame_ui_manager::display_startup_screens(bool first_time)
+void mame_ui_manager::display_startup_screens(bool first_time, bool warnings_enabled)
 {
 	const int maxstate = 3;
 	int const str = machine().options().seconds_to_run();
 	bool show_gameinfo = !machine().options().skip_gameinfo();
-	bool show_warnings = true;
+	bool show_warnings = warnings_enabled;
 	bool video_none = strcmp(downcast<osd_options &>(machine().options()).video(), OSDOPTVAL_NONE) == 0;
 
 	// disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -161,7 +161,7 @@ public:
 	void initialize(running_machine &machine);
 	std::vector<ui::menu_item> slider_init(running_machine &machine);
 
-	void display_startup_screens(bool first_time);
+	void display_startup_screens(bool first_time, bool warnings_enabled);
 	virtual void set_startup_text(const char *text, bool force) override;
 	bool update_and_render(render_target &target);
 


### PR DESCRIPTION
BletchMAME currently runs MAME in `-debug` mode, which is not necessarily desirable.  The warnings message is not desirable for BletchMAME, as we are replacing the MAME UI and showing our own messages and warnings.  Furthermore, there isn't really a way to differentiate when this message is being shown to the user through the LUA API.

This is being created as a LUA property because (I think) there used to be a `-skip_warnings` option, and I believe this was deliberately removed on the idea that we don't want to expose such an option.