### PR TITLE
swp30: two register field width fixes in the streaming block

### DIFF
--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -699,7 +699,7 @@ std::pair<s16, bool> swp30_device::streaming_block::step(memory_access<25, 2, -2
 				  ) >> 10;
 	s16 result = std::clamp<s32>(racc, -0x8000, 0x7fff);
 
-	u32 pitch = m_pitch + pitch_lfo;
+	u32 pitch = (m_pitch & 0x3fff) + pitch_lfo;
 	if(m_finetune_active) {
 		s32 ft = (m_loop >> 24) & 0x7f;
 		if(ft & 0x40)

--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -742,7 +742,7 @@ std::pair<s16, bool> swp30_device::streaming_block::step(memory_access<25, 2, -2
 
 void swp30_device::streaming_block::update_loop_size()
 {
-	m_loop_size = m_loop & 0x3ffffff;
+	m_loop_size = m_loop & 0xffffff;
 	if(!m_loop_size && !((m_loop & 0x80000000) || (m_start & 0x40000000)))
 		m_loop_size = 0x400;
 }


### PR DESCRIPTION
Two field-width fixes in the SWP30 AWM2 streaming block. Both are internal
inconsistencies — the register documentation at the top of `swp30.cpp`
disagrees with the code a few lines away — and both were verified against a
real MU2000.

### 1. The loop size is 24 bits, not 26

`update_loop_size()` masks with `0x3ffffff`, but the documented field is 24
bits wide:

```
cccccc 01010*  AMW2/Streaming   bfff ffff ssss ssss ssss ssss ssss ssss  Backwards. Finetune. Number of samples in the loop
```

Bits 24-30 are the finetune, which `step()` reads back as `(m_loop >> 24) &
0x7f` a few lines below. The two overlapping bits mean any sample with a
finetune >= 4 gets a loop size tens of millions of samples long, so it never
reaches the loop point and keeps reading forward through the wave rom.

Measured on `mu2000` with the oboe patch (program 68). The sample used at C4
has finetune 0 and loops correctly; the one used from E4 up does not:

```
note  loop register  finetune  loop size (24 bit)  loop size (26 bit)
C4    0000007a       0x00      122                 122
E4    07000057       0x07       87                 50331735
```

Audible as a note wandering through unrelated instruments — the reported
symptom was "it walks through pipe, then oboe, then sax".

### 2. The pitch's bit 14 trips the finetune clamp

The pitch register (slot 0x11) is documented as `?-pp pppp pppp pppp`, so 14
bits of pitch. `pitch_w()` stores the raw 16-bit value and `step()` adds it to
the LFO offset unmasked. Before the loop point that is harmless, because the
exponent/mantissa extraction only looks at bits 0-13. Once finetune becomes
active the clamp

```c
if(pitch & 0x4000) pitch = 0x3fff;
```

sees the bit the firmware sets on compressed samples and pins the pitch to
maximum for the rest of the note.

Measured on `mu2000`, one C4 on the strings patch (the firmware writes
`0x7e28`), pitch tracked every 10 ms from note-on:

```
+  0..150 ms    -5 cent      correct
+      170 ms  +557 cent     jumps
+ 190..8000 ms +544 cent     stays there
```

Masking at the point of use holds -5 cent for the whole note. The register is
still stored unmasked so `pitch_r()` returns what the firmware wrote.

### Reproducing

A 49-byte MIDI file with a single sustained note and a headless run is enough:

```
mame mu2000 -bios v200 -midiin1 long.mid -wavwrite out.wav \
    -seconds_to_run 20 -video none
```

The machine takes about 10 seconds to boot, so the note starts after that.
Measuring the pitch of `out.wav` over time shows both problems and their
absence after the fix.

The wave ROMs used were dumped from the author's own MU2000 and match the
hashes already registered for `mu2000`.
