### PR TITLE
ti/ti80.cpp: Add TI-80 graphing calculator

### DIFF
--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -2775,6 +2775,23 @@ if opt_tool(CPUS, "AVR8") then
 end
 
 --------------------------------------------------
+-- Toshiba T6M53 ASIC
+--@src/devices/cpu/t6m53/t6m53.h,CPUS["T6M53"] = true
+--------------------------------------------------
+
+if CPUS["T6M53"] then
+    files {
+        MAME_DIR .. "src/devices/cpu/t6m53/t6m53.cpp",
+        MAME_DIR .. "src/devices/cpu/t6m53/t6m53.h",
+    }
+end
+
+if opt_tool(CPUS, "T6M53") then
+    table.insert(disasm_files , MAME_DIR .. "src/devices/cpu/t6m53/t6m53_dasm.cpp")
+    table.insert(disasm_files , MAME_DIR .. "src/devices/cpu/t6m53/t6m53_dasm.h")
+end
+
+--------------------------------------------------
 -- Texas Instruments TMS1000 series
 --@src/devices/cpu/tms1000/tms1000.h,CPUS["TMS1000"] = true
 --@src/devices/cpu/tms1000/tms1000c.h,CPUS["TMS1000"] = true

--- a/scripts/src/video.lua
+++ b/scripts/src/video.lua
@@ -1609,6 +1609,18 @@ end
 
 --------------------------------------------------
 --
+--@src/devices/video/t6b79.h,VIDEOS["T6B79"] = true
+--------------------------------------------------
+
+if VIDEOS["T6B79"] then
+	files {
+		MAME_DIR .. "src/devices/video/t6b79.cpp",
+		MAME_DIR .. "src/devices/video/t6b79.h",
+	}
+end
+
+--------------------------------------------------
+--
 --@src/devices/video/tea1002.h,VIDEOS["TEA1002"] = true
 --------------------------------------------------
 

--- a/src/devices/cpu/t6m53/t6m53.cpp
+++ b/src/devices/cpu/t6m53/t6m53.cpp
@@ -264,7 +264,7 @@ inline void t6m53_device::set_dp(uint16_t value) {
 }
 
 
-inline uint16_t t6m53_device::add4(uint16_t x, uint8_t y) {
+inline uint16_t t6m53_device::add4(uint16_t x, uint8_t y) const {
     return (x & 0xfff0) | ((x + y) & 0x0f);
 }
 

--- a/src/devices/cpu/t6m53/t6m53.cpp
+++ b/src/devices/cpu/t6m53/t6m53.cpp
@@ -4,9 +4,6 @@
 
         Toshiba T6M53 ASIC
 
-        TODO: 
-            - Find the true name of this CPU
-
 ***************************************************************************/
 
 #include "emu.h"
@@ -50,10 +47,10 @@ void t6m53_device::device_start() {
     state_add(T6M53_A, "A", REG_A).formatstr("%02X");
     state_add(T6M53_SP, "SP", m_regs[0x118 >> 1]).formatstr("%01X");
     state_add(T6M53_REP, "REP", m_regs[0x110 >> 1]).formatstr("%01X");
-    state_add(T6M53_IL, "ILO", m_regs[0x100 >> 1]).formatstr("%02X");
-    state_add(T6M53_IH, "IHI", m_regs[0x102 >> 1]).formatstr("%02X");
-    state_add(T6M53_DPL, "DPLO", m_regs[0x11c >> 1]).formatstr("%02X");
-    state_add(T6M53_DPH, "DPHI", m_regs[0x11e >> 1]).formatstr("%02X");
+    state_add(T6M53_IL, "IL", m_regs[0x100 >> 1]).formatstr("%02X");
+    state_add(T6M53_IH, "IH", m_regs[0x102 >> 1]).formatstr("%02X");
+    state_add(T6M53_DPL, "DPL", m_regs[0x11c >> 1]).formatstr("%02X");
+    state_add(T6M53_DPH, "DPH", m_regs[0x11e >> 1]).formatstr("%02X");
 
     save_item(NAME(m_regs));
     save_item(NAME(m_pc));
@@ -65,6 +62,8 @@ void t6m53_device::device_start() {
     save_item(NAME(m_ftimer));
     save_item(NAME(m_vtimer));
     set_icountptr(m_icount);
+    
+    set_clock_scale(105.0 / m_divisors[0]);
 }
 
 
@@ -77,6 +76,8 @@ void t6m53_device::device_reset() {
     m_ftimer = 0;
     m_vtimer = 0;
     m_write_repeat = false;
+    
+    set_clock_scale(105.0 / m_divisors[0]);
 }
 
 
@@ -170,6 +171,10 @@ void t6m53_device::reg_w4_raw(uint16_t index, uint8_t data) {
                 m_regs[0x0f2 >> 1] = temp;
                 m_isel = data;
             }
+            break;
+
+        case 0x10d:
+            set_clock_scale(105.0 / m_divisors[(data >> 1)]);
             break;
 
         case 0x10f:
@@ -268,7 +273,7 @@ inline uint16_t t6m53_device::bcd(uint8_t x) {
     return (x >> 4) * 10 + (x & 0x0f);
 }
 
-uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op) {
+uint8_t t6m53_device::adc(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op) {
     if (bits > 0) {
         if (op & 0x0800) {
             const int sum = bcd(x) + bcd(y) + carry;
@@ -282,7 +287,7 @@ uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry
 
         const int sum = x + y + carry;
         carry = (sum >> bits) & 1;
-        return uint8_t(sum);
+        return sum;
     }
 
     if (op & 0x0800) {
@@ -326,30 +331,30 @@ uint16_t t6m53_device::ef(uint16_t op, uint16_t offset) const {
 }
 
 
-void t6m53_device::jump_call(bool conditional, bool condition) {
-    const uint16_t target = m_program->read_word(m_pc);
+void t6m53_device::jump_call(bool is_cond, bool condition) {
+    const uint16_t addr = m_program->read_word(m_pc);
 
-    if (conditional && !condition)
+    if (is_cond && !condition)
         return;
 
-    if (target & 0x8000) {
+    if (addr & 0x8000) {
         const uint8_t sp = reg_r4(0x118);
         if (sp < 8) m_stack[sp] = m_pc + 2;
         reg_w4(0x118, sp + 1);
     }
 
-    m_pc = (target & 0x7fff) << 1;
+    m_pc = (addr & 0x7fff) << 1;
     add_cycles(2);
 }
 
 void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry) {
-    const int s = BIT(op, 8);
-    const uint8_t SMASK = s ? 0x0f : 0xff;
-    const int SB = s ? 4 : 8;
-    const uint8_t B = ((op >> 9 & 2) | (op >> 8 & 1));
+    const bool s = BIT(op, 8);
+    const uint8_t s_mask = s ? 0x0f : 0xff;
+    const uint8_t SB = s ? 4 : 8;
+    const uint8_t B = (BIT(op, 10) << 1) | BIT(op, 8);
 
-    const auto reg_sr = [&](uint16_t addr) -> uint8_t { return s ? reg_r4(addr) : reg_r8(addr); };
-    const auto reg_sw = [&](uint16_t addr, uint8_t value) { if (s) reg_w4(addr, value); else reg_w8(addr, value); };
+    const auto reg_rS = [&](uint16_t addr) -> uint8_t { return s ? reg_r4(addr) : reg_r8(addr); };
+    const auto reg_wS = [&](uint16_t addr, uint8_t value) { if (s) reg_w4(addr, value); else reg_w8(addr, value); };
     const auto do_m_jump_call = [&](bool cond) {
         if (repeat)
             return;
@@ -374,7 +379,7 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
             if (op & 0x02)
                 m_program->write_byte(get_dp(), s ? reg_r4(get_i()) | (m_lasthigh << 4) : reg_r8(get_i()));
             else
-                reg_sw(get_i(), m_program->read_byte(get_dp()));
+                reg_wS(get_i(), m_program->read_byte(get_dp()));
 
             op & 0x01 ? set_dp(get_dp() - 1) : set_dp(get_dp() + 1);
             if (is_repeat) set_i(add4(get_i(), 2 - s));
@@ -397,15 +402,15 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
         if (op & 0x80) 
             m_pc = (m_regs[0x106 >> 1] << 9) | (m_regs[0x104 >> 1] << 1);
     } else if (op < 0x0400) {
-        reg_sw(jyx(op, offset), reg_sr(get_i()));
+        reg_wS(jyx(op, offset), reg_rS(get_i()));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0x0600) {
-        reg_sw(get_i(), reg_sr(jyx(op, offset)));
+        reg_wS(get_i(), reg_rS(jyx(op, offset)));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0x0800) {
-        const uint8_t temp = reg_sr(jyx(op, offset));
-        reg_sw(jyx(op, offset), reg_sr(get_i()));
-        reg_sw(get_i(), temp);
+        const uint8_t temp = reg_rS(jyx(op, offset));
+        reg_wS(jyx(op, offset), reg_rS(get_i()));
+        reg_wS(get_i(), temp);
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0x0c00) {
         reg_w4(0x102, op >> 8);
@@ -413,20 +418,20 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
         if (op & 0x0200)
             jump_call(false, true);
     } else if (op < 0x0e00) {
-        reg_sw(get_i(), op);
+        reg_wS(get_i(), op);
         set_i(add4(get_i(), 2 - s));
     } else if (op < 0x1000) {
         reg_w4(ef(op, offset), op);
     } else if (op < 0x1400) {
-        reg_sw(0x0f0, reg_sr(wyxs_no_i(op, offset)));
+        reg_wS(0x0f0, reg_rS(wyxs_no_i(op, offset)));
     } else if (op < 0x1800) {
-        const uint8_t temp = reg_sr(0x0f0);
-        reg_sw(0x0f0, reg_sr(wyxs_no_i(op, offset)));
-        reg_sw(wyxs_no_i(op, offset), temp);
+        const uint8_t temp = reg_rS(0x0f0);
+        reg_wS(0x0f0, reg_rS(wyxs_no_i(op, offset)));
+        reg_wS(wyxs_no_i(op, offset), temp);
     } else if (op < 0x1c00) {
-        reg_sw(wyxs_no_i(op, offset), reg_sr(0x0f0));
+        reg_wS(wyxs_no_i(op, offset), reg_rS(0x0f0));
     } else if (op < 0x1e00) {
-        reg_sw(0x0f0, op);
+        reg_wS(0x0f0, op);
     } else if (op < 0x2000) {
         reg_w4(ef(op, offset), op);
     } else if (op < 0x2800) {
@@ -440,14 +445,14 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
         reg_w4(addr, reg_r4(addr) | (1 << B));
     } else if (op < 0x3c00) {
         const uint16_t addr = ((op & 0x020f) == 0x020f) ? get_i() : wyxs(op, offset);
-        reg_sw(addr, ~reg_sr(addr));
+        reg_wS(addr, ~reg_rS(addr));
         if (is_repeat && (op & 0x020f) == 0x020f)
             set_i(add4(get_i(), 2 - s));
     } else if (op < 0x3e00) {
-        reg_sw(get_i(), reg_sr(get_i()) ^ reg_sr(jyx(op, offset)));
+        reg_wS(get_i(), reg_rS(get_i()) ^ reg_rS(jyx(op, offset)));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0x4000) {
-        reg_sw(get_i(), reg_sr(get_i()) | reg_sr(jyx(op, offset)));
+        reg_wS(get_i(), reg_rS(get_i()) | reg_rS(jyx(op, offset)));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0x6000) {
         const uint8_t x = reg_r4(ef(op, offset));
@@ -457,22 +462,22 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
             carry = !(op & 0x0800) ^ !carry;
         do_m_jump_call(carry);
     } else if (op < 0x7000) {
-        const uint8_t x = reg_sr(get_i());
-        const uint8_t y = op & SMASK;
+        const uint8_t x = reg_rS(get_i());
+        const uint8_t y = op & s_mask;
         carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
         if (!repeat)
             carry = !(op & 0x0800) ^ !carry;
         do_m_jump_call(carry);
         set_i(add4(get_i(), 2 - s));
     } else if (op < 0x8000) {
-        const uint8_t x = reg_sr(0x0f0);
-        const uint8_t y = op & SMASK;
+        const uint8_t x = reg_rS(0x0f0);
+        const uint8_t y = op & s_mask;
         carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
         if (!repeat)
             carry = !(op & 0x0800) ^ !carry;
         do_m_jump_call(carry);
     } else if (op < 0xa000) {
-        reg_sw(get_i(), add_with_carry(op & 0x1000 ? -SB : SB, reg_sr(get_i()), reg_sr(jyx(op, offset)), carry, op));
+        reg_wS(get_i(), adc(op & 0x1000 ? -SB : SB, reg_rS(get_i()), reg_rS(jyx(op, offset)), carry, op));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
         do_m_jump_call(carry);
     } else if (op < 0xb000) {
@@ -487,8 +492,8 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
         else
             m_pc += 2;
     } else if (op < 0xc000) {
-        const uint8_t x = reg_sr(get_i());
-        const uint8_t y = reg_sr(jyx(op, offset));
+        const uint8_t x = reg_rS(get_i());
+        const uint8_t y = reg_rS(jyx(op, offset));
         carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
         if (!repeat)
             carry = !(op & 0x0800) ^ !carry;
@@ -496,14 +501,14 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
         if (is_repeat) set_i(add4(get_i(), 2 - s));
     } else if (op < 0xe000) {
         const uint16_t addr = ef(op, offset);
-        reg_w4(addr, add_with_carry(4, reg_r4(addr), op & 0x0f, carry, op));
+        reg_w4(addr, adc(4, reg_r4(addr), op & 0x0f, carry, op));
         do_m_jump_call(carry);
     } else if (op < 0xf000) {
-        reg_sw(get_i(), add_with_carry(SB, reg_sr(get_i()), op & SMASK, carry, op));
+        reg_wS(get_i(), adc(SB, reg_rS(get_i()), op & s_mask, carry, op));
         if (is_repeat) set_i(add4(get_i(), 2 - s));
         do_m_jump_call(carry);
     } else {
-        reg_sw(0x0f0, add_with_carry(SB, reg_sr(0x0f0), op & SMASK, carry, op));
+        reg_wS(0x0f0, adc(SB, reg_rS(0x0f0), op & s_mask, carry, op));
         do_m_jump_call(carry);
     }
 }
@@ -511,7 +516,7 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
 void t6m53_device::add_cycles(int cycles) {
     m_icount -= cycles * 4;
 
-    if (((m_regs[0x10d >> 1] >> 4) & 0x01) || ((m_regs[0x10f >> 1] >> 4) & 0x0c)) {
+    if ((m_regs[0x10d >> 1] & 0x10) || (m_regs[0x10f >> 1] & 0xc0)) {
         m_vtimer = 0;
         return;
     }

--- a/src/devices/cpu/t6m53/t6m53.cpp
+++ b/src/devices/cpu/t6m53/t6m53.cpp
@@ -4,6 +4,9 @@
 
         Toshiba T6M53 ASIC
 
+        TODO: 
+            - Find the true name of this CPU
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -12,17 +15,7 @@
 
 DEFINE_DEVICE_TYPE(T6M53, t6m53_device, "t6m53", "Toshiba T6M53")
 
-#define REG_A       m_regs[0x0f0 >> 1]
-#define REG_I_LO    m_regs[0x100 >> 1]
-#define REG_I_HI    m_regs[0x102 >> 1]
-#define REG_ALT_I   m_regs[0x0f2 >> 1]
-#define REG_KCOL    m_regs[0x112 >> 1]
-#define REG_KROW    m_regs[0x114 >> 1]
-#define REG_SP      m_regs[0x118 >> 1]
-#define REG_DP_LO   m_regs[0x11c >> 1]
-#define REG_DP_HI   m_regs[0x11e >> 1]
-#define REG_TIMER_START m_regs[0x0f4 >> 1]
-
+#define REG_A m_regs[0x0f0 >> 1]
 
 t6m53_device::t6m53_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
     cpu_device(mconfig, T6M53, tag, owner, clock),
@@ -38,16 +31,14 @@ t6m53_device::t6m53_device(const machine_config &mconfig, const char *tag, devic
 }
 
 
-device_memory_interface::space_config_vector t6m53_device::memory_space_config() const
-{
-    return space_config_vector{
+device_memory_interface::space_config_vector t6m53_device::memory_space_config() const {
+    return space_config_vector {
         std::make_pair(AS_PROGRAM, &m_program_config)
     };
 }
 
 
-void t6m53_device::device_start()
-{
+void t6m53_device::device_start() {
     std::fill(std::begin(m_regs), std::end(m_regs), 0);
     std::fill(std::begin(m_stack), std::end(m_stack), 0);
 
@@ -57,14 +48,12 @@ void t6m53_device::device_start()
     state_add(STATE_GENPC, "GENPC", m_pc).formatstr("%04X").noshow();
     state_add(STATE_GENPCBASE, "CURPC", m_previous_pc).formatstr("%04X").noshow();
     state_add(T6M53_A, "A", REG_A).formatstr("%02X");
-    state_add(T6M53_SP, "SP", REG_SP).formatstr("%01X");
+    state_add(T6M53_SP, "SP", m_regs[0x118 >> 1]).formatstr("%01X");
     state_add(T6M53_REP, "REP", m_regs[0x110 >> 1]).formatstr("%01X");
-    state_add(T6M53_KCOL, "KCOL", REG_KCOL).formatstr("%02X");
-    state_add(T6M53_KROW, "KROW", REG_KROW).formatstr("%02X");
-    state_add(T6M53_IL, "ILO", REG_I_LO).formatstr("%02X");
-    state_add(T6M53_IH, "IHI", REG_I_HI).formatstr("%02X");
-    state_add(T6M53_DPL, "DPLO", REG_DP_LO).formatstr("%02X");
-    state_add(T6M53_DPH, "DPHI", REG_DP_HI).formatstr("%02X");
+    state_add(T6M53_IL, "ILO", m_regs[0x100 >> 1]).formatstr("%02X");
+    state_add(T6M53_IH, "IHI", m_regs[0x102 >> 1]).formatstr("%02X");
+    state_add(T6M53_DPL, "DPLO", m_regs[0x11c >> 1]).formatstr("%02X");
+    state_add(T6M53_DPH, "DPHI", m_regs[0x11e >> 1]).formatstr("%02X");
 
     save_item(NAME(m_regs));
     save_item(NAME(m_pc));
@@ -72,8 +61,6 @@ void t6m53_device::device_start()
     save_item(NAME(m_lastlow));
     save_item(NAME(m_lasthigh));
     save_item(NAME(m_isel));
-    save_item(NAME(m_previous_pc));
-    save_item(NAME(m_write_repeat));
 
     save_item(NAME(m_ftimer));
     save_item(NAME(m_vtimer));
@@ -81,10 +68,8 @@ void t6m53_device::device_start()
 }
 
 
-void t6m53_device::device_reset()
-{
+void t6m53_device::device_reset() {
     m_regs[0x10F >> 1] &= 0xB0;
-
     m_pc = 0;
     m_previous_pc = 0;
     m_lastlow = 0;
@@ -95,134 +80,127 @@ void t6m53_device::device_reset()
 }
 
 
-void t6m53_device::state_import(const device_state_entry &entry)
-{
-    switch (entry.index())
-    {
-    case STATE_GENPC:
-    case STATE_GENPCBASE:
-    case T6M53_PC:
-        // m_pc is directly bound to the debugger state entry.
-        break;
-    default:
-        break;
+void t6m53_device::state_import(const device_state_entry &entry) {
+    switch (entry.index()) {
+        case STATE_GENPC:
+        case STATE_GENPCBASE:
+        case T6M53_PC:
+            break;
+        default:
+            break;
     }
 }
 
 
-void t6m53_device::state_export(const device_state_entry &entry)
-{
-    switch (entry.index())
-    {
-    case STATE_GENPC:
-    case STATE_GENPCBASE:
-    case T6M53_PC:
-        break;
-    default:
-        break;
+void t6m53_device::state_export(const device_state_entry &entry) {
+    switch (entry.index()) {
+        case STATE_GENPC:
+        case STATE_GENPCBASE:
+        case T6M53_PC:
+            break;
+        default:
+            break;
     }
 }
 
-
-void t6m53_device::state_string_export(const device_state_entry &entry, std::string &str) const
-{
-}
-
-
-std::unique_ptr<util::disasm_interface> t6m53_device::create_disassembler()
-{
+std::unique_ptr<util::disasm_interface> t6m53_device::create_disassembler() {
     return std::make_unique<t6m53_disassembler>();
 }
 
-uint8_t t6m53_device::reg_r4_raw(uint16_t index, uint8_t &last)
-{
-    if ((index & 0x0f0) == 0x0f0)
-    {
+uint8_t t6m53_device::reg_r4_raw(uint16_t index, uint8_t &last) {
+    if ((index & 0x0f0) == 0x0f0) {
         last = REG_A & 0x0f;
         return last;
     }
-    else if (index == 0x103 || (index >= 0x10b && index <= 0x10d) || index == 0x10f ||
-        (index >= 0x110 && index <= 0x113) || index == 0x119)
-    {
-        return last;
-    }
-    else if (index == 0x117)
-    {
-        // In the supplied non-TiEmu build the link input reads as 0x3.
-        return 0x3;
-    }
 
-    const uint8_t reg = m_regs[index >> 1];
-    last = BIT(index, 0) ? (reg >> 4) : (reg & 0x0f);
-    if (index == 0x109)
-        last |= m_on_btn() << 2;
+    switch (index) {
+        case 0x103:
+        case 0x10b:
+        case 0x10c:
+        case 0x10d:
+        case 0x10f:
+        case 0x110:
+        case 0x111:
+        case 0x112:
+        case 0x113:
+        case 0x119:
+            return last;
 
-    return last;
+        case 0x117:
+            return (m_ring_in() << 1) | m_tip_in();
+
+        default:
+            last = BIT(index, 0) ? (m_regs[index >> 1] >> 4) : (m_regs[index >> 1] & 0x0f);
+            if (index == 0x109)
+                last |= m_on_btn() << 2;
+
+            return last;
+    }
 }
 
 
-void t6m53_device::reg_w4_raw(uint16_t index, uint8_t data)
-{
+void t6m53_device::reg_w4_raw(uint16_t index, uint8_t data) {
     data &= 0x0f;
 
-    if (index == 0x109 && ((data & 8) != (m_isel & 8)))
-    {
-        const uint8_t temp = (m_regs[0x101 >> 1] & 0xf0) | (m_regs[0x102 >> 1] & 1);
-
-        m_regs[0x101 >> 1] = (m_regs[0x101 >> 1] & 0x0f) | (REG_ALT_I & 0xf0);
-        m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | (REG_ALT_I & 1);
-        REG_ALT_I = temp;
-        m_isel = data;
-    }
-
-    if (index == 0x10f)
-    {
-        if ((data & 1) && !(m_regs[0x10F >> 1] & 0x10) && !(m_regs[0x10D >> 1] & 0x10))
-            m_regs[0x11a >> 1] = REG_TIMER_START;
-
-        if (data & 4)
-        {
-            reg_w8(0x11c, 0xaa);
-            reg_w8(0x11e, 0xaa);
-        }
-    }
-
-    if (index == 0x110)
-        m_write_repeat = true;
-
-    if (index == 0x116)
-    {
-        m_regs[0x116 >> 1] = (m_regs[0x116 >> 1] & 0xf0) | (data & 2);
-        m_stb(!(data & 2));
-        return;
-    }
-
-    if ((index & 0x0f0) == 0x0f0)
-    {
+    if ((index & 0x0f0) == 0x0f0) {
         REG_A = (REG_A & 0xf0) | data;
         return;
     }
 
-    if (index == 0x11a)
-        index = 0x0f4;
+    switch (index) {
+        case 0x102:
+            data &= 1;
+            break;
 
-    if (index == 0x11b)
-        index = 0x0f5;
+        case 0x107:
+            data &= 0x07;
+            break;
 
-    if (index == 0x102)
-    {
-        m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | (data & 1);
-        return;
+        case 0x108:
+        case 0x114:
+        case 0x115:
+            return;
+
+        case 0x109:
+            if ((data & 8) != (m_isel & 8)) {
+                const uint8_t temp = (m_regs[0x101 >> 1] & 0xf0) | (m_regs[0x102 >> 1] & 1);
+
+                m_regs[0x101 >> 1] = (m_regs[0x101 >> 1] & 0x0f) | (m_regs[0x0f2 >> 1] & 0xf0);
+                m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | (m_regs[0x0f2 >> 1] & 1);
+                m_regs[0x0f2 >> 1] = temp;
+                m_isel = data;
+            }
+            break;
+
+        case 0x10f:
+            if ((data & 1) && !(m_regs[0x10F >> 1] & 0x10) && !(m_regs[0x10D >> 1] & 0x10))
+                m_regs[0x11a >> 1] = m_regs[0x0f4 >> 1];
+
+            if (data & 4) {
+                reg_w8(0x11c, 0xaa);
+                reg_w8(0x11e, 0xaa);
+            }
+            break;
+
+        case 0x110:
+            m_write_repeat = true;
+            break;
+
+        case 0x116:
+            m_regs[0x116 >> 1] = (m_regs[0x116 >> 1] & 0xf0) | (data & 2);
+            m_stb(!(data & 2));
+            return;
+
+        case 0x117:
+            m_tip_out(BIT(data, 0));
+            m_ring_out(BIT(data, 1));
+            break;
+
+        case 0x11a:
+        case 0x11b:
+            index = (index - 0x11a) + 0x0f4;
+            break;
     }
-
-    if (index == 0x107)
-    {
-        m_regs[0x107 >> 1] = (m_regs[0x107 >> 1] & 0x0f) | ((data & 7) << 4);
-        return;
-    }
-
-    if (index == 0x108 || index == 0x114 || index == 0x115)
-        return;
 
     if (index & 1)
         m_regs[index >> 1] = (m_regs[index >> 1] & 0x0f) | (data << 4);
@@ -231,96 +209,73 @@ void t6m53_device::reg_w4_raw(uint16_t index, uint8_t data)
 }
 
 
-uint8_t t6m53_device::reg_r8(uint16_t index)
-{
-    if ((index & 0x0f0) == 0x0f0)
-    {
+uint8_t t6m53_device::reg_r8(uint16_t index) {
+    if ((index & 0x0f0) == 0x0f0) {
         m_lastlow = REG_A & 0x0f;
         m_lasthigh = REG_A >> 4;
         return REG_A;
-    }
-    else if ((index & 0x1e1) == 0x101)
-    {
+    } else if ((index & 0x1e1) == 0x101) {
         return reg_r4_raw(index, m_lastlow) | (m_lasthigh << 4);
     }
 
-    return reg_r4_raw(index, m_lastlow) |
-        (reg_r4_raw((index & 0x1f0) | ((index + 1) & 0x0f), m_lasthigh) << 4);
+    return reg_r4_raw(index, m_lastlow) | (reg_r4_raw((index & 0x1f0) | ((index + 1) & 0x0f), m_lasthigh) << 4);
 }
 
 
-void t6m53_device::reg_w8(uint16_t index, uint8_t data)
-{
+void t6m53_device::reg_w8(uint16_t index, uint8_t data) {
     m_lastlow = data & 0x0f;
     m_lasthigh = data >> 4;
 
-    if ((index & 0x0f0) == 0x0f0)
+    if ((index & 0x0f0) == 0x0f0) {
         REG_A = data;
-    else if ((index & 0x1e1) == 0x101)
+    } else if ((index & 0x1e1) == 0x101) {
         reg_w4(index, m_lastlow);
-    else
-    {
+    } else {
         reg_w4(index, m_lastlow);
         reg_w4((index & 0x1f0) | ((index + 1) & 0x0f), m_lasthigh);
     }
 }
 
 
-uint16_t t6m53_device::get_i() const
-{
-    return ((REG_I_HI & 1) << 8) | REG_I_LO;
+inline uint16_t t6m53_device::get_i() const {
+    return ((m_regs[0x102 >> 1] & 1) << 8) | m_regs[0x100 >> 1];
 }
 
 
-void t6m53_device::set_i(uint16_t value)
-{
-    REG_I_LO = value & 0xff;
-    REG_I_HI = (REG_I_HI & 0xf0) | !!(value & 0x100);
+inline void t6m53_device::set_i(uint16_t value) {
+    m_regs[0x100 >> 1] = value & 0xff;
+    m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | !!(value & 0x100);
 }
 
 
-uint16_t t6m53_device::get_dp() const
-{
-    return (REG_DP_HI << 8) | REG_DP_LO;
+inline uint16_t t6m53_device::get_dp() const {
+    return (m_regs[0x11e >> 1] << 8) | m_regs[0x11c >> 1];
 }
 
 
-void t6m53_device::set_dp(uint16_t value)
-{
-    REG_DP_LO = value & 0xff;
-    REG_DP_HI = value >> 8;
+inline void t6m53_device::set_dp(uint16_t value) {
+    m_regs[0x11c >> 1] = value & 0xff;
+    m_regs[0x11e >> 1] = value >> 8;
 }
 
 
-uint16_t t6m53_device::add4(uint16_t x, uint8_t y)
-{
+inline uint16_t t6m53_device::add4(uint16_t x, uint8_t y) {
     return (x & 0xfff0) | ((x + y) & 0x0f);
 }
 
 
-uint16_t t6m53_device::bcd(uint8_t x)
-{
+inline uint16_t t6m53_device::bcd(uint8_t x) {
     return (x >> 4) * 10 + (x & 0x0f);
 }
 
-
-uint8_t t6m53_device::reverse_bcd(uint16_t x)
-{
-    return ((x / 10) % 10) << 4 | (x % 10);
-}
-
-
-uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op)
-{
-    if (bits > 0)
-    {
-        if (op & 0x0800)
-        {
+uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op) {
+    if (bits > 0) {
+        if (op & 0x0800) {
             const int sum = bcd(x) + bcd(y) + carry;
             carry = sum > ((bits == 4) ? 9 : 99);
 
             if (bits == 4)
-                return reverse_bcd(sum);
+                return ((sum / 10) % 10) << 4 | (sum % 10);
 
             return ((sum / 100) << 8) | (((sum / 10) % 10) << 4) | (sum % 10);
         }
@@ -330,12 +285,11 @@ uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry
         return uint8_t(sum);
     }
 
-    if (op & 0x0800)
-    {
+    if (op & 0x0800) {
         int sum = bcd(x) - bcd(y) - carry;
         carry = sum < 0;
         sum = (bits == -4) ? (sum + 10) % 10 : (sum + 100) % 100;
-        return reverse_bcd(sum);
+        return ((sum / 10) % 10) << 4 | (sum % 10);
     }
 
     const int sum = x - y - carry;
@@ -344,48 +298,41 @@ uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry
 }
 
 
-uint16_t t6m53_device::jyx(uint16_t op, uint16_t offset) const
-{
+uint16_t t6m53_device::jyx(uint16_t op, uint16_t offset) const {
     const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
     const uint16_t effective_offset = BIT(op, 8) ? offset : offset << 1;
     return add4(((get_i() & 0x100) ^ 0x100) | YX, effective_offset);
 }
 
 
-uint16_t t6m53_device::wyx(uint16_t op, uint16_t offset) const
-{
+uint16_t t6m53_device::wyx(uint16_t op, uint16_t offset) const {
     const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
     return ((op & 0x020f) == 0x020f) ? get_i() : add4(((op >> 1) & 0x100) | YX, offset);
 }
 
 
-uint16_t t6m53_device::wyxs(uint16_t op, uint16_t offset) const
-{
+uint16_t t6m53_device::wyxs(uint16_t op, uint16_t offset) const {
     return ((op & 0x020f) == 0x020f) ? get_i() : wyxs_no_i(op, offset);
 }
 
-uint16_t t6m53_device::wyxs_no_i(uint16_t op, uint16_t offset) const
-{
+uint16_t t6m53_device::wyxs_no_i(uint16_t op, uint16_t offset) const {
     const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
     const uint16_t effective_offset = BIT(op, 8) ? offset : offset << 1;
     return add4(((op >> 1) & 0x100) | YX, effective_offset);
 }
 
-uint16_t t6m53_device::ef(uint16_t op, uint16_t offset) const
-{
+uint16_t t6m53_device::ef(uint16_t op, uint16_t offset) const {
     return add4(0x100 | ((op >> 7) & 0x20) | ((op >> 4) & 0x1f), offset);
 }
 
 
-void t6m53_device::jump_call(bool conditional, bool condition)
-{
+void t6m53_device::jump_call(bool conditional, bool condition) {
     const uint16_t target = m_program->read_word(m_pc);
 
     if (conditional && !condition)
         return;
 
-    if (target & 0x8000)
-    {
+    if (target & 0x8000) {
         const uint8_t sp = reg_r4(0x118);
         if (sp < 8) m_stack[sp] = m_pc + 2;
         reg_w4(0x118, sp + 1);
@@ -395,8 +342,7 @@ void t6m53_device::jump_call(bool conditional, bool condition)
     add_cycles(2);
 }
 
-void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry)
-{
+void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry) {
     const int s = BIT(op, 8);
     const uint8_t SMASK = s ? 0x0f : 0xff;
     const int SB = s ? 4 : 8;
@@ -404,8 +350,7 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
 
     const auto reg_sr = [&](uint16_t addr) -> uint8_t { return s ? reg_r4(addr) : reg_r8(addr); };
     const auto reg_sw = [&](uint16_t addr, uint8_t value) { if (s) reg_w4(addr, value); else reg_w8(addr, value); };
-    const auto do_m_jump_call = [&](bool cond)
-    {
+    const auto do_m_jump_call = [&](bool cond) {
         if (repeat)
             return;
 
@@ -439,10 +384,9 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
             reg_w8(0x0f0, reg_r8(0x0f0) >> (((op & 4) && DPsave < 0x4000) ? 2 : 1));
 
         if (op & 0x20)
-            REG_KROW = m_btn_rows(REG_KCOL);
+            m_regs[0x114 >> 1] = m_btn_rows(m_regs[0x112 >> 1]);
 
-        if (op & 0x40)
-        {
+        if (op & 0x40) {
             uint8_t sp = m_regs[0x118 >> 1] & 0x0f;
             if (sp > 0) {
                 reg_w4_raw(0x118, --sp);
@@ -564,8 +508,7 @@ void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is
     }
 }
 
-void t6m53_device::add_cycles(int cycles)
-{
+void t6m53_device::add_cycles(int cycles) {
     m_icount -= cycles * 4;
 
     if (((m_regs[0x10d >> 1] >> 4) & 0x01) || ((m_regs[0x10f >> 1] >> 4) & 0x0c)) {
@@ -594,20 +537,16 @@ void t6m53_device::add_cycles(int cycles)
     }
 }
 
-void t6m53_device::execute_run()
-{
+void t6m53_device::execute_run() {
     const bool call_debugger = debugger_enabled();
 
-    while (m_icount > 0)
-    {
-        if (m_on_btn() && (m_regs[0x10e >> 1] & 0x0c) == 0x0c)
-        {
+    while (m_icount > 0) {
+        if (m_on_btn() && (m_regs[0x10e >> 1] & 0x0c) == 0x0c) {
                 device_reset();
                 continue;
         }
 
-        if (m_regs[0x10f >> 1] & 0xc0)
-        {
+        if (m_regs[0x10f >> 1] & 0xc0) {
             add_cycles(8);
             continue;
         }
@@ -620,8 +559,7 @@ void t6m53_device::execute_run()
         bool carry = false;
         add_cycles(1);
 
-        for (int repeat = rep, offset = 0; repeat >= 0; --repeat, ++offset)
-        {
+        for (int repeat = rep, offset = 0; repeat >= 0; --repeat, ++offset) {
             m_pc = pc_save;
             m_write_repeat = false;
 
@@ -631,20 +569,15 @@ void t6m53_device::execute_run()
             m_pc += 2;
             execute_op(op, repeat, offset, rep != 0, carry);
 
-            if (m_write_repeat)
-            {
-                if (repeat)
-                {
+            if (m_write_repeat) {
+                if (repeat) {
                     repeat = repeat_count();
                     if (!repeat)
                         repeat = 0x10;
                 }
-            }
-            else
-            {
+            } else {
                 reg_w4_raw(0x110, repeat);
             }
         }
-    
     }
 }

--- a/src/devices/cpu/t6m53/t6m53.cpp
+++ b/src/devices/cpu/t6m53/t6m53.cpp
@@ -1,0 +1,650 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+/***************************************************************************
+
+        Toshiba T6M53 ASIC
+
+***************************************************************************/
+
+#include "emu.h"
+#include "t6m53.h"
+#include "t6m53_dasm.h"
+
+DEFINE_DEVICE_TYPE(T6M53, t6m53_device, "t6m53", "Toshiba T6M53")
+
+#define REG_A       m_regs[0x0f0 >> 1]
+#define REG_I_LO    m_regs[0x100 >> 1]
+#define REG_I_HI    m_regs[0x102 >> 1]
+#define REG_ALT_I   m_regs[0x0f2 >> 1]
+#define REG_KCOL    m_regs[0x112 >> 1]
+#define REG_KROW    m_regs[0x114 >> 1]
+#define REG_SP      m_regs[0x118 >> 1]
+#define REG_DP_LO   m_regs[0x11c >> 1]
+#define REG_DP_HI   m_regs[0x11e >> 1]
+#define REG_TIMER_START m_regs[0x0f4 >> 1]
+
+
+t6m53_device::t6m53_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+    cpu_device(mconfig, T6M53, tag, owner, clock),
+    m_program_config("program", ENDIANNESS_BIG, 8, 16, 0),
+    m_ring_out(*this),
+    m_tip_out(*this),
+    m_ring_in(*this, 0),
+    m_tip_in(*this, 0),
+    m_stb(*this),
+    m_btn_rows(*this, 0),
+    m_on_btn(*this, 0)
+{
+}
+
+
+device_memory_interface::space_config_vector t6m53_device::memory_space_config() const
+{
+    return space_config_vector{
+        std::make_pair(AS_PROGRAM, &m_program_config)
+    };
+}
+
+
+void t6m53_device::device_start()
+{
+    std::fill(std::begin(m_regs), std::end(m_regs), 0);
+    std::fill(std::begin(m_stack), std::end(m_stack), 0);
+
+    m_program = &space(AS_PROGRAM);
+
+    state_add(T6M53_PC, "PC", m_pc).formatstr("%04X");
+    state_add(STATE_GENPC, "GENPC", m_pc).formatstr("%04X").noshow();
+    state_add(STATE_GENPCBASE, "CURPC", m_previous_pc).formatstr("%04X").noshow();
+    state_add(T6M53_A, "A", REG_A).formatstr("%02X");
+    state_add(T6M53_SP, "SP", REG_SP).formatstr("%01X");
+    state_add(T6M53_REP, "REP", m_regs[0x110 >> 1]).formatstr("%01X");
+    state_add(T6M53_KCOL, "KCOL", REG_KCOL).formatstr("%02X");
+    state_add(T6M53_KROW, "KROW", REG_KROW).formatstr("%02X");
+    state_add(T6M53_IL, "ILO", REG_I_LO).formatstr("%02X");
+    state_add(T6M53_IH, "IHI", REG_I_HI).formatstr("%02X");
+    state_add(T6M53_DPL, "DPLO", REG_DP_LO).formatstr("%02X");
+    state_add(T6M53_DPH, "DPHI", REG_DP_HI).formatstr("%02X");
+
+    save_item(NAME(m_regs));
+    save_item(NAME(m_pc));
+    save_item(NAME(m_stack));
+    save_item(NAME(m_lastlow));
+    save_item(NAME(m_lasthigh));
+    save_item(NAME(m_isel));
+    save_item(NAME(m_previous_pc));
+    save_item(NAME(m_write_repeat));
+
+    save_item(NAME(m_ftimer));
+    save_item(NAME(m_vtimer));
+    set_icountptr(m_icount);
+}
+
+
+void t6m53_device::device_reset()
+{
+    m_regs[0x10F >> 1] &= 0xB0;
+
+    m_pc = 0;
+    m_previous_pc = 0;
+    m_lastlow = 0;
+    m_lasthigh = 0;
+    m_ftimer = 0;
+    m_vtimer = 0;
+    m_write_repeat = false;
+}
+
+
+void t6m53_device::state_import(const device_state_entry &entry)
+{
+    switch (entry.index())
+    {
+    case STATE_GENPC:
+    case STATE_GENPCBASE:
+    case T6M53_PC:
+        // m_pc is directly bound to the debugger state entry.
+        break;
+    default:
+        break;
+    }
+}
+
+
+void t6m53_device::state_export(const device_state_entry &entry)
+{
+    switch (entry.index())
+    {
+    case STATE_GENPC:
+    case STATE_GENPCBASE:
+    case T6M53_PC:
+        break;
+    default:
+        break;
+    }
+}
+
+
+void t6m53_device::state_string_export(const device_state_entry &entry, std::string &str) const
+{
+}
+
+
+std::unique_ptr<util::disasm_interface> t6m53_device::create_disassembler()
+{
+    return std::make_unique<t6m53_disassembler>();
+}
+
+uint8_t t6m53_device::reg_r4_raw(uint16_t index, uint8_t &last)
+{
+    if ((index & 0x0f0) == 0x0f0)
+    {
+        last = REG_A & 0x0f;
+        return last;
+    }
+    else if (index == 0x103 || (index >= 0x10b && index <= 0x10d) || index == 0x10f ||
+        (index >= 0x110 && index <= 0x113) || index == 0x119)
+    {
+        return last;
+    }
+    else if (index == 0x117)
+    {
+        // In the supplied non-TiEmu build the link input reads as 0x3.
+        return 0x3;
+    }
+
+    const uint8_t reg = m_regs[index >> 1];
+    last = BIT(index, 0) ? (reg >> 4) : (reg & 0x0f);
+    if (index == 0x109)
+        last |= m_on_btn() << 2;
+
+    return last;
+}
+
+
+void t6m53_device::reg_w4_raw(uint16_t index, uint8_t data)
+{
+    data &= 0x0f;
+
+    if (index == 0x109 && ((data & 8) != (m_isel & 8)))
+    {
+        const uint8_t temp = (m_regs[0x101 >> 1] & 0xf0) | (m_regs[0x102 >> 1] & 1);
+
+        m_regs[0x101 >> 1] = (m_regs[0x101 >> 1] & 0x0f) | (REG_ALT_I & 0xf0);
+        m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | (REG_ALT_I & 1);
+        REG_ALT_I = temp;
+        m_isel = data;
+    }
+
+    if (index == 0x10f)
+    {
+        if ((data & 1) && !(m_regs[0x10F >> 1] & 0x10) && !(m_regs[0x10D >> 1] & 0x10))
+            m_regs[0x11a >> 1] = REG_TIMER_START;
+
+        if (data & 4)
+        {
+            reg_w8(0x11c, 0xaa);
+            reg_w8(0x11e, 0xaa);
+        }
+    }
+
+    if (index == 0x110)
+        m_write_repeat = true;
+
+    if (index == 0x116)
+    {
+        m_regs[0x116 >> 1] = (m_regs[0x116 >> 1] & 0xf0) | (data & 2);
+        m_stb(!(data & 2));
+        return;
+    }
+
+    if ((index & 0x0f0) == 0x0f0)
+    {
+        REG_A = (REG_A & 0xf0) | data;
+        return;
+    }
+
+    if (index == 0x11a)
+        index = 0x0f4;
+
+    if (index == 0x11b)
+        index = 0x0f5;
+
+    if (index == 0x102)
+    {
+        m_regs[0x102 >> 1] = (m_regs[0x102 >> 1] & 0xf0) | (data & 1);
+        return;
+    }
+
+    if (index == 0x107)
+    {
+        m_regs[0x107 >> 1] = (m_regs[0x107 >> 1] & 0x0f) | ((data & 7) << 4);
+        return;
+    }
+
+    if (index == 0x108 || index == 0x114 || index == 0x115)
+        return;
+
+    if (index & 1)
+        m_regs[index >> 1] = (m_regs[index >> 1] & 0x0f) | (data << 4);
+    else
+        m_regs[index >> 1] = (m_regs[index >> 1] & 0xf0) | (data & 0x0f);
+}
+
+
+uint8_t t6m53_device::reg_r8(uint16_t index)
+{
+    if ((index & 0x0f0) == 0x0f0)
+    {
+        m_lastlow = REG_A & 0x0f;
+        m_lasthigh = REG_A >> 4;
+        return REG_A;
+    }
+    else if ((index & 0x1e1) == 0x101)
+    {
+        return reg_r4_raw(index, m_lastlow) | (m_lasthigh << 4);
+    }
+
+    return reg_r4_raw(index, m_lastlow) |
+        (reg_r4_raw((index & 0x1f0) | ((index + 1) & 0x0f), m_lasthigh) << 4);
+}
+
+
+void t6m53_device::reg_w8(uint16_t index, uint8_t data)
+{
+    m_lastlow = data & 0x0f;
+    m_lasthigh = data >> 4;
+
+    if ((index & 0x0f0) == 0x0f0)
+        REG_A = data;
+    else if ((index & 0x1e1) == 0x101)
+        reg_w4(index, m_lastlow);
+    else
+    {
+        reg_w4(index, m_lastlow);
+        reg_w4((index & 0x1f0) | ((index + 1) & 0x0f), m_lasthigh);
+    }
+}
+
+
+uint16_t t6m53_device::get_i() const
+{
+    return ((REG_I_HI & 1) << 8) | REG_I_LO;
+}
+
+
+void t6m53_device::set_i(uint16_t value)
+{
+    REG_I_LO = value & 0xff;
+    REG_I_HI = (REG_I_HI & 0xf0) | !!(value & 0x100);
+}
+
+
+uint16_t t6m53_device::get_dp() const
+{
+    return (REG_DP_HI << 8) | REG_DP_LO;
+}
+
+
+void t6m53_device::set_dp(uint16_t value)
+{
+    REG_DP_LO = value & 0xff;
+    REG_DP_HI = value >> 8;
+}
+
+
+uint16_t t6m53_device::add4(uint16_t x, uint8_t y)
+{
+    return (x & 0xfff0) | ((x + y) & 0x0f);
+}
+
+
+uint16_t t6m53_device::bcd(uint8_t x)
+{
+    return (x >> 4) * 10 + (x & 0x0f);
+}
+
+
+uint8_t t6m53_device::reverse_bcd(uint16_t x)
+{
+    return ((x / 10) % 10) << 4 | (x % 10);
+}
+
+
+uint8_t t6m53_device::add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op)
+{
+    if (bits > 0)
+    {
+        if (op & 0x0800)
+        {
+            const int sum = bcd(x) + bcd(y) + carry;
+            carry = sum > ((bits == 4) ? 9 : 99);
+
+            if (bits == 4)
+                return reverse_bcd(sum);
+
+            return ((sum / 100) << 8) | (((sum / 10) % 10) << 4) | (sum % 10);
+        }
+
+        const int sum = x + y + carry;
+        carry = (sum >> bits) & 1;
+        return uint8_t(sum);
+    }
+
+    if (op & 0x0800)
+    {
+        int sum = bcd(x) - bcd(y) - carry;
+        carry = sum < 0;
+        sum = (bits == -4) ? (sum + 10) % 10 : (sum + 100) % 100;
+        return reverse_bcd(sum);
+    }
+
+    const int sum = x - y - carry;
+    carry = (sum >> -bits) & 1;
+    return sum;
+}
+
+
+uint16_t t6m53_device::jyx(uint16_t op, uint16_t offset) const
+{
+    const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
+    const uint16_t effective_offset = BIT(op, 8) ? offset : offset << 1;
+    return add4(((get_i() & 0x100) ^ 0x100) | YX, effective_offset);
+}
+
+
+uint16_t t6m53_device::wyx(uint16_t op, uint16_t offset) const
+{
+    const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
+    return ((op & 0x020f) == 0x020f) ? get_i() : add4(((op >> 1) & 0x100) | YX, offset);
+}
+
+
+uint16_t t6m53_device::wyxs(uint16_t op, uint16_t offset) const
+{
+    return ((op & 0x020f) == 0x020f) ? get_i() : wyxs_no_i(op, offset);
+}
+
+uint16_t t6m53_device::wyxs_no_i(uint16_t op, uint16_t offset) const
+{
+    const uint16_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
+    const uint16_t effective_offset = BIT(op, 8) ? offset : offset << 1;
+    return add4(((op >> 1) & 0x100) | YX, effective_offset);
+}
+
+uint16_t t6m53_device::ef(uint16_t op, uint16_t offset) const
+{
+    return add4(0x100 | ((op >> 7) & 0x20) | ((op >> 4) & 0x1f), offset);
+}
+
+
+void t6m53_device::jump_call(bool conditional, bool condition)
+{
+    const uint16_t target = m_program->read_word(m_pc);
+
+    if (conditional && !condition)
+        return;
+
+    if (target & 0x8000)
+    {
+        const uint8_t sp = reg_r4(0x118);
+        if (sp < 8) m_stack[sp] = m_pc + 2;
+        reg_w4(0x118, sp + 1);
+    }
+
+    m_pc = (target & 0x7fff) << 1;
+    add_cycles(2);
+}
+
+void t6m53_device::execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry)
+{
+    const int s = BIT(op, 8);
+    const uint8_t SMASK = s ? 0x0f : 0xff;
+    const int SB = s ? 4 : 8;
+    const uint8_t B = ((op >> 9 & 2) | (op >> 8 & 1));
+
+    const auto reg_sr = [&](uint16_t addr) -> uint8_t { return s ? reg_r4(addr) : reg_r8(addr); };
+    const auto reg_sw = [&](uint16_t addr, uint8_t value) { if (s) reg_w4(addr, value); else reg_w8(addr, value); };
+    const auto do_m_jump_call = [&](bool cond)
+    {
+        if (repeat)
+            return;
+
+        if (op & 0x0400) {
+            if (BIT(op, 9) == cond)
+                jump_call(true, true);
+            else
+                m_pc += 2;
+        } else if (op & 0x0200) {
+            jump_call(false, true);
+        }
+    };
+
+    if (op < 0x0200) {
+        const uint16_t DPsave = get_dp();
+
+        if (op & 0x04) {
+            if (!repeat)
+                add_cycles(1);
+
+            if (op & 0x02)
+                m_program->write_byte(get_dp(), s ? reg_r4(get_i()) | (m_lasthigh << 4) : reg_r8(get_i()));
+            else
+                reg_sw(get_i(), m_program->read_byte(get_dp()));
+
+            op & 0x01 ? set_dp(get_dp() - 1) : set_dp(get_dp() + 1);
+            if (is_repeat) set_i(add4(get_i(), 2 - s));
+        }
+
+        if ((op & 0x18) == 0x18)
+            reg_w8(0x0f0, reg_r8(0x0f0) >> (((op & 4) && DPsave < 0x4000) ? 2 : 1));
+
+        if (op & 0x20)
+            REG_KROW = m_btn_rows(REG_KCOL);
+
+        if (op & 0x40)
+        {
+            uint8_t sp = m_regs[0x118 >> 1] & 0x0f;
+            if (sp > 0) {
+                reg_w4_raw(0x118, --sp);
+                m_pc = sp < 8 ? m_stack[sp] : 0x0000;
+            }
+        }
+
+        if (op & 0x80) 
+            m_pc = (m_regs[0x106 >> 1] << 9) | (m_regs[0x104 >> 1] << 1);
+    } else if (op < 0x0400) {
+        reg_sw(jyx(op, offset), reg_sr(get_i()));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x0600) {
+        reg_sw(get_i(), reg_sr(jyx(op, offset)));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x0800) {
+        const uint8_t temp = reg_sr(jyx(op, offset));
+        reg_sw(jyx(op, offset), reg_sr(get_i()));
+        reg_sw(get_i(), temp);
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x0c00) {
+        reg_w4(0x102, op >> 8);
+        reg_w8(0x100, op);
+        if (op & 0x0200)
+            jump_call(false, true);
+    } else if (op < 0x0e00) {
+        reg_sw(get_i(), op);
+        set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x1000) {
+        reg_w4(ef(op, offset), op);
+    } else if (op < 0x1400) {
+        reg_sw(0x0f0, reg_sr(wyxs_no_i(op, offset)));
+    } else if (op < 0x1800) {
+        const uint8_t temp = reg_sr(0x0f0);
+        reg_sw(0x0f0, reg_sr(wyxs_no_i(op, offset)));
+        reg_sw(wyxs_no_i(op, offset), temp);
+    } else if (op < 0x1c00) {
+        reg_sw(wyxs_no_i(op, offset), reg_sr(0x0f0));
+    } else if (op < 0x1e00) {
+        reg_sw(0x0f0, op);
+    } else if (op < 0x2000) {
+        reg_w4(ef(op, offset), op);
+    } else if (op < 0x2800) {
+        const uint16_t addr = wyx(op, offset);
+        reg_w4(addr, reg_r4(addr) ^ (1 << B));
+    } else if (op < 0x3000) {
+        const uint16_t addr = wyx(op, offset);
+        reg_w4(addr, reg_r4(addr) & ~(1 << B));
+    } else if (op < 0x3800) {
+        const uint16_t addr = wyx(op, offset);
+        reg_w4(addr, reg_r4(addr) | (1 << B));
+    } else if (op < 0x3c00) {
+        const uint16_t addr = ((op & 0x020f) == 0x020f) ? get_i() : wyxs(op, offset);
+        reg_sw(addr, ~reg_sr(addr));
+        if (is_repeat && (op & 0x020f) == 0x020f)
+            set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x3e00) {
+        reg_sw(get_i(), reg_sr(get_i()) ^ reg_sr(jyx(op, offset)));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x4000) {
+        reg_sw(get_i(), reg_sr(get_i()) | reg_sr(jyx(op, offset)));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x6000) {
+        const uint8_t x = reg_r4(ef(op, offset));
+        const uint8_t y = op & 0x0f;
+        carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
+        if (!repeat)
+            carry = !(op & 0x0800) ^ !carry;
+        do_m_jump_call(carry);
+    } else if (op < 0x7000) {
+        const uint8_t x = reg_sr(get_i());
+        const uint8_t y = op & SMASK;
+        carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
+        if (!repeat)
+            carry = !(op & 0x0800) ^ !carry;
+        do_m_jump_call(carry);
+        set_i(add4(get_i(), 2 - s));
+    } else if (op < 0x8000) {
+        const uint8_t x = reg_sr(0x0f0);
+        const uint8_t y = op & SMASK;
+        carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
+        if (!repeat)
+            carry = !(op & 0x0800) ^ !carry;
+        do_m_jump_call(carry);
+    } else if (op < 0xa000) {
+        reg_sw(get_i(), add_with_carry(op & 0x1000 ? -SB : SB, reg_sr(get_i()), reg_sr(jyx(op, offset)), carry, op));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+        do_m_jump_call(carry);
+    } else if (op < 0xb000) {
+        bool test = true;
+
+        do {
+            test &= BIT(reg_r4(wyx(op, offset)), B) == BIT(op, 11);
+        } while (repeat && repeat--);
+
+        if (test)
+            jump_call(true, true);
+        else
+            m_pc += 2;
+    } else if (op < 0xc000) {
+        const uint8_t x = reg_sr(get_i());
+        const uint8_t y = reg_sr(jyx(op, offset));
+        carry = (op & 0x0800) ? (x < y || (carry && x == y)) : (carry || x != y);
+        if (!repeat)
+            carry = !(op & 0x0800) ^ !carry;
+        do_m_jump_call(carry);
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+    } else if (op < 0xe000) {
+        const uint16_t addr = ef(op, offset);
+        reg_w4(addr, add_with_carry(4, reg_r4(addr), op & 0x0f, carry, op));
+        do_m_jump_call(carry);
+    } else if (op < 0xf000) {
+        reg_sw(get_i(), add_with_carry(SB, reg_sr(get_i()), op & SMASK, carry, op));
+        if (is_repeat) set_i(add4(get_i(), 2 - s));
+        do_m_jump_call(carry);
+    } else {
+        reg_sw(0x0f0, add_with_carry(SB, reg_sr(0x0f0), op & SMASK, carry, op));
+        do_m_jump_call(carry);
+    }
+}
+
+void t6m53_device::add_cycles(int cycles)
+{
+    m_icount -= cycles * 4;
+
+    if (((m_regs[0x10d >> 1] >> 4) & 0x01) || ((m_regs[0x10f >> 1] >> 4) & 0x0c)) {
+        m_vtimer = 0;
+        return;
+    }
+
+    m_ftimer += cycles * 10;
+    if (m_ftimer >= 262144) {
+        m_ftimer -= 262144;
+        m_regs[0x108 >> 1] = add4(m_regs[0x108 >> 1], 1);
+    }
+
+    if (m_regs[0x10f >> 1] & 0x10) {
+        int speed = 40960 >> ((m_regs[0x10b >> 1] >> 2) & 0x0c);
+        m_vtimer += cycles * speed;
+        if (m_vtimer >= 262144) {
+            m_vtimer -= 262144;
+            if (--m_regs[0x11a >> 1] == 0xff) {
+                m_regs[0x11a >> 1] = m_regs[0x0f4 >> 1];
+                m_regs[0x109 >> 1] |= 0x20;
+            }
+        }
+    } else {
+        m_vtimer = 0;
+    }
+}
+
+void t6m53_device::execute_run()
+{
+    const bool call_debugger = debugger_enabled();
+
+    while (m_icount > 0)
+    {
+        if (m_on_btn() && (m_regs[0x10e >> 1] & 0x0c) == 0x0c)
+        {
+                device_reset();
+                continue;
+        }
+
+        if (m_regs[0x10f >> 1] & 0xc0)
+        {
+            add_cycles(8);
+            continue;
+        }
+
+        const uint16_t pc_save = m_previous_pc = m_pc;
+        if (call_debugger)
+            debugger_instruction_hook(m_pc);
+
+        const uint8_t rep = repeat_count();
+        bool carry = false;
+        add_cycles(1);
+
+        for (int repeat = rep, offset = 0; repeat >= 0; --repeat, ++offset)
+        {
+            m_pc = pc_save;
+            m_write_repeat = false;
+
+            uint16_t op = m_program->read_word(m_pc);
+            add_cycles(1);
+
+            m_pc += 2;
+            execute_op(op, repeat, offset, rep != 0, carry);
+
+            if (m_write_repeat)
+            {
+                if (repeat)
+                {
+                    repeat = repeat_count();
+                    if (!repeat)
+                        repeat = 0x10;
+                }
+            }
+            else
+            {
+                reg_w4_raw(0x110, repeat);
+            }
+        }
+    
+    }
+}

--- a/src/devices/cpu/t6m53/t6m53.h
+++ b/src/devices/cpu/t6m53/t6m53.h
@@ -20,6 +20,7 @@ public:
     auto tip_out() { return m_tip_out.bind(); }
     auto ring_in() { return m_ring_in.bind(); }
     auto tip_in() { return m_tip_in.bind(); }
+
     auto lcd_stb() { return m_stb.bind(); }
     auto btn_rows() { return m_btn_rows.bind(); }
     auto on_btn() { return m_on_btn.bind(); }
@@ -36,7 +37,6 @@ protected:
 
 	virtual void state_import(const device_state_entry &entry) override;
 	virtual void state_export(const device_state_entry &entry) override;
-	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
 
 	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
 
@@ -76,6 +76,7 @@ private:
     devcb_write_line m_tip_out;
     devcb_read_line  m_ring_in;
     devcb_read_line  m_tip_in;
+
     devcb_write_line m_stb;
     devcb_read8 m_btn_rows;
     devcb_read_line m_on_btn;
@@ -94,7 +95,6 @@ private:
 	static uint16_t add4(uint16_t x, uint8_t y);
 
 	static uint16_t bcd(uint8_t x);
-	static uint8_t reverse_bcd(uint16_t x);
 	uint8_t add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op);
 
 	uint16_t jyx(uint16_t op, uint16_t offset) const;

--- a/src/devices/cpu/t6m53/t6m53.h
+++ b/src/devices/cpu/t6m53/t6m53.h
@@ -47,13 +47,13 @@ private:
 		T6M53_A,
 		T6M53_SP,
 		T6M53_REP,
-		T6M53_KCOL,
-		T6M53_KROW,
 		T6M53_IL,
 		T6M53_IH,
 		T6M53_DPL,
 		T6M53_DPH
 	};
+
+    const uint16_t m_divisors[8] = {5040, 2100, 1575, 1050, 350, 252, 180, 105};
 
 	uint8_t m_regs[0x100];
 	uint16_t m_stack[8];
@@ -92,10 +92,10 @@ private:
 	void set_i(uint16_t value);
 	uint16_t get_dp() const;
 	void set_dp(uint16_t value);
-	static uint16_t add4(uint16_t x, uint8_t y);
 
-	static uint16_t bcd(uint8_t x);
-	uint8_t add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op);
+	uint16_t add4(uint16_t x, uint8_t y);
+	uint16_t bcd(uint8_t x);
+	uint8_t adc(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op);
 
 	uint16_t jyx(uint16_t op, uint16_t offset) const;
 	uint16_t wyx(uint16_t op, uint16_t offset) const;
@@ -103,7 +103,7 @@ private:
 	uint16_t wyxs_no_i(uint16_t op, uint16_t offset) const;
 	uint16_t ef(uint16_t op, uint16_t offset) const;
 
-	void jump_call(bool conditional, bool condition);
+	void jump_call(bool is_cond, bool condition);
     void add_cycles(int cycles);
 	void execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry);
 

--- a/src/devices/cpu/t6m53/t6m53.h
+++ b/src/devices/cpu/t6m53/t6m53.h
@@ -1,0 +1,116 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+/***************************************************************************
+
+        Toshiba T6M53 ASIC
+
+***************************************************************************/
+
+#ifndef MAME_CPU_T6M53_T6M53_H
+#define MAME_CPU_T6M53_T6M53_H
+
+#pragma once
+
+class t6m53_device : public cpu_device
+{
+public:
+	t6m53_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+    auto ring_out() { return m_ring_out.bind(); }
+    auto tip_out() { return m_tip_out.bind(); }
+    auto ring_in() { return m_ring_in.bind(); }
+    auto tip_in() { return m_tip_in.bind(); }
+    auto lcd_stb() { return m_stb.bind(); }
+    auto btn_rows() { return m_btn_rows.bind(); }
+    auto on_btn() { return m_on_btn.bind(); }
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	virtual u32 execute_min_cycles() const noexcept override { return 4; }
+	virtual u32 execute_max_cycles() const noexcept override { return 32; }
+	virtual void execute_run() override;
+
+	virtual space_config_vector memory_space_config() const override;
+
+	virtual void state_import(const device_state_entry &entry) override;
+	virtual void state_export(const device_state_entry &entry) override;
+	virtual void state_string_export(const device_state_entry &entry, std::string &str) const override;
+
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+private:
+	enum : u32
+	{
+		T6M53_PC = 1,
+		T6M53_A,
+		T6M53_SP,
+		T6M53_REP,
+		T6M53_KCOL,
+		T6M53_KROW,
+		T6M53_IL,
+		T6M53_IH,
+		T6M53_DPL,
+		T6M53_DPH
+	};
+
+	uint8_t m_regs[0x100];
+	uint16_t m_stack[8];
+	uint16_t m_pc = 0;
+    uint8_t m_isel = 0;
+
+	int m_icount = 0;
+    int m_ftimer = 0;
+    int m_vtimer = 0;
+
+	uint8_t m_lastlow = 0;
+	uint8_t m_lasthigh = 0;
+	uint16_t m_previous_pc = 0;
+	bool m_write_repeat = false;
+
+	address_space_config m_program_config;
+	address_space *m_program = nullptr;
+
+    devcb_write_line m_ring_out;
+    devcb_write_line m_tip_out;
+    devcb_read_line  m_ring_in;
+    devcb_read_line  m_tip_in;
+    devcb_write_line m_stb;
+    devcb_read8 m_btn_rows;
+    devcb_read_line m_on_btn;
+
+	uint8_t reg_r4_raw(uint16_t index, uint8_t &last);
+	uint8_t reg_r4(uint16_t index) { return reg_r4_raw(index, m_lastlow); }
+	void reg_w4_raw(uint16_t index, uint8_t data);
+	void reg_w4(uint16_t index, uint8_t data) { m_lastlow = data & 0x0f; reg_w4_raw(index, m_lastlow); }
+	uint8_t reg_r8(uint16_t index);
+	void reg_w8(uint16_t index, uint8_t data);
+
+	uint16_t get_i() const;
+	void set_i(uint16_t value);
+	uint16_t get_dp() const;
+	void set_dp(uint16_t value);
+	static uint16_t add4(uint16_t x, uint8_t y);
+
+	static uint16_t bcd(uint8_t x);
+	static uint8_t reverse_bcd(uint16_t x);
+	uint8_t add_with_carry(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op);
+
+	uint16_t jyx(uint16_t op, uint16_t offset) const;
+	uint16_t wyx(uint16_t op, uint16_t offset) const;
+	uint16_t wyxs(uint16_t op, uint16_t offset) const;
+	uint16_t wyxs_no_i(uint16_t op, uint16_t offset) const;
+	uint16_t ef(uint16_t op, uint16_t offset) const;
+
+	void jump_call(bool conditional, bool condition);
+    void add_cycles(int cycles);
+	void execute_op(uint16_t op, int &repeat, uint16_t offset, bool is_repeat, bool &carry);
+
+	uint8_t repeat_count() const { return m_regs[0x110 >> 1] & 0x0f; }
+	uint8_t stack_pointer() const { return m_regs[0x118 >> 1] & 0x0f; }
+};
+
+DECLARE_DEVICE_TYPE(T6M53, t6m53_device)
+
+#endif // MAME_CPU_T6M53_T6M53_H

--- a/src/devices/cpu/t6m53/t6m53.h
+++ b/src/devices/cpu/t6m53/t6m53.h
@@ -93,7 +93,7 @@ private:
 	uint16_t get_dp() const;
 	void set_dp(uint16_t value);
 
-	uint16_t add4(uint16_t x, uint8_t y);
+	uint16_t add4(uint16_t x, uint8_t y) const;
 	uint16_t bcd(uint8_t x);
 	uint8_t adc(int bits, uint8_t x, uint8_t y, bool &carry, uint16_t op);
 

--- a/src/devices/cpu/t6m53/t6m53_dasm.cpp
+++ b/src/devices/cpu/t6m53/t6m53_dasm.cpp
@@ -4,124 +4,89 @@
 #include "emu.h"
 #include "t6m53_dasm.h"
 
-u32 t6m53_disassembler::opcode_alignment() const
-{
+u32 t6m53_disassembler::opcode_alignment() const {
 	return 2;
 }
 
-u16 t6m53_disassembler::bit_address(u16 op)
-{
-    const uint8_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
-	return (BIT(op, 9) << 8) | YX;
-}
-
-u16 t6m53_disassembler::ef(u16 op)
-{
+inline u16 t6m53_disassembler::ef(u16 op) {
     return 0x100 | ((op >> 7) & 0x20) | ((op >> 4) & 0x1f);
 }
 
-unsigned t6m53_disassembler::bit_number(u16 op)
-{
-	return unsigned(BIT(op, 8) | (BIT(op, 10) << 1));
-}
-
-const char *t6m53_disassembler::size_suffix(u16 op)
-{
+const char *t6m53_disassembler::size_suffix(u16 op) {
 	return BIT(op, 8) ? ".N" : ".B";
 }
 
-const char *t6m53_disassembler::compare_name(u16 op)
-{
-	switch (op & 0x0c00)
-	{
-	case 0x0400: return "=";
-	case 0x0600: return "!=";
-	case 0x0800: return "<";
-	case 0x0a00: return ">=";
-	default:      return "?";
+const char *t6m53_disassembler::compare_name(u16 op) {
+	switch (op & 0x0e00) {
+        case 0x0400: return "=";
+        case 0x0600: return "!=";
+        case 0x0c00: return "<";
+        case 0x0e00: return ">=";
+        default:     return "?";
 	}
 }
 
-bool t6m53_disassembler::has_branch(u16 op)
-{
-	/*
-	 * The assembler adds the branch modifier returned by jo():
-	 *
-	 *   000: no branch
-	 *   200: JUMP/CALL
-	 *   400: IF NO CARRY
-	 *   600: IF CARRY
-	 */
-	return (op & 0x0600) != 0;
-}
-
-void t6m53_disassembler::print_location(std::ostream &stream, u16 location)
-{
+void t6m53_disassembler::print_location(std::ostream &stream, u16 location) {
 	location &= 0x1ff;
 
-	switch (location)
-	{
-	case 0x0ff: stream << "A"; return;
-	case 0x100: stream << "I"; return;
-	case 0x118: stream << "SP"; return;
-	case 0x11c: stream << "DP"; return;
-	case 0x1ff: stream << "(I)"; return;
-	default: break;
+	switch (location) {
+        case 0x0ff: stream << "A"; return;
+        case 0x100: stream << "I"; return;
+        case 0x118: stream << "SP"; return;
+        case 0x11c: stream << "DP"; return;
+        case 0x1ff: stream << "(I)"; return;
+        default: break;
 	}
 
 	stream << "R" << util::string_format("%03X", location);
 }
 
-void t6m53_disassembler::print_bit_location(std::ostream &stream, u16 op)
-{
-	print_location(stream, bit_address(op));
-	stream << "." << bit_number(op);
+void t6m53_disassembler::print_bit_location(std::ostream &stream, u16 op) {
+	print_location(stream, (BIT(op, 9) << 8) | (((op & 0xf) << 4) | ((op >> 4) & 0xf)));
+	stream << "." << (BIT(op, 8) | (BIT(op, 10) << 1));
 }
 
-void t6m53_disassembler::print_target(std::ostream &stream, u16 target)
-{
+void t6m53_disassembler::print_target(std::ostream &stream, u16 target) {
 	if (target & 0x8000)
 		stream << "CALL   $" << util::string_format("%04X", (target & 0x7fff) << 1);
 	else
 		stream << "JUMP   $" << util::string_format("%04X", target << 1);
 }
 
-void t6m53_disassembler::print_branch(std::ostream &stream, u16 op, u16 target, offs_t &flags)
-{
-	switch (op & 0x0600)
-	{
-	case 0x0200:
-		print_target(stream, target);
-		flags |= BIT(target, 15) ? STEP_OVER : STEP_COND;
-		break;
+void t6m53_disassembler::print_branch(std::ostream &stream, u16 op, u16 target, offs_t &flags) {
+	switch (op & 0x0600) {
+        case 0x0200:
+            print_target(stream, target);
+            flags |= BIT(target, 15) ? STEP_OVER : STEP_COND;
+            break;
 
-	case 0x0400:
-		stream << "IF NO CARRY: ";
-		print_target(stream, target);
-		flags |= STEP_COND;
-		break;
+        case 0x0400:
+            stream << "IF NO CARRY: ";
+            print_target(stream, target);
+            flags |= STEP_COND;
+            break;
 
-	case 0x0600:
-		stream << "IF CARRY: ";
-		print_target(stream, target);
-		flags |= STEP_COND;
-		break;
+        case 0x0600:
+            stream << "IF CARRY: ";
+            print_target(stream, target);
+            flags |= STEP_COND;
+            break;
 
-	default:
-		break;
+        default:
+            break;
 	}
 }
 
-offs_t t6m53_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
-{
-	const u16 op = (u16(opcodes.r8(pc)) << 8) | opcodes.r8(pc + 1);
-	const u16 param0 = (u16(opcodes.r8(pc + 2)) << 8) | opcodes.r8(pc + 3);
+offs_t t6m53_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &addrs) {
+	const u16 op = (opcodes.r8(pc) << 8) | opcodes.r8(pc + 1);
+	const u16 addr = (opcodes.r8(pc + 2) << 8) | opcodes.r8(pc + 3);
 	offs_t flags = SUPPORTED;
 	offs_t words = 1;
 
-	// -----------------------------------------------------------------
-	// System / I / DP instructions
-	// -----------------------------------------------------------------
+	auto print_mnemonic = [&](const char *mnemonic) {
+		util::stream_format(stream, "%-8s", mnemonic);
+	};
+
     if ((op & 0xFE00) == 0x0000) {
         bool first = true;
         auto append_inst = [&](const char* fmt, auto... args) {
@@ -150,11 +115,11 @@ offs_t t6m53_disassembler::disassemble(std::ostream &stream, offs_t pc, const da
                     break;
             }
         } else if ((op & 0x03) == op) {
-			util::stream_format(stream, "SYS     $%03X", op & 0x1ff);
+			util::stream_format(stream, "%-8s$%03X", "SYS", op & 0x1ff);
         }
 
         if ((op & 0x0018) == 0x0018)
-            append_inst("SHR     A");
+            append_inst("SHR%-8sA");
 
         if (op & 0x0020)
             append_inst("SCANKEYS");
@@ -166,235 +131,155 @@ offs_t t6m53_disassembler::disassemble(std::ostream &stream, offs_t pc, const da
 
         if (op & 0x0080)
             append_inst("JUMP    (104)");
-    } else if ((op & 0x0ff0) == 0x0f00)
-	{
-		util::stream_format(stream, "REP     $%X", (op & 0x0f) + 1);
-	}
-
-	// -----------------------------------------------------------------
-	// Register transfers
-	// -----------------------------------------------------------------
-
-	else if (op < 0x0400)
-	{
-		stream << "LOAD" << size_suffix(op) << "  JYX, (I)";
-	}
-	else if (op < 0x0600)
-	{
-		stream << "LOAD" << size_suffix(op) << "  (I), JYX";
-	}
-	else if (op < 0x0800)
-	{
-		stream << "XCHG" << size_suffix(op) << "  (I), JYX";
-	}
-	else if (op < 0x0a00)
-	{
-		stream << "LOAD    I, ";
+    } else if ((op & 0x0ff0) == 0x0f00) {
+		util::stream_format(stream, "%-8s$%X", "REP", (op & 0x0f) + 1);
+	} else if (op < 0x0400) {
+		util::stream_format(stream, "%-8s", util::string_format("LOAD%s", size_suffix(op)));
+		stream << "JYX, (I)";
+	} else if (op < 0x0600) {
+		util::stream_format(stream, "%-8s", util::string_format("LOAD%s", size_suffix(op)));
+		stream << "(I), JYX";
+	} else if (op < 0x0800) {
+		util::stream_format(stream, "%-8s", util::string_format("XCHG%s", size_suffix(op)));
+		stream << "(I), JYX";
+	} else if (op < 0x0a00) {
+		print_mnemonic("LOAD");
+		stream << "I, ";
 		print_location(stream, op & 0x1ff);
-	}
-	else if (op < 0x0c00)
-	{
+	} else if (op < 0x0c00) {
 		words = 2;
-		stream << "LOAD    I, ";
+		print_mnemonic("LOAD");
+		stream << "I, ";
 		print_location(stream, op & 0x1ff);
 		stream << "; ";
-		print_target(stream, param0);
-		flags |= BIT(param0, 15) ? STEP_OVER : STEP_COND;
-	}
-	else if (op < 0x0e00)
-	{
-		stream << "LOAD    (I+), #$" << util::string_format("%02X", op & 0xff);
-	}
-	else if (op < 0x1000)
-	{
-		stream << "LOAD    ";
+		print_target(stream, addr);
+		flags |= BIT(addr, 15) ? STEP_OVER : STEP_COND;
+	} else if (op < 0x0e00) {
+		print_mnemonic("LOAD");
+		stream << "(I+), #$" << util::string_format("%02X", op & 0xff);
+	} else if (op < 0x1000) {
+		print_mnemonic("LOAD");
 		print_location(stream, ef(op));
 		stream << ", #$" << util::string_format("%02X", op & 0xf);
-	}
-	else if (op < 0x1400)
-	{
-		stream << "LOAD" << size_suffix(op) << "  A, WYX";
-	}
-	else if (op < 0x1800)
-	{
-		stream << "XCHG" << size_suffix(op) << "  A, WYX";
-	}
-	else if (op < 0x1c00)
-	{
-		stream << "STORE" << size_suffix(op) << " WYX, A";
-	}
-	else if (op < 0x1e00)
-	{
-		stream << "LOAD    A, #$" << util::string_format("%02X", op & 0xff);
-	}
-	else if (op < 0x2000)
-	{
-		stream << "LOAD.N  ";
+	} else if (op < 0x1400) {
+		util::stream_format(stream, "%-8s", util::string_format("LOAD%s", size_suffix(op)));
+		stream << "A, WYX";
+	} else if (op < 0x1800) {
+		util::stream_format(stream, "%-8s", util::string_format("XCHG%s", size_suffix(op)));
+		stream << "A, WYX";
+	} else if (op < 0x1c00) {
+		util::stream_format(stream, "%-8s", util::string_format("LOAD%s", size_suffix(op)));
+		stream << "WYX, A";
+	} else if (op < 0x1e00) {
+		print_mnemonic("LOAD");
+		stream << "A, #$" << util::string_format("%02X", op & 0xff);
+	} else if (op < 0x2000) {
+		print_mnemonic("LOAD.N");
 		print_location(stream, ef(op));
 		stream << ", #$" << util::string_format("%01X", op & 0x0f);
-	}
-
-	// -----------------------------------------------------------------
-	// Bit operations
-	// -----------------------------------------------------------------
-
-	else if (op < 0x2800)
-	{
-		stream << "TOGGLE  ";
+	} else if (op < 0x2800) {
+		print_mnemonic("TOGGLE");
 		print_bit_location(stream, op);
-	}
-	else if (op < 0x3000)
-	{
-		stream << "CLEAR   ";
+	} else if (op < 0x3000) {
+		print_mnemonic("CLEAR");
 		print_bit_location(stream, op);
-	}
-	else if (op < 0x3800)
-	{
-		stream << "SET     ";
+	} else if (op < 0x3800) {
+		print_mnemonic("SET");
 		print_bit_location(stream, op);
-	}
-	else if (op < 0x3c00)
-	{
-		stream << "NOT" << size_suffix(op) << "  WYX";
-	}
-	else if (op < 0x3e00)
-	{
-		stream << "XOR" << size_suffix(op) << "   JYX";
-	}
-	else if (op < 0x4000)
-	{
-		stream << "OR" << size_suffix(op) << "    JYX";
-	}
-
-	// -----------------------------------------------------------------
-	// IF / compare
-	// -----------------------------------------------------------------
-
-	else if (op < 0x6000)
-	{
+	} else if (op < 0x3c00) {
+		util::stream_format(stream, "%-8s", util::string_format("NOT%s", size_suffix(op)));
+		stream << "WYX";
+	} else if (op < 0x3e00) {
+		util::stream_format(stream, "%-8s", util::string_format("XOR%s", size_suffix(op)));
+		stream << "JYX";
+	} else if (op < 0x4000) {
+		util::stream_format(stream, "%-8s", util::string_format("OR%s", size_suffix(op)));
+		stream << "JYX";
+	} else if (op < 0x6000) {
 		words = 2;
-		stream << "IF      ";
+		print_mnemonic("IF");
 		print_location(stream, ef(op));
-		stream << " " << compare_name(op) << " #$"
-		       << util::string_format("%02X", op & 0xff);
-		stream << ": ";
-		print_target(stream, param0);
+		stream << " " << compare_name(op) << " #$" << util::string_format("%02X", op & 0xff) << ": ";
+		print_target(stream, addr);
 		flags |= STEP_COND;
-	}
-	else if (op < 0x7000)
-	{
+	} else if (op < 0x7000) {
 		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
 		words = 2;
-		stream << name << "   (I) " << compare_name(op) << " #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
-		stream << ": ";
-		print_target(stream, param0);
+		print_mnemonic(name);
+		stream << "(I) " << compare_name(op) << " #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff)) << ": ";
+		print_target(stream, addr);
 		flags |= STEP_COND;
-	}
-	else if (op < 0x8000)
-	{
+	} else if (op < 0x8000) {
 		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
 		words = 2;
-		stream << name << "   A " << compare_name(op) << " #$"
-		       << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
-		stream << ": ";
-		print_target(stream, param0);
+		print_mnemonic(name);
+		stream << "A " << compare_name(op) << " #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff)) << ": ";
+		print_target(stream, addr);
 		flags |= STEP_COND;
-	}
-
-	// -----------------------------------------------------------------
-	// Arithmetic register forms
-	// -----------------------------------------------------------------
-
-	else if (op < 0xa000)
-	{
+	} else if (op < 0xa000) {
 		const char *mnemonic;
-		switch (op & 0x1800)
-		{
-		case 0x0000: mnemonic = "ADD"; break;
-		case 0x0800: mnemonic = "DADD"; break;
-		case 0x1000: mnemonic = "SUB"; break;
-		default:      mnemonic = "DSUB"; break;
+		switch (op & 0x1800) {
+            case 0x0000: mnemonic = "ADD"; break;
+            case 0x0800: mnemonic = "DADD"; break;
+            case 0x1000: mnemonic = "SUB"; break;
+            default:     mnemonic = "DSUB"; break;
 		}
 
-		stream << mnemonic << size_suffix(op) << "  JYX";
+		util::stream_format(stream, "%-8s", util::string_format("%s%s", mnemonic, size_suffix(op)));
+		stream << "JYX";
 
-		if (has_branch(op))
-		{
+		if ((op & 0x0600) != 0) {
 			words = 2;
 			stream << "; ";
-			print_branch(stream, op, param0, flags);
+			print_branch(stream, op, addr, flags);
 		}
-	}
-
-	// -----------------------------------------------------------------
-	// Bit test
-	// -----------------------------------------------------------------
-
-	else if (op < 0xb000)
-	{
+	} else if (op < 0xb000) {
 		words = 2;
-		stream << "IF     ";
-		if (BIT(op, 11))
-			stream << "SET   ";
-		else
-			stream << "CLEAR ";
+		print_mnemonic("IF");
+		stream << (BIT(op, 11) ? "SET   " : "CLEAR ");
 		print_bit_location(stream, op);
 		stream << ": ";
-		print_target(stream, param0);
+		print_target(stream, addr);
 		flags |= STEP_COND;
-	}
-	else if (op == 0xb000)
-	{
+	} else if (op == 0xb000) {
 		stream << "BREAK";
-	}
-	else if (op < 0xc000)
-	{
+	} else if (op < 0xc000) {
 		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
 		words = 2;
-		stream << name << "    JYX";
-		stream << " " << compare_name(op) << " $" << util::string_format("%02X", op & 0xff) << ": ";
-		print_target(stream, param0);
+		print_mnemonic(name);
+		stream << "JYX " << compare_name(op) << " $" << util::string_format("%02X", op & 0xff) << ": ";
+		print_target(stream, addr);
 		flags |= STEP_COND;
-	}
+	} else if (op < 0xe000) {
+        const char *mnemonic = (op & 0x0800) ? "DADD" : "ADD";
+		print_mnemonic(mnemonic);
+		stream << "JYX, #$" << util::string_format("%01X", op & 0xf);
 
-	// -----------------------------------------------------------------
-	// Register/immediate arithmetic forms
-	// -----------------------------------------------------------------
-
-	else if (op < 0xe000)
-	{
-        stream << ((op & 0x0800) ? "DADD    JYX" : "ADD     JYX");
-		stream << ", #$" << util::string_format("%01X", op & 0xf);
-
-		if (has_branch(op))
+		if ((op & 0x0600) != 0)
 		{
 			words = 2;
 			stream << "; ";
-			print_branch(stream, op, param0, flags);
+			print_branch(stream, op, addr, flags);
 		}
-	}
-	else if (op < 0xf000)
-	{
+	} else if (op < 0xf000) {
 		const char *mnemonic = (op & 0x1000) ? "SUB" : "ADD";
-		stream << mnemonic << size_suffix(op) << "  (I), #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+		util::stream_format(stream, "%-8s", util::string_format("%s%s", mnemonic, size_suffix(op)));
+		stream << "(I), #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
 
-		if (has_branch(op))
-		{
+		if ((op & 0x0600) != 0) {
 			words = 2;
 			stream << "; ";
-			print_branch(stream, op, param0, flags);
+			print_branch(stream, op, addr, flags);
 		}
-	}
-	else
-	{
+	} else {
 		const char *mnemonic = (op & 0x1000) ? "SUB" : "ADD";
-		stream << mnemonic << size_suffix(op) << "  A, #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+		util::stream_format(stream, "%-8s", util::string_format("%s%s", mnemonic, size_suffix(op)));
+		stream << "A, #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
 
-		if (has_branch(op))
-		{
+		if ((op & 0x0600) != 0) {
 			words = 2;
 			stream << "; ";
-			print_branch(stream, op, param0, flags);
+			print_branch(stream, op, addr, flags);
 		}
 	}
 

--- a/src/devices/cpu/t6m53/t6m53_dasm.cpp
+++ b/src/devices/cpu/t6m53/t6m53_dasm.cpp
@@ -1,0 +1,402 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+
+#include "emu.h"
+#include "t6m53_dasm.h"
+
+u32 t6m53_disassembler::opcode_alignment() const
+{
+	return 2;
+}
+
+u16 t6m53_disassembler::bit_address(u16 op)
+{
+    const uint8_t YX = ((op & 0xf) << 4) | ((op >> 4) & 0xf);
+	return (BIT(op, 9) << 8) | YX;
+}
+
+u16 t6m53_disassembler::ef(u16 op)
+{
+    return 0x100 | ((op >> 7) & 0x20) | ((op >> 4) & 0x1f);
+}
+
+unsigned t6m53_disassembler::bit_number(u16 op)
+{
+	return unsigned(BIT(op, 8) | (BIT(op, 10) << 1));
+}
+
+const char *t6m53_disassembler::size_suffix(u16 op)
+{
+	return BIT(op, 8) ? ".N" : ".B";
+}
+
+const char *t6m53_disassembler::compare_name(u16 op)
+{
+	switch (op & 0x0c00)
+	{
+	case 0x0400: return "=";
+	case 0x0600: return "!=";
+	case 0x0800: return "<";
+	case 0x0a00: return ">=";
+	default:      return "?";
+	}
+}
+
+bool t6m53_disassembler::has_branch(u16 op)
+{
+	/*
+	 * The assembler adds the branch modifier returned by jo():
+	 *
+	 *   000: no branch
+	 *   200: JUMP/CALL
+	 *   400: IF NO CARRY
+	 *   600: IF CARRY
+	 */
+	return (op & 0x0600) != 0;
+}
+
+void t6m53_disassembler::print_location(std::ostream &stream, u16 location)
+{
+	location &= 0x1ff;
+
+	switch (location)
+	{
+	case 0x0ff: stream << "A"; return;
+	case 0x100: stream << "I"; return;
+	case 0x118: stream << "SP"; return;
+	case 0x11c: stream << "DP"; return;
+	case 0x1ff: stream << "(I)"; return;
+	default: break;
+	}
+
+	stream << "R" << util::string_format("%03X", location);
+}
+
+void t6m53_disassembler::print_bit_location(std::ostream &stream, u16 op)
+{
+	print_location(stream, bit_address(op));
+	stream << "." << bit_number(op);
+}
+
+void t6m53_disassembler::print_target(std::ostream &stream, u16 target)
+{
+	if (target & 0x8000)
+		stream << "CALL   $" << util::string_format("%04X", (target & 0x7fff) << 1);
+	else
+		stream << "JUMP   $" << util::string_format("%04X", target << 1);
+}
+
+void t6m53_disassembler::print_branch(std::ostream &stream, u16 op, u16 target, offs_t &flags)
+{
+	switch (op & 0x0600)
+	{
+	case 0x0200:
+		print_target(stream, target);
+		flags |= BIT(target, 15) ? STEP_OVER : STEP_COND;
+		break;
+
+	case 0x0400:
+		stream << "IF NO CARRY: ";
+		print_target(stream, target);
+		flags |= STEP_COND;
+		break;
+
+	case 0x0600:
+		stream << "IF CARRY: ";
+		print_target(stream, target);
+		flags |= STEP_COND;
+		break;
+
+	default:
+		break;
+	}
+}
+
+offs_t t6m53_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	const u16 op = (u16(opcodes.r8(pc)) << 8) | opcodes.r8(pc + 1);
+	const u16 param0 = (u16(opcodes.r8(pc + 2)) << 8) | opcodes.r8(pc + 3);
+	offs_t flags = SUPPORTED;
+	offs_t words = 1;
+
+	// -----------------------------------------------------------------
+	// System / I / DP instructions
+	// -----------------------------------------------------------------
+    if ((op & 0xFE00) == 0x0000) {
+        bool first = true;
+        auto append_inst = [&](const char* fmt, auto... args) {
+            if (!first)
+                stream << "; ";
+            util::stream_format(stream, fmt, args...);
+            first = false;
+        };
+
+        if (op & 0x04) {
+            switch (op & 0x07) {
+                case 0x04:
+                    append_inst("READU%s", BIT(op, 8) ? ".N" : "");
+                    break;
+
+                case 0x05:
+                    append_inst("READD%s", BIT(op, 8) ? ".N" : "");
+                    break;
+
+                case 0x06:
+                    append_inst("WRITEU%s", BIT(op, 8) ? ".N" : "");
+                    break;
+
+                case 0x07:
+                    append_inst("WRITED%s", BIT(op, 8) ? ".N" : "");
+                    break;
+            }
+        } else if ((op & 0x03) == op) {
+			util::stream_format(stream, "SYS     $%03X", op & 0x1ff);
+        }
+
+        if ((op & 0x0018) == 0x0018)
+            append_inst("SHR     A");
+
+        if (op & 0x0020)
+            append_inst("SCANKEYS");
+
+        if (op & 0x0040) {
+            append_inst("RET");
+            flags |= STEP_OUT;
+        }
+
+        if (op & 0x0080)
+            append_inst("JUMP    (104)");
+    } else if ((op & 0x0ff0) == 0x0f00)
+	{
+		util::stream_format(stream, "REP     $%X", (op & 0x0f) + 1);
+	}
+
+	// -----------------------------------------------------------------
+	// Register transfers
+	// -----------------------------------------------------------------
+
+	else if (op < 0x0400)
+	{
+		stream << "LOAD" << size_suffix(op) << "  JYX, (I)";
+	}
+	else if (op < 0x0600)
+	{
+		stream << "LOAD" << size_suffix(op) << "  (I), JYX";
+	}
+	else if (op < 0x0800)
+	{
+		stream << "XCHG" << size_suffix(op) << "  (I), JYX";
+	}
+	else if (op < 0x0a00)
+	{
+		stream << "LOAD    I, ";
+		print_location(stream, op & 0x1ff);
+	}
+	else if (op < 0x0c00)
+	{
+		words = 2;
+		stream << "LOAD    I, ";
+		print_location(stream, op & 0x1ff);
+		stream << "; ";
+		print_target(stream, param0);
+		flags |= BIT(param0, 15) ? STEP_OVER : STEP_COND;
+	}
+	else if (op < 0x0e00)
+	{
+		stream << "LOAD    (I+), #$" << util::string_format("%02X", op & 0xff);
+	}
+	else if (op < 0x1000)
+	{
+		stream << "LOAD    ";
+		print_location(stream, ef(op));
+		stream << ", #$" << util::string_format("%02X", op & 0xf);
+	}
+	else if (op < 0x1400)
+	{
+		stream << "LOAD" << size_suffix(op) << "  A, WYX";
+	}
+	else if (op < 0x1800)
+	{
+		stream << "XCHG" << size_suffix(op) << "  A, WYX";
+	}
+	else if (op < 0x1c00)
+	{
+		stream << "STORE" << size_suffix(op) << " WYX, A";
+	}
+	else if (op < 0x1e00)
+	{
+		stream << "LOAD    A, #$" << util::string_format("%02X", op & 0xff);
+	}
+	else if (op < 0x2000)
+	{
+		stream << "LOAD.N  ";
+		print_location(stream, ef(op));
+		stream << ", #$" << util::string_format("%01X", op & 0x0f);
+	}
+
+	// -----------------------------------------------------------------
+	// Bit operations
+	// -----------------------------------------------------------------
+
+	else if (op < 0x2800)
+	{
+		stream << "TOGGLE  ";
+		print_bit_location(stream, op);
+	}
+	else if (op < 0x3000)
+	{
+		stream << "CLEAR   ";
+		print_bit_location(stream, op);
+	}
+	else if (op < 0x3800)
+	{
+		stream << "SET     ";
+		print_bit_location(stream, op);
+	}
+	else if (op < 0x3c00)
+	{
+		stream << "NOT" << size_suffix(op) << "  WYX";
+	}
+	else if (op < 0x3e00)
+	{
+		stream << "XOR" << size_suffix(op) << "   JYX";
+	}
+	else if (op < 0x4000)
+	{
+		stream << "OR" << size_suffix(op) << "    JYX";
+	}
+
+	// -----------------------------------------------------------------
+	// IF / compare
+	// -----------------------------------------------------------------
+
+	else if (op < 0x6000)
+	{
+		words = 2;
+		stream << "IF      ";
+		print_location(stream, ef(op));
+		stream << " " << compare_name(op) << " #$"
+		       << util::string_format("%02X", op & 0xff);
+		stream << ": ";
+		print_target(stream, param0);
+		flags |= STEP_COND;
+	}
+	else if (op < 0x7000)
+	{
+		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
+		words = 2;
+		stream << name << "   (I) " << compare_name(op) << " #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+		stream << ": ";
+		print_target(stream, param0);
+		flags |= STEP_COND;
+	}
+	else if (op < 0x8000)
+	{
+		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
+		words = 2;
+		stream << name << "   A " << compare_name(op) << " #$"
+		       << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+		stream << ": ";
+		print_target(stream, param0);
+		flags |= STEP_COND;
+	}
+
+	// -----------------------------------------------------------------
+	// Arithmetic register forms
+	// -----------------------------------------------------------------
+
+	else if (op < 0xa000)
+	{
+		const char *mnemonic;
+		switch (op & 0x1800)
+		{
+		case 0x0000: mnemonic = "ADD"; break;
+		case 0x0800: mnemonic = "DADD"; break;
+		case 0x1000: mnemonic = "SUB"; break;
+		default:      mnemonic = "DSUB"; break;
+		}
+
+		stream << mnemonic << size_suffix(op) << "  JYX";
+
+		if (has_branch(op))
+		{
+			words = 2;
+			stream << "; ";
+			print_branch(stream, op, param0, flags);
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// Bit test
+	// -----------------------------------------------------------------
+
+	else if (op < 0xb000)
+	{
+		words = 2;
+		stream << "IF     ";
+		if (BIT(op, 11))
+			stream << "SET   ";
+		else
+			stream << "CLEAR ";
+		print_bit_location(stream, op);
+		stream << ": ";
+		print_target(stream, param0);
+		flags |= STEP_COND;
+	}
+	else if (op == 0xb000)
+	{
+		stream << "BREAK";
+	}
+	else if (op < 0xc000)
+	{
+		const char *name = BIT(op, 8) ? "IF.N" : "IF.B";
+		words = 2;
+		stream << name << "    JYX";
+		stream << " " << compare_name(op) << " $" << util::string_format("%02X", op & 0xff) << ": ";
+		print_target(stream, param0);
+		flags |= STEP_COND;
+	}
+
+	// -----------------------------------------------------------------
+	// Register/immediate arithmetic forms
+	// -----------------------------------------------------------------
+
+	else if (op < 0xe000)
+	{
+        stream << ((op & 0x0800) ? "DADD    JYX" : "ADD     JYX");
+		stream << ", #$" << util::string_format("%01X", op & 0xf);
+
+		if (has_branch(op))
+		{
+			words = 2;
+			stream << "; ";
+			print_branch(stream, op, param0, flags);
+		}
+	}
+	else if (op < 0xf000)
+	{
+		const char *mnemonic = (op & 0x1000) ? "SUB" : "ADD";
+		stream << mnemonic << size_suffix(op) << "  (I), #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+
+		if (has_branch(op))
+		{
+			words = 2;
+			stream << "; ";
+			print_branch(stream, op, param0, flags);
+		}
+	}
+	else
+	{
+		const char *mnemonic = (op & 0x1000) ? "SUB" : "ADD";
+		stream << mnemonic << size_suffix(op) << "  A, #$" << util::string_format("%02X", op & (BIT(op, 8) ? 0x0f : 0xff));
+
+		if (has_branch(op))
+		{
+			words = 2;
+			stream << "; ";
+			print_branch(stream, op, param0, flags);
+		}
+	}
+
+	return (words * 2) | flags;
+}

--- a/src/devices/cpu/t6m53/t6m53_dasm.h
+++ b/src/devices/cpu/t6m53/t6m53_dasm.h
@@ -1,8 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:grubbyplaya
 
-#ifndef MAME_CPU_T6M53_T6M53D_H
-#define MAME_CPU_T6M53_T6M53D_H
+#ifndef MAME_CPU_T6M53_T6M53_DASM_H
+#define MAME_CPU_T6M53_T6M53_DASM_H
 
 #pragma once
 
@@ -30,4 +30,4 @@ private:
 	static bool has_branch(u16 op);
 };
 
-#endif // MAME_CPU_T6M53_T6M53D_H
+#endif // MAME_CPU_T6M53_T6M53_DASM_H

--- a/src/devices/cpu/t6m53/t6m53_dasm.h
+++ b/src/devices/cpu/t6m53/t6m53_dasm.h
@@ -1,0 +1,35 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+
+#ifndef MAME_CPU_T6M53_T6M53D_H
+#define MAME_CPU_T6M53_T6M53D_H
+
+#pragma once
+
+#include "util/disasmintf.h"
+
+class t6m53_disassembler : public util::disasm_interface
+{
+public:
+	t6m53_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override;
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
+private:
+	static u16 bit_address(u16 op);
+	static u16 ef(u16 op);
+
+	static unsigned bit_number(u16 op);
+	static const char *size_suffix(u16 op);
+	static const char *compare_name(u16 op);
+
+	static void print_location(std::ostream &stream, u16 location);
+	static void print_bit_location(std::ostream &stream, u16 op);
+	static void print_target(std::ostream &stream, u16 target);
+	static void print_branch(std::ostream &stream, u16 op, u16 target, offs_t &flags);
+
+	static bool has_branch(u16 op);
+};
+
+#endif // MAME_CPU_T6M53_T6M53D_H

--- a/src/devices/cpu/t6m53/t6m53_dasm.h
+++ b/src/devices/cpu/t6m53/t6m53_dasm.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "util/disasmintf.h"
-
 class t6m53_disassembler : public util::disasm_interface
 {
 public:

--- a/src/devices/video/t6b79.cpp
+++ b/src/devices/video/t6b79.cpp
@@ -1,0 +1,203 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+/***************************************************************************
+
+        Toshiba T6B79 LCD controller
+
+***************************************************************************/
+
+#include "emu.h"
+#include "t6b79.h"
+
+DEFINE_DEVICE_TYPE(T6B79, t6b79_device, "t6b79", "Toshiba T6B79 LCD Controller")
+
+t6b79_device::t6b79_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, T6B79, tag, owner, clock),
+	m_display_on(0), m_contrast(0),
+	m_xpos(0), m_ypos(0), m_zpos(0),
+	m_direction(0), m_active_counter(0), m_word_len(0),
+	m_opa1(0), m_opa2(0), m_output_reg(0), m_stb(0),
+	m_height(48), m_width(64)
+{
+}
+
+void t6b79_device::device_start()
+{
+	save_item(NAME(m_display_on));
+	save_item(NAME(m_contrast));
+	save_item(NAME(m_xpos));
+	save_item(NAME(m_ypos));
+	save_item(NAME(m_zpos));
+	save_item(NAME(m_active_counter));
+	save_item(NAME(m_direction));
+	save_item(NAME(m_word_len));
+	save_item(NAME(m_opa1));
+	save_item(NAME(m_opa2));
+	save_item(NAME(m_output_reg));
+	save_item(NAME(m_stb));
+	save_item(NAME(m_lcd_ram));
+}
+
+void t6b79_device::device_reset()
+{
+	memset(m_lcd_ram, 0x00, sizeof(m_lcd_ram));
+	m_display_on = 0;
+	m_contrast = 0;
+	m_xpos = 0;
+	m_ypos = 0;
+	m_zpos = 0;
+	m_direction = 1;
+	m_active_counter = 1;
+	m_word_len = 1;
+	m_opa1 = 0;
+	m_opa2 = 0;
+	m_output_reg = 0;
+	m_stb = 0;
+}
+
+void t6b79_device::advance_y()
+{
+	if (m_active_counter)
+	{
+		m_ypos = (m_ypos + m_direction) & 0x0f;
+
+		if (m_direction > 0 && m_ypos == (m_word_len ? 8 : 11))
+			m_ypos = 0;
+		if (m_direction < 0 && m_ypos == 0x0f)
+			m_ypos = m_word_len ? 7 : 10;
+	}
+	else
+	{
+		m_xpos = (m_xpos + m_direction) & 0x3f;
+
+		if (m_direction > 0 && m_xpos == 48)
+			m_xpos = 0;
+		if (m_direction < 0 && m_xpos == 0x3f)
+			m_xpos = 47;
+	}
+}
+
+uint32_t t6b79_device::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	if (m_display_on && !m_stb) {
+        for (int x = 0; x < m_height; x++) {
+            uint8_t src_x = (x + m_zpos) % m_height;
+            for (int y = 0; y < (m_width >> 3); y++) {
+                uint8_t data = m_lcd_ram[src_x*8 + y];
+                for (int b = 0; b < 8; b++)
+                    bitmap.pix(x, y*8 + b) = BIT(data, 7 - b);
+            }
+        }
+	} else {
+		bitmap.fill(0, cliprect);
+	}
+
+	return 0;
+}
+
+void t6b79_device::control_write(uint8_t data)
+{
+    
+	if ((data & 0xc0) == 0xc0) // SCE (set contrast)
+	{
+		m_contrast = data & 0x3f;
+	}
+	else if ((data & 0xc0) == 0x80) // SXE (set x address)
+	{
+		m_xpos = data & 0x3f;
+	}
+	else if ((data & 0xc0) == 0x40) // SZE (set z address)
+	{
+		m_zpos = data & 0x3f;
+	}
+	else if ((data & 0xe0) == 0x20) // SYE (set y address)
+	{
+		m_ypos = data & 0x0f;
+	}
+	else if ((data & 0xf8) == 0x18) // CHE (test mode)
+	{
+		//???
+	}
+	else if ((data & 0xf8) == 0x10) // OPA2 (op-amp control 2)
+	{
+		m_opa2 = data & 3;
+	}
+	else if ((data & 0xf8) == 0x08) // OPA1 (op-amp control 1)
+	{
+		m_opa1 = data & 3;
+	}
+	else if ((data & 0xfc) == 0x04) // UDE (up/down mode)
+	{
+		m_active_counter = (data & 0x02) >> 1;
+		m_direction = (data & 0x01) ? 1 : -1;
+	}
+	else if ((data & 0xfe) == 0x02) // DPE (display on/off)
+	{
+		m_display_on = data & 1;
+	}
+	else if ((data & 0xfe) == 0x00) // 86E (word length)
+	{
+		m_word_len = data & 1;
+	}
+}
+
+uint8_t t6b79_device::control_read()
+{
+	return (m_stb << 7) | (m_word_len << 6) | (m_display_on << 5) | (m_active_counter << 1) | (m_direction == 1 ? 1 : 0);
+}
+
+void t6b79_device::data_write(uint8_t data)
+{
+	if (m_xpos > 47 || m_ypos > 10 || (m_word_len && m_ypos > 7)) {
+	} else if (m_word_len) {
+        m_lcd_ram[m_xpos * 8 + m_ypos] = data;
+	} else {
+		uint8_t &slot = m_lcd_ram[m_xpos*8 + m_ypos];
+        
+        if (m_ypos != 10)
+            slot = (slot & 0xc0) | (data & 0x3f);
+        else
+            slot = (slot & 0xc3) | (data & 0x3c);
+	}
+
+	advance_y();
+}
+
+uint8_t t6b79_device::data_read()
+{
+	uint8_t x = m_output_reg;
+
+	if (m_stb)
+		return 0x00;
+
+	if (!machine().side_effects_disabled())
+	{
+		if (!m_word_len && m_ypos > 10)
+			m_output_reg = 0x20 | m_ypos;
+		else if (m_xpos > 47 || (m_word_len && m_ypos > 7))
+			m_output_reg = m_word_len ? 0xff : 0x3c;
+		else
+		{
+			int lo = (!m_word_len && m_ypos == 10) ? 2 : 0;
+			int bits = m_word_len ? 8 : 6;
+			uint8_t out = 0;
+			for (int i = lo; i < bits; i++)
+				out |= ((m_lcd_ram[m_xpos*8 + m_ypos] >> i) & 1) << i;
+			m_output_reg = out;
+		}
+
+		advance_y();
+	}
+
+	return x;
+}
+
+void t6b79_device::stb_write(uint8_t data)
+{
+	m_stb = data & 1;
+}
+
+uint8_t t6b79_device::stb_read()
+{
+	return m_stb;
+}

--- a/src/devices/video/t6b79.h
+++ b/src/devices/video/t6b79.h
@@ -1,0 +1,57 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+/***************************************************************************
+
+        Toshiba T6B79 LCD controller
+
+***************************************************************************/
+
+#ifndef MAME_VIDEO_T6B79_H
+#define MAME_VIDEO_T6B79_H
+
+#pragma once
+
+class t6b79_device : public device_t
+{
+public:
+	t6b79_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	void control_write(uint8_t data);
+	uint8_t control_read();
+	void data_write(uint8_t data);
+	uint8_t data_read();
+	void stb_write(uint8_t data);
+	uint8_t stb_read();
+
+	uint32_t screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	uint8_t m_lcd_ram[64 * 48];
+
+	uint8_t m_busy_flag;
+	uint8_t m_display_on;
+	uint8_t m_contrast;
+	uint8_t m_xpos;
+	uint8_t m_ypos;
+	uint8_t m_zpos;
+	int8_t  m_direction;
+	uint8_t m_active_counter;
+	uint8_t m_word_len;
+	uint8_t m_opa1;
+	uint8_t m_opa2;
+	uint8_t m_output_reg;
+	uint8_t m_stb;
+
+	uint8_t m_height;
+	uint8_t m_width;
+
+	void advance_y();
+};
+
+DECLARE_DEVICE_TYPE(T6B79, t6b79_device)
+
+#endif // MAME_VIDEO_T6B79_H

--- a/src/devices/video/t6b79.h
+++ b/src/devices/video/t6b79.h
@@ -32,7 +32,6 @@ protected:
 private:
 	uint8_t m_lcd_ram[64 * 48];
 
-	uint8_t m_busy_flag;
 	uint8_t m_display_on;
 	uint8_t m_contrast;
 	uint8_t m_xpos;

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -47256,6 +47256,9 @@ ti74
 ti74a
 ti95
 
+@source:ti/ti80.cpp
+ti80
+
 @source:ti/ti85.cpp
 ti73
 ti73v7

--- a/src/mame/ti/ti80.cpp
+++ b/src/mame/ti/ti80.cpp
@@ -1,0 +1,167 @@
+// license:BSD-3-Clause
+// copyright-holders:grubbyplaya
+/*****************************************************************************
+
+    TI-80 graphing calculator
+
+****************************************************************************/
+
+#include "emu.h"
+#include "emupal.h"
+#include "screen.h"
+#include "cpu/t6m53/t6m53.h"
+#include "video/t6b79.h"
+
+class ti80_state : public driver_device
+{
+public:
+	ti80_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag), 
+          m_maincpu(*this, "maincpu"),
+          m_btn_cols(*this, "COL%u", 0U), 
+          m_on_button(*this, "ON")
+	{
+	}
+
+	void ti80(machine_config &config);
+    
+private:
+	required_device<t6m53_device> m_maincpu;
+	required_ioport_array<7> m_btn_cols;
+	required_ioport m_on_button;
+    
+    void ti80_mem(address_map &map);
+    uint8_t ti80_btns_r(offs_t cols);
+    uint8_t ti80_on_r();
+    void ti80_palette(palette_device &palette) const;
+};
+
+void ti80_state::ti80_mem(address_map &map)
+{
+    map(0x0000, 0x3FFD).rom();
+    map(0x3FFE, 0x3FFE).rw("t6b79", FUNC(t6b79_device::control_read), FUNC(t6b79_device::control_write));
+    map(0x3FFF, 0x3FFF).rw("t6b79", FUNC(t6b79_device::data_read), FUNC(t6b79_device::data_write));
+    map(0x4000, 0x4000).mirror(0x0FFE).rw("t6b79", FUNC(t6b79_device::control_read), FUNC(t6b79_device::control_write));
+    map(0x4001, 0x4001).mirror(0x0FFE).rw("t6b79", FUNC(t6b79_device::data_read), FUNC(t6b79_device::data_write));
+    map(0x5000, 0x6FFF).ram();
+    map(0x8000, 0xFFFF).rom();
+}
+
+static INPUT_PORTS_START (ti80)
+	PORT_START("COL0")   /* col 0 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Down") PORT_CODE(KEYCODE_DOWN)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Left") PORT_CODE(KEYCODE_LEFT)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Right") PORT_CODE(KEYCODE_RIGHT)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Up") PORT_CODE(KEYCODE_UP)
+	PORT_START("COL1")   /* col 1 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("ENTER") PORT_CODE(KEYCODE_ENTER)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("+") PORT_CODE(KEYCODE_EQUALS)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("-") PORT_CODE(KEYCODE_MINUS)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("*") PORT_CODE(KEYCODE_L)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("/") PORT_CODE(KEYCODE_SLASH)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("^") PORT_CODE(KEYCODE_P)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("CLEAR") PORT_CODE(KEYCODE_PGDN)
+	PORT_START("COL2")   /* col 2 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("(-)") PORT_CODE(KEYCODE_M)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("3") PORT_CODE(KEYCODE_3)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("6") PORT_CODE(KEYCODE_6)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("9") PORT_CODE(KEYCODE_9)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME(")") PORT_CODE(KEYCODE_CLOSEBRACE)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("TAN") PORT_CODE(KEYCODE_PGUP)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("VARS") PORT_CODE(KEYCODE_F9)
+	PORT_START("COL3")   /* col 3 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME(".") PORT_CODE(KEYCODE_STOP)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("2") PORT_CODE(KEYCODE_2)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("5") PORT_CODE(KEYCODE_5)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("8") PORT_CODE(KEYCODE_8)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("(") PORT_CODE(KEYCODE_OPENBRACE)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("COS") PORT_CODE(KEYCODE_HOME)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("PRGM") PORT_CODE(KEYCODE_F8)
+		PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("STAT") PORT_CODE(KEYCODE_TILDE)
+	PORT_START("COL4")   /* col 4 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("0") PORT_CODE(KEYCODE_0)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("1") PORT_CODE(KEYCODE_1)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("4") PORT_CODE(KEYCODE_4)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("7") PORT_CODE(KEYCODE_7)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME(",") PORT_CODE(KEYCODE_END)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("SIN") PORT_CODE(KEYCODE_INSERT)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("FRAC") PORT_CODE(KEYCODE_F7)
+		PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("X,T") PORT_CODE(KEYCODE_X)
+	PORT_START("COL5")   /* col 5 */
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("STORE") PORT_CODE(KEYCODE_TAB)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("LN") PORT_CODE(KEYCODE_BACKSLASH)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("LOG") PORT_CODE(KEYCODE_QUOTE)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("x^2") PORT_CODE(KEYCODE_COLON)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("x^-1") PORT_CODE(KEYCODE_COMMA)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("MATH") PORT_CODE(KEYCODE_F6)
+		PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("ALPHA") PORT_CODE(KEYCODE_LSHIFT)
+	PORT_START("COL6")   /* col 6 */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("GRAPH") PORT_CODE(KEYCODE_F5)
+		PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("TRACE") PORT_CODE(KEYCODE_F4)
+		PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("ZOOM") PORT_CODE(KEYCODE_F3)
+		PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("WINDOW") PORT_CODE(KEYCODE_F2)
+		PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("Y=") PORT_CODE(KEYCODE_F1)
+		PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("2nd") PORT_CODE(KEYCODE_LALT)
+		PORT_BIT(0x40, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("MODE") PORT_CODE(KEYCODE_ESC)
+		PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("DEL") PORT_CODE(KEYCODE_DEL)
+	PORT_START("ON")   /* ON */
+		PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYBOARD) PORT_NAME("ON/OFF") PORT_CODE(KEYCODE_Q)
+INPUT_PORTS_END
+
+uint8_t ti80_state::ti80_btns_r(offs_t cols)
+{
+    uint8_t data = 0;
+    for (int col = 0; col < 7; col++)
+        if (cols & (1 << col))
+            for (int row = 0; row < 8; row++)
+                data |= BIT(m_btn_cols[col]->read(), row) ? (1 << row) : 0;
+
+    return data;
+}
+
+uint8_t ti80_state::ti80_on_r()
+{
+    return m_on_button->read();
+}
+
+void ti80_state::ti80_palette(palette_device &palette) const
+{
+	palette.set_pen_color(0, rgb_t(160, 190, 170));
+	palette.set_pen_color(1, rgb_t(83, 111, 138));
+}
+
+void ti80_state::ti80(machine_config &config)
+{
+    T6M53(config, m_maincpu, 980'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ti80_state::ti80_mem);
+    m_maincpu->btn_rows().set(FUNC(ti80_state::ti80_btns_r));
+    m_maincpu->on_btn().set(FUNC(ti80_state::ti80_on_r));
+  
+	screen_device &screen(SCREEN(config, "screen").set_lcd());
+    screen.set_refresh_hz(60);
+	screen.set_size(64, 48);
+	screen.set_visarea(0, 64-1, 0, 48-1);
+
+    T6B79(config, "t6b79");
+	screen.set_screen_update("t6b79", FUNC(t6b79_device::screen_update));
+    m_maincpu->lcd_stb().set("t6b79", FUNC(t6b79_device::stb_write));
+    
+	PALETTE(config, "palette", FUNC(ti80_state::ti80_palette), 2, 2);
+	screen.set_palette("palette"); 
+}
+
+ROM_START (ti80)
+    ROM_REGION( 0x10000, "maincpu", 0)
+	ROM_DEFAULT_BIOS("v40")
+
+	ROM_SYSTEM_BIOS( 0, "v30", "V 3.0" )
+    ROMX_LOAD( "ti80v3.u1", 0x0000, 0x4000, CRC(701e2b6a) SHA1(8ffb402eabd70c3fc0750b55d5f0e4c3757fbe38), ROM_BIOS(0) )
+	ROMX_LOAD( "ti80v3.u2", 0x8000, 0x8000, CRC(9d9d47ac) SHA1(00f53bb4da90fb05458b031fc3a61f093652dfda), ROM_BIOS(0) )
+
+	ROM_SYSTEM_BIOS( 1, "v40", "V 4.0" )
+    ROMX_LOAD( "ti80v4.u1", 0x0000, 0x4000, CRC(5961a60c) SHA1(cb106586620d528007ea9dc04f46d7d3f5c25aeb), ROM_BIOS(1) )
+	ROMX_LOAD( "ti80v4.u2", 0x8000, 0x8000, CRC(f5c9edf9) SHA1(0e4bba1825f4d53f65957814f3a999f8d92a7ce4), ROM_BIOS(1) )
+ROM_END
+
+//    YEAR  NAME   PARENT   COMPAT  MACHINE   INPUT  STATE       INIT        COMPANY              FULLNAME    FLAGS
+COMP( 1995, ti80,  0,       0,      ti80,     ti80,  ti80_state, empty_init, "Texas Instruments", "TI-80",    MACHINE_NO_SOUND_HW | MACHINE_IMPERFECT_TIMING )

--- a/src/mame/ti/ti80.cpp
+++ b/src/mame/ti/ti80.cpp
@@ -135,7 +135,7 @@ void ti80_state::ti80_palette(palette_device &palette) const
 
 void ti80_state::ti80(machine_config &config)
 {
-    T6M53(config, m_maincpu, 980'000);
+    T6M53(config, m_maincpu, 1'960'000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &ti80_state::ti80_mem);
     m_maincpu->btn_rows().set(FUNC(ti80_state::ti80_btns_r));
     m_maincpu->on_btn().set(FUNC(ti80_state::ti80_on_r));
@@ -152,8 +152,7 @@ void ti80_state::ti80(machine_config &config)
 	PALETTE(config, "palette", FUNC(ti80_state::ti80_palette), 2, 2);
 	screen.set_palette("palette"); 
 
-    // The link port is only present on viewscreen TI-80s, 
-    // which have the exact same ROMs as a base TI-80.
+    // The link port is only present on viewscreen TI-80s, which have the exact same ROMs as a regular TI-80.
 	TI8X_LINK_PORT(config, m_link_port, default_ti8x_link_devices, nullptr);
     m_maincpu->ring_out().set(m_link_port, FUNC(ti8x_link_port_device::ring_w));
     m_maincpu->tip_out().set(m_link_port, FUNC(ti8x_link_port_device::tip_w));
@@ -175,4 +174,4 @@ ROM_START (ti80)
 ROM_END
 
 //    YEAR  NAME   PARENT   COMPAT  MACHINE   INPUT  STATE       INIT        COMPANY              FULLNAME    FLAGS
-COMP( 1995, ti80,  0,       0,      ti80,     ti80,  ti80_state, empty_init, "Texas Instruments", "TI-80",    MACHINE_NO_SOUND_HW | MACHINE_IMPERFECT_TIMING )
+COMP( 1995, ti80,  0,       0,      ti80,     ti80,  ti80_state, empty_init, "Texas Instruments", "TI-80",    MACHINE_NO_SOUND_HW )

--- a/src/mame/ti/ti80.cpp
+++ b/src/mame/ti/ti80.cpp
@@ -9,6 +9,7 @@
 #include "emu.h"
 #include "emupal.h"
 #include "screen.h"
+#include "bus/ti8x/ti8x.h"
 #include "cpu/t6m53/t6m53.h"
 #include "video/t6b79.h"
 
@@ -18,6 +19,7 @@ public:
 	ti80_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag), 
           m_maincpu(*this, "maincpu"),
+          m_link_port(*this, "linkport"),
           m_btn_cols(*this, "COL%u", 0U), 
           m_on_button(*this, "ON")
 	{
@@ -27,6 +29,7 @@ public:
     
 private:
 	required_device<t6m53_device> m_maincpu;
+    required_device<ti8x_link_port_device> m_link_port;
 	required_ioport_array<7> m_btn_cols;
 	required_ioport m_on_button;
     
@@ -148,6 +151,14 @@ void ti80_state::ti80(machine_config &config)
     
 	PALETTE(config, "palette", FUNC(ti80_state::ti80_palette), 2, 2);
 	screen.set_palette("palette"); 
+
+    // The link port is only present on viewscreen TI-80s, 
+    // which have the exact same ROMs as a base TI-80.
+	TI8X_LINK_PORT(config, m_link_port, default_ti8x_link_devices, nullptr);
+    m_maincpu->ring_out().set(m_link_port, FUNC(ti8x_link_port_device::ring_w));
+    m_maincpu->tip_out().set(m_link_port, FUNC(ti8x_link_port_device::tip_w));
+    m_maincpu->ring_in().set(m_link_port, FUNC(ti8x_link_port_device::ring_r));
+    m_maincpu->tip_in().set(m_link_port, FUNC(ti8x_link_port_device::tip_r));
 }
 
 ROM_START (ti80)

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -184,6 +184,7 @@ using util::BIT;
 #include "cpu/st9/st9dasm.h"
 #include "cpu/superfx/sfx_dasm.h"
 #include "cpu/t11/t11dasm.h"
+#include "cpu/t6m53/t6m53_dasm.h"
 #include "cpu/tlcs870/tlcs870d.h"
 #include "cpu/tlcs90/tlcs90d.h"
 #include "cpu/tlcs900/dasm900.h"
@@ -659,6 +660,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "st9p",            be,  0, []() -> util::disasm_interface * { return new st9p_disassembler; } },
 	{ "superfx",         le,  0, []() -> util::disasm_interface * { return new superfx_disassembler(&superfx_unidasm); } },
 	{ "t11",             le,  0, []() -> util::disasm_interface * { return new t11_disassembler; } },
+    { "t6m53",           be,  0, []() -> util::disasm_interface * { return new t6m53_disassembler; } },
 	{ "tlcs870",         le,  0, []() -> util::disasm_interface * { return new tlcs870_disassembler; } },
 	{ "tlcs900",         le,  0, []() -> util::disasm_interface * { return new tlcs900_disassembler; } },
 	{ "tmp90c051",       le,  0, []() -> util::disasm_interface * { return new tmp90c051_disassembler; } },


### PR DESCRIPTION
## New systems marked as working
TI-80 [mr womp womp, grubbyplaya]

## Details
This PR adds a driver for the TI-80 graphing calculator, originally released in 1995. To get it working, devices were also added for the Toshiba T6M53 ASIC, which includes a proprietary processor designed by TI, and the Toshiba T6B79 LCD controller, which is closely related to the Toshiba T6A04 controller used in the TI-83/84 line of calculators. 

The driver and the devices were created based on the documentation from these sources:
https://www.ticalc.org/archives/files/fileinfo/442/44237.html
https://www.ticalc.org/archives/files/fileinfo/442/44236.html
https://github.com/queueRAM/ti80_calculator
https://datasheet.datasheetarchive.com/originals/distributors/Datasheets-38/DSA-757769.pdf

### AI assistance disclosure
Claude Sonnet 5 was used to build the initial version of the T6M53 device and disassembler, which I later partially rewrote because Claude's implementation was completely broken and couldn't even boot the TI-80 firmware. Aside from that, everything else was written completely by hand and debugged with Claude.

<img width="518" height="375" alt="image" src="https://github.com/user-attachments/assets/c56ff5e8-14ef-4638-b1fc-330c70e829f4" />
<img width="518" height="375" alt="image" src="https://github.com/user-attachments/assets/14055c43-927e-4a9d-bb1e-e07f37c0bbf9" />