### PR TITLE
formats: fix get_track_data_fm_pc dropping the last sector of every track

### DIFF
--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -1848,7 +1848,7 @@ void floppy_image_format_t::get_track_data_fm_pc(int track, int head, const flop
 {
 	auto bitstream = generate_bitstream_from_track(track, head, cell_size, image);
 	auto sectors = extract_sectors_from_bitstream_fm_pc(bitstream);
-	for(unsigned int sector=1; sector < sector_count; sector++) {
+	for(int sector=1; sector <= sector_count; sector++) {
 		uint8_t *sd = sectdata + (sector-1)*sector_size;
 		if(sector < sectors.size() && !sectors[sector].empty()) {
 			unsigned int asize = sectors[sector].size();


### PR DESCRIPTION
`get_track_data_fm_pc()` loops `sector < sector_count`, so a call with
`sector_count = N` extracts sectors 1 to N-1 and never writes the buffer slot
for sector N.

Its MFM counterpart, `get_track_data_mfm_pc_sectors()`, loops
`sector <= end_sector` and does cover the last one, so the two helpers
currently disagree about what the count means.

Nothing in the tree calls `get_track_data_fm_pc()` today, which is presumably
why it has gone unnoticed. It bites as soon as a format uses it to save an FM
medium. I found it writing a `save()` for an 8 inch IBM 3740 format, 77 tracks
of 26 sectors of 128 bytes, where it silently loses sector 26 of every track;
I ended up open coding the extraction instead.

The induction variable also becomes `int`, matching the MFM version, rather
than comparing an `unsigned int` against the `int` parameter.

Verified by round tripping an 8 inch FM image through a format that loads and
saves it: with the helper as it stands the last sector of each track comes back
wrong, and with the fix the image is byte identical to the original.
