### PR TITLE
util/avhuff: enforce audio channel limit consistently

### DIFF
--- a/src/lib/util/avhuff.cpp
+++ b/src/lib/util/avhuff.cpp
@@ -212,6 +212,8 @@ avhuff_error avhuff_encoder::encode_data(const uint8_t *source, uint8_t *dest, u
 	// extract info from the header
 	uint32_t metasize = source[4];
 	uint32_t channels = source[5];
+	if (channels > AVHUFF_MAX_CHANNELS)
+		return AVHERR_TOO_MANY_CHANNELS;
 	uint32_t samples = get_u16be(&source[6]);
 	uint32_t width = get_u16be(&source[8]);
 	uint32_t height = get_u16be(&source[10]);
@@ -328,6 +330,8 @@ avhuff_error avhuff_encoder::assemble_data(std::vector<uint8_t> &buffer, bitmap_
 	// sanity check the inputs
 	if (metadatasize > 255)
 		return AVHERR_METADATA_TOO_LARGE;
+	if (channels > AVHUFF_MAX_CHANNELS)
+		return AVHERR_TOO_MANY_CHANNELS;
 	if (numsamples > 65535)
 		return AVHERR_AUDIO_TOO_LARGE;
 	if (bitmap.width() > 65535 || bitmap.height() > 65535)
@@ -719,6 +723,8 @@ avhuff_error avhuff_decoder::decode_data(const uint8_t *source, uint32_t complen
 		return AVHERR_INVALID_DATA;
 	uint32_t metasize = source[0];
 	uint32_t channels = source[1];
+	if (channels > AVHUFF_MAX_CHANNELS)
+		return AVHERR_TOO_MANY_CHANNELS;
 	uint32_t samples = get_u16be(&source[2]);
 	uint32_t width = get_u16be(&source[4]);
 	uint32_t height = get_u16be(&source[6]);
@@ -739,7 +745,7 @@ avhuff_error avhuff_decoder::decode_data(const uint8_t *source, uint32_t complen
 	uint32_t srcoffs = 10 + 2 * channels;
 
 	// if we are decoding raw, set up the output parameters
-	uint8_t *metastart, *videostart, *audiostart[16];
+	uint8_t *metastart, *videostart, *audiostart[AVHUFF_MAX_CHANNELS];
 	uint32_t audioxor, videoxor, videostride;
 	if (dest != nullptr)
 	{

--- a/src/lib/util/avhuff.h
+++ b/src/lib/util/avhuff.h
@@ -26,6 +26,7 @@
 
 #define AVHUFF_USE_FLAC     (1)
 
+constexpr uint8_t AVHUFF_MAX_CHANNELS = 16;
 
 // errors
 enum avhuff_error
@@ -128,7 +129,7 @@ public:
 		bitmap_yuy16 *  video = nullptr;            // pointer to video bitmap
 		uint32_t        maxsamples = 0;             // maximum number of samples per channel
 		uint32_t *      actsamples = nullptr;       // actual number of samples per channel
-		int16_t *       audio[16];                  // pointer to individual audio channels
+		int16_t *       audio[AVHUFF_MAX_CHANNELS]; // pointer to individual audio channels
 		uint32_t        maxmetalength = 0;          // maximum length of metadata
 		uint32_t *      actmetalength = nullptr;    // actual length of metadata
 		uint8_t *       metadata = nullptr;         // pointer to metadata buffer

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -587,9 +587,9 @@ public:
 				uint32_t samples = (uint64_t(m_info.rate) * uint64_t(effframe + 1) * uint64_t(1000000) + m_info.fps_times_1million - 1) / uint64_t(m_info.fps_times_1million) - first_sample;
 
 				// loop over channels and read the samples
-				int channels = unsigned(std::min<std::size_t>(m_info.channels, std::size(m_audio)));
+				uint32_t const channels = m_info.channels;
 				EQUIVALENT_ARRAY(m_audio, int16_t *) samplesptr;
-				for (int chnum = 0; chnum < channels; chnum++)
+				for (uint32_t chnum = 0; chnum < channels; chnum++)
 				{
 					// read the sound samples
 					m_audio[chnum].resize(samples);
@@ -647,7 +647,7 @@ private:
 	bitmap_yuy16                m_bitmap;
 	uint32_t                    m_start_frame;
 	uint32_t                    m_frame_count;
-	std::vector<int16_t>        m_audio[8];
+	std::array<std::vector<std::int16_t>, AVHUFF_MAX_CHANNELS> m_audio;
 	std::vector<uint8_t>        m_ldframedata;
 	std::vector<uint8_t>        m_rawdata;
 };
@@ -2354,6 +2354,9 @@ static void do_create_ld(parameters_map &params)
 	info.interlaced = ((info.fps_times_1million / 1000000) <= 30) && (info.height % 2 == 0) && (info.height > 288);
 	info.channels = aviinfo.audio_channels;
 	info.rate = aviinfo.audio_samplerate;
+	
+	if (info.channels > AVHUFF_MAX_CHANNELS)
+		report_error(1, "AVI input has too many audio channels (maximum is %u)", AVHUFF_MAX_CHANNELS);
 
 	// adjust for interlacing
 	if (info.interlaced)
@@ -3038,6 +3041,10 @@ static void do_extract_ld(parameters_map &params)
 			report_error(1, "Improperly formatted A/V metadata found");
 		fps_times_1million = fps * 1000000 + fpsfrac;
 	}
+
+	if (channels < 0 || channels > AVHUFF_MAX_CHANNELS)
+		report_error(1, "Invalid audio channel count in A/V metadata");
+	
 	uint8_t interlace_factor = interlaced ? 2 : 1;
 
 	// determine key parameters and validate
@@ -3092,7 +3099,7 @@ static void do_extract_ld(parameters_map &params)
 		// create the codec configuration
 		avhuff_decoder::config avconfig;
 		bitmap_yuy16 avvideo;
-		std::vector<int16_t> audio_data[16];
+		std::array<std::vector<std::int16_t>, AVHUFF_MAX_CHANNELS> audio_data;
 		uint32_t actsamples;
 		avconfig.video = &avvideo;
 		avconfig.maxsamples = max_samples_per_frame;


### PR DESCRIPTION
AVHuff's decoder configuration provides storage for up to 16 audio channels, but the channel count read from AVHuff data was not checked against this limit before being used to index fixed-size channel arrays. Malformed input specifying more than 16 channels could therefore access these arrays out of bounds.

Define the existing 16-channel AVHuff implementation limit in one place and enforce it in the encoder, assembler and decoder before channel-dependent arrays are accessed.

chdman also used an eight-channel local array and silently limited AVI input to eight channels. Use the shared AVHuff limit there as well, allowing up to 16 channels and explicitly rejecting inputs or A/V metadata that exceed the supported limit.

**AI Disclosure:** GPT-5.6 Sol (OpenAI) was used to review the affected code, identify the channel-limit issue, and help prepare the patch. All changes were manually reviewed and applied by me.