### PR TITLE
Sound Canvas SC-88/88Pro/8850, take 2

### DIFF
--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -933,6 +933,8 @@ if CPUS["SH"] then
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_port.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_sci.cpp",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_sci.h",
+		MAME_DIR .. "src/devices/cpu/sh/sh7014_wdt.cpp",
+		MAME_DIR .. "src/devices/cpu/sh/sh7014_wdt.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014.cpp",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh7021.cpp",

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -3695,6 +3695,23 @@ if CPUS["SWP30"] then
 end
 
 --------------------------------------------------
+-- Roland XP PCM chip and effect DSP
+--@src/devices/sound/roland_xp.h,CPUS["ROLANDXP"] = true
+--------------------------------------------------
+
+if CPUS["ROLANDXP"] then
+	files {
+		MAME_DIR .. "src/devices/sound/roland_xp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_xp.h",
+	}
+end
+
+if opt_tool(CPUS, "ROLANDXP") then
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_xpd.cpp")
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_xpd.h")
+end
+
+--------------------------------------------------
 -- Yamaha DSPV
 --@src/devices/sound/dspv.h,CPUS["DSPV"] = true
 --------------------------------------------------

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -3712,6 +3712,23 @@ if opt_tool(CPUS, "ROLANDXP") then
 end
 
 --------------------------------------------------
+-- Roland LSP (Fujitsu MB87837)
+--@src/devices/sound/roland_lsp.h,CPUS["ROLANDLSP"] = true
+--------------------------------------------------
+
+if CPUS["ROLANDLSP"] then
+	files {
+		MAME_DIR .. "src/devices/sound/roland_lsp.cpp",
+		MAME_DIR .. "src/devices/sound/roland_lsp.h",
+	}
+end
+
+if opt_tool(CPUS, "ROLANDLSP") then
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_lspd.cpp")
+	table.insert(disasm_files , MAME_DIR .. "src/devices/sound/roland_lspd.h")
+end
+
+--------------------------------------------------
 -- Yamaha DSPV
 --@src/devices/sound/dspv.h,CPUS["DSPV"] = true
 --------------------------------------------------

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -919,6 +919,8 @@ if CPUS["SH"] then
 		MAME_DIR .. "src/devices/cpu/sh/sh4regs.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh4tmu.cpp",
 		MAME_DIR .. "src/devices/cpu/sh/sh4tmu.h",
+		MAME_DIR .. "src/devices/cpu/sh/sh7014_adc.cpp",
+		MAME_DIR .. "src/devices/cpu/sh/sh7014_adc.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_bsc.cpp",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_bsc.h",
 		MAME_DIR .. "src/devices/cpu/sh/sh7014_dmac.cpp",

--- a/src/devices/cpu/h8500/h8510.cpp
+++ b/src/devices/cpu/h8500/h8510.cpp
@@ -51,7 +51,7 @@ void h8510_device::device_add_mconfig(machine_config &config)
 	H8_PORT(config, m_port5, *this, h8500_device::PORT_5, 0xff, 0x00);
 	H8_PORT(config, m_port6, *this, h8500_device::PORT_6, 0xff, 0x00);
 	H8_PORT(config, m_port7, *this, h8500_device::PORT_7, 0xff, 0xf0);
-	H8_PORT(config, m_port8, *this, h8500_device::PORT_8, 0xff, 0x00);
+	H8_PORT(config, m_port8, *this, h8500_device::PORT_8, 0x00, 0x00); // reset to inputs: the IRQ pins are read back through it
 	H8_SCI(config, m_sci[0], 0, *this, m_intc, 52, 53, 54, 55);
 	H8_SCI(config, m_sci[1], 1, *this, m_intc, 56, 57, 58, 59);
 	// the interval interrupt shares the IRQ0 priority level in IPRA but has its own vector
@@ -121,6 +121,8 @@ void h8510_device::internal_map(address_map &map)
 	map(0xff0b, 0xff0b).rw(m_intc, FUNC(h8500_intc_device::dted_r), FUNC(h8500_intc_device::dted_w));
 	map(0xff1c, 0xff1c).rw(m_intc, FUNC(h8500_intc_device::nmicr_r), FUNC(h8500_intc_device::nmicr_w));
 	map(0xff1d, 0xff1d).rw(m_intc, FUNC(h8500_intc_device::irqcr_r), FUNC(h8500_intc_device::irqcr_w));
+
+	map(0xff10, 0xff11).rw(m_watchdog, FUNC(h8_watchdog_device::wd_r), FUNC(h8_watchdog_device::wd_w));
 
 #if 0
 	map(0xfed8, 0xfed8).rw(FUNC(h8510_device::rfshcr_r), FUNC(h8510_device::rfshcr_w));

--- a/src/devices/cpu/sh/sh7014.cpp
+++ b/src/devices/cpu/sh/sh7014.cpp
@@ -152,7 +152,7 @@ void sh7014_device::execute_set_input(int irqline, int state)
 	sh7014_device::execute_set_input (for externally triggered IRQs)
 	-> sh7014_intc_device::set_input
 	-> sh7014_device::set_irq
-	-> sh2_device::execute_set_input (if not internal peripheral IRQ) OR DMA interception OR set sh2_device's internal IRQ flags
+	-> sh2_device::execute_set_input (NMI only) OR DMA interception OR set sh2_device's internal IRQ flags
 	*/
 	m_intc->set_input(irqline, state);
 }
@@ -166,7 +166,7 @@ void sh7014_device::set_irq(int vector, int level, bool is_internal)
 
 	// SH7014's DMA controller can be configured to trigger based on various
 	// on-board peripheral IRQs, so on-board peripheral IRQs must go through here
-	if (m_dmac->is_dma_activated(vector)) {
+	if (vector >= 0 && m_dmac->is_dma_activated(vector)) {
 		m_intc->set_interrupt(vector, CLEAR_LINE);
 		return;
 	}

--- a/src/devices/cpu/sh/sh7014.cpp
+++ b/src/devices/cpu/sh/sh7014.cpp
@@ -15,6 +15,7 @@ DEFINE_DEVICE_TYPE(SH7014, sh7014_device,  "sh7014",  "Hitachi SH-2 (SH7014)")
 
 sh7014_device::sh7014_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: sh2_device(mconfig, SH7014, tag, owner, clock, CPU_TYPE_SH2, address_map_constructor(FUNC(sh7014_device::sh7014_map), this), 32, 0xffffffff)
+	, m_adc(*this, "adc")
 	, m_sci(*this, "sci%u", 0u)
 	, m_bsc(*this, "bsc")
 	, m_dmac(*this, "dmac")
@@ -57,6 +58,8 @@ void sh7014_device::device_add_mconfig(machine_config &config)
 		sh7014_intc_device::INT_VECTOR_SCI_TXI1,
 		sh7014_intc_device::INT_VECTOR_SCI_TEI1
 	);
+
+	SH7014_ADC(config, m_adc, DERIVED_CLOCK(1, 1), m_intc);
 
 	SH7014_BSC(config, m_bsc);
 
@@ -109,8 +112,8 @@ void sh7014_device::sh7014_map(address_map &map)
 	// TODO: A/D - A/D Converter (High Speed, for SH7014)
 	// 0xffff83e0 - 0xffff83ff
 
-	// TODO: A/D - A/D Converter (Mid Speed, for SH7016/SH7017)
-	// 0xffff8420 - 0xffff8429
+	// A/D - A/D Converter (Mid Speed, for SH7016/SH7017)
+	map(0xffff8420, 0xffff842b).m(m_adc, FUNC(sh7014_adc_device::map));
 
 	// TODO: WDT - Watchdog Timer
 	// 0xffff8610 - 0xffff8613

--- a/src/devices/cpu/sh/sh7014.cpp
+++ b/src/devices/cpu/sh/sh7014.cpp
@@ -16,6 +16,7 @@ DEFINE_DEVICE_TYPE(SH7014, sh7014_device,  "sh7014",  "Hitachi SH-2 (SH7014)")
 sh7014_device::sh7014_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: sh2_device(mconfig, SH7014, tag, owner, clock, CPU_TYPE_SH2, address_map_constructor(FUNC(sh7014_device::sh7014_map), this), 32, 0xffffffff)
 	, m_adc(*this, "adc")
+	, m_wdt(*this, "wdt")
 	, m_sci(*this, "sci%u", 0u)
 	, m_bsc(*this, "bsc")
 	, m_dmac(*this, "dmac")
@@ -60,6 +61,7 @@ void sh7014_device::device_add_mconfig(machine_config &config)
 	);
 
 	SH7014_ADC(config, m_adc, DERIVED_CLOCK(1, 1), m_intc);
+	SH7014_WDT(config, m_wdt, DERIVED_CLOCK(1, 1), m_intc);
 
 	SH7014_BSC(config, m_bsc);
 
@@ -114,6 +116,8 @@ void sh7014_device::sh7014_map(address_map &map)
 
 	// A/D - A/D Converter (Mid Speed, for SH7016/SH7017)
 	map(0xffff8420, 0xffff842b).m(m_adc, FUNC(sh7014_adc_device::map));
+
+	map(0xffff8610, 0xffff8613).m(m_wdt, FUNC(sh7014_wdt_device::map));
 
 	// TODO: WDT - Watchdog Timer
 	// 0xffff8610 - 0xffff8613

--- a/src/devices/cpu/sh/sh7014.h
+++ b/src/devices/cpu/sh/sh7014.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "sh2.h"
+#include "sh7014_adc.h"
 #include "sh7014_bsc.h"
 #include "sh7014_dmac.h"
 #include "sh7014_intc.h"
@@ -47,6 +48,8 @@ public:
 
 	auto read_portf()  { return m_port.lookup()->port_f_read_callback(); }
 
+	template <int Channel> auto read_adc() { return m_adc.lookup()->analog_callback<Channel>(); }
+
 protected:
 	virtual void device_start() override ATTR_COLD;
 	virtual void device_reset() override ATTR_COLD;
@@ -66,6 +69,7 @@ private:
 	uint16_t ccr_r();
 	void ccr_w(offs_t offset, uint16_t dat, uint16_t mem_mask = ~0);
 
+	required_device<sh7014_adc_device> m_adc;
 	required_device_array<sh7014_sci_device, 2> m_sci;
 	required_device<sh7014_bsc_device> m_bsc;
 	required_device<sh7014_dmac_device> m_dmac;

--- a/src/devices/cpu/sh/sh7014.h
+++ b/src/devices/cpu/sh/sh7014.h
@@ -29,6 +29,10 @@ public:
 		return m_sci[Sci].lookup()->write_sci_tx();
 	}
 
+	template<int Sci> void sci_rx_w(int state) {
+		m_sci[Sci]->rx_w(state);
+	}
+
 	template<int Sci> void sci_set_external_clock_period(const attotime &period) {
 		m_sci[Sci].lookup()->set_external_clock_period(period);
 	}

--- a/src/devices/cpu/sh/sh7014.h
+++ b/src/devices/cpu/sh/sh7014.h
@@ -13,6 +13,7 @@
 
 #include "sh2.h"
 #include "sh7014_adc.h"
+#include "sh7014_wdt.h"
 #include "sh7014_bsc.h"
 #include "sh7014_dmac.h"
 #include "sh7014_intc.h"
@@ -74,6 +75,7 @@ private:
 	void ccr_w(offs_t offset, uint16_t dat, uint16_t mem_mask = ~0);
 
 	required_device<sh7014_adc_device> m_adc;
+	required_device<sh7014_wdt_device> m_wdt;
 	required_device_array<sh7014_sci_device, 2> m_sci;
 	required_device<sh7014_bsc_device> m_bsc;
 	required_device<sh7014_dmac_device> m_dmac;

--- a/src/devices/cpu/sh/sh7014_adc.cpp
+++ b/src/devices/cpu/sh/sh7014_adc.cpp
@@ -1,0 +1,137 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/***************************************************************************
+
+  SH7016/SH7017 mid-speed A/D converter
+
+  Four multiplexed inputs, one 10 bit result register each, left aligned in
+  the upper ten bits.  Single mode converts the channel ADCSR names and stops;
+  scan mode sweeps channel 0 up to that channel and restarts until ADST is
+  cleared.  A conversion takes 266 states, or 134 with CKS set.
+
+  TODO list (not comprehensive):
+  - external trigger (ADCR TRGE) and the MTU's conversion start request
+  - the SH7014's own high speed converter is a different module
+
+***************************************************************************/
+
+#include "emu.h"
+#include "sh7014_adc.h"
+
+#define LOG_READ (1U << 1)
+#define LOG_WRITE (1U << 2)
+
+// #define VERBOSE (LOG_GENERAL | LOG_READ | LOG_WRITE)
+
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(SH7014_ADC, sh7014_adc_device, "sh7014adc", "SH7014 A/D Converter")
+
+
+sh7014_adc_device::sh7014_adc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, SH7014_ADC, tag, owner, clock)
+	, m_intc(*this, finder_base::DUMMY_TAG)
+	, m_analog_cb(*this, 0)
+{
+}
+
+void sh7014_adc_device::device_start()
+{
+	m_timer = timer_alloc(FUNC(sh7014_adc_device::conversion_done), this);
+
+	save_item(NAME(m_addr));
+	save_item(NAME(m_adcsr));
+	save_item(NAME(m_adcr));
+	save_item(NAME(m_int_state));
+}
+
+void sh7014_adc_device::device_reset()
+{
+	std::fill(std::begin(m_addr), std::end(m_addr), 0);
+	m_adcsr = 0;
+	m_adcr = 0x7f;
+	m_int_state = false;
+	m_timer->adjust(attotime::never);
+}
+
+void sh7014_adc_device::map(address_map &map)
+{
+	map(0x00, 0x07).r(FUNC(sh7014_adc_device::addr_r));
+	map(0x08, 0x08).rw(FUNC(sh7014_adc_device::adcsr_r), FUNC(sh7014_adc_device::adcsr_w));
+	map(0x09, 0x09).rw(FUNC(sh7014_adc_device::adcr_r), FUNC(sh7014_adc_device::adcr_w));
+}
+
+uint16_t sh7014_adc_device::addr_r(offs_t offset)
+{
+	LOGMASKED(LOG_READ, "addr_r %d %04x\n", offset & 3, m_addr[offset & 3]);
+	return m_addr[offset & 3];
+}
+
+uint8_t sh7014_adc_device::adcsr_r()
+{
+	LOGMASKED(LOG_READ, "adcsr_r %02x\n", m_adcsr);
+	return m_adcsr;
+}
+
+void sh7014_adc_device::adcsr_w(uint8_t data)
+{
+	LOGMASKED(LOG_WRITE, "adcsr_w %02x\n", data);
+
+	const bool was_running = m_adcsr & ADCSR_ADST;
+
+	// ADF only clears, and only by a zero written over a one
+	m_adcsr = (m_adcsr & data & ADCSR_ADF) | (data & ~ADCSR_ADF);
+	update_interrupt();
+
+	if ((m_adcsr & ADCSR_ADST) && !was_running)
+		start_conversion();
+	else if (!(m_adcsr & ADCSR_ADST))
+		m_timer->adjust(attotime::never);
+}
+
+uint8_t sh7014_adc_device::adcr_r()
+{
+	return m_adcr;
+}
+
+void sh7014_adc_device::adcr_w(uint8_t data)
+{
+	LOGMASKED(LOG_WRITE, "adcr_w %02x\n", data);
+	m_adcr = data | 0x7f;
+}
+
+void sh7014_adc_device::start_conversion()
+{
+	const int channels = (m_adcsr & ADCSR_SCAN) ? (m_adcsr & ADCSR_CH) + 1 : 1;
+	m_timer->adjust(attotime::from_ticks(((m_adcsr & ADCSR_CKS) ? 134 : 266) * channels, clock()));
+}
+
+void sh7014_adc_device::update_interrupt()
+{
+	const bool state = (m_adcsr & (ADCSR_ADF | ADCSR_ADIE)) == (ADCSR_ADF | ADCSR_ADIE);
+	if (state != m_int_state)
+	{
+		m_int_state = state;
+		m_intc->set_interrupt(sh7014_intc_device::INT_VECTOR_AD, state ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+TIMER_CALLBACK_MEMBER(sh7014_adc_device::conversion_done)
+{
+	const int last = m_adcsr & ADCSR_CH;
+	if (m_adcsr & ADCSR_SCAN)
+	{
+		for (int channel = 0; channel <= last; channel++)
+			m_addr[channel] = (m_analog_cb[channel]() & 0x3ff) << 6;
+		start_conversion();
+	}
+	else
+	{
+		m_addr[last] = (m_analog_cb[last]() & 0x3ff) << 6;
+		m_adcsr &= ~ADCSR_ADST;
+	}
+
+	m_adcsr |= ADCSR_ADF;
+	update_interrupt();
+}

--- a/src/devices/cpu/sh/sh7014_adc.h
+++ b/src/devices/cpu/sh/sh7014_adc.h
@@ -1,0 +1,71 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/***************************************************************************
+
+  SH7016/SH7017 mid-speed A/D converter
+
+***************************************************************************/
+
+#ifndef MAME_CPU_SH_SH7014_ADC_H
+#define MAME_CPU_SH_SH7014_ADC_H
+
+#pragma once
+
+#include "sh7014_intc.h"
+
+
+class sh7014_adc_device : public device_t
+{
+public:
+	sh7014_adc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	template <typename T> sh7014_adc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&intc)
+		: sh7014_adc_device(mconfig, tag, owner, clock)
+	{
+		m_intc.set_tag(std::forward<T>(intc));
+	}
+
+	template <int Channel> auto analog_callback() { return m_analog_cb[Channel].bind(); }
+
+	void map(address_map &map) ATTR_COLD;
+
+	uint16_t addr_r(offs_t offset);
+	uint8_t adcsr_r();
+	void adcsr_w(uint8_t data);
+	uint8_t adcr_r();
+	void adcr_w(uint8_t data);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	enum : uint8_t
+	{
+		ADCSR_ADF  = 0x80,
+		ADCSR_ADIE = 0x40,
+		ADCSR_ADST = 0x20,
+		ADCSR_SCAN = 0x10,
+		ADCSR_CKS  = 0x08,
+		ADCSR_CH   = 0x03
+	};
+
+	TIMER_CALLBACK_MEMBER(conversion_done);
+
+	void start_conversion();
+	void update_interrupt();
+
+	required_device<sh7014_intc_device> m_intc;
+	devcb_read16::array<4> m_analog_cb;
+
+	emu_timer *m_timer;
+
+	uint16_t m_addr[4];
+	uint8_t m_adcsr;
+	uint8_t m_adcr;
+	bool m_int_state;
+};
+
+DECLARE_DEVICE_TYPE(SH7014_ADC, sh7014_adc_device)
+
+#endif // MAME_CPU_SH_SH7014_ADC_H

--- a/src/devices/cpu/sh/sh7014_dmac.cpp
+++ b/src/devices/cpu/sh/sh7014_dmac.cpp
@@ -356,7 +356,9 @@ TIMER_CALLBACK_MEMBER( sh7014_dmac_channel_device::dma_timer_callback )
 
 void sh7014_dmac_channel_device::dma_check()
 {
-	if (!m_dmac->is_transfer_allowed()) {
+	// a transfer runs only while DE and DME are both set, the transfer end
+	// flag is clear and neither error flag is up
+	if (!m_dmac->is_transfer_allowed() || !is_enabled() || (m_chcr & CHCR_TE) != 0) {
 		if (m_dma_timer_active) {
 			LOG("SH7014: DMA %d cancelled in-flight\n", m_channel_id);
 			m_dma_current_active_timer->adjust(attotime::never);

--- a/src/devices/cpu/sh/sh7014_intc.cpp
+++ b/src/devices/cpu/sh/sh7014_intc.cpp
@@ -267,7 +267,7 @@ void sh7014_intc_device::set_interrupt(int vector, int state)
 
 void sh7014_intc_device::update_irq_state()
 {
-	int cur_vector = 0;
+	int cur_vector = -1;
 	int cur_level = -1;
 
 	// isr has the bits in reverse order
@@ -296,11 +296,11 @@ void sh7014_intc_device::update_irq_state()
 		}
 	}
 
+	// the IRQ pins have vectors and priorities of their own, so they go the
+	// same way as the on-chip sources; a vector of -1 says nothing is asking
 	if (cur_vector == INT_VECTOR_NMI)
 		m_set_irq_cb(INPUT_LINE_NMI, cur_level, false);
-	else if ((cur_vector >= INT_VECTOR_IRQ0 && cur_vector <= INT_VECTOR_IRQ3) || cur_vector == INT_VECTOR_IRQ6 || cur_vector == INT_VECTOR_IRQ7)
-		m_set_irq_cb(cur_vector - INT_VECTOR_IRQ0, cur_level, false);
-	else if (cur_vector > INT_VECTOR_IRQ7)
+	else
 		m_set_irq_cb(cur_vector, cur_level, true);
 }
 

--- a/src/devices/cpu/sh/sh7014_sci.cpp
+++ b/src/devices/cpu/sh/sh7014_sci.cpp
@@ -317,12 +317,13 @@ void sh7014_sci_device::update_data_format()
 		return;
 	}
 
-	// Async
+	// Async.  CHR 0 is eight data bits and STOP 0 one stop bit; the parity mode bit picks even or odd
+	// and is only consulted when PE enables parity at all, which multiprocessor mode overrides.
 	set_data_frame(
 		1,
-		(m_smr & SMR_CHR) ? 8 : 7,
-		(m_smr & SMR_MP) ? PARITY_NONE : ((m_smr & SMR_PE) ? PARITY_ODD : PARITY_EVEN), // Multiprocessor mode does not use parity
-		(m_smr & SMR_STOP) ? STOP_BITS_1 : STOP_BITS_2
+		(m_smr & SMR_CHR) ? 7 : 8,
+		((m_smr & (SMR_MP | SMR_PE)) != SMR_PE) ? PARITY_NONE : ((m_smr & SMR_OE) ? PARITY_ODD : PARITY_EVEN),
+		(m_smr & SMR_STOP) ? STOP_BITS_2 : STOP_BITS_1
 	);
 }
 
@@ -354,7 +355,8 @@ void sh7014_sci_device::update_clock()
 		case INTERNAL_ASYNC_OUT:
 		case INTERNAL_SYNC_OUT:
 		{
-			int divider = (1 << (2 * (m_smr & SMR_CKS))) * (m_brr + 1);
+			// phi / (64 x 2^(2n-1) x (N + 1)) asynchronous, phi / (8 x 2^(2n-1) x (N + 1)) synchronous
+			int divider = (1 << (2 * (m_smr & SMR_CKS))) * (m_brr + 1) * ((m_smr & SMR_CA) ? 4 : 32);
 			clock_speed = attotime::from_ticks(divider, clock());
 		}
 		break;

--- a/src/devices/cpu/sh/sh7014_sci.cpp
+++ b/src/devices/cpu/sh/sh7014_sci.cpp
@@ -142,24 +142,15 @@ void sh7014_sci_device::scr_w(uint8_t data)
 			  (data & SCR_TEIE) ? " tei" : "",
 			  data & SCR_CKE);
 
-	if ((m_scr & SCR_TE) && !(data & SCR_TE))
+	if ((old & SCR_TE) && !(data & SCR_TE))
 		m_ssr |= SSR_TEND | SSR_TDRE;
-
-	if ((m_scr & SCR_TIE) && !(data & SCR_TIE))
-		m_intc->set_interrupt(m_txi_int, CLEAR_LINE);
-
-	if ((m_scr & SCR_TEIE) && !(data & SCR_TEIE))
-		m_intc->set_interrupt(m_tei_int, CLEAR_LINE);
-
-	if ((m_scr & SCR_RIE) && !(data & SCR_RIE)) {
-		m_intc->set_interrupt(m_rxi_int, CLEAR_LINE);
-		m_intc->set_interrupt(m_eri_int, CLEAR_LINE);
-	}
 
 	m_scr = data;
 
 	if ((data & SCR_CKE) != (old & SCR_CKE))
 		update_clock();
+
+	update_interrupts();
 }
 
 uint8_t sh7014_sci_device::ssr_r()
@@ -171,26 +162,26 @@ uint8_t sh7014_sci_device::ssr_r()
 void sh7014_sci_device::ssr_w(uint8_t data)
 {
 	const auto old = m_ssr;
-	bool do_tx_update = false;
 
-	m_ssr = (data & (m_ssr & (SSR_TDRE | SSR_RDRF | SSR_ORER | SSR_FER | SSR_PER)))
-		| (m_ssr & (SSR_TEND | SSR_MPB))
-		| (data & SSR_MPBT);
+	// TDRE, RDRF, ORER, FER and PER only ever fall, and only where the written value has a zero
+	// over them; TEND and MPB are read only, MPBT is plain.
+	const uint8_t writable = SSR_TDRE | SSR_RDRF | SSR_ORER | SSR_FER | SSR_PER;
+	m_ssr = (old & ~(writable | SSR_MPBT)) | (old & data & writable) | (data & SSR_MPBT);
 
-	if (!(m_scr & SCR_TE)) {
+	// The transmitter is loaded by a write that actually takes TDRE from one to zero
+	const bool start_tx = (old & SSR_TDRE) && !(m_ssr & SSR_TDRE);
+	if (start_tx)
+		m_ssr &= ~SSR_TEND;
+
+	if (!(m_scr & SCR_TE))
 		m_ssr |= SSR_TEND | SSR_TDRE;
-	} else if ((old & SSR_TDRE) || !(m_scr & SSR_TDRE)) {
-		do_tx_update = true;
-		m_ssr &= ~(SSR_TEND | SSR_TDRE);
-	}
-
-	if ((old & (SSR_ORER | SSR_FER | SSR_PER)) && !(data & (SSR_ORER | SSR_FER | SSR_PER)))
-		m_intc->set_interrupt(m_eri_int, CLEAR_LINE);
 
 	LOGMASKED(LOG_REGISTERS, "ssr_w %02x | %02x -> %02x\n", data, old, m_ssr);
 
-	if (do_tx_update)
+	if (start_tx)
 		update_tx_state();
+	else
+		update_interrupts();
 }
 
 uint8_t sh7014_sci_device::brr_r()
@@ -251,23 +242,31 @@ void sh7014_sci_device::tra_complete()
 	LOGMASKED(LOG_TXRX, "transmit ended\n");
 
 	m_ssr |= SSR_TEND;
-	if (m_scr & SCR_TEIE)
-		m_intc->set_interrupt(m_tei_int, ASSERT_LINE);
+
+	update_interrupts();
 }
 
 void sh7014_sci_device::update_tx_state()
 {
-	if (!(m_scr & SCR_TE) || (m_ssr & SSR_TDRE) || !is_transmit_register_empty())
-		return;
+	if ((m_scr & SCR_TE) && !(m_ssr & SSR_TDRE) && is_transmit_register_empty()) {
+		LOGMASKED(LOG_TXRX, "transmitting %02x\n", m_tdr);
 
-	LOGMASKED(LOG_TXRX, "transmitting %02x\n", m_tdr);
+		transmit_register_setup(m_tdr);
 
-	transmit_register_setup(m_tdr);
+		m_ssr = (m_ssr & ~SSR_TEND) | SSR_TDRE;
+	}
 
-	m_ssr = (m_ssr & ~SSR_TEND) | SSR_TDRE;
+	update_interrupts();
+}
 
-	if (m_scr & SCR_TIE)
-		m_intc->set_interrupt(m_txi_int, ASSERT_LINE);
+void sh7014_sci_device::update_interrupts()
+{
+	// The four requests are levels; the INTC's latch is cleared when an interrupt is taken, so all
+	// four are presented again at every change of state.
+	m_intc->set_interrupt(m_eri_int, ((m_scr & SCR_RIE) && (m_ssr & (SSR_ORER | SSR_FER | SSR_PER))) ? ASSERT_LINE : CLEAR_LINE);
+	m_intc->set_interrupt(m_rxi_int, ((m_scr & SCR_RIE) && (m_ssr & SSR_RDRF)) ? ASSERT_LINE : CLEAR_LINE);
+	m_intc->set_interrupt(m_txi_int, ((m_scr & SCR_TIE) && (m_ssr & SSR_TDRE)) ? ASSERT_LINE : CLEAR_LINE);
+	m_intc->set_interrupt(m_tei_int, ((m_scr & SCR_TEIE) && (m_ssr & SSR_TEND)) ? ASSERT_LINE : CLEAR_LINE);
 }
 
 uint8_t sh7014_sci_device::rdr_r()
@@ -277,8 +276,10 @@ uint8_t sh7014_sci_device::rdr_r()
 	LOGMASKED(LOG_TXRX, "rdr_r%s %02x\n", m_is_dma_source_rx ? " (dma)" : "", m_rdr);
 
 	// DMA reads cause RDRF to be cleared
-	if (m_is_dma_source_rx)
+	if (m_is_dma_source_rx) {
 		m_ssr &= ~SSR_RDRF;
+		update_interrupts();
+	}
 
 	return r;
 }
@@ -298,15 +299,11 @@ void sh7014_sci_device::rcv_complete()
 	if (!(m_ssr & SSR_RDRF)) {
 		m_rdr = get_received_char();
 		m_ssr |= SSR_RDRF;
-
-		if (m_scr & SCR_RIE)
-			m_intc->set_interrupt(m_rxi_int, ASSERT_LINE);
-
-		if ((m_ssr & SSR_FER) | (m_ssr & SSR_PER) || (m_ssr & SSR_ORER))
-			m_intc->set_interrupt(m_eri_int, ASSERT_LINE);
 	} else {
 		m_ssr |= SSR_ORER;
 	}
+
+	update_interrupts();
 }
 
 void sh7014_sci_device::update_data_format()

--- a/src/devices/cpu/sh/sh7014_sci.h
+++ b/src/devices/cpu/sh/sh7014_sci.h
@@ -108,6 +108,7 @@ private:
 	uint8_t rdr_r();
 
 	void update_tx_state();
+	void update_interrupts();
 	void update_clock();
 	void update_data_format();
 

--- a/src/devices/cpu/sh/sh7014_wdt.cpp
+++ b/src/devices/cpu/sh/sh7014_wdt.cpp
@@ -1,0 +1,171 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/***************************************************************************
+
+  SH7014 watchdog timer
+
+  An eight bit up counter off a divided peripheral clock.  In interval timer
+  mode, the mode it comes out of reset in, an overflow raises the interval
+  timer interrupt and the counter carries on; in watchdog timer mode it sets
+  WOVF instead and, with RSTE, resets the chip.
+
+  The three registers are written as words with a key in the upper byte, 0x5a
+  for the counter and 0xa5 for the two control registers, and read as bytes.
+
+  TODO list (not comprehensive):
+  - the reset RSTE asks for, and the WDTOVF pin
+  - the standby control the module shares its address block with
+
+***************************************************************************/
+
+#include "emu.h"
+#include "sh7014_wdt.h"
+
+#define LOG_READ (1U << 1)
+#define LOG_WRITE (1U << 2)
+
+// #define VERBOSE (LOG_GENERAL | LOG_READ | LOG_WRITE)
+
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(SH7014_WDT, sh7014_wdt_device, "sh7014wdt", "SH7014 Watchdog Timer")
+
+
+sh7014_wdt_device::sh7014_wdt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, SH7014_WDT, tag, owner, clock)
+	, m_intc(*this, finder_base::DUMMY_TAG)
+{
+}
+
+void sh7014_wdt_device::device_start()
+{
+	m_timer = timer_alloc(FUNC(sh7014_wdt_device::overflow), this);
+
+	save_item(NAME(m_count_time));
+	save_item(NAME(m_tcsr));
+	save_item(NAME(m_tcnt));
+	save_item(NAME(m_rstcsr));
+	save_item(NAME(m_int_state));
+}
+
+void sh7014_wdt_device::device_reset()
+{
+	m_count_time = attotime::zero;
+	m_tcsr = 0x18;
+	m_tcnt = 0;
+	m_rstcsr = 0x1f;
+	m_int_state = false;
+	m_timer->adjust(attotime::never);
+}
+
+void sh7014_wdt_device::map(address_map &map)
+{
+	map(0x00, 0x00).r(FUNC(sh7014_wdt_device::tcsr_r));
+	map(0x01, 0x01).r(FUNC(sh7014_wdt_device::tcnt_r));
+	map(0x03, 0x03).r(FUNC(sh7014_wdt_device::rstcsr_r));
+	map(0x00, 0x01).w(FUNC(sh7014_wdt_device::timer_w));
+	map(0x02, 0x03).w(FUNC(sh7014_wdt_device::reset_w));
+}
+
+int sh7014_wdt_device::prescaler() const
+{
+	static const int shift[8] = { 1, 6, 7, 8, 9, 10, 12, 13 };
+	return shift[m_tcsr & TCSR_CKS];
+}
+
+uint8_t sh7014_wdt_device::counter() const
+{
+	if (!(m_tcsr & TCSR_TME))
+		return m_tcnt;
+	const uint64_t elapsed = (machine().time() - m_count_time).as_ticks(clock()) >> prescaler();
+	return uint8_t(m_tcnt + elapsed);
+}
+
+void sh7014_wdt_device::update_timer()
+{
+	if (!(m_tcsr & TCSR_TME))
+	{
+		m_timer->adjust(attotime::never);
+		return;
+	}
+
+	m_count_time = machine().time();
+	m_timer->adjust(attotime::from_ticks(uint64_t(0x100 - m_tcnt) << prescaler(), clock()));
+}
+
+void sh7014_wdt_device::update_interrupt()
+{
+	const bool state = (m_tcsr & (TCSR_OVF | TCSR_WT_IT)) == TCSR_OVF;
+	if (state != m_int_state)
+	{
+		m_int_state = state;
+		m_intc->set_interrupt(sh7014_intc_device::INT_VECTOR_WDT, state ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+TIMER_CALLBACK_MEMBER(sh7014_wdt_device::overflow)
+{
+	m_tcnt = 0;
+
+	if (m_tcsr & TCSR_WT_IT)
+		m_rstcsr |= RSTCSR_WOVF;
+	else
+		m_tcsr |= TCSR_OVF;
+
+	update_timer();
+	update_interrupt();
+}
+
+uint8_t sh7014_wdt_device::tcsr_r()
+{
+	LOGMASKED(LOG_READ, "tcsr_r %02x\n", m_tcsr);
+	return m_tcsr;
+}
+
+uint8_t sh7014_wdt_device::tcnt_r()
+{
+	const uint8_t data = counter();
+	LOGMASKED(LOG_READ, "tcnt_r %02x\n", data);
+	return data;
+}
+
+uint8_t sh7014_wdt_device::rstcsr_r()
+{
+	return m_rstcsr;
+}
+
+void sh7014_wdt_device::timer_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	LOGMASKED(LOG_WRITE, "timer_w %04x\n", data);
+
+	if ((data >> 8) == 0x5a)
+	{
+		m_tcnt = data & 0xff;
+		update_timer();
+	}
+	else if ((data >> 8) == 0xa5)
+	{
+		m_tcnt = counter();
+
+		// OVF only clears, and only by a zero written over a one
+		m_tcsr = (m_tcsr & data & TCSR_OVF) | (data & ~TCSR_OVF) | 0x18;
+
+		// clearing TME initialises the counter
+		if (!(m_tcsr & TCSR_TME))
+			m_tcnt = 0;
+
+		update_timer();
+		update_interrupt();
+	}
+}
+
+void sh7014_wdt_device::reset_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	LOGMASKED(LOG_WRITE, "reset_w %04x\n", data);
+
+	if ((data >> 8) == 0x5a)
+		m_rstcsr &= ~RSTCSR_WOVF;
+	else if ((data >> 8) == 0xa5)
+		m_rstcsr = (data & RSTCSR_RSTE) | 0x1f;
+}

--- a/src/devices/cpu/sh/sh7014_wdt.h
+++ b/src/devices/cpu/sh/sh7014_wdt.h
@@ -1,0 +1,72 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/***************************************************************************
+
+  SH7014 watchdog timer
+
+***************************************************************************/
+
+#ifndef MAME_CPU_SH_SH7014_WDT_H
+#define MAME_CPU_SH_SH7014_WDT_H
+
+#pragma once
+
+#include "sh7014_intc.h"
+
+
+class sh7014_wdt_device : public device_t
+{
+public:
+	sh7014_wdt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	template <typename T> sh7014_wdt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&intc)
+		: sh7014_wdt_device(mconfig, tag, owner, clock)
+	{
+		m_intc.set_tag(std::forward<T>(intc));
+	}
+
+	void map(address_map &map) ATTR_COLD;
+
+	uint8_t tcsr_r();
+	uint8_t tcnt_r();
+	uint8_t rstcsr_r();
+	void timer_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void reset_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	enum : uint8_t
+	{
+		TCSR_OVF   = 0x80,
+		TCSR_WT_IT = 0x40,
+		TCSR_TME   = 0x20,
+		TCSR_CKS   = 0x07,
+
+		RSTCSR_WOVF = 0x80,
+		RSTCSR_RSTE = 0x40
+	};
+
+	TIMER_CALLBACK_MEMBER(overflow);
+
+	uint8_t counter() const;
+	int prescaler() const;
+	void update_timer();
+	void update_interrupt();
+
+	required_device<sh7014_intc_device> m_intc;
+
+	emu_timer *m_timer;
+	attotime m_count_time;
+
+	uint8_t m_tcsr;
+	uint8_t m_tcnt;
+	uint8_t m_rstcsr;
+	bool m_int_state;
+};
+
+DECLARE_DEVICE_TYPE(SH7014_WDT, sh7014_wdt_device)
+
+#endif // MAME_CPU_SH_SH7014_WDT_H

--- a/src/devices/sound/roland_lsp.cpp
+++ b/src/devices/sound/roland_lsp.cpp
@@ -1,0 +1,491 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+// thanks-to: giulioz
+/*
+ *  Roland LSP (Fujitsu MB87837)
+ *
+ *  Effect processor of the Boss ME-6 and, as the insertion-effect DSP, of the Roland
+ *  SC-88Pro and successors. A 384-instruction program runs once per sample -
+ *  the clock is 2 x 384 x Fs and the program is the sample period, so the chip
+ *  is a CPU with a fixed schedule rather than a streaming sound device: the host PCM
+ *  chip writes the serial inputs, runs one pass and reads the outputs back.
+ *
+ *  Host window: sixteen byte registers, a 24-bit data latch committed by the write of
+ *  the address low byte, a read latch loaded by the read address, and a configuration
+ *  word that starts and halts the program. The address space is 128 words of internal
+ *  RAM below the 384 program words, and the firmware patches individual program words
+ *  while the program runs - the coefficient bytes are the effect's parameters and there
+ *  are no parameter registers.
+ *
+ *  Datapath: two 24-bit accumulators over the internal RAM, which is a delay line whose
+ *  pointer steps back once per sample, so an instruction's 7-bit offset is a fixed
+ *  delay. A store writes the accumulator as it stood three slots earlier, saturating or
+ *  merely narrowed depending on the store field, and it lands before the same slot reads
+ *  its operand. Long delays live in an external DRAM that steps back the same way; an
+ *  access carries no address of its own, but assembles one from the three-bit external
+ *  RAM field of the six slots following an opener. The opener schedules its own access a
+ *  fixed delay later, twelve slots for a read and eight for a write, and the write commits
+ *  at the first external RAM store at or after that; one program in the corpus puts that
+ *  store a slot late, which is why the search here is written backwards. It keeps twenty
+ *  of a word's twenty-four bits. Stereo is by program
+ *  position: the first half of a sample's 384 slots is one channel and the second half the
+ *  other, counted by the slot rather than by the program counter, which a jump moves.
+ *
+ *  In the SC-88Pro, the XP is the pump, so the device is halted as far as the scheduler
+ *  is concerned and execute_run() serves the debugger; run_once() is one sample.
+ *
+ *  TODO:
+ *  - the DRAM row/column walk, modelled here as a flat ring
+ *  - what raises INT, and the busy bit's timing
+ *  - the serial word width the configuration word selects
+ *  - whether the program can write the program area
+ */
+#include "emu.h"
+#include "roland_lsp.h"
+
+#include "roland_lspd.h"
+
+#include <algorithm>
+
+#define LOG_HOST    (1U << 1)
+#define LOG_CONFIG  (1U << 2)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(ROLAND_LSP, roland_lsp_device, "roland_lsp", "Roland LSP")
+
+namespace {
+
+// offsets 1 to 4 are not memory reads but a power-of-two operand, so the coefficient is an immediate
+constexpr s32 IMMEDIATE[5] = { 0, 1 << 7, 1 << 12, 1 << 17, 1 << 22 };
+
+constexpr bool is_immediate(int offset) { return offset >= 1 && offset <= 4; }
+
+} // anonymous namespace
+
+roland_lsp_device::roland_lsp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: cpu_device(mconfig, ROLAND_LSP, tag, owner, clock)
+	, m_program_config("program", ENDIANNESS_BIG, 32, 9, -2, address_map_constructor(FUNC(roland_lsp_device::program_map), this))
+{
+}
+
+void roland_lsp_device::program_map(address_map &map)
+{
+	map(0x000, 0x1ff).rw(FUNC(roland_lsp_device::internal_r), FUNC(roland_lsp_device::internal_w));
+}
+
+device_memory_interface::space_config_vector roland_lsp_device::memory_space_config() const
+{
+	return space_config_vector { std::make_pair(AS_PROGRAM, &m_program_config) };
+}
+
+std::unique_ptr<util::disasm_interface> roland_lsp_device::create_disassembler()
+{
+	return std::make_unique<roland_lsp_disassembler>();
+}
+
+void roland_lsp_device::device_start()
+{
+	m_eram = make_unique_clear<s32[]>(ERAM_SIZE);
+	set_icountptr(m_icount);
+
+	state_add(STATE_GENPC, "GENPC", m_pc).noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_pc).noshow();
+	state_add(0, "PC", m_pc);
+	state_add(1, "ACCA", m_acc[0]);
+	state_add(2, "ACCB", m_acc[1]);
+	state_add(3, "BUF", m_buffer_pos);
+	state_add(4, "ERAM", m_eram_pos);
+	state_add(5, "MUL0", m_multiplier[0]);
+	state_add(6, "MUL1", m_multiplier[1]);
+	state_add(7, "TAP", m_tap);
+
+	save_pointer(NAME(m_eram), ERAM_SIZE);
+	save_item(NAME(m_program));
+	save_item(NAME(m_iram));
+	save_item(NAME(m_pc));
+	save_item(NAME(m_slot));
+	save_item(NAME(m_configuration));
+	save_item(NAME(m_running));
+	save_item(NAME(m_halted));
+	save_item(NAME(m_acc));
+	save_item(NAME(m_history));
+	save_item(NAME(m_prev_offset));
+	save_item(NAME(m_eram_read));
+	save_item(NAME(m_multiplier));
+	save_item(NAME(m_eram_cmd));
+	save_item(NAME(m_eram_base));
+	save_item(NAME(m_eram_tap2));
+	save_item(NAME(m_eram_latch));
+	save_item(NAME(m_tap));
+	save_item(NAME(m_buffer_pos));
+	save_item(NAME(m_eram_pos));
+	save_item(NAME(m_jump_target));
+	save_item(NAME(m_jump_delay));
+	save_item(NAME(m_serial_in));
+	save_item(NAME(m_serial_out));
+	save_item(NAME(m_audio_out));
+	save_item(NAME(m_host_data));
+	save_item(NAME(m_host_read));
+	save_item(NAME(m_host_address));
+}
+
+void roland_lsp_device::device_reset()
+{
+	std::fill(std::begin(m_program), std::end(m_program), 0);
+	std::fill(std::begin(m_iram), std::end(m_iram), 0);
+	std::fill_n(m_eram.get(), ERAM_SIZE, 0);
+
+	m_icount = 0;
+	m_pc = PROGRAM_BASE;
+	m_slot = 0;
+	m_configuration = 0;
+	m_running = false;
+	m_halted = true;
+
+	m_acc[0] = m_acc[1] = 0;
+	std::fill(&m_history[0][0], &m_history[0][0] + 6, 0);
+	m_prev_offset = 0;
+	m_eram_read = 0;
+	m_multiplier[0] = m_multiplier[1] = 0;
+	std::fill(std::begin(m_eram_cmd), std::end(m_eram_cmd), 0);
+	m_eram_base[0] = m_eram_base[1] = 0;
+	m_eram_tap2[0] = m_eram_tap2[1] = false;
+	m_eram_latch = 0;
+	m_tap = 0;
+	m_buffer_pos = 0;
+	m_eram_pos = 0;
+	m_jump_target = PROGRAM_BASE;
+	m_jump_delay = 0;
+
+	m_serial_in[0] = m_serial_in[1] = 0;
+	m_serial_out[0] = m_serial_out[1] = 0;
+	m_audio_out = 0;
+
+	m_host_data = 0;
+	m_host_read = 0;
+	m_host_address = 0;
+}
+
+roland_lsp_device::instruction roland_lsp_device::decode(u32 word)
+{
+	instruction s;
+	s.opcode = (word >> 21) & 7;
+	s.store = (word >> 19) & 3;
+	s.eram_cmd = (word >> 16) & 7;
+	s.offset = (word >> 8) & 0x7f;
+	s.coefficient = word & 0xff;
+	s.shift = BIT(word, 15) ? 5 : 7;
+	return s;
+}
+
+u32 roland_lsp_device::internal_r(offs_t address)
+{
+	return (address < PROGRAM_BASE) ? (m_iram[address] & 0xffffff) : m_program[address - PROGRAM_BASE];
+}
+
+void roland_lsp_device::internal_w(offs_t address, u32 data)
+{
+	if (address < PROGRAM_BASE)
+		m_iram[address] = narrow(data);
+	else
+		m_program[address - PROGRAM_BASE] = data & 0xffffff;
+}
+
+void roland_lsp_device::configure(u16 word)
+{
+	LOGMASKED(LOG_CONFIG, "configure %04x\n", word);
+
+	m_configuration = word;
+	if (BIT(word, 12))
+		m_running = false;
+	else if (!m_running)
+	{
+		m_running = true;
+		m_pc = PROGRAM_BASE;
+		m_slot = 0;
+		m_jump_delay = 0;
+	}
+}
+
+u8 roland_lsp_device::host_r(offs_t offset)
+{
+	switch (offset & 0x0f)
+	{
+	case HOST_ADDRESS_LOW:  return m_host_read & 0xff;
+	case HOST_ADDRESS_HIGH: return (m_host_read >> 8) & 0xff;
+	case HOST_DATA_LOW:     return (m_host_read >> 16) & 0xff;
+	case HOST_DATA_MID:     return 0;
+	}
+	return 0;
+}
+
+void roland_lsp_device::host_w(offs_t offset, u8 data)
+{
+	switch (offset & 0x0f)
+	{
+	case HOST_ADDRESS_LOW:
+		m_host_address = (m_host_address & 0xff00) | data;
+		LOGMASKED(LOG_HOST, "write %03x = %06x\n", m_host_address & 0x1ff, m_host_data);
+		internal_w(m_host_address & 0x1ff, m_host_data);
+		break;
+
+	case HOST_ADDRESS_HIGH:
+		m_host_address = (m_host_address & 0x00ff) | (data << 8);
+		break;
+
+	case HOST_DATA_LOW:
+		m_host_data = (m_host_data & 0xffff00) | data;
+		break;
+
+	case HOST_DATA_MID:
+		m_host_data = (m_host_data & 0xff00ff) | (data << 8);
+		break;
+
+	case HOST_DATA_HIGH:
+		m_host_data = (m_host_data & 0x00ffff) | (data << 16);
+		break;
+
+	case HOST_CONFIGURE:
+		configure(m_host_data & 0xffff);
+		break;
+
+	case HOST_READ_LOW:
+		m_host_address = (m_host_address & 0xff00) | data;
+		m_host_read = internal_r(m_host_address & 0x1ff);
+		break;
+
+	case HOST_READ_HIGH:
+		m_host_address = (m_host_address & 0x00ff) | (data << 8);
+		break;
+	}
+}
+
+void roland_lsp_device::eram_clock(u8 command)
+{
+	for (int n = 15; n > 0; n--)
+		m_eram_cmd[n] = m_eram_cmd[n - 1];
+	m_eram_cmd[0] = command;
+
+	// Bits 2:1 of a command say what the slot opens -- nothing, a read, a read on the second tap, or a
+	// write -- and a transaction issued that way presents its address a fixed number of slots later,
+	// twelve for a read and eight for a write. The six commands that followed the opener are its
+	// address, least significant first. The address then stays in this latch until the next
+	// transaction of the same direction replaces it, so an access instruction that arrives a slot late
+	// still finds it; nothing here looks at the program.
+	for (int read = 0; read < 2; read++)
+	{
+		const int delay = read ? 12 : 8;
+		const u8 kind = (m_eram_cmd[delay] >> 1) & 3;
+
+		if (read ? (kind != 1 && kind != 2) : (kind != 3))
+			continue;
+
+		if (kind == 2)
+		{
+			m_eram_base[read] = (m_eram_cmd[delay - 1] == 2) ? 1 : 0;
+			m_eram_tap2[read] = true;
+			continue;
+		}
+
+		u16 base = 0;
+		for (int n = 0; n < 5; n++)
+			base += m_eram_cmd[delay - 1 - n] << (n * 3);
+		if (BIT(m_eram_cmd[delay - 6], 0))
+			base += m_eram_cmd[delay - 6] << 15;
+
+		m_eram_base[read] = base;
+		m_eram_tap2[read] = false;
+	}
+}
+
+u16 roland_lsp_device::eram_address(bool read) const
+{
+	return m_eram_pos + m_eram_base[read] + ((read && m_eram_tap2[read]) ? m_tap : 0);
+}
+
+s32 roland_lsp_device::source(const instruction &s) const
+{
+	const s32 value = m_history[s.store == 2][2];
+	return (s.store == 3) ? narrow(value) : saturate(value);
+}
+
+void roland_lsp_device::multiply(const instruction &s, s32 operand)
+{
+	const u8 code = s.coefficient;
+	const s32 reg = m_multiplier[BIT(code, 1)];
+	s32 &acc = m_acc[BIT(code, 4)];
+	s32 product;
+
+	if (BIT(code, 6))
+		product = s32(((s64(operand) * ((reg & 0xffff) >> 9)) >> s.shift) >> 7);
+	else
+		product = s32((s64(operand) * (reg >> 16)) >> s.shift);
+
+	if (BIT(code, 2))
+		product = -product;
+
+	acc = (BIT(code, 3) && !BIT(code, 6)) ? product : add(saturate(acc), product);
+}
+
+void roland_lsp_device::special(const instruction &s)
+{
+	const int slot = s.slot();
+	s32 value = s.store ? source(s) : 0;
+	s32 &acc = m_acc[s.opcode & 1];
+
+	switch (slot)
+	{
+	case SLOT_JUMP_NEGATIVE:
+	case SLOT_JUMP_POSITIVE:
+	case SLOT_JUMP:
+		if (slot == SLOT_JUMP || (value < 0) == (slot == SLOT_JUMP_NEGATIVE))
+		{
+			m_jump_target = (s.coefficient << 1) & ADDRESS_MASK;
+			m_jump_delay = 2;
+		}
+		return;
+
+	case SLOT_ERAM_WRITE:
+		if (s.store)
+			m_eram_latch = value;
+		else
+		{
+			const s32 previous = is_immediate(m_prev_offset) ? IMMEDIATE[m_prev_offset] : m_iram[iram_address(m_prev_offset)];
+			acc = add(s.replace() ? 0 : acc, s32(((s64(previous) * s.coefficient) >> 8) >> s.shift));
+		}
+		return;
+
+	case SLOT_TAP:
+		if (s.store == 3)
+		{
+			const s32 raw = m_history[0][2];
+			m_tap = u16(raw >> 10);
+			m_multiplier[0] = (raw & 0x3ff) << 13;
+		}
+		return;
+
+	case SLOT_MULTIPLIER:
+	case SLOT_MULTIPLIER + 1:
+		m_multiplier[slot - SLOT_MULTIPLIER] = value;
+		return;
+
+	case SLOT_AUDIO_OUT:
+		m_audio_out = value;
+		if (first_half())
+			m_serial_out[1] = value;
+		break;
+
+	case SLOT_ERAM_READ:
+	case SLOT_ERAM_READ + 1:
+	case SLOT_ERAM_READ + 2:
+	case SLOT_ERAM_READ + 3:
+		if (s.store)
+			m_eram_read = m_eram[eram_address(true)] << 4;
+		value = m_eram_read;
+		break;
+
+	case SLOT_AUDIO_IN:
+		value = m_serial_in[first_half()];
+		break;
+
+	default:
+		return;
+	}
+
+	m_iram[iram_address(0x60 + slot)] = value;
+	acc = add(s.replace() ? 0 : acc, s32((s64(value) * s8(s.coefficient)) >> s.shift));
+}
+
+void roland_lsp_device::step()
+{
+	// the program counter is nine bits and wraps; the 128 addresses below the 384-word store are not
+	// program memory and what they fetch is unknown, so take them as nops rather than invent a source
+	const u32 raw = (m_pc >= PROGRAM_BASE) ? m_program[m_pc - PROGRAM_BASE] : 0;
+	const instruction s = decode(raw);
+
+	eram_clock((raw >> 16) & 7);
+
+	if (raw && s.opcode >= OP_SPECIAL_A)
+		special(s);
+	else if (raw)
+	{
+		const int address = iram_address(s.offset);
+		if (s.store)
+			m_iram[address] = source(s);
+
+		const s32 operand = s.immediate() ? IMMEDIATE[s.offset] : m_iram[address];
+		const s32 product = s32((s64(operand) * s8(s.coefficient)) >> s.shift);
+
+		switch (s.opcode)
+		{
+		case OP_MAC_A: m_acc[0] = add(m_acc[0], product); break;
+		case OP_SET_A: m_acc[0] = product; break;
+		case OP_MAC_B: m_acc[1] = add(m_acc[1], product); break;
+		case OP_SET_B: m_acc[1] = product; break;
+		case OP_MUL:   multiply(s, operand); break;
+		case OP_ABS:   m_acc[0] = std::abs(product); break;
+		}
+	}
+
+	for (int n = 0; n < 2; n++)
+	{
+		m_history[n][2] = m_history[n][1];
+		m_history[n][1] = m_history[n][0];
+		m_history[n][0] = m_acc[n];
+	}
+	m_prev_offset = s.offset;
+
+	if (raw && s.opcode >= OP_SPECIAL_A && s.slot() == SLOT_ERAM_WRITE && s.store)
+		m_eram[eram_address(false)] = m_eram_latch >> 4;
+
+	if (m_jump_delay && !--m_jump_delay)
+		m_pc = m_jump_target;
+	else
+		m_pc = (m_pc + 1) & ADDRESS_MASK;
+
+	if (++m_slot >= PROGRAM_SIZE)
+	{
+		finish_sample();
+		m_pc = PROGRAM_BASE;
+		m_slot = 0;
+	}
+}
+
+void roland_lsp_device::finish_sample()
+{
+	m_serial_out[0] = m_audio_out;
+	m_jump_delay = 0;
+	m_buffer_pos = (m_buffer_pos - 1) & 0x7f;
+	m_eram_pos--;
+}
+
+void roland_lsp_device::execute_run()
+{
+	while (m_icount > 0)
+	{
+		if (m_halted || !m_running)
+		{
+			m_icount = 0;
+			return;
+		}
+
+		debugger_instruction_hook(m_pc);
+		step();
+		m_icount--;
+	}
+}
+
+void roland_lsp_device::run_once()
+{
+	m_halted = false;
+	for (int n = 0; m_running && n < PROGRAM_SIZE; n++)
+	{
+		m_icount = 1;
+		execute_run();
+		if (!m_slot)
+			break;
+	}
+	m_halted = true;
+}

--- a/src/devices/sound/roland_lsp.h
+++ b/src/devices/sound/roland_lsp.h
@@ -1,0 +1,144 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_LSP_H
+#define MAME_SOUND_ROLAND_LSP_H
+
+#pragma once
+
+class roland_lsp_device : public cpu_device
+{
+public:
+	static constexpr int PROGRAM_SIZE = 384;
+	static constexpr int PROGRAM_BASE = 0x080;
+	static constexpr u16 ADDRESS_MASK = 0x1ff;
+	static constexpr int IRAM_SIZE = 0x80;
+	static constexpr int ERAM_SIZE = 0x10000;
+
+	// the slots of the two special opcodes, by slot number
+	enum special_slot
+	{
+		SLOT_JUMP_NEGATIVE = 0x0d, SLOT_JUMP_POSITIVE = 0x0e, SLOT_JUMP = 0x0f,
+		SLOT_ERAM_WRITE = 0x10, SLOT_TAP = 0x13, SLOT_MULTIPLIER = 0x14,
+		SLOT_AUDIO_OUT = 0x18, SLOT_ERAM_READ = 0x1a, SLOT_AUDIO_IN = 0x1e
+	};
+
+	// the sixteen host registers at CA0-3
+	enum host_register
+	{
+		HOST_ADDRESS_LOW = 0x00, HOST_ADDRESS_HIGH = 0x01, HOST_DATA_LOW = 0x02,
+		HOST_DATA_MID = 0x03, HOST_DATA_HIGH = 0x04, HOST_CONFIGURE = 0x06,
+		HOST_READ_LOW = 0x08, HOST_READ_HIGH = 0x09
+	};
+
+	roland_lsp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	u8 host_r(offs_t offset);
+	void host_w(offs_t offset, u8 data);
+
+	// TRR in and TRS0 out, channel 0 left and 1 right, one pair per sample
+	void ser_w(int channel, s32 sample) { m_serial_in[channel & 1] = sample; }
+	s32 ser_r(int channel) const { return m_serial_out[channel & 1]; }
+	void run_once();
+
+protected:
+	// device_t implementation
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+	// device_execute_interface implementation
+	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 1) / 2; }
+	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return cycles * 2; }
+	virtual u32 execute_min_cycles() const noexcept override { return 1; }
+	virtual u32 execute_max_cycles() const noexcept override { return 1; }
+	virtual void execute_run() override;
+
+	// device_memory_interface implementation
+	virtual space_config_vector memory_space_config() const override;
+
+	// device_disasm_interface implementation
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+	// one instruction word, split into its fields
+	struct instruction
+	{
+		u8 opcode;
+		u8 store;
+		u8 eram_cmd;
+		u8 offset;
+		u8 coefficient;
+		u8 shift;
+
+		int slot() const { return offset & 0x1f; }
+		bool replace() const { return BIT(offset, 5); }
+		bool immediate() const { return offset >= 1 && offset <= 4; }
+	};
+
+	enum opcode_family
+	{
+		OP_MAC_A = 0, OP_SET_A = 1, OP_MAC_B = 2, OP_SET_B = 3,
+		OP_MUL = 4, OP_ABS = 5, OP_SPECIAL_A = 6, OP_SPECIAL_B = 7
+	};
+
+	static instruction decode(u32 word);
+
+	static s32 saturate(s32 value) { return std::clamp<s32>(value, -0x800000, 0x7fffff); }
+	static s32 narrow(s32 value) { return s32(u32(value) << 8) >> 8; }
+	static s32 add(s32 accumulator, s32 term) { return s32(u32(accumulator) + u32(term)); }
+
+	void program_map(address_map &map) ATTR_COLD;
+
+	u32 internal_r(offs_t address);
+	void internal_w(offs_t address, u32 data);
+	void configure(u16 word);
+
+	void eram_clock(u8 command);
+	u16 eram_address(bool read) const;
+	int iram_address(int offset) const { return (offset + m_buffer_pos) & 0x7f; }
+	bool first_half() const { return m_slot < PROGRAM_SIZE / 2; }
+
+	s32 source(const instruction &s) const;
+	void multiply(const instruction &s, s32 operand);
+	void special(const instruction &s);
+	void step();
+	void finish_sample();
+
+	address_space_config m_program_config;
+
+	std::unique_ptr<s32[]> m_eram;
+	u32 m_program[PROGRAM_SIZE];
+	s32 m_iram[IRAM_SIZE];
+
+	int m_icount;
+	u16 m_pc;
+	u16 m_slot;
+	u16 m_configuration;
+	bool m_running;
+	bool m_halted;
+
+	s32 m_acc[2];
+	s32 m_history[2][3];
+	s32 m_eram_read;
+	u8 m_prev_offset;
+	s32 m_multiplier[2];
+	u8 m_eram_cmd[16];
+	u16 m_eram_base[2];
+	bool m_eram_tap2[2];
+	s32 m_eram_latch;
+	u16 m_tap;
+	u8 m_buffer_pos;
+	u16 m_eram_pos;
+	u16 m_jump_target;
+	u8 m_jump_delay;
+
+	s32 m_serial_in[2];
+	s32 m_serial_out[2];
+	s32 m_audio_out;
+
+	u32 m_host_data;
+	u32 m_host_read;
+	u16 m_host_address;
+};
+
+DECLARE_DEVICE_TYPE(ROLAND_LSP, roland_lsp_device)
+
+#endif // MAME_SOUND_ROLAND_LSP_H

--- a/src/devices/sound/roland_lspd.cpp
+++ b/src/devices/sound/roland_lspd.cpp
@@ -1,0 +1,130 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/*
+ *  Roland LSP (MB87837) disassembler
+ */
+#include "emu.h"
+#include "roland_lspd.h"
+
+namespace {
+
+const char *const ACCUMULATOR[4] = { "", "accA", "accB", "accA!" };
+
+// offsets 1 to 4 read a power of two instead of memory, so the coefficient becomes an immediate
+const int IMMEDIATE[5] = { 0, 7, 12, 17, 22 };
+
+void operand(std::ostream &stream, u8 offset)
+{
+	if (offset >= 1 && offset <= 4)
+		util::stream_format(stream, "#%d", IMMEDIATE[offset]);
+	else
+		util::stream_format(stream, "$%02x", offset);
+}
+
+void product(std::ostream &stream, u8 offset, u8 coefficient, int shift)
+{
+	operand(stream, offset);
+	util::stream_format(stream, "*%c%02x>>%d", BIT(coefficient, 7) ? '-' : '+', BIT(coefficient, 7) ? -s8(coefficient) & 0xff : coefficient, shift);
+}
+
+void slot_source(std::ostream &stream, int slot, u8 coefficient)
+{
+	switch (slot)
+	{
+	case 0x18: stream << "audio_out"; break;
+	case 0x1a: case 0x1b: case 0x1c: case 0x1d: util::stream_format(stream, "eram%d", slot - 0x1a); break;
+	case 0x1e: stream << "audio_in"; break;
+	default:   util::stream_format(stream, "slot%02x", slot); break;
+	}
+}
+
+} // anonymous namespace
+
+void roland_lsp_disassembler::describe(std::ostream &stream, offs_t pc, u32 word)
+{
+	const int op = (word >> 21) & 7;
+	const int store = (word >> 19) & 3;
+	const int eram = (word >> 16) & 7;
+	const int shift = BIT(word, 15) ? 5 : 7;
+	const u8 offset = (word >> 8) & 0x7f;
+	const u8 coefficient = word & 0xff;
+	const int slot = offset & 0x1f;
+	const bool replace = BIT(offset, 5);
+
+	if (op < 6 && store)
+		util::stream_format(stream, "[$%02x] = %s, ", offset, ACCUMULATOR[store]);
+
+	switch (op)
+	{
+	case 0: case 1: case 2: case 3:
+		util::stream_format(stream, "acc%c %s ", (op & 2) ? 'B' : 'A', (op & 1) ? " =" : "+=");
+		product(stream, offset, coefficient, shift);
+		break;
+
+	case 4:
+		util::stream_format(stream, "acc%c %s %c", BIT(coefficient, 4) ? 'B' : 'A',
+			(BIT(coefficient, 3) && !BIT(coefficient, 6)) ? " =" : "+=", BIT(coefficient, 2) ? '-' : ' ');
+		operand(stream, offset);
+		util::stream_format(stream, "*mul%d%s>>%d", BIT(coefficient, 1), BIT(coefficient, 6) ? ".lo" : ".hi", shift);
+		break;
+
+	case 5:
+		stream << "accA  = |";
+		product(stream, offset, coefficient, shift);
+		stream << '|';
+		break;
+
+	default:
+		switch (slot)
+		{
+		case 0x0d: case 0x0e: case 0x0f:
+			util::stream_format(stream, "%s %03x", (slot == 0x0d) ? "jmpn" : (slot == 0x0e) ? "jmpp" : "jmp ", coefficient << 1);
+			if (store)
+				util::stream_format(stream, ", %s", ACCUMULATOR[store]);
+			break;
+
+		case 0x10:
+			if (store)
+				util::stream_format(stream, "eram = %s", ACCUMULATOR[store]);
+			else
+			{
+				util::stream_format(stream, "acc%c %s prev*%02x>>%d", (op & 1) ? 'B' : 'A', replace ? " =" : "+=", coefficient, 8 + shift);
+			}
+			break;
+
+		case 0x13:
+			util::stream_format(stream, "tap:mul0 = %s", ACCUMULATOR[store]);
+			break;
+
+		case 0x14: case 0x15:
+			util::stream_format(stream, "mul%d = %s", slot - 0x14, ACCUMULATOR[store]);
+			break;
+
+		case 0x18:
+			util::stream_format(stream, "audio_out = %s", ACCUMULATOR[store]);
+			if (replace)
+				util::stream_format(stream, ", acc%c = 0", (op & 1) ? 'B' : 'A');
+			break;
+
+		case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e:
+			util::stream_format(stream, "acc%c %s ", (op & 1) ? 'B' : 'A', replace ? " =" : "+=");
+			slot_source(stream, slot, coefficient);
+			util::stream_format(stream, "*%c%02x>>%d", BIT(coefficient, 7) ? '-' : '+', BIT(coefficient, 7) ? -s8(coefficient) & 0xff : coefficient, shift);
+			break;
+
+		default:
+			util::stream_format(stream, "slot%02x = %s", slot, ACCUMULATOR[store]);
+			break;
+		}
+		break;
+	}
+
+	if (eram)
+		util::stream_format(stream, "  ; e%d", eram);
+}
+
+offs_t roland_lsp_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	describe(stream, pc, opcodes.r32(pc) & 0xffffff);
+	return 1 | SUPPORTED;
+}

--- a/src/devices/sound/roland_lspd.h
+++ b/src/devices/sound/roland_lspd.h
@@ -1,0 +1,20 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_LSPD_H
+#define MAME_SOUND_ROLAND_LSPD_H
+
+#pragma once
+
+class roland_lsp_disassembler : public util::disasm_interface
+{
+public:
+	roland_lsp_disassembler() = default;
+	virtual ~roland_lsp_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override { return 1; }
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
+	static void describe(std::ostream &stream, offs_t pc, u32 word);
+};
+
+#endif // MAME_SOUND_ROLAND_LSPD_H

--- a/src/devices/sound/roland_xp.cpp
+++ b/src/devices/sound/roland_xp.cpp
@@ -1,0 +1,1649 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr, giulioz
+/*
+ *  Roland XP (MBCS30109 / RA01-005 / RA09-002)
+ *
+ *  64-voice custom sound generator with built-in microcoded effect DSP.
+ *
+ *  Host window: 44 voice pages of 64 x 32 bits (page * 0x100 + voice * 4, high word first,
+ *  committed by the low word through one chip-wide high-word latch), CRAM/IRAM/PRAM of the
+ *  effect DSP, the control block at 0x3900 (run mask, readback latch, interrupt event and
+ *  acknowledge, ROM window page/bank, serial and DSP configuration, the transposed per-voice
+ *  window), four banks of mixer sends at 0x3a00 and the wave ROM access window at 0x3c00. A
+ *  read of a voice page, CRAM, IRAM, PRAM, a send or the ROM window returns nothing on the
+ *  bus: it loads the readback latch, masked to the register's width, which 0x3912/0x3910
+ *  return. A voice is launched by a read of the run mask: a write only shadows a newly set
+ *  bit, and a read of any of the four words commits every shadowed bit; a cleared bit parks
+ *  the voice on the write. CONTROL bit 15 enables the voice's marker and mute interrupts.
+ *
+ *  Voice: every piece of a voice's runtime is one of its pages, and this device keeps it
+ *  there - the read pointer (01), the exponent cache (04), the DPCM accumulator (0C), the
+ *  decoded pitch increment (0D), the 14-bit phase (0E), the service counter and launch phase
+ *  (10), the ramp currents (the seed pages 1B-1E and 21), the filter coefficient (22), the two
+ *  amplitude stages (23, 27), the linear ramp step registers (24-26), the filter states (28,
+ *  29) and the output sample (2A). A launch takes three frames (preload, initialize, starting)
+ *  before the first sample. Each frame a running voice steps one of its five ramps, chosen by
+ *  its service counter (odd counts the amplitude envelope TVA1, 0/2/4/6 TVA2, RESO, TVF and
+ *  PITCH), gated by the control word's hold divider against a chip-global clock: the linear
+ *  law walks a double-resolution step register, the exponential law recomputes its step from
+ *  the distance every service, the fade-to-zero steers a velocity, RESO steps in quanta of
+ *  four, and a target's bit 0 is the chip's acknowledge of a host write. PITCH and TVF are
+ *  decoded on their service slot into pages 0D and 22 and held flat; only the amplitude is
+ *  smoothed, by the one-pole filter in page 27. The reader is a DPCM decoder with forward,
+ *  alternate and reverse loops over 1 MB ROM regions into an 18-bit accumulator; a one-shot
+ *  parks its pointer at END and a backward one at LOOP, the marker interrupt fires on every
+ *  advance at or past LOOP in the direction of travel (the two-stage latch in CONTROL bits
+ *  17/16 limits it to two reports), and no other event comes from the reader. The 4-tap
+ *  128-phase interpolator forms four times the accumulator plus the weighted deltas, wraps
+ *  at 20 bits and shifts by the wave gain (page 10); the Chamberlin state-variable filter
+ *  runs with Q19 coefficients and every line saturated at 24 bits; the smoothed amplitude
+ *  multiplies the result into page 2A, from which the four sends (10-bit level, 0x200 =
+ *  unity, 6-bit destination) deposit on the voice's own four DSP slots into the mixer bank,
+ *  the first send to name a word clearing it - for every voice up to the highest, a parked
+ *  voice depositing zero. Every product in the voice path divides towards zero.
+ *
+ *  DSP: 288 instruction slots, of which (highest voice + 1) x 4 run a frame, over three RAMs -
+ *  IRAM1 and IRAM2, 64 x 24 bits, which words 00-7f address with bit 6 XOR the frame parity,
+ *  so one range names this frame's bank and the other the previous frame's and the mixer
+ *  deposits under the program into the bank it is not reading, and which 80-bf address
+ *  unswapped; and IRAM3, 64 x 26 bits, at c0-ff, whose top 0x3926 [12:8] words are gain
+ *  registers, a signed 16-bit current above a 10-bit target that the host writes at 0x3300
+ *  and the chip approaches proportionally on odd frames at the rate registers' slew - and a
+ *  64K-word external delay ring addressed relative to a cursor that steps back once per frame.
+ *  The datapath is one multiplier and one ALU on a 29-bit wrapping accumulator: products
+ *  divide towards zero and saturate at 29 bits, the accumulator is saturated to 24 bits where
+ *  it feeds the multiplier. A slot's col field is a 4 x 16 grid: bits 5..4 the multiply input
+ *  (the previous multiply's input, the accumulator, the IRAM read latch, the ERAM read latch)
+ *  and bits 3..0 the ALU function, applied to the previous slot's product; a slot issues a
+ *  multiply only on functions 1-12, and the product and input latches stand otherwise.
+ *  Function 0 selects a special by the input field: a no-op, a branch on the accumulator with
+ *  the condition and target in the CRAM word, the indexed ERAM read, or the parallel op, which
+ *  hands the CRAM word over as a second instruction: a product shift, a post-function (absolute
+ *  value, wrap, the PRNG step, the fold, a one's complement of the negative half), whether a
+ *  multiply is issued, a factor (the interpolation fraction, the accumulator's magnitude or
+ *  value, or a gain register, each complementable), an input and a function, the sixteen
+ *  functions being the primary ones with three further sums in place of the immediates. ERAM
+ *  accesses span two slots and a read lands two slots after its start; a write stores the
+ *  accumulator or the read latch.
+ *
+ *  Serial ports: the chip keeps one word position a frame that every ext strobe of 1 or 2
+ *  advances, and the strobe clocks the previous frame's word at that position out of RAM.
+ *  Strobe 2 drives ports B, C and D (SDOB, SDOC, SDOD) in rotation, three-strobe group by
+ *  group, each port enabled by its descriptor (0x3924 [15:8] for B, 0x3926 [7:0] for the other
+ *  two, bits 7..6 non-zero); the word goes out with its top 18 bits and two guard bits, or 14
+ *  and three with 0x3932 bit 5, and a DAC takes it at a quarter of the word's full scale. The
+ *  stream carries the three ports' two halves. Strobe 1 drives port A, the six-line bus that
+ *  also receives: it presents its word and takes one back after the strobe's instruction has
+ *  run, so a `col 0x0c` on the strobe multiplies the word taken at the previous strobe. Port B's
+ *  input is refreshed at the first strobe of each group and `col 0x1c` reads it.
+ *
+ *  The DSP program is the chip's schedule - one pass of the slots is one sample - so the
+ *  device is a CPU as much as a sound chip: execute_run() steps one cycle per slot, voice n
+ *  taking cycles 4n to 4n+3, and the output stream is synchronous at the frame rate. The DSP
+ *  runs on bit 2 of 0x3916, bit 1 enables the serial input and bits 1 and 0 together the
+ *  serial output. Interrupts are one event register with back-pressure: a source whose event
+ *  finds the line busy, or the frame's one event already taken, offers it again later.
+ *
+ *  TODO:
+ *  - the sample FIFO and the fetch-overload interrupt (reason 7)
+ *  - the 16-bit wave bus and the alternate decoding of 0x3908
+ *  - paired voice structures and ring modulation (FILTER bits 15..12)
+ *  - the sign-aware immediate min/max variants
+ *  - wait states
+ */
+#include "emu.h"
+#include "roland_xp.h"
+
+#include "roland_xpd.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+#define LOG_VOICE   (1U << 1)
+#define LOG_CRAM    (1U << 2)
+#define LOG_IRAM    (1U << 3)
+#define LOG_PRAM    (1U << 4)
+#define LOG_RUNMASK (1U << 5)
+#define LOG_CTRL    (1U << 6)
+#define LOG_MIX     (1U << 7)
+#define LOG_READ    (1U << 8)
+#define LOG_UNKNOWN (1U << 9)
+
+#define VERBOSE (LOG_GENERAL | LOG_UNKNOWN)
+#include "logmacro.h"
+
+DEFINE_DEVICE_TYPE(ROLAND_XP, roland_xp_device, "roland_xp", "Roland XP")
+
+namespace {
+
+const s16 interp_weights[3][128] = {
+	{
+		3385, 3401, 3417, 3432, 3448, 3463, 3478, 3492, 3506, 3521, 3535, 3548, 3562, 3575, 3588, 3601,
+		3614, 3626, 3638, 3650, 3662, 3673, 3685, 3696, 3707, 3718, 3728, 3739, 3749, 3759, 3768, 3778,
+		3787, 3796, 3805, 3814, 3823, 3831, 3839, 3847, 3855, 3863, 3870, 3878, 3885, 3892, 3899, 3905,
+		3912, 3918, 3924, 3930, 3936, 3942, 3948, 3953, 3958, 3963, 3968, 3973, 3978, 3983, 3987, 3991,
+		3995, 4000, 4004, 4007, 4011, 4015, 4018, 4022, 4025, 4028, 4031, 4034, 4037, 4040, 4042, 4045,
+		4047, 4050, 4052, 4054, 4057, 4059, 4061, 4063, 4064, 4066, 4068, 4070, 4071, 4073, 4074, 4076,
+		4077, 4078, 4079, 4081, 4082, 4083, 4084, 4085, 4086, 4086, 4087, 4088, 4089, 4089, 4090, 4091,
+		4091, 4092, 4092, 4093, 4093, 4094, 4094, 4094, 4094, 4095, 4095, 4095, 4095, 4095, 4095, 4095,
+	},
+	{
+		 710,  726,  742,  758,  775,  792,  809,  826,  844,  861,  879,  897,  915,  933,  952,  971,
+		 990, 1009, 1028, 1047, 1067, 1087, 1106, 1126, 1147, 1167, 1188, 1208, 1229, 1250, 1271, 1292,
+		1314, 1335, 1357, 1379, 1400, 1423, 1445, 1467, 1489, 1512, 1534, 1557, 1580, 1602, 1625, 1648,
+		1671, 1695, 1718, 1741, 1764, 1788, 1811, 1835, 1858, 1882, 1906, 1929, 1953, 1977, 2000, 2024,
+		2048, 2071, 2095, 2119, 2143, 2166, 2190, 2214, 2237, 2261, 2284, 2308, 2331, 2355, 2378, 2401,
+		2425, 2448, 2471, 2494, 2517, 2539, 2562, 2585, 2607, 2630, 2652, 2674, 2696, 2718, 2740, 2762,
+		2783, 2805, 2826, 2847, 2868, 2889, 2910, 2931, 2951, 2971, 2991, 3011, 3031, 3051, 3070, 3089,
+		3108, 3127, 3146, 3164, 3182, 3200, 3218, 3236, 3253, 3271, 3288, 3304, 3321, 3338, 3354, 3370,
+	},
+	{
+		   0,    0,    0,    1,    1,    1,    2,    2,    3,    3,    3,    4,    4,    5,    5,    6,
+		   6,    7,    8,    8,    9,   10,   10,   11,   12,   13,   14,   15,   16,   17,   18,   19,
+		  20,   22,   23,   24,   26,   27,   29,   30,   32,   34,   36,   38,   40,   42,   44,   46,
+		  49,   51,   53,   56,   59,   62,   65,   68,   71,   74,   77,   81,   84,   88,   92,   96,
+		 100,  104,  109,  113,  118,  122,  127,  132,  137,  143,  148,  154,  160,  165,  171,  178,
+		 184,  191,  197,  204,  211,  219,  226,  234,  241,  249,  257,  266,  274,  283,  292,  301,
+		 310,  319,  329,  339,  349,  359,  369,  380,  391,  402,  413,  424,  436,  448,  460,  472,
+		 484,  497,  510,  523,  536,  549,  563,  577,  591,  605,  619,  634,  648,  663,  679,  694,
+	},
+};
+
+const u32 hold_masks[4] = { 0, 7, 31, 127 };
+const u8 phase_dither[4] = { 3, 0, 2, 1 };
+const u8 shift_select[4] = { 0, 1, 2, 4 };
+
+// the readback latch takes a page at its own width
+u32 page_mask(int index)
+{
+	if (index <= 0x04 || (index >= 0x20 && index <= 0x26))
+		return 0xfffff;
+	if (index >= 0x08 && index <= 0x0b)
+		return 0xfff;
+	if (index >= 0x0c && index <= 0x1e)
+		return 0x3ffff;
+	if (index == 0x27)
+		return 0xffff;
+	if (index >= 0x28 && index <= 0x2a)
+		return 0xffffff;
+	return 0xffffffff;
+}
+
+int bit_reverse4(int v)
+{
+	return ((v & 1) << 3) | ((v & 2) << 1) | ((v & 4) >> 1) | ((v & 8) >> 3);
+}
+
+} // anonymous namespace
+
+const roland_xp_device::ramp_pages roland_xp_device::RAMPS[5] = {
+	{ roland_xp_device::PITCH_SEED, roland_xp_device::PITCH_CONTROL, roland_xp_device::PITCH_TARGET, roland_xp_device::PITCH_STEP, roland_xp_device::IRQ_PITCH_DONE },
+	{ roland_xp_device::TVF_SEED, roland_xp_device::TVF_CONTROL, roland_xp_device::TVF_TARGET, roland_xp_device::TVF_STEP, roland_xp_device::IRQ_TVF_DONE },
+	{ roland_xp_device::RESO_SEED, roland_xp_device::RESO_CONTROL, roland_xp_device::RESO_TARGET, 0, roland_xp_device::IRQ_RESO_DONE },
+	{ roland_xp_device::TVA2_SEED, roland_xp_device::TVA2_CONTROL, roland_xp_device::TVA2_TARGET, 0, roland_xp_device::IRQ_TVA2_DONE },
+	{ roland_xp_device::TVA1_SEED, roland_xp_device::TVA1_CONTROL, roland_xp_device::TVA1_TARGET, roland_xp_device::TVA1_STEP, roland_xp_device::IRQ_VOICE_DONE },
+};
+
+
+//-------------------------------------------------
+//  device
+//-------------------------------------------------
+
+roland_xp_device::roland_xp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: cpu_device(mconfig, ROLAND_XP, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_pram_config("pram", ENDIANNESS_BIG, 32, 10, -2, address_map_constructor(FUNC(roland_xp_device::pram_map), this))
+	, m_wave_config("wave", ENDIANNESS_LITTLE, 8, 27)
+	, m_iram_config("iram", ENDIANNESS_BIG, 32, 10, -2, address_map_constructor(FUNC(roland_xp_device::iram_map), this))
+	, m_eram_config("eram", ENDIANNESS_BIG, 32, 18, -2, address_map_constructor(FUNC(roland_xp_device::eram_map), this))
+	, m_int_callback(*this)
+	, m_port_out_cb(*this)
+	, m_port_a_in_cb(*this, 0)
+	, m_port_b_in_cb(*this, 0)
+	, m_frame_cb(*this)
+	, m_stream(nullptr)
+	, m_bus_written(0)
+	, m_run_mask(0)
+	, m_run_pending(0)
+	, m_read_latch(0)
+	, m_write_latch(0)
+	, m_frame_counter(0)
+	, m_irq_event(0)
+	, m_irq_active(false)
+	, m_irq_frame_used(false)
+	, m_int_state(false)
+	, m_landing_valid(0)
+	, m_program_dirty(true)
+	, m_dsp_enabled(false)
+	, m_parity(0)
+	, m_icount(0)
+	, m_pc(0)
+	, m_cycle(0)
+	, m_position(0)
+	, m_strobe_a(0)
+	, m_strobe_bcd(0)
+	, m_port_a_out{ 0 }
+	, m_port_word{ { 0 } }
+	, m_port_a_in(0)
+	, m_port_b_in(0)
+	, m_port_in_enabled(false)
+	, m_pumped(false)
+{
+}
+
+void roland_xp_device::pram_map(address_map &map)
+{
+	map(0x000, 0x3ff).rw(FUNC(roland_xp_device::pram_r), FUNC(roland_xp_device::pram_w));
+}
+
+void roland_xp_device::iram_map(address_map &map)
+{
+	map(0x000, 0x3ff).rw(FUNC(roland_xp_device::iram_r), FUNC(roland_xp_device::iram_w));
+}
+
+void roland_xp_device::eram_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).rw(FUNC(roland_xp_device::eram_r), FUNC(roland_xp_device::eram_w));
+}
+
+device_memory_interface::space_config_vector roland_xp_device::memory_space_config() const
+{
+	return space_config_vector {
+		std::make_pair(AS_PROGRAM, &m_pram_config),
+		std::make_pair(AS_WAVE, &m_wave_config),
+		std::make_pair(AS_IRAM, &m_iram_config),
+		std::make_pair(AS_ERAM, &m_eram_config)
+	};
+}
+
+std::unique_ptr<util::disasm_interface> roland_xp_device::create_disassembler()
+{
+	return std::make_unique<roland_xp_disassembler>(this);
+}
+
+u32 roland_xp_device::pram_r(offs_t address)
+{
+	const int word = (PRAM_BASE >> 1) + (address % DSP_SLOTS) * 2;
+	return (u32(m_regs[word]) << 16) | m_regs[word | 1];
+}
+
+void roland_xp_device::pram_w(offs_t address, u32 data)
+{
+	const int word = (PRAM_BASE >> 1) + (address % DSP_SLOTS) * 2;
+	m_regs[word] = u16(data >> 16);
+	m_regs[word | 1] = u16(data);
+	m_program_dirty = true;
+}
+
+void roland_xp_device::device_start()
+{
+	m_regs = make_unique_clear<u16[]>(0x2000);
+	m_eram = make_unique_clear<s32[]>(ERAM_SIZE);
+	space(AS_WAVE).cache(m_wave_cache);
+	m_stream = stream_alloc(0, OUTPUTS, clock() / 768, STREAM_SYNCHRONOUS);
+
+	for (int i = 0; i <= 256; i++)
+		m_exp_table[i] = s32(std::floor(std::exp2(14.0 + i / 256.0) + 0.5));
+
+	set_icountptr(m_icount);
+
+	state_add(STATE_GENPC, "GENPC", m_pc).noshow();
+	state_add(STATE_GENPCBASE, "CURPC", m_pc).noshow();
+	state_add(0, "PC", m_pc);
+	state_add(1, "ACC", m_dsp.acc);
+	state_add(2, "R", m_dsp.r);
+	state_add(3, "P", m_dsp.product);
+	state_add(4, "LATCH", m_dsp.latch);
+	state_add(5, "G", m_dsp.gain);
+	state_add(6, "CURSOR", m_dsp.cursor);
+	state_add(7, "CYCLE", m_cycle);
+
+	save_pointer(NAME(m_regs), 0x2000);
+	save_pointer(NAME(m_eram), ERAM_SIZE);
+	save_item(NAME(m_iram));
+	save_item(NAME(m_iram_ramping));
+	save_item(NAME(m_dsp.acc));
+	save_item(NAME(m_dsp.product));
+	save_item(NAME(m_dsp.product_prev));
+	save_item(NAME(m_dsp.r));
+	save_item(NAME(m_dsp.input));
+	save_item(NAME(m_dsp.input_prev));
+	save_item(NAME(m_dsp.now));
+	save_item(NAME(m_dsp.latch));
+	save_item(NAME(m_dsp.gain));
+	save_item(NAME(m_dsp.now_valid));
+	save_item(NAME(m_dsp.cursor));
+	save_item(NAME(m_landing));
+	save_item(NAME(m_landing_valid));
+	save_item(NAME(m_dsp_enabled));
+	save_item(NAME(m_parity));
+	save_item(NAME(m_pc));
+	save_item(NAME(m_cycle));
+	save_item(NAME(m_position));
+	save_item(NAME(m_strobe_a));
+	save_item(NAME(m_strobe_bcd));
+	save_item(NAME(m_port_a_out));
+	save_item(NAME(m_port_word));
+	save_item(NAME(m_port_a_in));
+	save_item(NAME(m_port_b_in));
+	save_item(NAME(m_port_in_enabled));
+	save_item(NAME(m_bus_written));
+	save_item(NAME(m_run_mask));
+	save_item(NAME(m_run_pending));
+	save_item(NAME(m_read_latch));
+	save_item(NAME(m_write_latch));
+	save_item(NAME(m_frame_counter));
+	save_item(NAME(m_irq_event));
+	save_item(NAME(m_irq_active));
+	save_item(NAME(m_irq_frame_used));
+	save_item(NAME(m_int_state));
+	save_item(STRUCT_MEMBER(m_voices, phase));
+	save_item(STRUCT_MEMBER(m_voices, format));
+	save_item(STRUCT_MEMBER(m_voices, fade_entry));
+}
+
+void roland_xp_device::device_reset()
+{
+	std::fill_n(m_regs.get(), 0x2000, 0);
+	std::fill_n(m_eram.get(), ERAM_SIZE, 0);
+	m_bus_written = 0;
+	std::fill(std::begin(m_iram), std::end(m_iram), 0);
+	std::fill(std::begin(m_iram_ramping), std::end(m_iram_ramping), 0);
+	for (voice &v : m_voices)
+		v = voice();
+	m_dsp = dsp_state();
+	m_dsp.latch = -0x800000;
+	std::fill(std::begin(m_landing), std::end(m_landing), 0);
+	m_landing_valid = 0;
+	m_program_dirty = true;
+	m_dsp_enabled = false;
+	m_parity = 0;
+	m_pc = 0;
+	m_cycle = 0;
+
+	m_position = 0;
+	m_strobe_a = 0;
+	m_strobe_bcd = 0;
+	std::fill(std::begin(m_port_a_out), std::end(m_port_a_out), 0);
+	for (auto &port : m_port_word)
+		port[0] = port[1] = 0;
+	m_port_a_in = 0;
+	m_port_b_in = 0;
+	m_port_in_enabled = false;
+
+	m_run_mask = 0;
+	m_run_pending = 0;
+	m_read_latch = 0;
+	m_write_latch = 0;
+	m_frame_counter = 0;
+	m_irq_event = 0;
+	m_irq_active = false;
+	m_irq_frame_used = false;
+	update_int();
+}
+
+void roland_xp_device::device_clock_changed()
+{
+	m_stream->set_sample_rate(frame_rate());
+}
+
+void roland_xp_device::device_post_load()
+{
+	m_program_dirty = true;
+}
+
+void roland_xp_device::update_int()
+{
+	if (m_irq_active != m_int_state)
+	{
+		m_int_state = m_irq_active;
+		m_int_callback(m_int_state ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+bool roland_xp_device::offer_irq(int voice, int reason)
+{
+	if (!BIT(m_regs[IRQ_STATUS >> 1], reason))
+		return true;
+	if (m_irq_active || m_irq_frame_used)
+		return false;
+
+	m_irq_event = u16((voice << 8) | reason);
+	m_irq_active = true;
+	m_irq_frame_used = true;
+	update_int();
+	return true;
+}
+
+
+//-------------------------------------------------
+//  host interface
+//-------------------------------------------------
+
+u32 roland_xp_device::page(int voice, int index) const
+{
+	const int word = page_word(voice, index);
+	return (u32(m_regs[word]) << 16) | m_regs[word | 1];
+}
+
+void roland_xp_device::set_page(int voice, int index, u32 value)
+{
+	const int word = page_word(voice, index);
+	m_regs[word] = u16(value >> 16);
+	m_regs[word | 1] = u16(value);
+}
+
+void roland_xp_device::load_latch(offs_t address)
+{
+	if (address < CRAM_BASE)
+	{
+		if (BIT(address, 1))
+			m_read_latch = page((address >> 2) & 63, address >> 8) & page_mask(address >> 8);
+	}
+	else if (address < IRAM_BASE)
+		m_read_latch = m_regs[address >> 1];
+	else if (address < IRAM3_TARGET_BASE)
+	{
+		if (BIT(address, 1))
+		{
+			const int c = host_cell(address);
+			m_read_latch = u32(m_iram[c]) & (c >= 128 ? 0x3ffffff : 0xffffff);
+		}
+	}
+	else if (address < PRAM_BASE)
+		m_read_latch = 0;
+	else if (address < RUN_MASK)
+	{
+		if (BIT(address, 1))
+			m_read_latch = ((u32(m_regs[(address >> 1) & ~1]) << 16) | m_regs[address >> 1]) & 0x0fffffff;
+	}
+	else if (address >= SEND_BASE && address < ROM_WINDOW)
+		m_read_latch = m_regs[address >> 1];
+	else if (address >= ROM_WINDOW)
+	{
+		const u32 byte = (u32(m_regs[ROM_BANK >> 1] & 0x7f) << 20) | (u32(m_regs[ROM_PAGE >> 1] & 0x3ff) << 10) | (address - ROM_WINDOW);
+		m_read_latch = m_wave_cache.read_byte(byte) | (u32(m_wave_cache.read_byte(byte + 1)) << 8);
+	}
+}
+
+u16 roland_xp_device::read(offs_t offset, u16 mem_mask)
+{
+	offs_t address = (offset << 1) & 0x3ffe;
+	u16 data = 0;
+
+	if (address >= VOICE_WINDOW && address < VOICE_WINDOW_END)
+		address = ((address - VOICE_WINDOW) >> 2) * 0x100 + (m_regs[VOICE_SELECT >> 1] & 0x3f) * 4 + (address & 2);
+	else if (address >= SEND_WINDOW && address < SEND_BASE)
+		address = SEND_BASE + ((address - SEND_WINDOW) >> 1) * 0x80 + (m_regs[VOICE_SELECT >> 1] & 0x3f) * 2;
+
+	if (address < RUN_MASK || address >= SEND_BASE)
+	{
+		if (!machine().side_effects_disabled())
+			load_latch(address);
+	}
+	else
+	{
+		if (address < ROM_SELECT && !machine().side_effects_disabled())
+			commit_run_mask();
+
+		switch (address)
+		{
+		case RUN_MASK: case RUN_MASK + 2: case RUN_MASK + 4: case RUN_MASK + 6:
+		case DSP_MODE:
+		case VOICE_SELECT:
+			break;
+		case READBACK_LOW:
+			data = m_read_latch & 0xffff;
+			break;
+		case READBACK_HIGH:
+			data = m_read_latch >> 16;
+			break;
+		case IRQ_STATUS:
+			data = m_irq_event;
+			break;
+		case IRQ_ACK:
+			if (!machine().side_effects_disabled())
+			{
+				m_irq_active = false;
+				update_int();
+			}
+			break;
+		case STATUS:
+			data = (m_regs[STATUS >> 1] & ~0x40) | (((m_regs[DIAG_SELECT >> 1] & 0x7ff) >= 0x5a0) ? 0x40 : 0);
+			break;
+		default:
+			data = m_regs[address >> 1];
+			break;
+		}
+	}
+
+	if (!machine().side_effects_disabled())
+		LOGMASKED(LOG_READ, "%s: read %04x = %04x\n", machine().describe_context(), address, data);
+	return data;
+}
+
+void roland_xp_device::write(offs_t offset, u16 data, u16 mem_mask)
+{
+	offs_t address = (offset << 1) & 0x3ffe;
+
+	if (address >= VOICE_WINDOW && address < VOICE_WINDOW_END)
+		address = ((address - VOICE_WINDOW) >> 2) * 0x100 + (m_regs[VOICE_SELECT >> 1] & 0x3f) * 4 + (address & 2);
+	else if (address >= SEND_WINDOW && address < SEND_BASE)
+		address = SEND_BASE + ((address - SEND_WINDOW) >> 1) * 0x80 + (m_regs[VOICE_SELECT >> 1] & 0x3f) * 2;
+
+	if (address < CRAM_BASE)
+	{
+		LOGMASKED(LOG_VOICE, "%s: voice %2d page %02x%s = %04x\n", machine().describe_context(), (address >> 2) & 0x3f, address >> 8, BIT(address, 1) ? "+2" : "  ", data);
+		if (!BIT(address, 1))
+			m_write_latch = data;
+		else
+		{
+			m_regs[(address >> 1) & ~1] = m_write_latch;
+			m_regs[address >> 1] = data;
+			if ((address >> 8) == TVA1_CONTROL)
+				m_voices[(address >> 2) & 0x3f].fade_entry = 1;
+		}
+	}
+	else if (address < IRAM_BASE)
+	{
+		LOGMASKED(LOG_CRAM, "%s: cram %3d = %04x\n", machine().describe_context(), (address - CRAM_BASE) >> 1, data);
+		m_regs[address >> 1] = data;
+		m_program_dirty = true;
+	}
+	else if (address < IRAM3_TARGET_BASE)
+	{
+		LOGMASKED(LOG_IRAM, "%s: iram%d %2d%s = %04x\n", machine().describe_context(), ((address - IRAM_BASE) >> 8) + 1, (address & 0xff) >> 2, BIT(address, 1) ? "+2" : "  ", data);
+		if (!BIT(address, 1))
+			m_write_latch = data;
+		else
+			write_iram(host_cell(address), (u32(m_write_latch) << 16) | data);
+	}
+	else if (address < PRAM_BASE)
+	{
+		LOGMASKED(LOG_IRAM, "%s: iram4 %2d   = %04x\n", machine().describe_context(), (address & 0xff) >> 1, data);
+		m_regs[address >> 1] = data;
+		write_iram_target(0xe0 + ((address >> 1) & 0x1f), data);
+	}
+	else if (address < RUN_MASK)
+	{
+		LOGMASKED(LOG_PRAM, "%s: pram %3d%s = %04x\n", machine().describe_context(), (address - PRAM_BASE) >> 2, BIT(address, 1) ? "+2" : "  ", data);
+		if (!BIT(address, 1))
+			m_write_latch = data;
+		else
+		{
+			m_regs[(address >> 1) & ~1] = m_write_latch;
+			m_regs[address >> 1] = data;
+			m_program_dirty = true;
+		}
+	}
+	else if (address < SEND_BASE)
+	{
+		m_regs[address >> 1] = data;
+		if (address < ROM_SELECT)
+		{
+			LOGMASKED(LOG_RUNMASK, "%s: runmask %04x = %04x\n", machine().describe_context(), address, data);
+			write_run_mask((address - RUN_MASK) >> 1, data);
+		}
+		else
+		{
+			LOGMASKED(LOG_CTRL, "%s: ctrl %04x = %04x\n", machine().describe_context(), address, data);
+			if (address == HIGHEST_VOICE)
+			{
+				m_stream->set_sample_rate(frame_rate());
+				m_program_dirty = true;
+			}
+			else if (address == DSP_CONFIG)
+				m_program_dirty = true;
+		}
+	}
+	else if (address < ROM_WINDOW)
+	{
+		LOGMASKED(LOG_MIX, "%s: mix bank %d voice %2d = %04x\n", machine().describe_context(), (address - SEND_BASE) >> 7, (address >> 1) & 0x3f, data);
+		m_regs[address >> 1] = data;
+	}
+	else
+		LOGMASKED(LOG_CTRL, "%s: window write %04x = %04x\n", machine().describe_context(), address, data);
+}
+
+void roland_xp_device::write_run_mask(int word, u16 data)
+{
+	const u64 written = u64(data) << (word * 16);
+	const u64 field = u64(0xffff) << (word * 16);
+	const u64 cleared = m_run_mask & field & ~written;
+
+	m_run_mask &= ~cleared;
+	m_run_pending = (m_run_pending & ~field) | (written & ~m_run_mask);
+
+	for (int n = word * 16; n < word * 16 + 16; n++)
+		if (BIT(cleared, n))
+			m_voices[n].phase = IDLE;
+}
+
+void roland_xp_device::commit_run_mask()
+{
+	const u64 launched = m_run_pending;
+	if (!launched)
+		return;
+
+	m_run_mask |= launched;
+	m_run_pending = 0;
+	for (int n = 0; n < MAX_VOICES; n++)
+		if (BIT(launched, n))
+			m_voices[n].phase = PRELOAD;
+}
+
+
+//-------------------------------------------------
+//  ramps
+//-------------------------------------------------
+
+s32 roland_xp_device::exp_decode(s32 value) const
+{
+	if (value == 0)
+		return 0;
+
+	const int index = (value >> 6) & 0xff;
+	const int fraction = value & 0x3f;
+	const s32 v = (((64 - fraction) * m_exp_table[index]) >> 2) + ((fraction * m_exp_table[index + 1]) >> 2);
+	return (v >> 1) >> (15 - ((value >> 14) & 15));
+}
+
+bool roland_xp_device::linear_law(int index, u32 control)
+{
+	switch (index)
+	{
+	case RAMP_PITCH: case RAMP_TVF: case RAMP_TVA1: return ((control >> 14) & 3) == 1;
+	default: return false;
+	}
+}
+
+s32 roland_xp_device::linear_step(s32 target, s32 current, int rate)
+{
+	const s32 diff = target - current;
+	return 2 * (((diff >> 3) * rate) >> 10) + (diff > 0 ? 1 : 0);
+}
+
+bool roland_xp_device::s_curve_law(int index, u32 control)
+{
+	return index == RAMP_TVA1 && ((control >> 14) & 3) >= 2;
+}
+
+void roland_xp_device::service_ramp(int n, int k, bool launching)
+{
+	const ramp_pages &rp = RAMPS[k];
+	u32 control = page(n, rp.control);
+	if (BIT(control, 17))
+		return;
+
+	const int curve = (control >> 14) & 3;
+	const bool linear = linear_law(k, control);
+	const bool s_curve = s_curve_law(k, control);
+	const int rate = control & 0xfff;
+	const bool reso = k == RAMP_RESO;
+	const u32 tpage = page(n, rp.target);
+	const s32 target = s_curve ? 0 : reso ? s32(tpage & 0x3fffe) << 2 : s32(tpage & 0x3fffe);
+	s32 current = s32(page(n, rp.current) & (reso ? 0xfffff : 0x3ffff));
+	s32 step = rp.step ? wrap20(s32(page(n, rp.step))) : 0;
+
+	const bool fresh = k == RAMP_TVA1 && m_voices[n].fade_entry;
+	if (k == RAMP_TVA1)
+		m_voices[n].fade_entry = 0;
+
+	if (launching)
+	{
+		if (linear)
+			step = linear_step(target, current, rate);
+	}
+	else if (s_curve)
+	{
+		if (curve == 2 && (!BIT(tpage, 0) || fresh))
+		{
+			set_page(n, rp.target, (u32(current) >> 1) | 1);
+			set_page(n, rp.step, 0);
+			return;
+		}
+	}
+	else if (!BIT(tpage, 0))
+	{
+		set_page(n, rp.target, tpage | 1);
+		if (linear)
+		{
+			set_page(n, rp.step, u32(linear_step(target, current, rate)) & 0xfffff);
+			return;
+		}
+	}
+
+	const u32 tick = (k == RAMP_TVA1) ? (m_frame_counter >> 1) : (m_frame_counter >> 3);
+	if (tick & hold_masks[(control >> 12) & 3])
+		return;
+	s32 parity;
+	switch (k)
+	{
+	case RAMP_TVA1: parity = (page(n, SERVICE) >> 1) & 1; break;
+	case RAMP_TVA2: parity = (m_frame_counter >> 3) & 1; break;
+	case RAMP_RESO: parity = 0; break;
+	default: parity = ((m_frame_counter >> 3) & 1) ^ 1; break;
+	}
+
+	if (s_curve)
+	{
+		const s32 previous = current;
+		const s32 next = current + ((step + parity) >> 1);
+		current = (next < 0 || next > 0x3ffff) ? 0 : next;
+		const s32 threshold = s32(tpage & 0x3fffe);
+		set_page(n, rp.step, u32(step + (previous > threshold ? -rate : rate)) & 0xfffff);
+		set_page(n, rp.current, u32(current));
+		if (previous && !current)
+		{
+			control |= 0x4000;
+			if (BIT(control, 16) && offer_irq(n, rp.reason))
+				control |= 0x20000;
+			set_page(n, rp.control, control);
+		}
+		return;
+	}
+	else if (linear)
+	{
+		if (current != target)
+		{
+			const s32 moved = current + ((step + parity) >> 1);
+			current = (target > current) ? std::min(moved, target) : std::max(moved, target);
+		}
+	}
+	else
+	{
+		const s32 diff = target - current;
+		const int quantum = reso ? 4 : 1;
+		s32 s = ((((diff / quantum) >> 3) * rate) >> 10) * quantum;
+		if ((diff > 0 && current + s < target) || (!rate && diff))
+			s += reso ? 2 : parity;
+		current = std::max(current + s, 0) & (reso ? 0xffffe : 0x3ffff);
+	}
+	set_page(n, rp.current, u32(current));
+
+	if (current == target)
+	{
+		if (BIT(control, 16) && offer_irq(n, rp.reason))
+			control |= 0x20000;
+		set_page(n, rp.control, control);
+	}
+}
+
+void roland_xp_device::update_amplitude(int n)
+{
+	const s32 tva1 = page(n, TVA1_SEED) & 0x3ffff;
+	const s32 tva2 = page(n, TVA2_SEED) & 0x3ffff;
+	s32 amplitude;
+	if (BIT(page(n, TVA2_CONTROL), 14))
+		amplitude = s32(std::clamp<s64>((s64(tva1) + tva2) << 2, 0, 0xffffe)) & ~1;
+	else
+		amplitude = s32((s64(tva1 >> 3) * (tva2 >> 4)) >> 8) & ~1;
+	set_page(n, AMPLITUDE, u32(amplitude));
+}
+
+
+//-------------------------------------------------
+//  address generator and DPCM
+//-------------------------------------------------
+
+roland_xp_device::wave_cell roland_xp_device::cell_at(int n, u32 control, u32 address)
+{
+	const u8 byte = rom_byte(control, address);
+	const voice &v = m_voices[n];
+	if (BIT(v.format, 1))
+	{
+		const int shift = (byte >> 4) & 7;
+		const int mantissa = shift ? (byte & 0x0f) + 16 : (byte & 0x0f);
+		return wave_cell{ BIT(byte, 7) ? -mantissa : mantissa, shift ? shift + 5 : 6 };
+	}
+	if (BIT(v.format, 0))
+		return wave_cell{ s8(byte), 0 };
+
+	const u8 shifts = rom_byte(control, address >> 5);
+	const int exponent = BIT(address, 4) ? (shifts >> 4) : (shifts & 0x0f);
+	return wave_cell{ exponent > 10 ? 0 : s8(byte), exponent };
+}
+
+s32 roland_xp_device::delta_of(wave_cell c)
+{
+	return c.mantissa << c.exponent;
+}
+
+s32 roland_xp_device::tap(s32 weight, wave_cell c)
+{
+	const s32 p = (weight * c.mantissa) & ~3;
+	return c.exponent <= 10 ? p >> (10 - c.exponent) : p << (c.exponent - 10);
+}
+
+void roland_xp_device::launch(int n)
+{
+	voice &v = m_voices[n];
+	u32 control = page(n, CONTROL);
+
+	v.format = (BIT(control, 9) << 1) | BIT(control, 7);
+	set_page(n, CONTROL, control | 0x80);
+
+	const u32 address = page(n, ADDRESS) & 0xfffff;
+	const u32 span = (address >> 5) & ~1;
+	set_page(n, EXPONENTS, rom_byte(control, span) | (u32(rom_byte(control, span + 1)) << 8));
+}
+
+roland_xp_device::address_step roland_xp_device::advance(int n, u32 control, address_step s) const
+{
+	const u32 loop = page(n, LOOP) & 0xfffff;
+	const u32 end = page(n, END) & 0xfffff;
+	const bool looping = loop < end;
+	const bool alternate = BIT(control, 12);
+
+	if (!s.backward)
+	{
+		if (!looping)
+			return { s.address >= end ? s.address : s.address + 1, false };
+		if (s.address >= end)
+			return alternate ? address_step{ s.address, true } : address_step{ loop, false };
+		return { s.address + 1, false };
+	}
+
+	if (s.address <= loop)
+	{
+		if (alternate && looping)
+			return { s.address, false };
+		return { s.address, true };
+	}
+	return { s.address - 1, true };
+}
+
+bool roland_xp_device::at_marker(int n, u32 control, address_step s) const
+{
+	const u32 loop = page(n, LOOP) & 0xfffff;
+	return s.backward ? (s.address <= loop) : (s.address >= loop);
+}
+
+void roland_xp_device::marker_reached(int n)
+{
+	const u32 control = page(n, CONTROL);
+	if (BIT(control, 16))
+		return;
+	if (BIT(control, 15) && !offer_irq(n, BIT(control, 14) ? IRQ_LOOP_ALTERNATE : IRQ_LOOP_REACHED))
+		return;
+
+	set_page(n, CONTROL, control | (BIT(control, 17) ? 0x10000 : 0x20000));
+}
+
+void roland_xp_device::update_mute(int n)
+{
+	const u32 control = page(n, CONTROL);
+	if (BIT(control, 19) == BIT(control, 18))
+		return;
+	if (BIT(control, 15) && !offer_irq(n, IRQ_MUTE_CHANGED))
+		return;
+
+	set_page(n, CONTROL, control ^ 0x40000);
+}
+
+
+//-------------------------------------------------
+//  the voice
+//-------------------------------------------------
+
+void roland_xp_device::deposit(int n, int bank)
+{
+	const u16 s = send(n, bank);
+	const int word = s & 63;
+	const int c = cell(0x40 + word, m_parity ^ 1);
+
+	if (!BIT(m_bus_written, word))
+	{
+		m_bus_written |= u64(1) << word;
+		m_iram[c] = 0;
+	}
+	const s32 output = running(n) ? wrap24(s32(page(n, OUTPUT))) : 0;
+	m_iram[c] = clamp24(m_iram[c] + (s64(output) * (s >> 6)) / 512);
+}
+
+void roland_xp_device::run_voice(int n)
+{
+	voice &v = m_voices[n];
+
+	if (!running(n))
+	{
+		const s32 smooth = page(n, SMOOTH) & 0xffff;
+		if (smooth)
+			set_page(n, SMOOTH, u32(std::max((smooth * 7) >> 3, 1)));
+		set_page(n, FILTER_BAND, 0);
+		set_page(n, FILTER_LOW, 0);
+		set_page(n, OUTPUT, 0);
+		return;
+	}
+
+	s32 smooth = page(n, SMOOTH) & 0xffff;
+	if (v.phase == STARTING || v.phase == RUNNING)
+	{
+		smooth = std::clamp<s32>((7 * smooth + s32((page(n, AMPLITUDE) & 0xfffff) >> 4) + 3) >> 3, 0, 0xffff);
+		set_page(n, SMOOTH, u32(smooth));
+	}
+
+	update_mute(n);
+
+	switch (v.phase)
+	{
+	case PRELOAD:
+		launch(n);
+		v.phase = INITIALIZE;
+		return;
+
+	case INITIALIZE:
+		set_page(n, INCREMENT, u32(exp_decode(page(n, PITCH_SEED) & 0x3ffff)) & 0x3ffff);
+		set_page(n, CUTOFF, u32(exp_decode(page(n, TVF_SEED) & 0x3ffff) << 2) & 0xfffff);
+		service_ramp(n, RAMP_PITCH, true);
+		set_page(n, SERVICE, (page(n, SERVICE) & 0x1f) | 0x10000);
+		v.phase = STARTING;
+		return;
+
+	case STARTING:
+		service_ramp(n, RAMP_TVF, true);
+		set_page(n, SERVICE, (page(n, SERVICE) & 0x1f) | 0x30000);
+		v.phase = RUNNING;
+		return;
+
+	default:
+		break;
+	}
+
+	const u32 service = page(n, SERVICE);
+	const int counter = (service + 1) & 7;
+	set_page(n, SERVICE, (service & ~7) | counter);
+
+	u32 control = page(n, CONTROL);
+	const bool halted = BIT(control, 10);
+	s32 sample = 0;
+	if (!halted)
+	{
+		const u32 packed = page(n, PHASE);
+		u32 phase = (packed >> 4) & 0x3fff;
+		u32 address = page(n, ADDRESS) & 0xfffff;
+		s32 predictor = wrap18(s32(page(n, PREDICTOR)));
+		const bool backward = BIT(control, 11) ^ BIT(control, 13);
+
+		address_step s{ address, backward };
+		s32 sum = 4 * predictor;
+		for (int i = 0; i < 3; i++)
+		{
+			sum += tap(interp_weights[i][phase >> 7], cell_at(n, control, s.address));
+			s = advance(n, control, s);
+		}
+		sample = wrap20(sum) >> (3 - ((service >> 3) & 3));
+
+		const u32 increment = page(n, INCREMENT) & 0x3ffff;
+		const u32 span = address >> 6;
+		u32 accumulated = phase + (increment >> 2) + (((increment & 3) > phase_dither[m_frame_counter & 3]) ? 1 : 0);
+		phase = accumulated & 0x3fff;
+		address_step current{ address, backward };
+		for (u32 carry = accumulated >> 14; carry; carry--)
+		{
+			predictor = wrap18(predictor + delta_of(cell_at(n, control, current.address)));
+			if (at_marker(n, control, current))
+				marker_reached(n);
+			const address_step next = advance(n, control, current);
+			if (next.backward != current.backward)
+			{
+				control ^= 0x2000;
+				set_page(n, CONTROL, control);
+			}
+			current = next;
+		}
+		if ((current.address >> 6) != span)
+		{
+			const u32 exponents = (current.address >> 5) & ~1;
+			set_page(n, EXPONENTS, rom_byte(control, exponents) | (u32(rom_byte(control, exponents + 1)) << 8));
+		}
+		set_page(n, PHASE, (phase << 4) | ((packed + (accumulated >> 14)) & 15));
+		set_page(n, ADDRESS, current.address);
+		set_page(n, PREDICTOR, u32(predictor) & 0x3ffff);
+	}
+
+	if (counter == 6)
+	{
+		set_page(n, INCREMENT, u32(exp_decode(page(n, PITCH_SEED) & 0x3ffff)) & 0x3ffff);
+		set_page(n, CUTOFF, u32(exp_decode(page(n, TVF_SEED) & 0x3ffff) << 2) & 0xfffff);
+	}
+
+	if (counter & 1)
+	{
+		update_amplitude(n);
+		service_ramp(n, RAMP_TVA1, false);
+	}
+	else
+	{
+		switch (counter)
+		{
+		case 0:
+			service_ramp(n, RAMP_TVA2, false);
+			break;
+		case 2:
+			service_ramp(n, RAMP_RESO, false);
+			break;
+		case 4:
+		{
+			const u32 tpage = page(n, TVF_TARGET);
+			const u32 cutoff = page(n, TVF_SEED) & 0x3ffff;
+			if (!BIT(tpage, 0) || cutoff != (tpage & 0x3fffe))
+				set_page(n, CUTOFF, u32(exp_decode(s32(cutoff)) << 2) & 0xfffff);
+			service_ramp(n, RAMP_TVF, false);
+			break;
+		}
+		default:
+			service_ramp(n, RAMP_PITCH, false);
+			break;
+		}
+	}
+
+	if (halted)
+		return;
+
+	const s32 f = page(n, CUTOFF) & 0xfffff;
+	const s32 q = page(n, RESO_SEED) & 0xfffff;
+	s32 low = wrap24(s32(page(n, FILTER_LOW)));
+	s32 band = wrap24(s32(page(n, FILTER_BAND)));
+	low = clamp24(low + (s64(f) * band) / (1 << 19));
+	const s32 high = clamp24(sample - (s32((s64(q) * band) / (1 << 19)) + low));
+	band = clamp24(band + (s64(f) * high) / (1 << 19));
+	set_page(n, FILTER_LOW, u32(low) & 0xffffff);
+	set_page(n, FILTER_BAND, u32(band) & 0xffffff);
+	switch ((page(n, FILTER) >> 10) & 3)
+	{
+	case 0: sample = low; break;
+	case 1: sample = band; break;
+	case 2: sample = high; break;
+	case 3: sample = clamp24(s64(high) - low); break;
+	}
+
+	set_page(n, OUTPUT, u32(clamp24((s64(sample) * (smooth << 4)) / (1 << 19))) & 0xffffff);
+}
+
+
+//-------------------------------------------------
+//  the DSP
+//-------------------------------------------------
+
+int roland_xp_device::cell(int word, int parity) const
+{
+	if (word < 0x80)
+		return ((BIT(word, 6) ^ parity) << 6) | (word & 0x3f);
+	if (word < 0xc0)
+		return (BIT(word, 5) << 6) | 0x20 | (word & 0x1f);
+	return 0x80 | (word & 0x3f);
+}
+
+s32 roland_xp_device::gain_goal(s32 cell)
+{
+	const int target = cell & 0x3ff;
+	s32 goal = s16(u16(target << 6));
+	if (target > 0 && target < 0x1ff)
+		goal++;
+	return goal;
+}
+
+s32 roland_xp_device::fold24(s32 value)
+{
+	u32 v = u32(value) & 0xffffff;
+	if (BIT(v, 23) != BIT(v, 22))
+		v ^= 0x7fffff;
+	return wrap24(s32(v));
+}
+
+s32 roland_xp_device::wire_word(s32 word) const
+{
+	return clamp24(word) & (BIT(m_regs[SERIAL_FORMAT >> 1], 5) ? ~0x3ff : ~0x3f);
+}
+
+void roland_xp_device::write_iram(int c, u32 value)
+{
+	m_iram[c] = c >= 0x80 ? s32(value << 6) >> 6 : wrap24(s32(value));
+	if (c >= 0x80)
+		m_iram_ramping[c & 0x3f] = 0;
+}
+
+void roland_xp_device::write_iram_target(int word, u16 value)
+{
+	const int c = cell(word);
+	if (word >= ramp_base())
+	{
+		m_iram[c] = (m_iram[c] & ~0x3ff) | (value & 0x3ff);
+		m_iram_ramping[c & 0x3f] = 1;
+	}
+	else
+	{
+		m_iram[c] = value;
+		m_iram_ramping[c & 0x3f] = 0;
+	}
+}
+
+void roland_xp_device::update_iram_ramps()
+{
+	if (!(m_frame_counter & 1))
+		return;
+
+	const int threshold = bit_reverse4((m_frame_counter >> 1) & 15);
+	for (int word = ramp_base(); word < 256; word++)
+	{
+		const int c = cell(word);
+		if (!m_iram_ramping[c & 0x3f])
+			continue;
+
+		const s32 code = m_iram[c] & 0x3ff;
+		if (code == 0x200)
+		{
+			m_iram_ramping[c & 0x3f] = 0;
+			continue;
+		}
+
+		const s32 goal = gain_goal(m_iram[c]);
+		s32 current = gain_current(m_iram[c]);
+		const s32 diff = goal - current;
+		if (diff)
+		{
+			const s64 product = s64(std::abs(diff)) * m_regs[(IRAM3_RATE >> 1) + (word & 3)];
+			s32 step = s32(product >> 17);
+			int fraction = int(((product & 0x1ffff) + 0x1000) >> 13);
+			if (fraction >= 16)
+			{
+				step++;
+				fraction -= 16;
+			}
+			if (diff > 0)
+			{
+				if (threshold < fraction)
+					step++;
+				current = std::min(current + step, goal);
+			}
+			else
+			{
+				if (threshold >= 16 - fraction)
+					step++;
+				if (!step)
+					step = 2;
+				current = std::max(current - step, goal);
+			}
+			m_iram[c] = ((current << 10) | code) & 0x3ffffff;
+		}
+		if (current == goal)
+			m_iram_ramping[c & 0x3f] = 0;
+	}
+}
+
+void roland_xp_device::decode_program()
+{
+	for (int i = 0; i < DSP_SLOTS; i++)
+	{
+		const u32 w = (u32(m_regs[(PRAM_BASE >> 1) + i * 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 1];
+		const u16 c = m_regs[(CRAM_BASE >> 1) + i];
+		const s32 mantissa = s32(s16(c << 2)) >> 2;
+		dsp_slot &s = m_program[i];
+		s.st = (w >> 14) & 3;
+		s.word = (w >> 6) & 0xff;
+		s.input = (w >> 4) & 3;
+		s.function = w & 0xf;
+		s.ext = (w >> 25) & 7;
+		s.eram_op = 0;
+		s.eram_second = 0;
+		s.eram_offset = 0;
+		s.cram = c;
+		s.coefficient = mantissa << shift_select[c >> 14];
+		s.raw = BIT(c, 15) ? s32((c & 0x3fff) << 13) : mantissa;
+	}
+
+	for (int i = 0; i < DSP_SLOTS - 1; )
+	{
+		const u32 w = (u32(m_regs[(PRAM_BASE >> 1) + i * 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 1];
+		const u32 next = (u32(m_regs[(PRAM_BASE >> 1) + i * 2 + 2]) << 16) | m_regs[(PRAM_BASE >> 1) + i * 2 + 3];
+		const int op = (w >> 23) & 3;
+		if (op)
+		{
+			m_program[i].eram_op = op;
+			m_program[i].eram_offset = (((w >> 16) & 0x7f) << 9) | ((next >> 16) & 0x1ff);
+			m_program[i + 1].eram_second = 1;
+			i += 2;
+		}
+		else
+			i++;
+	}
+
+	m_program_dirty = false;
+}
+
+s32 roland_xp_device::operand(const dsp_slot &s) const
+{
+	const dsp_state &d = m_dsp;
+
+	switch (s.input)
+	{
+	case INPUT_PREVIOUS: return d.input;
+	case INPUT_ACC: return clamp24(d.acc);
+	case INPUT_R: return d.r;
+	default: return d.latch;
+	}
+}
+
+s32 roland_xp_device::factor(int select, bool complement) const
+{
+	const s32 acc = clamp24(m_dsp.acc);
+	s32 f;
+
+	switch (select)
+	{
+	case 0: f = (acc & 0xfff) << 3; return complement ? 0x7fff - f : f;
+	case 1: f = (acc & 0x7fffff) >> 8; return complement ? 0x7fff - f : f;
+	case 2: f = acc >> 8; return complement ? ~f : f;
+	default: f = m_dsp.gain; return complement ? ~f : f;
+	}
+}
+
+// the ALU functions both encodings share; returns whether the function is one of them
+bool roland_xp_device::alu(int function, int mode, s32 immediate)
+{
+	dsp_state &d = m_dsp;
+	const s32 p = d.product;
+	const s32 r = d.r;
+	s64 result;
+
+	switch (function)
+	{
+	case 0x1: return true;
+	case 0x2: result = s64(d.acc) + r; break;
+	case 0x3: result = s64(d.acc) + p; break;
+	case 0x4: result = r; break;
+	case 0x5: result = p; break;
+	case 0x6: result = -s64(d.acc); break;
+	case 0x7: result = s64(r) - d.acc; break;
+	case 0x8: result = s64(p) - d.acc; break;
+	case 0x9: result = s64(r) + p; break;
+	case 0xa: result = std::min(d.acc, r); break;
+	case 0xb: result = std::max(d.acc, r); break;
+
+	case 0xc:
+		if (mode == 2)
+			result = s64(d.acc) + (p >> 13);
+		else if (mode == 3)
+			result = p >> 13;
+		else
+			return true;
+		break;
+
+	case 0xd:
+		switch (mode)
+		{
+		case 0: result = d.acc & immediate; break;
+		case 1: result = d.acc | immediate; break;
+		case 2: result = d.acc ^ immediate; break;
+		default: return true;
+		}
+		break;
+
+	case 0xe:
+		if (mode == 0)
+			result = std::min(d.acc, immediate);
+		else if (mode == 1)
+			result = std::max(d.acc, immediate);
+		else
+			return true;
+		break;
+
+	case 0xf:
+		switch (mode)
+		{
+		case 0: result = s64(d.acc) + immediate; break;
+		case 1: result = s64(r) + immediate; break;
+		case 2: result = s64(p) + immediate; break;
+		default: result = s64(immediate) - d.acc; break;
+		}
+		break;
+
+	default:
+		return false;
+	}
+
+	d.acc = wrap29(result);
+	return true;
+}
+
+void roland_xp_device::parallel_op(const dsp_slot &s)
+{
+	dsp_state &d = m_dsp;
+	const u16 c = s.cram;
+	const int function = c & 0xf;
+	const int input_select = (c >> 4) & 3;
+	const int factor_select = (c >> 6) & 3;
+	const bool complement = BIT(c, 8);
+	const bool multiply_issued = BIT(c, 9);
+	const int post = (c >> 11) & 7;
+	const int shift = shift_select[c >> 14];
+	const s32 p = d.product;
+	const s32 r = d.r;
+	s32 input, product;
+
+	if (!multiply_issued)
+	{
+		input = d.now_valid ? d.now : 0;
+		product = input;
+	}
+	else
+	{
+		switch (input_select)
+		{
+		case 0: input = d.input; break;
+		case 1: input = clamp24(d.acc); break;
+		case 2: input = r; break;
+		default: input = d.latch; break;
+		}
+		product = multiply_q15(input, factor(factor_select, complement), shift);
+	}
+
+	s64 result = d.acc;
+	switch (function)
+	{
+	case 0x0: result = s64(d.acc) + p + r; break;
+	case 0xc: result = s64(r) + p - d.acc; break;
+	case 0xd: result = s64(d.acc) + p - r; break;
+	case 0xe: result = s64(p) - r - d.acc; break;
+	case 0xf: result = s64(p) - r; break;
+	default:
+		alu(function, input_select, s.raw);
+		result = d.acc;
+		break;
+	}
+	d.acc = wrap29(result);
+
+	switch (post)
+	{
+	case 1:
+		d.acc = std::abs(d.acc);
+		break;
+
+	case 2:
+		d.acc = wrap24(d.acc);
+		break;
+
+	case 3:
+	{
+		const u32 v = u32(d.acc) & 0xffffff;
+		d.acc = wrap24(s32((v << 1) | (((v >> 23) ^ (v >> 6) ^ (v >> 1)) & 1)));
+		break;
+	}
+
+	case 4:
+		d.acc = fold24(d.acc);
+		break;
+
+	case 5:
+		d.acc = wrap24(d.acc);
+		if (d.acc < 0)
+			d.acc = ~d.acc;
+		break;
+
+	default:
+		break;
+	}
+
+	if (BIT(c, 10))
+		d.acc = wrap24(d.acc);
+
+	d.input = input;
+	d.product = product;
+}
+
+void roland_xp_device::execute(const dsp_slot &s)
+{
+	dsp_state &d = m_dsp;
+
+	if (s.special(SPECIAL_PARALLEL))
+	{
+		parallel_op(s);
+		return;
+	}
+
+	const bool multiply_issued = s.function >= 1 && s.function <= 0xc;
+
+	s32 input = 0, product = 0;
+	if (multiply_issued)
+	{
+		if (s.function == 0xc && s.input == INPUT_PREVIOUS)
+			input = m_port_a_in;
+		else if (s.function == 0xc && s.input == INPUT_ACC)
+			input = m_port_b_in;
+		else
+			input = operand(s);
+		product = multiply(input, s.coefficient);
+	}
+
+	alu(s.function, s.input, s.raw);
+
+	if (s.special(SPECIAL_BRANCH))
+	{
+		const int condition = (s.cram >> 10) & 0xf;
+		bool taken;
+		switch (condition)
+		{
+		case 0: taken = d.acc == 0; break;
+		case 1: taken = d.acc != 0; break;
+		case 3: case 5: case 13: case 14: taken = true; break;
+		case 6: case 8: taken = d.acc >= 0; break;
+		case 7: case 9: taken = d.acc < 0; break;
+		case 10: taken = d.acc > 0; break;
+		case 11: taken = d.acc <= 0; break;
+		default: taken = false; break;
+		}
+		if (taken)
+			m_pc = u16((BIT(s.cram, 9) ? m_pc + 1 + s8(s.cram) : (s.cram & 0xff)) % DSP_SLOTS) - 1;
+	}
+
+	if (multiply_issued)
+	{
+		d.input = input;
+		d.product = product;
+	}
+}
+
+// a strobe presents the previous frame's word at the frame's word position, and the ports
+// take their inputs after the strobe's instruction has run
+void roland_xp_device::strobe(const dsp_slot &s)
+{
+	if (s.ext != 1 && s.ext != 2)
+		return;
+
+	const s32 word = clamp24(m_iram[cell(m_position, m_parity ^ 1)]);
+	m_position++;
+
+	if (s.ext == 1)
+	{
+		m_port_a_out[m_strobe_a] = word;
+		m_port_a_in = (m_port_in_enabled && !m_port_a_in_cb.isunset()) ? wrap24(s32(m_port_a_in_cb(m_strobe_a))) : 0;
+		m_strobe_a++;
+		return;
+	}
+
+	const int port = m_strobe_bcd % 3;
+	const int half = (m_strobe_bcd / 3) & 1;
+	m_strobe_bcd++;
+
+	const int descriptor = port == PORT_B ? (m_regs[SERIAL_CONFIG >> 1] >> 8) : (m_regs[DSP_CONFIG >> 1] & 0xff);
+	const s32 out = (descriptor & 0xc0) ? wire_word(word) : 0;
+	m_port_word[port][half] = out;
+	if ((descriptor & 0xc0) && (m_regs[DSP_MODE >> 1] & 3) == 3 && !m_port_out_cb.isunset())
+		m_port_out_cb(port * 2 + half, u32(out));
+
+	if (port == PORT_B)
+		m_port_b_in = (m_port_in_enabled && !m_port_b_in_cb.isunset()) ? wrap24(s32(m_port_b_in_cb(half))) : 0;
+}
+
+u32 roland_xp_device::port_a_out_r(int strobe)
+{
+	return strobe < DSP_SLOTS ? u32(m_port_a_out[strobe]) : 0;
+}
+
+void roland_xp_device::dsp_frame_start()
+{
+	m_bus_written = 0;
+	m_irq_frame_used = false;
+	m_position = 0;
+	m_strobe_a = 0;
+	m_strobe_bcd = 0;
+	m_pc = 0;
+
+	m_dsp_enabled = BIT(m_regs[DSP_MODE >> 1], 2);
+	m_port_in_enabled = BIT(m_regs[DSP_MODE >> 1], 1);
+	if (!m_dsp_enabled)
+	{
+		for (auto &port : m_port_word)
+			port[0] = port[1] = 0;
+		return;
+	}
+
+	if (m_program_dirty)
+		decode_program();
+
+	update_iram_ramps();
+	m_dsp.product = 0;
+}
+
+void roland_xp_device::dsp_step()
+{
+	if (!m_dsp_enabled)
+		return;
+
+	const dsp_slot &s = m_program[m_pc];
+	dsp_state &d = m_dsp;
+
+	if (BIT(m_landing_valid, 0))
+		d.latch = m_landing[0];
+	m_landing[0] = m_landing[1];
+	m_landing_valid >>= 1;
+
+	if (s.eram_op == 1)
+	{
+		m_landing[1] = m_eram[(s.eram_offset + d.cursor) & 0xffff];
+		m_landing_valid |= 2;
+	}
+	else if (s.special(SPECIAL_INDEXED_READ) && !s.eram_second)
+	{
+		m_landing[1] = m_eram[(d.cursor + (d.acc >> 12)) & 0xffff];
+		m_landing_valid |= 2;
+	}
+
+	d.now_valid = 0;
+	s32 gain_pending = 0;
+	bool gain_arrives = false;
+	if (s.st == 1)
+	{
+		const s32 v = m_iram[cell(s.word)];
+		if (s.word >= ramp_base())
+		{
+			gain_pending = gain_current(v);
+			gain_arrives = true;
+		}
+		else
+		{
+			d.now = v;
+			d.now_valid = 1;
+		}
+	}
+
+	const s32 acc_before = d.acc;
+	const s32 r_before = d.r;
+	execute(s);
+
+	if (gain_arrives)
+		d.gain = gain_pending;
+	if (d.now_valid)
+		d.r = d.now;
+
+	if (s.st == 2)
+		m_iram[cell(s.word)] = d.latch;
+	else if (s.st == 3)
+		m_iram[cell(s.word)] = clamp24(acc_before);
+
+	if (s.eram_op == 3)
+		m_eram[(s.eram_offset + d.cursor) & 0xffff] = clamp24(acc_before);
+	else if (s.eram_op == 2)
+		m_eram[(s.eram_offset + d.cursor) & 0xffff] = clamp24(r_before);
+
+	strobe(s);
+
+	m_pc = (m_pc + 1) % DSP_SLOTS;
+}
+
+void roland_xp_device::frame_end()
+{
+	m_parity ^= 1;
+	if (m_dsp_enabled)
+		m_dsp.cursor--;
+	m_frame_counter++;
+	m_cycle = 0;
+}
+
+// one cycle of the frame: voice n's four cycles carry its deposits and its own run
+void roland_xp_device::cycle()
+{
+	if (!m_cycle)
+		dsp_frame_start();
+
+	const int n = m_cycle >> 2;
+	if (n < voice_count())
+	{
+		switch (m_cycle & 3)
+		{
+		case 0:
+			deposit(n, 0);
+			break;
+		case 2:
+			deposit(n, 1);
+			deposit(n, 2);
+			break;
+		case 3:
+			deposit(n, 3);
+			run_voice(n);
+			break;
+		default:
+			break;
+		}
+	}
+
+	debugger_instruction_hook(m_pc);
+	dsp_step();
+
+	if (++m_cycle >= slot_count())
+		frame_end();
+}
+
+void roland_xp_device::execute_run()
+{
+	if (m_pumped)
+	{
+		m_icount = 0;
+		return;
+	}
+
+	while (m_icount > 0)
+	{
+		cycle();
+		m_icount--;
+
+		if (!m_cycle)
+			m_frame_cb(1);
+	}
+}
+
+void roland_xp_device::run_frame()
+{
+	do
+		cycle();
+	while (m_cycle);
+}
+
+void roland_xp_device::sound_stream_update(sound_stream &stream)
+{
+	for (int port = 0; port < OUTPUT_PORTS; port++)
+		for (int half = 0; half < 2; half++)
+			stream.put_int(port * 2 + half, 0, m_port_word[port][half], 1 << 23);
+}

--- a/src/devices/sound/roland_xp.h
+++ b/src/devices/sound/roland_xp.h
@@ -1,0 +1,329 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr, giulioz
+#ifndef MAME_SOUND_ROLAND_XP_H
+#define MAME_SOUND_ROLAND_XP_H
+
+#pragma once
+
+#include "roland_xpd.h"
+
+class roland_xp_device : public cpu_device, public device_sound_interface, public roland_xp_disassembler::info
+{
+public:
+	static constexpr feature_type imperfect_features() { return feature::SOUND; }
+
+	// the wave ROM, the internal RAM and the external delay RAM, beside the program
+	enum { AS_WAVE = AS_DATA, AS_IRAM = AS_IO, AS_ERAM = AS_OPCODES + 1 };
+
+	static constexpr int MAX_VOICES = 64;
+	static constexpr int BUS_COUNT = 64;
+	static constexpr int DSP_SLOTS = 288;
+	static constexpr int DSP_BUDGET = 256;
+	static constexpr int IRAM_CELLS = 192;
+	static constexpr int ERAM_SIZE = 0x10000;
+	static constexpr int OUTPUT_PORTS = 3;
+	static constexpr int OUTPUTS = OUTPUT_PORTS * 2;
+
+	// the serial ports the `ext=2` strobes clock out on, in the order of the stream's channel pairs;
+	// port A, the six-line bus the `ext=1` strobes clock, has its own interface below
+	enum output_port { PORT_B = 0, PORT_C = 1, PORT_D = 2 };
+
+	// the per-voice pages, by page number
+	enum page_index
+	{
+		CONTROL = 0x00, ADDRESS = 0x01, LOOP = 0x02, END = 0x03, EXPONENTS = 0x04,
+		PREDICTOR = 0x0c, INCREMENT = 0x0d, PHASE = 0x0e, SERVICE = 0x10,
+		RESO_TARGET = 0x11, PITCH_TARGET = 0x12, TVF_TARGET = 0x13, TVA2_TARGET = 0x14, TVA1_TARGET = 0x15,
+		RESO_CONTROL = 0x16, PITCH_CONTROL = 0x17, TVF_CONTROL = 0x18, TVA2_CONTROL = 0x19, TVA1_CONTROL = 0x1a,
+		PITCH_SEED = 0x1b, TVF_SEED = 0x1c, TVA2_SEED = 0x1d, TVA1_SEED = 0x1e,
+		FILTER = 0x20, RESO_SEED = 0x21, CUTOFF = 0x22, AMPLITUDE = 0x23,
+		PITCH_STEP = 0x24, TVF_STEP = 0x25, TVA1_STEP = 0x26, SMOOTH = 0x27,
+		FILTER_BAND = 0x28, FILTER_LOW = 0x29, OUTPUT = 0x2a
+	};
+
+	// the control block and the other blocks, by byte address
+	enum register_address
+	{
+		CRAM_BASE = 0x2c00, IRAM_BASE = 0x3000, IRAM3_BASE = 0x3200, IRAM3_TARGET_BASE = 0x3300, PRAM_BASE = 0x3400,
+		RUN_MASK = 0x3900, ROM_SELECT = 0x3908, READBACK_LOW = 0x3910, READBACK_HIGH = 0x3912, HIGHEST_VOICE = 0x3914,
+		DSP_MODE = 0x3916, IRQ_STATUS = 0x3918, IRQ_ACK = 0x391a, STATUS = 0x391c, ROM_PAGE = 0x3920, ROM_BANK = 0x3922,
+		SERIAL_CONFIG = 0x3924, DSP_CONFIG = 0x3926, IRAM3_RATE = 0x3928, DIAG_SELECT = 0x3930, SERIAL_FORMAT = 0x3932,
+		VOICE_SELECT = 0x3934, VOICE_WINDOW = 0x3940, VOICE_WINDOW_END = 0x39f0, SEND_WINDOW = 0x39f8,
+		SEND_BASE = 0x3a00, ROM_WINDOW = 0x3c00
+	};
+
+	// one per interrupt source, as the status word reports them
+	enum irq_reason
+	{
+		IRQ_RESO_DONE = 0, IRQ_TVF_DONE = 1, IRQ_PITCH_DONE = 2, IRQ_TVA2_DONE = 3, IRQ_VOICE_DONE = 4,
+		IRQ_LOOP_REACHED = 5, IRQ_LOOP_ALTERNATE = 6, IRQ_FETCH_OVERLOAD = 7, IRQ_MUTE_CHANGED = 8,
+		IRQ_REASONS = 16
+	};
+
+	roland_xp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	auto int_callback() { return m_int_callback.bind(); }
+
+	// a word clocked out on port B, C or D (SDOB, SDOC, SDOD): the offset is port * 2 + half, the word
+	// the 24-bit word with the bits the wire does not carry cleared.  The stream carries the same six words.
+	auto port_out_callback() { return m_port_out_cb.bind(); }
+
+	// port A, the six-line bidirectional bus (SDIA0-5, SDOA0-5): the input is taken once per `ext=1`
+	// strobe and the argument is the strobe's ordinal in the frame; what this chip presented at that
+	// strobe in its last frame is port_a_out_r() -- the SC-8850's two chips read each other through it
+	auto port_a_in_callback() { return m_port_a_in_cb.bind(); }
+	u32 port_a_out_r(int strobe);
+
+	// port B's input (SDIB), sampled once per three-strobe group; the argument is the group's ordinal
+	auto port_b_in_callback() { return m_port_b_in_cb.bind(); }
+
+	// a chip whose frame another device clocks, as the SC-8850's slave is clocked by its master:
+	// execute_run() stands still and run_frame() is one frame
+	void set_pumped(bool pumped) { m_pumped = pumped; }
+	void run_frame();
+	auto frame_callback() { return m_frame_cb.bind(); }
+
+	u16 read(offs_t offset, u16 mem_mask = ~0);
+	void write(offs_t offset, u16 data, u16 mem_mask = ~0);
+
+	// roland_xp_disassembler::info implementation
+	virtual u16 xpd_cram_r(offs_t address) const override { return m_regs[(CRAM_BASE >> 1) + (address % DSP_SLOTS)]; }
+	virtual int xpd_ramp_base() const override { return ramp_base(); }
+
+protected:
+	// device_t implementation
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_clock_changed() override;
+	virtual void device_post_load() override;
+
+	// device_execute_interface implementation
+	virtual u64 execute_clocks_to_cycles(u64 clocks) const noexcept override { return (clocks + 1) / 3; }
+	virtual u64 execute_cycles_to_clocks(u64 cycles) const noexcept override { return cycles * 3; }
+	virtual u32 execute_min_cycles() const noexcept override { return 1; }
+	virtual u32 execute_max_cycles() const noexcept override { return 1; }
+	virtual void execute_run() override;
+
+	// device_memory_interface implementation
+	virtual space_config_vector memory_space_config() const override;
+
+	// device_disasm_interface implementation
+	virtual std::unique_ptr<util::disasm_interface> create_disassembler() override;
+
+	// device_sound_interface implementation
+	virtual void sound_stream_update(sound_stream &stream) override;
+
+	enum ramp_index { RAMP_PITCH, RAMP_TVF, RAMP_RESO, RAMP_TVA2, RAMP_TVA1 };
+	enum ramp_law { LAW_LINEAR, LAW_EXPONENTIAL, LAW_S_CURVE };
+	enum launch_phase { IDLE, PRELOAD, INITIALIZE, STARTING, RUNNING };
+
+	// the pages a ramp lives in
+	struct ramp_pages
+	{
+		u8 current;
+		u8 control;
+		u8 target;
+		u8 step;
+		u8 reason;
+	};
+
+	// what a voice keeps outside its pages
+	struct voice
+	{
+		u8 phase = IDLE;
+		u8 format = 0;
+		u8 fade_entry = 0;
+	};
+
+	static const ramp_pages RAMPS[5];
+
+	struct address_step
+	{
+		u32 address;
+		bool backward;
+	};
+
+	struct wave_cell
+	{
+		s32 mantissa;
+		int exponent;
+	};
+
+	// one decoded DSP instruction with its coefficient
+	// the multiply input a slot's col[5:4] selects
+	enum dsp_input { INPUT_PREVIOUS = 0, INPUT_ACC = 1, INPUT_R = 2, INPUT_LATCH = 3 };
+
+	// what col[5:4] selects instead when the function is 0
+	enum dsp_special { SPECIAL_NOP = 0, SPECIAL_BRANCH = 1, SPECIAL_INDEXED_READ = 2, SPECIAL_PARALLEL = 3 };
+
+	struct dsp_slot
+	{
+		u8 st;
+		u8 word;
+		u8 input;
+		u8 function;
+		u8 ext;
+		u8 eram_op;
+		u8 eram_second;
+		u16 eram_offset;
+		u16 cram;
+		s32 coefficient;
+		s32 raw;
+
+		bool special(dsp_special which) const { return function == 0 && input == which; }
+	};
+
+	// the DSP datapath registers that live across slots and samples
+	struct dsp_state
+	{
+		s32 acc = 0;
+		s32 product = 0;
+		s32 product_prev = 0;
+		s32 r = 0;
+		s32 input = 0;
+		s32 input_prev = 0;
+		s32 now = 0;
+		s32 latch = 0;
+		s32 gain = 0;
+		u8 now_valid = 0;
+		u16 cursor = 0;
+	};
+
+	s32 exp_decode(s32 value) const;
+
+	int voice_count() const { return (m_regs[HIGHEST_VOICE >> 1] & 0x3f) + 1; }
+	int slot_count() const { return voice_count() * 4; }
+	int ramp_base() const { return 256 - ((m_regs[DSP_CONFIG >> 1] >> 8) & 0x1f); }
+	u32 frame_rate() const { return clock() / (3 * slot_count()); }
+
+	static int page_word(int voice, int index) { return ((index & 0xff) << 7) | ((voice & 63) << 1); }
+	u32 page(int voice, int index) const;
+	void set_page(int voice, int index, u32 value);
+	u16 send(int voice, int bank) const { return m_regs[(SEND_BASE >> 1) + (bank & 3) * 64 + (voice & 63)]; }
+	bool running(int voice) const { return BIT(m_run_mask, voice & 63); }
+
+	void write_run_mask(int word, u16 data);
+	void commit_run_mask();
+	void load_latch(offs_t address);
+	void update_int();
+	bool offer_irq(int voice, int reason);
+	void marker_reached(int voice);
+	void update_mute(int voice);
+
+	static bool linear_law(int index, u32 control);
+	static s32 linear_step(s32 target, s32 current, int rate);
+	static bool s_curve_law(int index, u32 control);
+	void service_ramp(int voice, int index, bool launching);
+	void update_amplitude(int voice);
+
+	u8 rom_byte(int region, u32 offset) { return m_wave_cache.read_byte((u32(region & 0x7f) << 20) | (offset & 0xfffff)); }
+	wave_cell cell_at(int voice, u32 control, u32 address);
+	static s32 delta_of(wave_cell c);
+	static s32 tap(s32 weight, wave_cell c);
+	void launch(int voice);
+	address_step advance(int voice, u32 control, address_step s) const;
+	bool at_marker(int voice, u32 control, address_step s) const;
+	void deposit(int voice, int bank);
+	void run_voice(int voice);
+
+	static s32 clamp24(s64 value) { return s32(std::clamp<s64>(value, -0x800000, 0x7fffff)); }
+	static s32 clamp29(s64 value) { return s32(std::clamp<s64>(value, -0x10000000, 0x0fffffff)); }
+	static s32 wrap29(s64 value) { return s32(s64(u64(value) << 35) >> 35); }
+	static s32 wrap24(s32 value) { return s32(u32(value) << 8) >> 8; }
+	static s32 wrap20(s32 value) { return s32(u32(value) << 12) >> 12; }
+	static s32 wrap18(s32 value) { return s32(u32(value) << 14) >> 14; }
+	static s32 fold24(s32 value);
+	static s32 multiply(s32 operand, s32 coefficient) { return clamp29((s64(operand) * coefficient) / 8192); }
+	static s32 multiply_q15(s32 operand, s32 factor, int shift) { return clamp29(((s64(operand) * factor) << shift) / 32768); }
+	static s32 gain_current(s32 cell) { return s16(cell >> 10); }
+	static s32 gain_goal(s32 cell);
+	int cell(int word, int parity) const;
+	int cell(int word) const { return cell(word, m_parity); }
+	static int host_cell(offs_t address) { return (address - IRAM_BASE) >> 2; }
+	s32 wire_word(s32 word) const;
+	void write_iram(int cell, u32 value);
+	void write_iram_target(int word, u16 value);
+	void decode_program();
+	void update_iram_ramps();
+	static const char *unimplemented(const dsp_slot &s);
+	s32 operand(const dsp_slot &s) const;
+	s32 factor(int select, bool complement) const;
+	bool alu(int function, int mode, s32 immediate);
+	void parallel_op(const dsp_slot &s);
+	void execute(const dsp_slot &s);
+	void strobe(const dsp_slot &s);
+	void dsp_frame_start();
+	void dsp_step();
+	void frame_end();
+	void cycle();
+
+	void pram_map(address_map &map) ATTR_COLD;
+	void iram_map(address_map &map) ATTR_COLD;
+	void eram_map(address_map &map) ATTR_COLD;
+
+	u32 pram_r(offs_t address);
+	void pram_w(offs_t address, u32 data);
+	u32 iram_r(offs_t address) { return m_iram[address % IRAM_CELLS] & 0x3ffffff; }
+	void iram_w(offs_t address, u32 data) { write_iram(address % IRAM_CELLS, data); }
+	u32 eram_r(offs_t address) { return m_eram[address & 0xffff] & 0xffffff; }
+	void eram_w(offs_t address, u32 data) { m_eram[address & 0xffff] = wrap24(data); }
+
+	address_space_config m_pram_config;
+	address_space_config m_wave_config;
+	address_space_config m_iram_config;
+	address_space_config m_eram_config;
+	memory_access<27, 0, 0, ENDIANNESS_LITTLE>::cache m_wave_cache;
+
+	devcb_write_line m_int_callback;
+	devcb_write32 m_port_out_cb;
+	devcb_read32 m_port_a_in_cb;
+	devcb_read32 m_port_b_in_cb;
+	devcb_write_line m_frame_cb;
+
+	sound_stream *m_stream;
+
+	std::unique_ptr<u16[]> m_regs;
+	struct voice m_voices[MAX_VOICES];
+	u64 m_bus_written;
+
+	u64 m_run_mask;
+	u64 m_run_pending;
+	u32 m_read_latch;
+	u16 m_write_latch;
+	u32 m_frame_counter;
+
+	u16 m_irq_event;
+	bool m_irq_active;
+	bool m_irq_frame_used;
+	bool m_int_state;
+
+	std::unique_ptr<s32[]> m_eram;
+	s32 m_exp_table[257];
+	s32 m_iram[IRAM_CELLS];
+	u8 m_iram_ramping[64];
+	dsp_slot m_program[DSP_SLOTS];
+	dsp_state m_dsp;
+	s32 m_landing[2];
+	u8 m_landing_valid;
+	bool m_program_dirty;
+	bool m_dsp_enabled;
+	u8 m_parity;
+
+	int m_icount;
+	u16 m_pc;
+	u16 m_cycle;
+
+	u8 m_position;
+	u8 m_strobe_a;
+	u8 m_strobe_bcd;
+	s32 m_port_a_out[DSP_SLOTS];
+	s32 m_port_word[OUTPUT_PORTS][2];
+	s32 m_port_a_in;
+	s32 m_port_b_in;
+	bool m_port_in_enabled;
+	bool m_pumped;
+};
+
+DECLARE_DEVICE_TYPE(ROLAND_XP, roland_xp_device)
+
+#endif // MAME_SOUND_ROLAND_XP_H

--- a/src/devices/sound/roland_xpd.cpp
+++ b/src/devices/sound/roland_xpd.cpp
@@ -1,0 +1,255 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr, giulioz
+/*
+ *  Roland XP effect DSP disassembler
+ */
+#include "emu.h"
+#include "roland_xpd.h"
+
+namespace {
+
+// col[5:4] names the multiply input
+const char *const INPUT[4] = { "prev", "acc", "R", "latch" };
+
+const int SHIFT[4] = { 0, 1, 2, 4 };
+
+constexpr int SLOTS = 288;
+
+std::string word_name(int word)
+{
+	return util::string_format("$%02x", word);
+}
+
+const char *condition_name(int code)
+{
+	switch (code)
+	{
+	case 0: return "acc==0";
+	case 1: return "acc!=0";
+	case 3: case 5: case 13: case 14: return "always";
+	case 6: case 8: return "acc>=0";
+	case 7: case 9: return "acc<0";
+	case 10: return "acc>0";
+	case 11: return "acc<=0";
+	default: return "never";
+	}
+}
+
+} // anonymous namespace
+
+void roland_xp_disassembler::append(std::string &r, const std::string &e)
+{
+	if (!r.empty())
+		r += ", ";
+	r += e;
+}
+
+std::string roland_xp_disassembler::coefficient(offs_t pc) const
+{
+	if (!has_coefficient())
+		return "C";
+
+	const u16 c = coefficient_word(pc);
+	const s32 mantissa = s32(s16(c << 2)) >> 2;
+	return util::string_format("%g", double(mantissa << SHIFT[c >> 14]) / 8192.0);
+}
+
+std::string roland_xp_disassembler::constant(offs_t pc) const
+{
+	if (!has_coefficient())
+		return "K";
+
+	const u16 c = coefficient_word(pc);
+	return util::string_format("%d", BIT(c, 15) ? s32(c & 0x3fff) << 13 : s32(s16(c << 2)) >> 2);
+}
+
+// an external RAM access spans two slots, so the second slot's field is address, not command
+bool roland_xp_disassembler::continuation(offs_t pc, const data_buffer &opcodes)
+{
+	bool second = false;
+	for (offs_t slot = 0; slot < (pc % SLOTS); slot++)
+		second = !second && ((opcodes.r32(slot) >> 23) & 3) != 0;
+	return second;
+}
+
+// the ALU functions both encodings share
+void roland_xp_disassembler::function(std::string &r, int fn, int mode, const std::string &k)
+{
+	switch (fn)
+	{
+	case 0x2: append(r, "acc += R"); break;
+	case 0x3: append(r, "acc += p"); break;
+	case 0x4: append(r, "acc = R"); break;
+	case 0x5: append(r, "acc = p"); break;
+	case 0x6: append(r, "acc = -acc"); break;
+	case 0x7: append(r, "acc = R - acc"); break;
+	case 0x8: append(r, "acc = p - acc"); break;
+	case 0x9: append(r, "acc = R + p"); break;
+	case 0xa: append(r, "acc = min(acc, R)"); break;
+	case 0xb: append(r, "acc = max(acc, R)"); break;
+	case 0xc:
+		if (mode == 2)
+			append(r, "acc += p>>13");
+		else if (mode == 3)
+			append(r, "acc = p>>13");
+		break;
+	case 0xd:
+		switch (mode)
+		{
+		case 0: append(r, util::string_format("acc &= #%s", k)); break;
+		case 1: append(r, util::string_format("acc |= #%s", k)); break;
+		case 2: append(r, util::string_format("acc ^= #%s", k)); break;
+		default: append(r, "?"); break;
+		}
+		break;
+	case 0xe:
+		switch (mode)
+		{
+		case 0: append(r, util::string_format("acc = min(acc, #%s)", k)); break;
+		case 1: append(r, util::string_format("acc = max(acc, #%s)", k)); break;
+		default: append(r, "?"); break;
+		}
+		break;
+	case 0xf:
+		switch (mode)
+		{
+		case 0: append(r, util::string_format("acc += #%s", k)); break;
+		case 1: append(r, util::string_format("acc = R + #%s", k)); break;
+		case 2: append(r, util::string_format("acc = p + #%s", k)); break;
+		default: append(r, util::string_format("acc = #%s - acc", k)); break;
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+// col 0x30: the CRAM word is a second instruction
+void roland_xp_disassembler::parallel(std::string &r, offs_t pc, int st, int word) const
+{
+	const u16 c = coefficient_word(pc);
+	const int fn = c & 0xf;
+	const int input = (c >> 4) & 3;
+	const int factor_select = (c >> 6) & 3;
+	const bool complement = BIT(c, 8);
+	const bool multiply = BIT(c, 9);
+	const int post = (c >> 11) & 7;
+
+	std::string factor;
+	switch (factor_select)
+	{
+	case 0: factor = complement ? "(1-f)" : "f"; break;
+	case 1: factor = complement ? "(1-mag)" : "mag"; break;
+	case 2: factor = complement ? "~acc>>8" : "acc>>8"; break;
+	default: factor = complement ? "~G" : "G"; break;
+	}
+	// unity is a gain register at shift 1 and the other factors at shift 0
+	const int unit = factor_select == 3 ? 1 : 0;
+	if (SHIFT[c >> 14] > unit)
+		factor += util::string_format("*%d", 1 << (SHIFT[c >> 14] - unit));
+	else if (SHIFT[c >> 14] < unit)
+		factor += "/2";
+
+	if (!multiply)
+	{
+		if (st == 1 && word < ramp_base())
+			append(r, util::string_format("P = %s", word_name(word)));
+	}
+	else
+		append(r, util::string_format("P = %s*%s", INPUT[input], factor));
+
+	switch (fn)
+	{
+	case 0x0: append(r, "acc += p + R"); break;
+	case 0x1: break;
+	case 0xc: append(r, "acc = R + p - acc"); break;
+	case 0xd: append(r, "acc = acc + p - R"); break;
+	case 0xe: append(r, "acc = p - R - acc"); break;
+	case 0xf: append(r, "acc = p - R"); break;
+	default: function(r, fn, input, constant(pc)); break;
+	}
+
+	switch (post)
+	{
+	case 1: append(r, "acc = abs(acc)"); break;
+	case 2: append(r, "acc = wrap(acc)"); break;
+	case 3: append(r, "acc = prng(acc)"); break;
+	case 4: append(r, "acc = fold(acc)"); break;
+	case 5: append(r, "acc = abs(wrap(acc))"); break;
+	default: break;
+	}
+	if (BIT(c, 10) && post != 2)
+		append(r, "acc = wrap(acc)");
+
+	append(r, util::string_format("[%04x]", c));
+}
+
+offs_t roland_xp_disassembler::disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params)
+{
+	const u32 w = opcodes.r32(pc);
+	const u16 cram = coefficient_word(pc);
+	const int ext = (w >> 25) & 7;
+	const int st = (w >> 14) & 3;
+	const int word = (w >> 6) & 0xff;
+	const int fn = w & 0xf;
+	const int input = (w >> 4) & 3;
+	const std::string source = word_name(word);
+
+	std::string r;
+
+	if (st == 1)
+		append(r, util::string_format("%s = %s", word >= ramp_base() ? "G" : "R", source));
+
+	if (fn == 0 && input == 3)
+	{
+		if (has_coefficient())
+			parallel(r, pc, st, word);
+		else
+			append(r, "parallel [C]");
+	}
+	else
+	{
+		if (fn == 0xc && input < 2)
+			append(r, util::string_format("P = %s*%s", input ? "serB" : "ser", coefficient(pc)));
+		else if (fn >= 1 && fn <= 0xc)
+			append(r, util::string_format("P = %s*%s", INPUT[input], coefficient(pc)));
+
+		switch (fn ? -1 : input)
+		{
+		case 1:
+			if (BIT(cram, 9))
+				append(r, util::string_format("branch %s pc%+d", condition_name((cram >> 10) & 0xf), s8(cram)));
+			else
+				append(r, util::string_format("branch %s $%02x", condition_name((cram >> 10) & 0xf), cram & 0xff));
+			break;
+		case 2: append(r, "eread [acc>>12]"); break;
+		default: function(r, fn, input, constant(pc)); break;
+		}
+	}
+
+	if (st == 2)
+		append(r, util::string_format("%s = latch", source));
+	else if (st == 3)
+		append(r, util::string_format("%s = acc", source));
+
+	if (!continuation(pc, opcodes))
+	{
+		const u16 offset = u16(((w >> 16) & 0x7f) << 9) | u16((opcodes.r32(pc + 1) >> 16) & 0x1ff);
+		switch ((w >> 23) & 3)
+		{
+		case 1: append(r, util::string_format("latch = eram[+%04x]", offset)); break;
+		case 2: append(r, util::string_format("eram[+%04x] = R", offset)); break;
+		case 3: append(r, util::string_format("eram[+%04x] = acc", offset)); break;
+		default: break;
+		}
+	}
+
+	if (ext)
+		append(r, util::string_format("ext %d", ext));
+
+	if (r.empty())
+		r = "nop";
+
+	stream << r;
+	return 1 | SUPPORTED;
+}

--- a/src/devices/sound/roland_xpd.h
+++ b/src/devices/sound/roland_xpd.h
@@ -1,0 +1,42 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+#ifndef MAME_SOUND_ROLAND_XPD_H
+#define MAME_SOUND_ROLAND_XPD_H
+
+#pragma once
+
+class roland_xp_disassembler : public util::disasm_interface
+{
+public:
+	// the coefficient of a slot lives in a second memory the disassembler cannot address
+	class info
+	{
+	public:
+		virtual ~info() = default;
+
+		virtual u16 xpd_cram_r(offs_t address) const = 0;
+		virtual int xpd_ramp_base() const = 0;
+	};
+
+	roland_xp_disassembler(info *inf = nullptr) : m_info(inf) { }
+	virtual ~roland_xp_disassembler() = default;
+
+	virtual u32 opcode_alignment() const override { return 1; }
+	virtual offs_t disassemble(std::ostream &stream, offs_t pc, const data_buffer &opcodes, const data_buffer &params) override;
+
+private:
+	info *m_info;
+
+	bool has_coefficient() const { return m_info != nullptr; }
+	u16 coefficient_word(offs_t pc) const { return m_info ? m_info->xpd_cram_r(pc) : 0; }
+	int ramp_base() const { return m_info ? m_info->xpd_ramp_base() : 0xf0; }
+	std::string coefficient(offs_t pc) const;
+	std::string constant(offs_t pc) const;
+
+	static bool continuation(offs_t pc, const data_buffer &opcodes);
+	static void append(std::string &r, const std::string &e);
+	static void function(std::string &r, int fn, int mode, const std::string &k);
+	void parallel(std::string &r, offs_t pc, int st, int word) const;
+};
+
+#endif // MAME_SOUND_ROLAND_XPD_H

--- a/src/devices/video/sed1330.cpp
+++ b/src/devices/video/sed1330.cpp
@@ -606,36 +606,27 @@ void sed1330_device::data_w(uint8_t data)
 
 void sed1330_device::draw_text_scanline(bitmap_ind16 &bitmap, const rectangle &cliprect, int y, int r, uint16_t va, bool cursor)
 {
-	uint16_t *p = &bitmap.pix(y);
-
-	for (int sx = 0; sx < m_cr; sx++, p += m_fx)
+	for (int sx = 0; sx < m_cr; sx++)
 	{
+		const int sox = sx * m_fx;
+
 		if (m_m0 && !m_m1)
 		{
 			uint8_t c = m_cache.read_byte(va + sx);
 			uint8_t data = m_cache.read_byte(0xf000 | (m_m2 ? u16(c) << 4 | r : u16(c) << 3 | (r & 7)));
 			for (int x = 0; x < m_fx; x++, data <<= 1)
-				if (BIT(data, 7))
-					p[x] = 1;
+				if (BIT(data, 7) && cliprect.contains(sox + x, y))
+					bitmap.pix(y, sox + x) = 1;
 		}
 
 		if (cursor && (va + sx) == m_csr)
 		{
-			if (m_cm)
+			// block cursor, or an underscore on the last line of the cell
+			if (m_cm ? (r < m_cry) : (r == m_cry))
 			{
-				// block cursor
-				if (r < m_cry)
-				{
-					std::fill_n(p, m_crx, 1);
-				}
-			}
-			else
-			{
-				// underscore cursor
-				if (r == m_cry)
-				{
-					std::fill_n(p, m_crx, 1);
-				}
+				for (int x = 0; x < m_crx; x++)
+					if (cliprect.contains(sox + x, y))
+						bitmap.pix(y, sox + x) = 1;
 			}
 		}
 	}
@@ -652,10 +643,12 @@ void sed1330_device::draw_graphics_scanline(bitmap_ind16 &bitmap, const rectangl
 	{
 		uint8_t data = readbyte(va++);
 
-		for (int x = 0; x < m_fx; x++)
+		for (int x = 0; x < m_fx; x++, data <<= 1)
 		{
-			bitmap.pix(y, (sx * m_fx) + x) = BIT(data, 7);
-			data <<= 1;
+			// the character pitch need not divide the panel width
+			const int px = (sx * m_fx) + x;
+			if (cliprect.contains(px, y))
+				bitmap.pix(y, px) = BIT(data, 7);
 		}
 	}
 }

--- a/src/mame/layout/roland_sc88.lay
+++ b/src/mame/layout/roland_sc88.lay
@@ -1,0 +1,268 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+copyright-holders:superctr
+
+Roland Sound Canvas SC-88 front panel.
+
+The display is the RCM2024T glass of the SC-55mkII, rendered into the screen
+bitmap by the driver; the field labels printed on the glass are overlaid here.
+-->
+<mamelayout version="2">
+
+	<element name="panel"><rect><color red="0.22" green="0.22" blue="0.23"/></rect></element>
+	<element name="bezel"><rect><color red="0.02" green="0.02" blue="0.02"/></rect></element>
+	<element name="trim"><rect><color red="0.30" green="0.30" blue="0.32"/></rect></element>
+
+	<element name="button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="round_button" defstate="0">
+		<disk state="0"><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="1"><color red="0.30" green="0.30" blue="0.30"/></disk>
+	</element>
+	<element name="led_button" defstate="0">
+		<disk state="0"><color red="0.72" green="0.72" blue="0.70"/></disk>
+		<disk state="1"><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_circle" defstate="0">
+		<disk><color red="0.45" green="0.45" blue="0.45"/></disk>
+		<disk state="0"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.25" green="0.08" blue="0.05"/></disk>
+		<disk state="1"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_triangle" defstate="0">
+		<text state="0" string="&gt;"><color red="0.40" green="0.40" blue="0.40"/></text>
+		<text state="1" string="&gt;"><color red="1.0" green="0.20" blue="0.10"/></text>
+	</element>
+	<element name="knob" defstate="0">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="0"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.15" green="0.15" blue="0.15"/></disk>
+		<disk state="1"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.30" green="0.30" blue="0.30"/></disk>
+		<rect><bounds x="0.47" y="0.18" width="0.06" height="0.3"/><color red="0.70" green="0.70" blue="0.70"/></rect>
+	</element>
+	<element name="power_button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="jack">
+		<disk><color red="0.55" green="0.55" blue="0.55"/></disk>
+		<disk><bounds x="0.25" y="0.25" width="0.5" height="0.5"/><color red="0.02" green="0.02" blue="0.02"/></disk>
+	</element>
+	<element name="midi_jack">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.1" y="0.1" width="0.8" height="0.8"/><color red="0.60" green="0.60" blue="0.60"/></disk>
+		<disk><bounds x="0.44" y="0.72" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.22" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.66" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.15" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.73" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+	</element>
+	<element name="divider"><rect><color red="0.10" green="0.10" blue="0.11"/></rect></element>
+
+	<element name="arrow_l"><text string="&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_r"><text string="&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_up"><text string="&#9650;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_down"><text string="&#9660;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_power"><text string="POWER"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_volume"><text string="VOLUME"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_preview"><text string="PREVIEW(PUSH)"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midiinb"><text string="MIDI IN B"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_phones"><text string="PHONES"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_part"><text string="PART"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_level"><text string="LEVEL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_pan"><text string="PAN"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_reverb"><text string="REVERB"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_chorus"><text string="CHORUS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_keyshift"><text string="KEY SHIFT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midich"><text string="MIDI CH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_all"><text string="ALL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_mute"><text string="MUTE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc55"><text string="SC-55"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_map"><text string="MAP"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_eq"><text string="EQ"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_userinstedit"><text string="USER INST EDIT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_onoff"><text string="ON/OFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_select"><text string="SELECT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibrate"><text string="VIB RATE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_attack"><text string="ATTACK"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_delay"><text string="DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdepth"><text string="VIB DEPTH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_cutoff"><text string="CUTOFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_decay"><text string="DECAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument2"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdelay"><text string="VIB DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_resonance"><text string="RESONANCE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_release"><text string="RELEASE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_variation"><text string="VARIATION"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_roland"><text string="Roland"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_soundcanvas"><text string="SOUND Canvas"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_gs"><text string="GS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_model"><text string="SC-88"><color red="0.95" green="0.55" blue="0.10"/></text></element>
+	<element name="glass_level"><text string="LEVEL" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_pan"><text string="PAN" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_reverb"><text string="REVERB" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_chorus"><text string="CHORUS" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_kshift"><text string="K SHIFT" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_midich"><text string="MIDI CH" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_1"><text string="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_2"><text string="2"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_3"><text string="3"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_4"><text string="4"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_5"><text string="5"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_6"><text string="6"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_7"><text string="7"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_8"><text string="8"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_9"><text string="9"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_10"><text string="10"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_11"><text string="11"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_12"><text string="12"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_13"><text string="13"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_14"><text string="14"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_15"><text string="15"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_16"><text string="16"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+
+	<view name="Front Panel">
+		<bounds x="0" y="0" width="1800" height="640"/>
+		<element ref="panel"><bounds x="0" y="0" width="1800" height="640"/></element>
+		<element ref="divider"><bounds x="0" y="440" width="1800" height="6"/></element>
+
+		<!-- power, volume / preview, front jacks -->
+		<element ref="label_power"><bounds x="40" y="50" width="160" height="26"/></element>
+		<element ref="power_button"><bounds x="50" y="85" width="140" height="55"/></element>
+		<element ref="midi_jack"><bounds x="65" y="215" width="110" height="110"/></element>
+		<element ref="label_midiinb"><bounds x="35" y="335" width="170" height="24"/></element>
+		<element ref="label_volume"><bounds x="215" y="50" width="120" height="26"/></element>
+		<element ref="knob" inputtag="KEY0" inputmask="0x80"><bounds x="230" y="85" width="90" height="90"/></element>
+		<element ref="label_preview"><bounds x="195" y="182" width="160" height="22"/></element>
+		<element ref="jack"><bounds x="245" y="245" width="60" height="60"/></element>
+		<element ref="label_phones"><bounds x="215" y="335" width="120" height="24"/></element>
+
+		<!-- display -->
+		<element ref="trim"><bounds x="355" y="70" width="770" height="322"/></element>
+		<element ref="bezel"><bounds x="365" y="80" width="750" height="302"/></element>
+		<screen index="0"><bounds x="380" y="95" width="720" height="272"/></screen>
+		<element ref="label_part"><bounds x="400" y="44" width="80" height="22"/></element>
+		<element ref="label_instrument"><bounds x="520" y="44" width="160" height="22"/></element>
+		<element ref="glass_level"><bounds x="404" y="161" width="90" height="12"/></element>
+		<element ref="glass_pan"><bounds x="523" y="161" width="90" height="12"/></element>
+		<element ref="glass_reverb"><bounds x="404" y="225" width="90" height="12"/></element>
+		<element ref="glass_chorus"><bounds x="523" y="225" width="90" height="12"/></element>
+		<element ref="glass_kshift"><bounds x="404" y="289" width="90" height="12"/></element>
+		<element ref="glass_midich"><bounds x="523" y="289" width="90" height="12"/></element>
+		<element ref="glass_1"><bounds x="663" y="349" width="24" height="12"/></element>
+		<element ref="glass_2"><bounds x="689" y="349" width="24" height="12"/></element>
+		<element ref="glass_3"><bounds x="715" y="349" width="24" height="12"/></element>
+		<element ref="glass_4"><bounds x="741" y="349" width="24" height="12"/></element>
+		<element ref="glass_5"><bounds x="767" y="349" width="24" height="12"/></element>
+		<element ref="glass_6"><bounds x="793" y="349" width="24" height="12"/></element>
+		<element ref="glass_7"><bounds x="819" y="349" width="24" height="12"/></element>
+		<element ref="glass_8"><bounds x="845" y="349" width="24" height="12"/></element>
+		<element ref="glass_9"><bounds x="871" y="349" width="24" height="12"/></element>
+		<element ref="glass_10"><bounds x="897" y="349" width="24" height="12"/></element>
+		<element ref="glass_11"><bounds x="923" y="349" width="24" height="12"/></element>
+		<element ref="glass_12"><bounds x="949" y="349" width="24" height="12"/></element>
+		<element ref="glass_13"><bounds x="975" y="349" width="24" height="12"/></element>
+		<element ref="glass_14"><bounds x="1001" y="349" width="24" height="12"/></element>
+		<element ref="glass_15"><bounds x="1027" y="349" width="24" height="12"/></element>
+		<element ref="glass_16"><bounds x="1053" y="349" width="24" height="12"/></element>
+		<element ref="label_delay"><bounds x="400" y="398" width="80" height="20"/></element>
+		<element ref="label_part"><bounds x="810" y="398" width="60" height="20"/></element>
+
+		<!-- ALL / MUTE / SC-55 MAP / EQ -->
+		<element ref="label_all"><bounds x="1145" y="79" width="65" height="30"/></element>
+		<element name="led0" ref="led_button" inputtag="KEY0" inputmask="0x40"><bounds x="1215" y="69" width="50" height="50"/></element>
+		<element ref="label_mute"><bounds x="1135" y="163" width="75" height="30"/></element>
+		<element name="led1" ref="led_button" inputtag="KEY0" inputmask="0x20"><bounds x="1215" y="153" width="50" height="50"/></element>
+		<element ref="arrow_up"><bounds x="1160" y="212" width="40" height="22"/></element>
+		<element ref="label_sc55"><bounds x="1135" y="236" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="258" width="75" height="22"/></element>
+		<element name="led2" ref="led_button" inputtag="KEY0" inputmask="0x04"><bounds x="1215" y="237" width="50" height="50"/></element>
+		<element ref="label_eq"><bounds x="1145" y="331" width="65" height="30"/></element>
+		<element ref="arrow_down"><bounds x="1160" y="366" width="40" height="22"/></element>
+		<element name="led3" ref="led_button" inputtag="KEY0" inputmask="0x02"><bounds x="1215" y="321" width="50" height="50"/></element>
+
+		<!-- parameter buttons -->
+		<element ref="label_part"><bounds x="1300" y="40" width="206" height="24"/></element>
+		<element ref="round_button" inputtag="KEY2" inputmask="0x40"><bounds x="1324" y="70" width="48" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="81" width="35" height="26"/></element>
+		<element ref="round_button" inputtag="KEY1" inputmask="0x40"><bounds x="1430" y="70" width="48" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="81" width="35" height="26"/></element>
+		<element ref="label_instrument"><bounds x="1546" y="40" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x08"><bounds x="1546" y="70" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="81" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x10"><bounds x="1652" y="70" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="81" width="35" height="26"/></element>
+		<element ref="label_level"><bounds x="1300" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x10"><bounds x="1300" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x20"><bounds x="1406" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="165" width="35" height="26"/></element>
+		<element ref="label_pan"><bounds x="1546" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x10"><bounds x="1546" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x20"><bounds x="1652" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="165" width="35" height="26"/></element>
+		<element ref="label_reverb"><bounds x="1300" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x04"><bounds x="1300" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x08"><bounds x="1406" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="249" width="35" height="26"/></element>
+		<element ref="label_chorus"><bounds x="1546" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x04"><bounds x="1546" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x08"><bounds x="1652" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="249" width="35" height="26"/></element>
+		<element ref="label_keyshift"><bounds x="1300" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x01"><bounds x="1300" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x02"><bounds x="1406" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="333" width="35" height="26"/></element>
+		<element ref="label_midich"><bounds x="1546" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x01"><bounds x="1546" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x02"><bounds x="1652" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="333" width="35" height="26"/></element>
+
+		<!-- lower panel: user instrument editing -->
+		<element ref="label_gs"><bounds x="50" y="500" width="60" height="30"/></element>
+		<element ref="label_soundcanvas"><bounds x="120" y="520" width="300" height="40"/></element>
+		<element ref="label_model"><bounds x="430" y="522" width="180" height="36"/></element>
+
+		<element name="led7" ref="lens_circle"><bounds x="700" y="532" width="34" height="34"/></element>
+		<element ref="label_userinstedit"><bounds x="745" y="500" width="200" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x01"><bounds x="750" y="528" width="90" height="42"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x02"><bounds x="846" y="528" width="90" height="42"/></element>
+		<element ref="label_onoff"><bounds x="745" y="578" width="100" height="22"/></element>
+		<element ref="label_select"><bounds x="846" y="578" width="100" height="22"/></element>
+
+		<element name="led4" ref="lens_triangle"><bounds x="975" y="464" width="22" height="22"/></element>
+		<element name="led5" ref="lens_triangle"><bounds x="975" y="486" width="22" height="22"/></element>
+		<element name="led6" ref="lens_triangle"><bounds x="975" y="510" width="22" height="22"/></element>
+		<element ref="label_vibrate"><bounds x="1010" y="462" width="206" height="22"/></element>
+		<element ref="label_attack"><bounds x="1010" y="506" width="206" height="22"/></element>
+		<element ref="label_delay"><bounds x="1010" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x04"><bounds x="1010" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1042" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x08"><bounds x="1116" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1148" y="544" width="35" height="26"/></element>
+		<element ref="label_vibdepth"><bounds x="1256" y="462" width="206" height="22"/></element>
+		<element ref="label_cutoff"><bounds x="1256" y="486" width="206" height="22"/></element>
+		<element ref="label_decay"><bounds x="1256" y="510" width="206" height="22"/></element>
+		<element ref="label_instrument2"><bounds x="1256" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x10"><bounds x="1256" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1288" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x20"><bounds x="1362" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1394" y="544" width="35" height="26"/></element>
+		<element ref="label_vibdelay"><bounds x="1502" y="462" width="206" height="22"/></element>
+		<element ref="label_resonance"><bounds x="1502" y="486" width="206" height="22"/></element>
+		<element ref="label_release"><bounds x="1502" y="510" width="206" height="22"/></element>
+		<element ref="label_variation"><bounds x="1502" y="582" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x40"><bounds x="1502" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1534" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x80"><bounds x="1608" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1640" y="544" width="35" height="26"/></element>
+	</view>
+
+</mamelayout>

--- a/src/mame/layout/roland_sc88pro.lay
+++ b/src/mame/layout/roland_sc88pro.lay
@@ -1,0 +1,283 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+copyright-holders:superctr
+
+Roland Sound Canvas SC-88Pro front panel.
+
+The display is the RCM2024T glass of the SC-55mkII, rendered into the screen
+bitmap by the driver; the field labels printed on the glass are overlaid here.
+
+The bottom lens holds a dual-die LED: the green die (led7) sits on the
+SC-88's lens position in the LED matrix, the red die (led8) is driven
+directly by the gate array.  Red alone marks user editing, both lit show
+orange in EFX mode.
+-->
+<mamelayout version="2">
+
+	<element name="panel"><rect><color red="0.22" green="0.22" blue="0.23"/></rect></element>
+	<element name="bezel"><rect><color red="0.02" green="0.02" blue="0.02"/></rect></element>
+	<element name="trim"><rect><color red="0.30" green="0.30" blue="0.32"/></rect></element>
+
+	<element name="button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="round_button" defstate="0">
+		<disk state="0"><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="1"><color red="0.30" green="0.30" blue="0.30"/></disk>
+	</element>
+	<element name="led_button" defstate="0">
+		<disk state="0"><color red="0.72" green="0.72" blue="0.70"/></disk>
+		<disk state="1"><color red="1.0" green="0.15" blue="0.10"/></disk>
+	</element>
+	<element name="lens_circle" defstate="0">
+		<disk><color red="0.45" green="0.45" blue="0.45"/></disk>
+		<disk state="0"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.12" green="0.10" blue="0.08"/></disk>
+		<disk state="1"><bounds x="0.2" y="0.2" width="0.6" height="0.6"/><color red="0.30" green="1.0" blue="0.25"/></disk>
+	</element>
+	<element name="lens_red_overlay" defstate="0">
+		<disk state="0"><color red="0.0" green="0.0" blue="0.0" alpha="0.0"/></disk>
+		<disk state="1"><color red="1.0" green="0.12" blue="0.08" alpha="0.65"/></disk>
+	</element>
+	<element name="lens_triangle" defstate="0">
+		<text state="0" string="&gt;"><color red="0.40" green="0.40" blue="0.40"/></text>
+		<text state="1" string="&gt;"><color red="1.0" green="0.20" blue="0.10"/></text>
+	</element>
+	<element name="knob" defstate="0">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk state="0"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.15" green="0.15" blue="0.15"/></disk>
+		<disk state="1"><bounds x="0.15" y="0.15" width="0.7" height="0.7"/><color red="0.30" green="0.30" blue="0.30"/></disk>
+		<rect><bounds x="0.47" y="0.18" width="0.06" height="0.3"/><color red="0.70" green="0.70" blue="0.70"/></rect>
+	</element>
+	<element name="power_button" defstate="0">
+		<rect state="0"><color red="0.05" green="0.05" blue="0.05"/></rect>
+		<rect state="1"><color red="0.30" green="0.30" blue="0.30"/></rect>
+	</element>
+	<element name="jack">
+		<disk><color red="0.55" green="0.55" blue="0.55"/></disk>
+		<disk><bounds x="0.25" y="0.25" width="0.5" height="0.5"/><color red="0.02" green="0.02" blue="0.02"/></disk>
+	</element>
+	<element name="midi_jack">
+		<disk><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.1" y="0.1" width="0.8" height="0.8"/><color red="0.60" green="0.60" blue="0.60"/></disk>
+		<disk><bounds x="0.44" y="0.72" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.22" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.66" y="0.58" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.15" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+		<disk><bounds x="0.73" y="0.33" width="0.12" height="0.12"/><color red="0.05" green="0.05" blue="0.05"/></disk>
+	</element>
+	<element name="divider"><rect><color red="0.10" green="0.10" blue="0.11"/></rect></element>
+
+	<element name="arrow_l"><text string="&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_r"><text string="&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_up"><text string="&#9650;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_down"><text string="&#9660;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_power"><text string="POWER"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_volume"><text string="VOLUME"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_preview"><text string="PREVIEW(PUSH)"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midiinb"><text string="MIDI IN B"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_phones"><text string="PHONES"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_part"><text string="PART"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_instrument"><text string="INSTRUMENT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_level"><text string="LEVEL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_pan"><text string="PAN"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_reverb"><text string="REVERB"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_chorus"><text string="CHORUS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_keyshift"><text string="KEY SHIFT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midich"><text string="MIDI CH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_all"><text string="ALL"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_mute"><text string="MUTE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc55"><text string="SC-55"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_sc88"><text string="SC-88"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_map"><text string="MAP"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_userinst"><text string="USER INST"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_select"><text string="SELECT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibrate"><text string="VIB RATE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_attack"><text string="ATTACK"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_delay"><text string="DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdepth"><text string="VIB DEPTH"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_cutoff"><text string="CUTOFF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_decay"><text string="DECAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_vibdelay"><text string="VIB DELAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_resonance"><text string="RESONANCE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_release"><text string="RELEASE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_roland"><text string="Roland"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_soundcanvas"><text string="SOUND Canvas"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_gs"><text string="GS"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_model"><text string="SC-88 Pro"><color red="0.95" green="0.55" blue="0.10"/></text></element>
+	<element name="efx"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_onoff"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="ON/OFF"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_type"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX TYPE"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_param"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX PARAM"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="efx_value"><rect><color red="0.88" green="0.88" blue="0.88"/></rect><text string="EFX VALUE"><color red="0.25" green="0.25" blue="0.26"/></text></element>
+	<element name="glass_level"><text string="LEVEL" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_pan"><text string="PAN" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_reverb"><text string="REVERB" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_chorus"><text string="CHORUS" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_kshift"><text string="K SHIFT" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_midich"><text string="MIDI CH" align="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_1"><text string="1"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_2"><text string="2"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_3"><text string="3"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_4"><text string="4"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_5"><text string="5"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_6"><text string="6"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_7"><text string="7"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_8"><text string="8"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_9"><text string="9"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_10"><text string="10"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_11"><text string="11"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_12"><text string="12"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_13"><text string="13"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_14"><text string="14"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_15"><text string="15"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+	<element name="glass_16"><text string="16"><color red="0.15" green="0.08" blue="0.0"/></text></element>
+
+	<view name="Front Panel">
+		<bounds x="0" y="0" width="1800" height="640"/>
+		<element ref="panel"><bounds x="0" y="0" width="1800" height="640"/></element>
+		<element ref="divider"><bounds x="0" y="440" width="1800" height="6"/></element>
+
+		<!-- power, volume / preview, front jacks -->
+		<element ref="label_power"><bounds x="40" y="50" width="160" height="26"/></element>
+		<element ref="power_button"><bounds x="50" y="85" width="140" height="55"/></element>
+		<element ref="midi_jack"><bounds x="65" y="215" width="110" height="110"/></element>
+		<element ref="label_midiinb"><bounds x="35" y="335" width="170" height="24"/></element>
+		<element ref="label_volume"><bounds x="215" y="50" width="120" height="26"/></element>
+		<element ref="knob" inputtag="KEY0" inputmask="0x80"><bounds x="230" y="85" width="90" height="90"/></element>
+		<element ref="label_preview"><bounds x="195" y="182" width="160" height="22"/></element>
+		<element ref="jack"><bounds x="245" y="245" width="60" height="60"/></element>
+		<element ref="label_phones"><bounds x="215" y="335" width="120" height="24"/></element>
+
+		<!-- display -->
+		<element ref="trim"><bounds x="355" y="70" width="770" height="322"/></element>
+		<element ref="bezel"><bounds x="365" y="80" width="750" height="302"/></element>
+		<screen index="0"><bounds x="380" y="95" width="720" height="272"/></screen>
+		<element ref="label_part"><bounds x="400" y="44" width="80" height="22"/></element>
+		<element ref="label_instrument"><bounds x="520" y="44" width="160" height="22"/></element>
+		<element ref="glass_level"><bounds x="404" y="161" width="90" height="12"/></element>
+		<element ref="glass_pan"><bounds x="523" y="161" width="90" height="12"/></element>
+		<element ref="glass_reverb"><bounds x="404" y="225" width="90" height="12"/></element>
+		<element ref="glass_chorus"><bounds x="523" y="225" width="90" height="12"/></element>
+		<element ref="glass_kshift"><bounds x="404" y="289" width="90" height="12"/></element>
+		<element ref="glass_midich"><bounds x="523" y="289" width="90" height="12"/></element>
+		<element ref="glass_1"><bounds x="663" y="349" width="24" height="12"/></element>
+		<element ref="glass_2"><bounds x="689" y="349" width="24" height="12"/></element>
+		<element ref="glass_3"><bounds x="715" y="349" width="24" height="12"/></element>
+		<element ref="glass_4"><bounds x="741" y="349" width="24" height="12"/></element>
+		<element ref="glass_5"><bounds x="767" y="349" width="24" height="12"/></element>
+		<element ref="glass_6"><bounds x="793" y="349" width="24" height="12"/></element>
+		<element ref="glass_7"><bounds x="819" y="349" width="24" height="12"/></element>
+		<element ref="glass_8"><bounds x="845" y="349" width="24" height="12"/></element>
+		<element ref="glass_9"><bounds x="871" y="349" width="24" height="12"/></element>
+		<element ref="glass_10"><bounds x="897" y="349" width="24" height="12"/></element>
+		<element ref="glass_11"><bounds x="923" y="349" width="24" height="12"/></element>
+		<element ref="glass_12"><bounds x="949" y="349" width="24" height="12"/></element>
+		<element ref="glass_13"><bounds x="975" y="349" width="24" height="12"/></element>
+		<element ref="glass_14"><bounds x="1001" y="349" width="24" height="12"/></element>
+		<element ref="glass_15"><bounds x="1027" y="349" width="24" height="12"/></element>
+		<element ref="glass_16"><bounds x="1053" y="349" width="24" height="12"/></element>
+		<element ref="label_delay"><bounds x="400" y="398" width="80" height="20"/></element>
+		<element ref="label_part"><bounds x="810" y="398" width="60" height="20"/></element>
+
+		<!-- ALL / MUTE / SC-55 MAP / SC-88 MAP -->
+		<element ref="label_all"><bounds x="1145" y="79" width="65" height="30"/></element>
+		<element name="led0" ref="led_button" inputtag="KEY0" inputmask="0x40"><bounds x="1215" y="69" width="50" height="50"/></element>
+		<element ref="label_mute"><bounds x="1135" y="163" width="75" height="30"/></element>
+		<element name="led1" ref="led_button" inputtag="KEY0" inputmask="0x20"><bounds x="1215" y="153" width="50" height="50"/></element>
+		<element ref="arrow_up"><bounds x="1160" y="212" width="40" height="22"/></element>
+		<element ref="label_sc55"><bounds x="1135" y="236" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="258" width="75" height="22"/></element>
+		<element name="led2" ref="led_button" inputtag="KEY0" inputmask="0x04"><bounds x="1215" y="237" width="50" height="50"/></element>
+		<element ref="label_sc88"><bounds x="1135" y="321" width="75" height="22"/></element>
+		<element ref="label_map"><bounds x="1135" y="343" width="75" height="22"/></element>
+		<element name="led3" ref="led_button" inputtag="KEY0" inputmask="0x02"><bounds x="1215" y="321" width="50" height="50"/></element>
+		<element ref="arrow_down"><bounds x="1160" y="376" width="40" height="22"/></element>
+
+		<!-- parameter buttons -->
+		<element ref="label_part"><bounds x="1300" y="40" width="206" height="24"/></element>
+		<element ref="round_button" inputtag="KEY2" inputmask="0x40"><bounds x="1324" y="70" width="48" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="81" width="35" height="26"/></element>
+		<element ref="round_button" inputtag="KEY1" inputmask="0x40"><bounds x="1430" y="70" width="48" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="81" width="35" height="26"/></element>
+		<element ref="label_instrument"><bounds x="1546" y="40" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x08"><bounds x="1546" y="70" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="81" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x10"><bounds x="1652" y="70" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="81" width="35" height="26"/></element>
+		<element ref="label_level"><bounds x="1300" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x10"><bounds x="1300" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x20"><bounds x="1406" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="165" width="35" height="26"/></element>
+		<element ref="label_pan"><bounds x="1546" y="124" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x10"><bounds x="1546" y="154" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="165" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x20"><bounds x="1652" y="154" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="165" width="35" height="26"/></element>
+		<element ref="label_reverb"><bounds x="1300" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x04"><bounds x="1300" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x08"><bounds x="1406" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="249" width="35" height="26"/></element>
+		<element ref="label_chorus"><bounds x="1546" y="208" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x04"><bounds x="1546" y="238" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="249" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x08"><bounds x="1652" y="238" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="249" width="35" height="26"/></element>
+		<element ref="label_keyshift"><bounds x="1300" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x01"><bounds x="1300" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1332" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x02"><bounds x="1406" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1438" y="333" width="35" height="26"/></element>
+		<element ref="label_delay"><bounds x="1300" y="376" width="206" height="20"/></element>
+		<element ref="label_midich"><bounds x="1546" y="292" width="206" height="24"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x01"><bounds x="1546" y="322" width="100" height="48"/></element>
+		<element ref="arrow_l"><bounds x="1578" y="333" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x02"><bounds x="1652" y="322" width="100" height="48"/></element>
+		<element ref="arrow_r"><bounds x="1684" y="333" width="35" height="26"/></element>
+
+		<!-- lower panel: user instrument editing / EFX -->
+		<element ref="label_gs"><bounds x="50" y="500" width="60" height="30"/></element>
+		<element ref="label_soundcanvas"><bounds x="120" y="520" width="300" height="40"/></element>
+		<element ref="label_model"><bounds x="430" y="522" width="230" height="36"/></element>
+
+		<element name="led7" ref="lens_circle"><bounds x="700" y="532" width="34" height="34"/></element>
+		<element name="led8" ref="lens_red_overlay"><bounds x="706" y="538" width="22" height="22"/></element>
+		<element ref="label_userinst"><bounds x="745" y="500" width="100" height="22"/></element>
+		<element ref="label_select"><bounds x="846" y="500" width="90" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x01"><bounds x="750" y="528" width="90" height="42"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x02"><bounds x="846" y="528" width="90" height="42"/></element>
+		<element ref="efx"><bounds x="750" y="580" width="90" height="24"/></element>
+		<element ref="efx_onoff"><bounds x="846" y="580" width="90" height="24"/></element>
+
+		<element name="led4" ref="lens_triangle"><bounds x="975" y="460" width="22" height="22"/></element>
+		<element name="led5" ref="lens_triangle"><bounds x="975" y="484" width="22" height="22"/></element>
+		<element name="led6" ref="lens_triangle"><bounds x="975" y="508" width="22" height="22"/></element>
+		<element ref="label_vibrate"><bounds x="1010" y="460" width="206" height="22"/></element>
+		<element ref="label_attack"><bounds x="1010" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x04"><bounds x="1010" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1042" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x08"><bounds x="1116" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1148" y="544" width="35" height="26"/></element>
+		<element ref="efx_type"><bounds x="1010" y="580" width="206" height="24"/></element>
+		<element ref="label_vibdepth"><bounds x="1256" y="460" width="206" height="22"/></element>
+		<element ref="label_cutoff"><bounds x="1256" y="484" width="206" height="22"/></element>
+		<element ref="label_decay"><bounds x="1256" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x10"><bounds x="1256" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1288" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x20"><bounds x="1362" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1394" y="544" width="35" height="26"/></element>
+		<element ref="efx_param"><bounds x="1256" y="580" width="206" height="24"/></element>
+		<element ref="label_vibdelay"><bounds x="1502" y="460" width="206" height="22"/></element>
+		<element ref="label_resonance"><bounds x="1502" y="484" width="206" height="22"/></element>
+		<element ref="label_release"><bounds x="1502" y="508" width="206" height="22"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x40"><bounds x="1502" y="536" width="100" height="42"/></element>
+		<element ref="arrow_l"><bounds x="1534" y="544" width="35" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x80"><bounds x="1608" y="536" width="100" height="42"/></element>
+		<element ref="arrow_r"><bounds x="1640" y="544" width="35" height="26"/></element>
+		<element ref="efx_value"><bounds x="1502" y="580" width="206" height="24"/></element>
+	</view>
+
+</mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -40299,6 +40299,7 @@ sc55mk2
 sc88
 sc88vl
 sc88pro
+vegspro
 
 @source:roland/roland_tb303.cpp
 tb303

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -40295,6 +40295,10 @@ cm300
 @source:roland/roland_sc55mk2.cpp
 sc55mk2
 
+@source:roland/roland_sc8850.cpp
+sc8850
+sc8820
+
 @source:roland/roland_sc88.cpp
 sc88
 sc88vl

--- a/src/mame/roland/roland_sc88.cpp
+++ b/src/mame/roland/roland_sc88.cpp
@@ -1,15 +1,70 @@
 // license:BSD-3-Clause
-// copyright-holders:AJR
+// copyright-holders:AJR, superctr
 /****************************************************************************
 
-    Skeleton driver for Roland SC-88 MIDI sound generator.
+    Roland SC-88 family of MIDI sound generators.
+
+    The SC-88 is the successor of the SC-55mkII: two 16-part banks with the
+    SC-55 and a new native tone set, a second MIDI IN, an equalizer and an
+    editable user instrument set, driven by the "XP" PCM chip.
+
+    Main board (service notes, June 1994):
+    - IC29 H8/510 (HD6415108) at 20 MHz, mode 4 (16-bit external bus,
+      A20/A21 unused); both on-chip SCIs are unused, all serial traffic goes
+      through the sub CPU
+    - IC27 uPD65622 gate array: chip select decoder, LCD interface, front
+      panel LEDs, interrupt and wait control
+    - IC11 M38881M2 sub CPU (Roland R00232667, 8 KB ROM, undumped): scans the
+      panel switch matrix, merges MIDI IN A/B and the RS-422/RS-232 computer
+      port, talks to the main CPU through a shared window on /CS5
+    - IC15 MBCS30109 "XP" PCM chip at 24.576 MHz on /CS3, four 2 MB wave
+      ROMs, 2 x 256K x 4 effect DRAM, PCM69AU DAC
+    - RCM2024T LCD unit: the SC-55mkII glass on an HD44780 command set
+    - IC17 512 KB program ROM on /CS0, 2 x 32 KB battery backed SRAM on /CS1
+
+    Interrupts: IRQ0 gate array, IRQ1 XP, IRQ2 sub CPU.  The analog inputs
+    read the backup battery (AN0) and the rear COMPUTER selector (AN1-AN3).
+
+    SC-88VL: compact (1U half-rack) version of SC-88 with standby function
+
+    SC-88Pro: the SC-88 with expanded sample ROM and external effect processor
+    (LSP) for insertion effects. Address decoding is handled by the LSP rather
+    than the gate array.
+
+    VE-GSPro: the SC-88Pro tone generator as a voice expansion board for the
+    MC-80 and A-70/A-90. Does not have the sub MCU, rather receives MIDI
+    directly using the H8/510 SCIs.
+
+    SK-88Pro: 37-key keyboard with a built in SC-88Pro compatible tone
+    generator. Contains a 4M overlay ROM.
 
 ****************************************************************************/
 
 #include "emu.h"
+
+#include "sc88_sub.h"
+
+#include "bus/midi/midiinport.h"
+#include "bus/midi/midioutport.h"
 #include "cpu/h8500/h8510.h"
-//#include "cpu/m6502/m38881.h"
 #include "machine/nvram.h"
+#include "sound/roland_lsp.h"
+#include "sound/roland_xp.h"
+#include "video/hd44780.h"
+
+#include "emupal.h"
+#include "screen.h"
+#include "speaker.h"
+
+#include "roland_sc88.lh"
+#include "roland_sc88pro.lh"
+
+#define LOG_GA      (1U << 1)
+#define LOG_PORT    (1U << 2)
+#define LOG_SUB     (1U << 3)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
 
 
 namespace {
@@ -20,70 +75,701 @@ public:
 	roland_sc88_state(const machine_config &mconfig, device_type type, const char *tag)
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
+		, m_subcpu(*this, "subcpu")
+		, m_xp(*this, "xp")
+		, m_lsp(*this, "lsp")
+		, m_nvram(*this, "nvram")
+		, m_screen(*this, "screen")
+		, m_lcd(*this, "lcd")
+		, m_keys(*this, "KEY%u", 0U)
+		, m_computer_sw(*this, "COMPUTER")
+		, m_leds(*this, "led%u", 0U)
 	{
 	}
 
 	void sc88(machine_config &config);
 	void sc88vl(machine_config &config);
 	void sc88pro(machine_config &config);
+	void vegspro(machine_config &config);
+
+	void init_sc88() ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
 
 private:
+	HD44780_PIXEL_UPDATE(lcd_pixel_update);
+	void lcd_palette(palette_device &palette) const;
+
 	void main_map(address_map &map) ATTR_COLD;
-	void pro_map(address_map &map) ATTR_COLD;
+	void sc88pro_map(address_map &map) ATTR_COLD;
+	void vegspro_map(address_map &map) ATTR_COLD;
+	void xp_rom_map(address_map &map) ATTR_COLD;
+	void pro_xp_rom_map(address_map &map) ATTR_COLD;
+
+	u8 ga_r(offs_t offset);
+	void ga_w(offs_t offset, u8 data);
+	void ga_int_update();
+	TIMER_CALLBACK_MEMBER(lcd_done);
+	// the upper half of the battery RAM is also selected in pages 0 and E
+	u16 ram_alias_r(offs_t offset) { return m_nvram[0x4000 + offset]; }
+	void ram_alias_w(offs_t offset, u16 data, u16 mem_mask) { COMBINE_DATA(&m_nvram[0x4000 + offset]); }
+	void xp_int_w(int state);
+	void lsp_serial_w(offs_t port, u32 data);
+	u32 lsp_serial_r(offs_t strobe);
+	void lsp_mute_w(u8 data);
+	u8 port4_r();
+	u8 port5_r();
+	void port4_w(u8 data);
+	u8 port8_r();
+	u16 battery_r();
+	u16 computer_sw_r();
 
 	required_device<h8510_device> m_maincpu;
+	optional_device<sc88_sub_device> m_subcpu;
+	required_device<roland_xp_device> m_xp;
+	optional_device<roland_lsp_device> m_lsp;
+	required_shared_ptr<u16> m_nvram;
+	optional_device<screen_device> m_screen;
+	optional_device<hd44780_device> m_lcd;
+	optional_ioport_array<4> m_keys;
+	optional_ioport m_computer_sw;
+	output_finder<9> m_leds;
+
+	u8 m_ga_regs[0x100]{};
+	u8 m_ga_int_mask = 0;
+	u8 m_ga_int_pending = 0;
+	u8 m_lcd_fifo[13]{};
+	u8 m_lcd_fifo_count = 0;
+	bool m_lcd_command_pending = false;
+	emu_timer *m_lcd_timer = nullptr;
+	bool m_xp_int = false;
+	bool m_lsp_mute = true;
 };
 
+
+// The wave ROMs are stored as dumped; the board wiring permutes address lines
+// within each 256 KB block and the data lines.
+void roland_sc88_state::init_sc88()
+{
+	memory_region *region = memregion("waverom");
+	u8 *rom = region->base();
+	const u32 size = region->bytes();
+
+	static const u8 address_lines[18] = { 0, 4, 2, 3, 1, 13, 7, 12, 5, 10, 16, 9, 6, 8, 14, 17, 11, 15 };
+	static const u8 data_lines[8] = { 2, 0, 4, 5, 7, 6, 3, 1 };
+
+	std::vector<u8> scrambled(rom, rom + size);
+	for (u32 i = 0; i < size; i++)
+	{
+		u32 address = i & ~0x3ffff;
+		for (int bit = 0; bit < 18; bit++)
+			if (BIT(i, bit))
+				address |= 1 << address_lines[bit];
+
+		const u8 source = scrambled[address];
+		u8 data = 0;
+		for (int bit = 0; bit < 8; bit++)
+			if (BIT(source, data_lines[bit]))
+				data |= 1 << bit;
+		rom[i] = data;
+	}
+}
+
+void roland_sc88_state::machine_start()
+{
+	m_lcd_timer = timer_alloc(FUNC(roland_sc88_state::lcd_done), this);
+
+	save_item(NAME(m_ga_regs));
+	save_item(NAME(m_ga_int_mask));
+	save_item(NAME(m_ga_int_pending));
+	save_item(NAME(m_lcd_fifo));
+	save_item(NAME(m_lcd_fifo_count));
+	save_item(NAME(m_lcd_command_pending));
+	save_item(NAME(m_xp_int));
+	save_item(NAME(m_lsp_mute));
+}
+
+void roland_sc88_state::machine_reset()
+{
+	std::fill(std::begin(m_ga_regs), std::end(m_ga_regs), 0);
+	m_ga_int_mask = 0xff;
+	m_ga_int_pending = 0;
+	m_lcd_fifo_count = 0;
+	m_lcd_command_pending = false;
+	m_lcd_timer->adjust(attotime::never);
+
+}
+
+
+//-------------------------------------------------
+//  gate array: LEDs, interrupt aggregator on IRQ0 and the LCD interface.
+//  The LCD is written through a command register and a data FIFO; the
+//  strobe transfers both and raises interrupt source 0 when done.
+//
+//    00     LEDs                 04     1 + pending interrupt source (read)
+//    01-02  ?                    05     interrupt mask, bit n masks source n
+//    03/07  LCD setup            1e     LCD strobe    1f  LCD command
+//                                20-2c  LCD data FIFO
+//-------------------------------------------------
+
+void roland_sc88_state::ga_int_update()
+{
+	m_maincpu->set_input_line(0, (m_ga_int_pending & ~m_ga_int_mask) ? ASSERT_LINE : CLEAR_LINE);
+}
+
+TIMER_CALLBACK_MEMBER(roland_sc88_state::lcd_done)
+{
+	m_ga_int_pending |= 1;
+	ga_int_update();
+}
+
+u8 roland_sc88_state::ga_r(offs_t offset)
+{
+	u8 data = m_ga_regs[offset];
+	switch (offset)
+	{
+	case 0x04:
+	{
+		// 1 + number of the lowest pending source, 0 when none; reading acknowledges it
+		const u8 active = m_ga_int_pending & ~m_ga_int_mask;
+		data = 0;
+		for (int source = 0; source < 8 && !data; source++)
+			if (BIT(active, source))
+			{
+				data = source + 1;
+				if (!machine().side_effects_disabled())
+				{
+					m_ga_int_pending &= ~(1 << source);
+					ga_int_update();
+				}
+			}
+		return data;
+	}
+	default:
+		break;
+	}
+	if (!machine().side_effects_disabled())
+		LOGMASKED(LOG_GA, "%s: gate array read %02x = %02x\n", machine().describe_context(), offset, data);
+	return data;
+}
+
+void roland_sc88_state::ga_w(offs_t offset, u8 data)
+{
+	LOGMASKED(LOG_GA, "%s: ga w %02x = %02x\n", machine().describe_context(), offset, data);
+	m_ga_regs[offset] = data;
+	switch (offset)
+	{
+	case 0x00:
+	case 0x01:
+	{
+		// 00 = LED data (ALL, MUTE, INST MAP, EQ, EDIT (upper, middle, lower),
+		// USER INST), gated by the common in 01 bit 0 (active low).  01 bit 1
+		// drives the SC-88Pro's second lens die directly (red; the green one is
+		// on the USER INST data line, and both lit show orange in EFX mode).
+		const u8 data = m_ga_regs[0x00];
+		const u8 commons = m_ga_regs[0x01];
+		for (int i = 0; i < 8; i++)
+			m_leds[i] = BIT(data, i) && !BIT(commons, 0);
+		m_leds[8] = BIT(commons, 1);
+		break;
+	}
+	case 0x05:
+		m_ga_int_mask = data;
+		ga_int_update();
+		break;
+	case 0x1e:
+	{
+		int bytes = m_lcd_fifo_count;
+		if (m_lcd_command_pending)
+		{
+			m_lcd->write(0, m_ga_regs[0x1f]);
+			bytes++;
+		}
+		for (int i = 0; i < m_lcd_fifo_count; i++)
+			m_lcd->write(1, m_lcd_fifo[i]);
+		m_lcd_command_pending = false;
+		m_lcd_fifo_count = 0;
+		m_lcd_timer->adjust(attotime::from_usec(40 * (bytes + 1)));
+		break;
+	}
+	case 0x1f:
+		m_lcd_command_pending = true;
+		break;
+	case 0x20: case 0x21: case 0x22: case 0x23: case 0x24: case 0x25:
+	case 0x26: case 0x27: case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c:
+		if (m_lcd_fifo_count < 13)
+			m_lcd_fifo[m_lcd_fifo_count++] = data;
+		break;
+	default:
+		LOGMASKED(LOG_GA, "%s: gate array write %02x = %02x\n", machine().describe_context(), offset, data);
+		break;
+	}
+}
+
+
+//-------------------------------------------------
+//  XP PCM chip on IRQ1; the interrupt handler polls the pin through port 8
+//-------------------------------------------------
+
+void roland_sc88_state::xp_int_w(int state)
+{
+	m_xp_int = state;
+	m_maincpu->set_input_line(1, state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+//-------------------------------------------------
+//  the XP clocks the LSP: SDOB carries the EFX send to TRR, TRS0 comes back on SDIA5
+//-------------------------------------------------
+
+// the XP's port carries the top 18 bits of its word, which are the top 18 of the LSP's; the return
+// comes back eight bits down and inverted. A linear effect only ever sees the product of the two,
+// so it took a clipping one to tell the split apart
+void roland_sc88_state::lsp_serial_w(offs_t port, u32 data)
+{
+	if ((port >> 1) != roland_xp_device::PORT_B)
+		return;
+	m_lsp->ser_w(port & 1, s32(data));
+	if (port & 1)
+		m_lsp->run_once();
+}
+
+u32 roland_sc88_state::lsp_serial_r(offs_t strobe)
+{
+	return m_lsp_mute ? 0 : u32(-(m_lsp->ser_r(strobe & 1) >> 8));
+}
+
+// P3-7 is LSPMUTE, the second input of the gate the return passes through: the firmware holds it low
+// while it uploads a program, and for ten seconds over the boot.
+void roland_sc88_state::lsp_mute_w(u8 data)
+{
+	m_lsp_mute = !BIT(data, 7);
+}
+
+//-------------------------------------------------
+//  port 4: the LCD contrast ladder and the audio mute
+//-------------------------------------------------
+
+// bit 4-7: LCD contrast
+// bit 3: timer output
+// bit 2: analog mute
+// bit 1: timer clock in
+// bit 0: sub-CPU reset (88VL only)
+u8 roland_sc88_state::port4_r()
+{
+	return 0xff;
+}
+
+void roland_sc88_state::port4_w(u8 data)
+{
+	LOGMASKED(LOG_PORT, "%s: port 4 = %02x (contrast %2d, mute %s)\n", machine().describe_context(),
+			data, ~data >> 4 & 0x0f, BIT(data, 2) ? "off" : "on");
+	if (m_subcpu.found())
+		m_subcpu->reset_w(BIT(data, 0));
+}
+
+// port 5 is the option strap block: P5-2, P5-3 and P5-4 trim the master output ramp by 1.5, 3 and 6 dB,
+// and P5-7 picks the serial format of the output pair. The boards ground P5-7, P5-6, P5-4 and P5-1.
+u8 roland_sc88_state::port5_r()
+{
+	return 0x2d;
+}
+
+u8 roland_sc88_state::port8_r()
+{
+	return m_xp_int ? 0xfd : 0xff;
+}
+
+
+//-------------------------------------------------
+//  analog inputs
+//-------------------------------------------------
+
+u16 roland_sc88_state::battery_r()
+{
+	return 0x2a0;
+}
+
+// the rear selector is a resistor ladder into three inputs; until the
+// thresholds are known each position pulls one input high
+u16 roland_sc88_state::computer_sw_r()
+{
+	return m_computer_sw.read_safe(0) ? 0x3ff : 0;
+}
+
+
+//-------------------------------------------------
+//  memory maps
+//-------------------------------------------------
 
 void roland_sc88_state::main_map(address_map &map)
 {
 	map(0x000000, 0x07ffff).rom().region("progrom", 0);
-	map(0x080000, 0x08ffff).ram().share("nvram");
+	map(0x008000, 0x00ffff).rw(FUNC(roland_sc88_state::ram_alias_r), FUNC(roland_sc88_state::ram_alias_w));
+	map(0x080000, 0x08ffff).ram().share(m_nvram);
+	map(0x0e8000, 0x0effff).rw(FUNC(roland_sc88_state::ram_alias_r), FUNC(roland_sc88_state::ram_alias_w));
+	map(0x0e0000, 0x0e3fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0x0f0000, 0x0f00ff).rw(m_subcpu, FUNC(sc88_sub_device::read), FUNC(sc88_sub_device::write));
+	map(0x0fc100, 0x0fc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
 }
 
-void roland_sc88_state::pro_map(address_map &map)
+void roland_sc88_state::sc88pro_map(address_map &map)
 {
 	map(0x000000, 0x0fffff).rom().region("progrom", 0);
-	map(0x100000, 0x10ffff).ram().share("nvram");	// TODO: probably incorrect
+	map(0xc00000, 0xc0ffff).ram().share(m_nvram);
+	map(0xc80000, 0xc83fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0xe00000, 0xe000ff).rw(m_subcpu, FUNC(sc88_sub_device::read), FUNC(sc88_sub_device::write));
+	map(0xefc100, 0xefc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
+	map(0xf00000, 0xf000ff).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
 }
 
+void roland_sc88_state::vegspro_map(address_map &map)
+{
+	map(0x000000, 0x0fffff).rom().region("progrom", 0);
+	map(0xc00000, 0xc0ffff).ram().share(m_nvram);
+	map(0xc80000, 0xc83fff).rw(m_xp, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0xefc100, 0xefc1ff).rw(FUNC(roland_sc88_state::ga_r), FUNC(roland_sc88_state::ga_w));
+	map(0xf00000, 0xf000ff).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
+}
+
+// the XP's region number: bits 6-4 select the ROM chip, bits 3-0 the 1 MB page in it
+void roland_sc88_state::xp_rom_map(address_map &map)
+{
+	map(0x0000000, 0x01fffff).rom().region("waverom", 0x000000);
+	map(0x1000000, 0x11fffff).rom().region("waverom", 0x200000);
+	map(0x2000000, 0x21fffff).rom().region("waverom", 0x400000);
+	map(0x3000000, 0x31fffff).rom().region("waverom", 0x600000);
+}
+
+// five 32 Mbit ROMs, XWCS0-4 = IC20-IC24 (service notes, main circuit diagram)
+void roland_sc88_state::pro_xp_rom_map(address_map &map)
+{
+	map(0x0000000, 0x03fffff).rom().region("waverom", 0x000000);
+	map(0x1000000, 0x13fffff).rom().region("waverom", 0x400000);
+	map(0x2000000, 0x23fffff).rom().region("waverom", 0x800000);
+	map(0x3000000, 0x33fffff).rom().region("waverom", 0xc00000);
+	map(0x4000000, 0x43fffff).rom().region("waverom", 0x1000000);
+}
+
+
+//-------------------------------------------------
+//  LCD: the RCM2024T glass of the SC-55mkII, see roland_sc55mk2.cpp
+//-------------------------------------------------
+
+void roland_sc88_state::lcd_palette(palette_device &palette) const
+{
+	palette.set_pen_color(0, rgb_t(0xf8, 0xc8, 0x40)); // background
+	palette.set_pen_color(1, rgb_t(0x20, 0x10, 0x00)); // segment on
+}
+
+static constexpr int LCD_CHAR_PITCH = 35;
+static constexpr int LCD_DOT_PITCH = 6;
+static constexpr int LCD_DOT_SIZE = 5;
+static constexpr int LCD_COL0_X = 24;
+static constexpr int LCD_COL1_X = 143;
+static constexpr int LCD_ROW_Y[4] = { 14, 78, 142, 206 };
+static constexpr int LCD_BAR_X = 283;
+static constexpr int LCD_BAR_Y = 74;
+static constexpr int LCD_BAR_PITCH_X = 26;
+static constexpr int LCD_BAR_PITCH_Y = 11;
+static constexpr int LCD_BAR_W = 24;
+static constexpr int LCD_BAR_H = 9;
+static constexpr int LCD_LR_X = 254;
+static constexpr int LCD_LR_Y[2] = { 74, 234 };
+
+static void lcd_fill(bitmap_ind16 &bitmap, int x, int y, int w, int h, int state)
+{
+	for (int yy = y; yy < y + h; yy++)
+		for (int xx = x; xx < x + w; xx++)
+			bitmap.pix(yy, xx) = state;
+}
+
+HD44780_PIXEL_UPDATE(roland_sc88_state::lcd_pixel_update)
+{
+	if (pos >= 20 && pos < 24 && line < 2)
+	{
+		int const bar = (pos - 20) * 5 + x;
+		if (bar < 16)
+			lcd_fill(bitmap, LCD_BAR_X + bar * LCD_BAR_PITCH_X, LCD_BAR_Y + (line * 8 + y) * LCD_BAR_PITCH_Y, LCD_BAR_W, LCD_BAR_H, state);
+		return;
+	}
+
+	if (line == 1 && pos == 18)
+	{
+		if (y == 0 && x == 4)
+		{
+			static constexpr u16 L_SHAPE[12] = { 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x600, 0x7ff, 0x7ff };
+			static constexpr u16 R_SHAPE[12] = { 0x7fc, 0x7fe, 0x606, 0x606, 0x606, 0x7fe, 0x7fc, 0x630, 0x618, 0x60c, 0x606, 0x603 };
+			for (int i = 0; i < 12; i++)
+				for (int j = 0; j < 11; j++)
+				{
+					if (BIT(L_SHAPE[i], 10 - j))
+						bitmap.pix(LCD_LR_Y[0] + i, LCD_LR_X + j) = state;
+					if (BIT(R_SHAPE[i], 10 - j))
+						bitmap.pix(LCD_LR_Y[1] + i, LCD_LR_X + j) = state;
+				}
+		}
+		return;
+	}
+
+	if (y >= 7)
+		return;
+
+	int cx, cy;
+	if (line == 0)
+	{
+		if (pos < 3)
+			cx = LCD_COL0_X + pos * LCD_CHAR_PITCH;
+		else if (pos < 19)
+			cx = LCD_COL1_X + (pos - 3) * LCD_CHAR_PITCH;
+		else
+			return;
+		cy = LCD_ROW_Y[0];
+	}
+	else if (line == 1 && pos < 18)
+	{
+		int const field = pos / 3;
+		static constexpr int FIELD_COL[6] = { 0, 1, 1, 0, 0, 1 };
+		static constexpr int FIELD_ROW[6] = { 1, 1, 2, 2, 3, 3 };
+		cx = (FIELD_COL[field] ? LCD_COL1_X : LCD_COL0_X) + (pos % 3) * LCD_CHAR_PITCH;
+		cy = LCD_ROW_Y[FIELD_ROW[field]];
+	}
+	else
+		return;
+
+	lcd_fill(bitmap, cx + x * LCD_DOT_PITCH, cy + y * LCD_DOT_PITCH, LCD_DOT_SIZE, LCD_DOT_SIZE, state);
+}
+
+
+//-------------------------------------------------
+//  machine configuration
+//-------------------------------------------------
+
+// front panel switch matrix: SSC0-SSC3 strobes select the columns, SD0-SD7 are
+// the rows (switch board, service notes p.15); PREVIEW is the volume knob's
+// push switch on the VR board, on SSC0/SD7.
 static INPUT_PORTS_START(sc88)
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EQ")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-55 Map")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument <")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument >")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Mute")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("All")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Preview")
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part >")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst Edit On/Off")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst Edit Select")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / Delay <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / Delay >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release >")
+
+	// rear panel selector, read through the analog inputs as a resistor ladder
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x03, 0x00, "Computer Switch")
+	PORT_CONFSETTING(0x00, "MIDI")
+	PORT_CONFSETTING(0x01, "PC-1")
+	PORT_CONFSETTING(0x02, "PC-2")
+	PORT_CONFSETTING(0x03, "Mac")
 INPUT_PORTS_END
 
-static INPUT_PORTS_START(sc88vl)
-INPUT_PORTS_END
-
+// same matrix positions as the SC-88; SC-88 MAP replaces EQ, and the lower
+// row doubles as the EFX controls
 static INPUT_PORTS_START(sc88pro)
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-88 Map")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SC-55 Map")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument <")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Instrument >")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Mute")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("All")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Preview")
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MIDI Ch >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Chorus >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pan >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part >")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift / Delay <")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Key Shift / Delay >")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Reverb >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Level >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Part <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("User Inst / EFX")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Select / EFX On/Off")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / EFX Type <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Rate / Attack / EFX Type >")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay / EFX Param <")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Depth / Cutoff / Decay / EFX Param >")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release / EFX Value <")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Vib Delay / Resonance / Release / EFX Value >")
+
+	// rear panel selector, read through the analog inputs as a resistor ladder
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x03, 0x00, "Computer Switch")
+	PORT_CONFSETTING(0x00, "MIDI")
+	PORT_CONFSETTING(0x01, "PC-1")
+	PORT_CONFSETTING(0x02, "PC-2")
+	PORT_CONFSETTING(0x03, "Mac")
 INPUT_PORTS_END
 
 void roland_sc88_state::sc88(machine_config &config)
 {
 	HD6415108(config, m_maincpu, 20_MHz_XTAL);
 	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::main_map);
+	m_maincpu->read_adc<0>().set(FUNC(roland_sc88_state::battery_r));
+	m_maincpu->read_adc<1>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<2>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<3>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_port4().set(FUNC(roland_sc88_state::port4_r));
+	m_maincpu->write_port4().set(FUNC(roland_sc88_state::port4_w));
+	m_maincpu->read_port5().set(FUNC(roland_sc88_state::port5_r));
+	m_maincpu->read_port8().set(FUNC(roland_sc88_state::port8_r));
 
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // ??
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // 2 x SRM2A256 + battery
 
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	SC88_SUB(config, m_subcpu, 20_MHz_XTAL / 2); // M38881M2, clocked from the H8's phi output
+	m_subcpu->int_callback().set_inputline(m_maincpu, 2); // IRQ2
+	m_subcpu->keys_callback<0>().set_ioport("KEY0");
+	m_subcpu->keys_callback<1>().set_ioport("KEY1");
+	m_subcpu->keys_callback<2>().set_ioport("KEY2");
+	m_subcpu->keys_callback<3>().set_ioport("KEY3");
+	m_subcpu->tx_callback().set("mdout", FUNC(midi_port_device::write_txd));
+
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_subcpu, FUNC(sc88_sub_device::rxd_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_subcpu, FUNC(sc88_sub_device::rxd_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	SCREEN(config, m_screen).set_lcd();
+	m_screen->set_refresh_hz(80);
+	m_screen->set_screen_update("lcd", FUNC(hd44780_device::screen_update));
+	m_screen->set_size(720, 272);
+	m_screen->set_visarea_full();
+	m_screen->set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(roland_sc88_state::lcd_palette), 2);
+
+	HD44780(config, m_lcd, 270'000);
+	m_lcd->set_lcd_size(2, 40);
+	m_lcd->set_pixel_update_cb(FUNC(roland_sc88_state::lcd_pixel_update));
+
+	config.set_default_layout(layout_roland_sc88);
+
+	SPEAKER(config, "speaker", 2).front();
+
+	ROLAND_XP(config, m_xp, 24.576_MHz_XTAL);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::xp_rom_map);
+	m_xp->int_callback().set(FUNC(roland_sc88_state::xp_int_w));
+	// one DAC on SDOC, the frame half picking left or right
+	m_xp->add_route(2, "speaker", 1.0, 0);
+	m_xp->add_route(3, "speaker", 1.0, 1);
 }
 
 void roland_sc88_state::sc88vl(machine_config &config)
 {
-	HD6415108(config, m_maincpu, 20_MHz_XTAL);
-	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::main_map);
-
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // SRM2A256SLM-70 x2 + battery
-
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	sc88(config);
 }
 
 void roland_sc88_state::sc88pro(machine_config &config)
 {
+	sc88(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::sc88pro_map);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::pro_xp_rom_map);
+
+	// OUTPUT 1 on SDOC, OUTPUT 2 on SDOD, the frame half picking left or right on each
+	SPEAKER(config, "output2", 2).front();
+	m_xp->add_route(4, "output2", 1.0, 0);
+	m_xp->add_route(5, "output2", 1.0, 1);
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+
+	// the EFX send leaves on port B; TRS0 comes back on port A
+	m_xp->port_out_callback().set(FUNC(roland_sc88_state::lsp_serial_w));
+	m_xp->port_a_in_callback().set(FUNC(roland_sc88_state::lsp_serial_r));
+	m_maincpu->write_port3().set(FUNC(roland_sc88_state::lsp_mute_w));
+
+	config.set_default_layout(layout_roland_sc88pro);
+}
+
+void roland_sc88_state::vegspro(machine_config &config)
+{
 	HD6415108(config, m_maincpu, 20_MHz_XTAL);
-	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::pro_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc88_state::vegspro_map);
+	m_maincpu->read_adc<0>().set(FUNC(roland_sc88_state::battery_r));
+	// the expansion board has no rear selector, but the SC-88Pro's firmware still polls the ladder
+	m_maincpu->read_adc<1>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<2>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_adc<3>().set(FUNC(roland_sc88_state::computer_sw_r));
+	m_maincpu->read_port4().set(FUNC(roland_sc88_state::port4_r));
+	m_maincpu->write_port4().set(FUNC(roland_sc88_state::port4_w));
+	m_maincpu->read_port8().set(FUNC(roland_sc88_state::port8_r));
+	m_maincpu->write_sci_tx<0>().set("mdout", FUNC(midi_port_device::write_txd));
 
-	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // ??
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0);
 
-	//M38881M2(config, "subcpu", 20_MHz_XTAL / 2);
+	// MIDI IN A/B go straight to the H8's serial ports, MIDI OUT comes from SCI1
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_maincpu, FUNC(hd6415108_device::sci_rx_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_maincpu, FUNC(hd6415108_device::sci_rx_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	SPEAKER(config, "speaker", 2).front();
+
+	ROLAND_XP(config, m_xp, 24.576_MHz_XTAL);
+	m_xp->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc88_state::pro_xp_rom_map);
+	m_xp->int_callback().set(FUNC(roland_sc88_state::xp_int_w));
+	// one DAC on SDOC, the frame half picking left or right: the board's firmware patches the Pro's
+	// program to strobe the pair out on one line, and halves the output gain for the host's mixer
+	m_xp->add_route(2, "speaker", 1.0, 0);
+	m_xp->add_route(3, "speaker", 1.0, 1);
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+
+	// the EFX send leaves on port B; TRS0 comes back on port A
+	m_xp->port_out_callback().set(FUNC(roland_sc88_state::lsp_serial_w));
+	m_xp->port_a_in_callback().set(FUNC(roland_sc88_state::lsp_serial_r));
+	m_maincpu->write_port3().set(FUNC(roland_sc88_state::lsp_mute_w));
 }
 
 #define ROM_LOAD16_WORD_SWAP_BIOS(bios,name,offset,length,hash) \
@@ -93,7 +779,7 @@ void roland_sc88_state::sc88pro(machine_config &config)
 
 ROM_START(sc88)
 	ROM_REGION16_BE(0x80000, "progrom", 0)
-	ROM_DEFAULT_BIOS("102")
+	ROM_DEFAULT_BIOS("104")
 	ROM_SYSTEM_BIOS(0, "102", "Control ROM 1.0.2")	// v1.02, 1994-06-16, 18:43 (offset 0x7cff6)
 	ROM_LOAD16_WORD_SWAP_BIOS(0, "roland_sc88-control-1.02-hn27c4096h.ic17", 0x00000, 0x80000, CRC(9e9c56f9) SHA1(9291a4e4ac0fea9fb5a39777be501ab3d34877c8))
 	ROM_SYSTEM_BIOS(1, "103", "Control ROM 1.0.3")	// v1.03, 1994-07-01, 10:48 (offset 0x7d136)
@@ -105,7 +791,7 @@ ROM_START(sc88)
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("subcpu.ic11", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x800000, "waverom", 0)
+	ROM_REGION(0x800000, "waverom", 0)
 	ROM_LOAD("sc88-pcm-ic-325.ic14", 0x000000, 0x200000, CRC(f9dd9e49) SHA1(860dcd9804ded4cd46aab38bfc3764a1ad7a6b65))
 	ROM_LOAD("sc88-pcm-ic-326.ic8",  0x200000, 0x200000, CRC(05f939f2) SHA1(ac95c26c46c40aacb944f5d45634c93bee9e6d90))
 	ROM_LOAD("sc88-pcm-ic-327.ic7",  0x400000, 0x200000, CRC(a6fc7393) SHA1(d88bf13c3d74097991b783295d95ccfae2c9282d))
@@ -119,31 +805,69 @@ ROM_START(sc88vl)
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("roland-r00232667-m38881m2-150gp.ic23", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x800000, "waverom", 0)
-	ROM_LOAD("roland-r00785356-hn624316fbc25.ic10", 0x000000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00785367-hn624316fbc26.ic7",  0x200000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00788489-hn624316fbc27.ic4",  0x400000, 0x200000, NO_DUMP)
-	ROM_LOAD("roland-r00788490-hn624316fbc28.ic2",  0x600000, 0x200000, NO_DUMP)
+	ROM_REGION(0x800000, "waverom", 0)
+	// the VL's own mask ROMs (roland-r00785356-hn624316fbc25.ic10, roland-r00785367-hn624316fbc26.ic7,
+	// roland-r00788489-hn624316fbc27.ic4, roland-r00788490-hn624316fbc28.ic2) are undumped;
+	// the sample data should be identical to the SC-88's, so use the parent's images
+	ROM_LOAD("sc88-pcm-ic-325.ic14", 0x000000, 0x200000, BAD_DUMP CRC(f9dd9e49) SHA1(860dcd9804ded4cd46aab38bfc3764a1ad7a6b65))
+	ROM_LOAD("sc88-pcm-ic-326.ic8",  0x200000, 0x200000, BAD_DUMP CRC(05f939f2) SHA1(ac95c26c46c40aacb944f5d45634c93bee9e6d90))
+	ROM_LOAD("sc88-pcm-ic-327.ic7",  0x400000, 0x200000, BAD_DUMP CRC(a6fc7393) SHA1(d88bf13c3d74097991b783295d95ccfae2c9282d))
+	ROM_LOAD("sc88-pcm-ic-328.ic6",  0x600000, 0x200000, BAD_DUMP CRC(7bc514aa) SHA1(03e70ae2efd190f41af24be01b1abaa84bfa93d9))
 ROM_END
 
 ROM_START(sc88pro)
 	ROM_REGION16_BE(0x100000, "progrom", 0)
-	ROM_LOAD16_WORD_SWAP("roland-r01780078.ic26", 0x00000, 0x100000, CRC(6cf8fc8b) SHA1(c07cbbd026781428ae83f4b897a51cb7bcdafeb6))
+	ROM_DEFAULT_BIOS("104")
+	ROM_SYSTEM_BIOS(0, "102", "Control ROM 1.0.2")	// v1.02, 1996-09-17, 08:01 (offset 0xcf554)
+	ROM_LOAD16_WORD_BIOS(0, "roland_sc88pro-1.02.ic26", 0x00000, 0x100000, CRC(7b0d392d) SHA1(19906eea7655bc105ef5077ce4fac10c21678225))
+	ROM_SYSTEM_BIOS(1, "104", "Control ROM 1.0.4")	// v1.04, 1997-02-18, 12:11 (offset 0xcf45c)
+	ROM_LOAD16_WORD_BIOS(1, "roland_sc88pro-1.04.ic26", 0x00000, 0x100000, CRC(820824d2) SHA1(6d06f00a1f8195a76b3af600ca708003f9a3abdc))
 
 	ROM_REGION(0x2000, "subcpu", 0)
 	ROM_LOAD("subcpu.ic10", 0x0000, 0x2000, NO_DUMP)
 
-	ROM_REGION16_LE(0x1400000, "waverom", 0)
-	// source unverified - the SC-88Pro service manual lists IC20..24 but the dumped files were called:
-	// "R01567167 301 (Samples A).bin", "R01567178 302 (Samples B).BIN" and "R01233667 314 (Samples C).BIN"
-	ROM_LOAD("roland-r01567167-301.ic20-21", 0x0000000, 0x800000, CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
-	ROM_LOAD("roland-r01567178-302.ic22-23", 0x0800000, 0x800000, CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
-	ROM_LOAD("roland-r01233667-314.ic24",    0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+	ROM_REGION(0x1400000, "waverom", 0)
+	// Wave ROM reconstructed from vegspro (same sample data, wider chips)
+	ROM_LOAD("roland-r01017834-378.ic20", 0x0000000, 0x400000, BAD_DUMP CRC(84dfea65) SHA1(1af429154193dfcda17d609fd73719750c133220))
+	ROM_LOAD("roland-r01017845-379.ic21", 0x0400000, 0x400000, BAD_DUMP CRC(60210227) SHA1(5a453a1bd93d1ddee7cc809430768d4a08739d2b))
+	ROM_LOAD("roland-r01124778-519.ic22", 0x0800000, 0x400000, BAD_DUMP CRC(5f883ddd) SHA1(78b17450d969c23fba5e9e3f8e4cbc4178096674))
+	ROM_LOAD("roland-r01124789-520.ic23", 0x0c00000, 0x400000, BAD_DUMP CRC(ecb4dd39) SHA1(a6b29144b165248162bef8ba4cded49efa4f5b90))
+	ROM_LOAD("roland-r01124790-521.ic24", 0x1000000, 0x400000, BAD_DUMP CRC(93541e95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+ROM_END
+
+/*
+ROM_START(sk88pro)
+	ROM_REGION16_BE(0x100000, "progrom", 0)
+	ROM_LOAD("roland-r01348078.ic8", 0x00000, 0x100000, NO_DUMP)
+	ROM_LOAD("roland_r01454223.ic7", 0x00000, 0x80000, NO_DUMP) // overlay
+
+	ROM_REGION(0x2000, "subcpu", 0)
+	ROM_LOAD("roland-r01235734-m38881m2-152gp.ic5", 0x0000, 0x2000, NO_DUMP)
+
+	ROM_REGION(0x1400000, "waverom", 0)
+	ROM_LOAD("roland-r01348723.ic13", 0x0000000, 0x800000, BAD_DUMP CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
+	ROM_LOAD("roland-r01348734.ic15", 0x0800000, 0x800000, BAD_DUMP CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
+	ROM_LOAD("roland-r01233667-314.ic17", 0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
+ROM_END
+*/
+
+ROM_START(vegspro)
+	ROM_REGION16_BE(0x100000, "progrom", 0)
+	// "SC88PRO (MK03B)" v1.02, 1997-05-19
+	ROM_LOAD16_WORD_SWAP("roland-r01780078.bin", 0x00000, 0x100000, CRC(6cf8fc8b) SHA1(c07cbbd026781428ae83f4b897a51cb7bcdafeb6))
+
+	ROM_REGION(0x1400000, "waverom", 0)
+	// dumped as "R01567167 301 (Samples A).bin", "R01567178 302 (Samples B).BIN", "R01233667 314 (Samples C).BIN"
+	ROM_LOAD("roland-r01567167-301.bin", 0x0000000, 0x800000, CRC(5754EE2E) SHA1(5cc1700b3f41921ed81fe3b92ba9ec28bd6649c9))
+	ROM_LOAD("roland-r01567178-302.bin", 0x0800000, 0x800000, CRC(E2B57861) SHA1(78b37ce0e735ad2c3e51338e74219a103d7fadba))
+	ROM_LOAD("roland-r01233667-314.bin", 0x1000000, 0x400000, CRC(93541E95) SHA1(e2ad5f0b2e5bdad84e42d080fc2e2fad523cb84b))
 ROM_END
 
 } // anonymous namespace
 
 
-SYST(1994, sc88, 0, 0, sc88, sc88, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-SYST(1995, sc88vl, 0, 0, sc88vl, sc88vl, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88VL", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
-SYST(1996, sc88pro, 0, 0, sc88pro, sc88pro, roland_sc88_state, empty_init, "Roland", "SoundCanvas SC-88Pro", MACHINE_NO_SOUND | MACHINE_NOT_WORKING)
+SYST(1994, sc88, 0, 0, sc88, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88", 0)
+SYST(1995, sc88vl, sc88, 0, sc88vl, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88VL", MACHINE_NOT_WORKING) // needs its own panel layout and input assignments
+SYST(1996, sc88pro, 0, 0, sc88pro, sc88pro, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SC-88Pro", 0)
+//SYST(1998, sk88pro, 0, 0, sk88pro, sc88, roland_sc88_state, init_sc88, "Roland", "Sound Canvas SK-88Pro", MACHINE_NOT_WORKING)
+SYST(1998, vegspro, 0, 0, vegspro, 0, roland_sc88_state, init_sc88, "Roland", "VE-GSPro Voice Expansion Board", MACHINE_NOT_WORKING)

--- a/src/mame/roland/roland_sc8850.cpp
+++ b/src/mame/roland/roland_sc8850.cpp
@@ -1,0 +1,794 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/****************************************************************************
+
+    Roland ED Sound Canvas SC-8850 and SC-8820.
+
+    The last of the Sound Canvas line: 64 parts over two MIDI ports, USB,
+    and on the SC-8850 two "XP" PCM chips splitting a 128 voice machine
+    between them.
+
+    SC-8850 main board (service notes and the control ROM):
+    - IC1 HD64F7017F28 SH-2 at 28.224 MHz in on-chip ROM enabled mode.  The
+      block diagram draws an SH7016 with a 64 kB mask ROM instead; the 64 kB
+      dump is self contained, so the flash part is a later production change.
+    - IC2 TC160G22AF gate array: LEDs, panel, reset and enable lines
+    - IC3 SED1335F0B graphics LCD controller with 32 kB of VRAM of its own,
+      driving a 160 x 64 panel
+    - IC4 M37640M8 USB controller (undumped), reached through two byte wide
+      mailboxes the firmware calls UIPC
+    - IC5/IC6 RA09-002 (XP6) PCM chips, the slave at 0x00a00000 and the
+      master at 0x00a80000, each with 512 kB of effect DRAM
+    - IC7 MB87837 (LSP) insertion effect processor on the slave's serial out
+    - IC9 1 MB program flash, IC10 2 MB tone parameter flash
+    - IC53/IC54 two 16 MB wave mask ROMs
+    - IC36/IC39 AK4324 DACs, 20 bit / 32 kHz, driven by the master's SDOC and
+      SDOD lines as OUTPUT 1 and OUTPUT 2
+
+    The two XPs split the machine: the master carries the reverb, the
+    equalizer, the output stage and both DACs, the slave the chorus, the
+    system delay and the link to the LSP, and fourteen words cross the
+    SDOA/SDIA link between them every frame.
+
+    SC-8820: the same firmware and the same sounds on one XP, with the
+    program and the tone parameters in a single 2 MB flash and no graphics
+    LCD.  Its own CPU is not dumped, and its USB controller is the one time
+    PROM part M37640E8FP at IC2, undumped as well.
+
+    Not emulated yet: the USB controller, which the firmware reports as a
+    hardware error and then carries on without - and without it the machine
+    cannot reach its second MIDI port, so half of its 64 parts are out of
+    reach - the program flash's writes, which is where the settings are
+    kept (see the memory map), and on the SC-8820 the panel and the
+    display, which do not go through a gate array there.
+
+****************************************************************************/
+
+#include "emu.h"
+
+#include "bus/midi/midiinport.h"
+#include "bus/midi/midioutport.h"
+#include "cpu/sh/sh7014.h"
+#include "sound/roland_lsp.h"
+#include "sound/roland_xp.h"
+#include "video/sed1330.h"
+
+#include "emupal.h"
+#include "screen.h"
+#include "speaker.h"
+
+#include <algorithm>
+
+#define LOG_GA      (1U << 1)
+#define LOG_UIPC    (1U << 2)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+
+namespace {
+
+class roland_sc8850_state : public driver_device
+{
+public:
+	roland_sc8850_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_master(*this, "xp1")
+		, m_slave(*this, "xp2")
+		, m_lsp(*this, "lsp")
+		, m_lcdc(*this, "lcdc")
+		, m_computer_sw(*this, "COMPUTER")
+		, m_keys(*this, "KEY%u", 0U)
+		, m_dial(*this, "VALUE")
+		, m_leds(*this, "led%u", 0U)
+	{
+	}
+
+	void sc8850(machine_config &config);
+	void sc8820(machine_config &config);
+
+	void init_sc8850() ATTR_COLD;
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	void sc8850_map(address_map &map) ATTR_COLD;
+	void sc8820_map(address_map &map) ATTR_COLD;
+	void lcdc_map(address_map &map) ATTR_COLD;
+	void xp_rom_map(address_map &map) ATTR_COLD;
+	void sc8820_xp_rom_map(address_map &map) ATTR_COLD;
+
+	void lcd_palette(palette_device &palette) const;
+
+	u8 ga_r(offs_t offset);
+	void ga_w(offs_t offset, u8 data);
+	void ga_raise(u8 source);
+	void ga_present();
+	void ga_lower();
+	TIMER_CALLBACK_MEMBER(ga_scan);
+	TIMER_CALLBACK_MEMBER(ga_tick);
+	TIMER_CALLBACK_MEMBER(ga_sequencer);
+	u16 porta_r();
+
+	template <int Channel> u8 uipc_r(offs_t offset);
+	template <int Channel> void uipc_w(offs_t offset, u8 data);
+
+	u16 computer_sw_r() { return m_computer_sw.read_safe(0); }
+
+	void pump_slave(int state);
+	u32 master_link_r(offs_t strobe);
+	u32 slave_link_r(offs_t strobe);
+	void lsp_serial_w(offs_t port, u32 data);
+	u32 lsp_serial_r(offs_t group);
+
+	required_device<sh7014_device> m_maincpu;
+	required_device<roland_xp_device> m_master;
+	optional_device<roland_xp_device> m_slave;
+	required_device<roland_lsp_device> m_lsp;
+	optional_device<sed1330_device> m_lcdc;
+	optional_ioport m_computer_sw;
+	optional_ioport_array<4> m_keys;
+	optional_ioport m_dial;
+	output_finder<16> m_leds;
+
+	// the voice service tick, timed against the machine's own portamento
+	static constexpr int TICK_HZ = 100;
+	// the sequencer clock, one millisecond
+	static constexpr int SEQUENCER_HZ = 1000;
+
+	emu_timer *m_ga_timer = nullptr;
+	emu_timer *m_ga_tick_timer = nullptr;
+	emu_timer *m_ga_sequencer_timer = nullptr;
+	u16 m_ga_requests = 0;
+	u8 m_ga_regs[0x100]{};
+	u8 m_ga_event = 0;
+	u8 m_ga_source = 0;
+	bool m_ga_pending = false;
+	u8 m_key_state[4]{};
+	u8 m_scan_position = 0;
+	bool m_scan_encoder = false;
+	u8 m_dial_position = 0;
+	s32 m_encoder = 0;
+	u32 m_uipc_step = 0;
+};
+
+
+//-------------------------------------------------
+//  the wave ROMs are stored as dumped: the board permutes the address lines
+//  within each 256 KB block and the data lines.  The permutation is the pair
+//  the SC-88 family uses, but this generation wires it the other way round.
+//-------------------------------------------------
+
+void roland_sc8850_state::init_sc8850()
+{
+	memory_region *region = memregion("waverom");
+	u8 *rom = region->base();
+	const u32 size = region->bytes();
+
+	static const u8 address_lines[18] = { 0, 4, 2, 3, 1, 8, 12, 6, 13, 11, 9, 16, 7, 5, 14, 17, 10, 15 };
+	static const u8 data_lines[8] = { 2, 0, 4, 5, 7, 6, 3, 1 };
+
+	std::vector<u8> scrambled(rom, rom + size);
+	for (u32 i = 0; i < size; i++)
+	{
+		u32 address = i & ~0x3ffff;
+		for (int bit = 0; bit < 18; bit++)
+			if (BIT(i, bit))
+				address |= 1 << address_lines[bit];
+
+		const u8 source = scrambled[address];
+		u8 data = 0;
+		for (int bit = 0; bit < 8; bit++)
+			if (BIT(source, data_lines[bit]))
+				data |= 1 << bit;
+		rom[i] = data;
+	}
+}
+
+void roland_sc8850_state::machine_start()
+{
+	m_ga_timer = timer_alloc(FUNC(roland_sc8850_state::ga_scan), this);
+	m_ga_tick_timer = timer_alloc(FUNC(roland_sc8850_state::ga_tick), this);
+	m_ga_sequencer_timer = timer_alloc(FUNC(roland_sc8850_state::ga_sequencer), this);
+
+	save_item(NAME(m_ga_regs));
+	save_item(NAME(m_ga_event));
+	save_item(NAME(m_ga_requests));
+	save_item(NAME(m_ga_source));
+	save_item(NAME(m_ga_pending));
+	save_item(NAME(m_key_state));
+	save_item(NAME(m_scan_position));
+	save_item(NAME(m_scan_encoder));
+	save_item(NAME(m_dial_position));
+	save_item(NAME(m_encoder));
+	save_item(NAME(m_uipc_step));
+}
+
+void roland_sc8850_state::machine_reset()
+{
+	std::fill(std::begin(m_ga_regs), std::end(m_ga_regs), 0);
+	std::fill(std::begin(m_key_state), std::end(m_key_state), 0);
+	m_ga_event = 0;
+	m_ga_source = 0;
+	m_ga_pending = false;
+	m_ga_requests = 0;
+	m_scan_position = 0;
+	m_scan_encoder = false;
+	m_dial_position = 0;
+	m_encoder = 0;
+	m_uipc_step = 0;
+
+	if (m_keys[0].found())
+	{
+		m_ga_timer->adjust(attotime::from_usec(250), 0, attotime::from_usec(250));
+		m_ga_tick_timer->adjust(attotime::from_hz(TICK_HZ), 0, attotime::from_hz(TICK_HZ));
+		m_ga_sequencer_timer->adjust(attotime::from_hz(SEQUENCER_HZ), 0, attotime::from_hz(SEQUENCER_HZ));
+	}
+}
+
+
+//-------------------------------------------------
+//  the TC160G22AF gate array
+//
+//  Sixteen sources share IRQ2 and the line the CPU sees on PA8.  0x40 names
+//  the one that is waiting; the handler the firmware picks out of a table in
+//  DRAM reads that source's own data register, which is what takes the event
+//  and drops the line.  Two of the sixteen are the front panel.
+//
+//  Source 0 is the switches, a four by eight matrix read at 0x43: the row in
+//  bits 6-3, the column in bits 2-0, and bit 7 set when the switch has come
+//  up.  The two column seven positions are not in the matrix and read the
+//  other way round, which the firmware undoes for exactly those two codes.
+//
+//  Source 1 is the value encoder, read at 0x42 as the movement since the
+//  last read, a signed byte.
+//
+//  Source 10 is the voice service tick, and nothing else in the machine wakes
+//  the task that owns the chip's ramps: its handler counts the tick and posts
+//  that task's only event, so without it a note starts and never moves again.
+//  A source with no data register of its own is taken by the read of 0x40.
+//  It steps a portamento by one pitch step, which is what times it: a glide
+//  takes the same number of steps whatever the rate, and three of them against
+//  the machine make it a hundredth of a second.
+//
+//  Source 11 is the sequencer clock, and it is the machine's millisecond: the
+//  phrase player registers a handler on it only while it has something to
+//  play, and steps the phrase by the microseconds its tempo gives each step.
+//  Without it the preview and the demo start and then stand still.
+//
+//  0x3e and 0x3f carry the sixteen interrupt enables, one bit a source, and
+//  the firmware keeps them shadowed at 0x01052cd9 and 0x01052cda; a source
+//  whose bit is clear waits.  0x38 and 0x39 are the sixteen LED drives, active
+//  low and rewritten whenever the panel is redrawn; five are fitted, SOLO and
+//  MUTE in the first byte and EDIT, DRUM and EFFECT in the second.  0x3a
+//  carries two reset or enable bits.  The rest the boot ROM writes once and
+//  neither it nor the firmware reads.
+//-------------------------------------------------
+
+void roland_sc8850_state::ga_raise(u8 source)
+{
+	m_ga_requests |= 1 << source;
+	ga_present();
+}
+
+void roland_sc8850_state::ga_present()
+{
+	const u16 enabled = m_ga_requests & (m_ga_regs[0x3e] | (m_ga_regs[0x3f] << 8));
+	if (m_ga_pending || !enabled)
+		return;
+
+	for (m_ga_source = 0; !BIT(enabled, m_ga_source); m_ga_source++)
+		;
+
+	m_ga_pending = true;
+	m_maincpu->set_input_line(2, ASSERT_LINE);
+}
+
+void roland_sc8850_state::ga_lower()
+{
+	m_ga_requests &= ~(1 << m_ga_source);
+	m_ga_pending = false;
+	m_maincpu->set_input_line(2, CLEAR_LINE);
+	ga_present();
+}
+
+TIMER_CALLBACK_MEMBER(roland_sc8850_state::ga_tick)
+{
+	ga_raise(10);
+}
+
+TIMER_CALLBACK_MEMBER(roland_sc8850_state::ga_sequencer)
+{
+	ga_raise(11);
+}
+
+TIMER_CALLBACK_MEMBER(roland_sc8850_state::ga_scan)
+{
+	if (BIT(m_ga_requests, 0) || BIT(m_ga_requests, 1))
+		return;
+
+	const u8 dial = m_dial.read_safe(0);
+	m_encoder += s8(dial - m_dial_position);
+	m_dial_position = dial;
+
+	m_scan_encoder = !m_scan_encoder;
+	if (m_scan_encoder && m_encoder != 0)
+	{
+		ga_raise(1);
+		return;
+	}
+
+	for (int i = 0; i < 32; i++)
+	{
+		m_scan_position = (m_scan_position + 1) & 0x1f;
+		const int row = m_scan_position >> 3, column = m_scan_position & 7;
+		const u8 mask = 1 << column;
+		if (BIT(m_keys[row].read_safe(0), column) == bool(m_key_state[row] & mask))
+			continue;
+
+		m_key_state[row] ^= mask;
+		const bool up = bool(m_key_state[row] & mask) == (column == 7);
+		m_ga_event = (up ? 0x80 : 0x00) | (row << 3) | column;
+		ga_raise(0);
+		return;
+	}
+}
+
+u8 roland_sc8850_state::ga_r(offs_t offset)
+{
+	u8 data = m_ga_regs[offset];
+	switch (offset)
+	{
+	case 0x40:
+		data = m_ga_source;
+		if (!machine().side_effects_disabled() && m_ga_source > 1)
+			ga_lower();
+		break;
+
+	case 0x42:
+		data = u8(std::clamp<s32>(m_encoder, -128, 127));
+		if (!machine().side_effects_disabled())
+		{
+			m_encoder -= s8(data);
+			ga_lower();
+		}
+		break;
+
+	case 0x43:
+		data = m_ga_event;
+		if (!machine().side_effects_disabled())
+			ga_lower();
+		break;
+
+	default:
+		if (!machine().side_effects_disabled())
+			LOGMASKED(LOG_GA, "%s: gate array read %02x = %02x\n", machine().describe_context(), offset, data);
+		break;
+	}
+	return data;
+}
+
+void roland_sc8850_state::ga_w(offs_t offset, u8 data)
+{
+	m_ga_regs[offset] = data;
+	switch (offset)
+	{
+	case 0x38:
+	case 0x39:
+		for (int i = 0; i < 8; i++)
+			m_leds[(offset & 1) * 8 + i] = !BIT(data, i);
+		break;
+
+	case 0x3e:
+	case 0x3f:
+		ga_present();
+		break;
+	default:
+		LOGMASKED(LOG_GA, "%s: gate array write %02x = %02x\n", machine().describe_context(), offset, data);
+		break;
+	}
+}
+
+// the gate array pulls PA8 down while it has an event waiting.  The boot
+// ROM's own panel pass takes the pin off IRQ2, polls it and puts it back.
+u16 roland_sc8850_state::porta_r()
+{
+	return m_ga_pending ? 0x0000 : 0x0100;
+}
+
+
+//-------------------------------------------------
+//  the two host channels of the M37640 USB controller, "UIPC" to the
+//  firmware: +0 data, +1 status, with bit 0 of the status saying a byte has
+//  arrived on channel 1 and bit 1 that channel 0 will take one.  A byte
+//  whose status has any of bits 4-7 set is a tagged one and the firmware's
+//  plain reader discards it.
+//
+//  The controller runs a 32 KB program that the SC-8850's own flash carries
+//  at 0x00250674 and pushes across this mailbox at power-on: it waits for
+//  fa, answers a tagged byte, then fb, sends the two bytes of a constant,
+//  waits for fc, and then either fe (send the program) or fd followed by ff
+//  (the controller is already running).  Nothing here emulates the
+//  controller, so this walks the short branch of that handshake and then
+//  goes quiet, which is what gets the machine past its power-on wait.
+//-------------------------------------------------
+
+template <int Channel>
+u8 roland_sc8850_state::uipc_r(offs_t offset)
+{
+	if (Channel == 0)
+		return offset ? 0x02 : 0x00;
+
+	static const u8 boot[][2] = {
+		{ 0x01, 0xfa }, { 0xf1, 0x00 }, { 0x01, 0xfb }, { 0x01, 0xfc }, { 0x01, 0xfd }, { 0x01, 0xff }
+	};
+
+	if (m_uipc_step >= std::size(boot))
+		return 0x00;
+
+	if (offset == 0)
+	{
+		const u8 data = boot[m_uipc_step][1];
+		if (!machine().side_effects_disabled())
+		{
+			LOGMASKED(LOG_UIPC, "%s: uipc handshake byte %02x\n", machine().describe_context(), data);
+			m_uipc_step++;
+		}
+		return data;
+	}
+
+	return boot[m_uipc_step][0];
+}
+
+template <int Channel>
+void roland_sc8850_state::uipc_w(offs_t offset, u8 data)
+{
+	LOGMASKED(LOG_UIPC, "%s: uipc%d write %d = %02x\n", machine().describe_context(), Channel, offset, data);
+}
+
+
+
+
+//-------------------------------------------------
+//  the link between the two XPs: six SDOA and six SDIA lines in both
+//  directions, carrying fourteen words a frame.  Both programs strobe port A
+//  on the same eight slots, so each chip reads what the other has at that
+//  strobe; and because every word the master sends is written before its
+//  strobe and every word the slave sends after it, running the master's frame
+//  and then the slave's gives each side exactly what the wire would.
+//-------------------------------------------------
+
+void roland_sc8850_state::pump_slave(int state)
+{
+	m_slave->run_frame();
+}
+
+u32 roland_sc8850_state::master_link_r(offs_t strobe)
+{
+	return m_master->port_a_out_r(strobe);
+}
+
+u32 roland_sc8850_state::slave_link_r(offs_t strobe)
+{
+	return m_slave->port_a_out_r(strobe);
+}
+
+
+//-------------------------------------------------
+//  the slave clocks the insertion effect's send out on SDOC and takes its
+//  return on port B, which the program reads with `col 0x1c`.  The chip
+//  refreshes that node at each group's first strobe, after the strobe's own
+//  instruction, so the program's read on the strobe sees the other half's
+//  word: the half-frame rotation is the chip's, on both machines.
+//-------------------------------------------------
+
+void roland_sc8850_state::lsp_serial_w(offs_t port, u32 data)
+{
+	if ((port >> 1) != roland_xp_device::PORT_C)
+		return;
+	m_lsp->ser_w(port & 1, s32(data));
+	if (port & 1)
+		m_lsp->run_once();
+}
+
+u32 roland_sc8850_state::lsp_serial_r(offs_t group)
+{
+	return u32(-(m_lsp->ser_r(group & 1) >> 8));
+}
+
+
+//-------------------------------------------------
+//  memory maps
+//
+//  The SH7010 series decodes A23/A22 into CS0-CS3.  The boot ROM sets CS1
+//  eight bits wide and everything else sixteen; CS1's five devices are
+//  decoded again on a 256 KB grid.
+//
+//  The two flashes on CS0 and CS3 are mapped as plain ROM, and that is
+//  where the machine's settings would go: it has no battery SRAM, and every
+//  user setting lives in block 0xe of the program flash, 0x2e0000-0x2effff.
+//  A save - the Utility page's ENTER, a user instrument's write - runs the
+//  boot ROM's flash driver over it: read the chip's ID at 0x200000, clear
+//  the block's lock bits, erase it, program 14340 words (the system
+//  parameters first, then the user instruments and drum sets) and set
+//  block 0's lock bit again.  That driver knows two Sharp parts, 00b0/0050
+//  for the program flash, sixteen 64 KB blocks with its write enable on
+//  port B bit 9, and 00b0/00d0 for the tone flash, thirty-two blocks on
+//  bit 8, which no user action ever writes.  Against plain ROM the ID read
+//  comes back as data, so the firmware takes its unknown-chip path, skips
+//  the erase and aims its lock commands at address 4, and the settings are
+//  the dump's again at the next power-on.  Emulating the chip - word
+//  programming, block erase, status and ID in place of data while it is
+//  out of read-array mode - is what an NVRAM would take; it is not done.
+//-------------------------------------------------
+
+void roland_sc8850_state::sc8850_map(address_map &map)
+{
+	map(0x00000000, 0x0000ffff).rom().region("cpurom", 0);
+	map(0x00200000, 0x002fffff).rom().region("progrom", 0);
+	map(0x00500000, 0x00500000).rw(m_lcdc, FUNC(sed1330_device::data_r), FUNC(sed1330_device::data_w));
+	map(0x00500001, 0x00500001).rw(m_lcdc, FUNC(sed1330_device::status_r), FUNC(sed1330_device::command_w));
+	map(0x00540000, 0x00540001).rw(FUNC(roland_sc8850_state::uipc_r<0>), FUNC(roland_sc8850_state::uipc_w<0>));
+	map(0x00580000, 0x00580001).rw(FUNC(roland_sc8850_state::uipc_r<1>), FUNC(roland_sc8850_state::uipc_w<1>));
+	map(0x005c0000, 0x005c000f).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
+	map(0x006c0000, 0x006c00ff).rw(FUNC(roland_sc8850_state::ga_r), FUNC(roland_sc8850_state::ga_w));
+	map(0x00a00000, 0x00a03fff).rw(m_slave, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0x00a80000, 0x00a83fff).rw(m_master, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0x00d00000, 0x00efffff).rom().region("toneprm", 0);
+	map(0x01000000, 0x0107ffff).mirror(0x00f80000).ram();
+}
+
+// the SC-8820 keeps the two mailboxes where they are, moves the LSP down to
+// where the SC-8850 puts its LCD controller, has no gate array, and carries
+// its program and its tone parameters in one flash on CS3
+void roland_sc8850_state::sc8820_map(address_map &map)
+{
+	map(0x00000000, 0x0000ffff).rom().region("cpurom", 0);
+	map(0x00500000, 0x0050000f).rw(m_lsp, FUNC(roland_lsp_device::host_r), FUNC(roland_lsp_device::host_w));
+	map(0x00540000, 0x00540001).rw(FUNC(roland_sc8850_state::uipc_r<0>), FUNC(roland_sc8850_state::uipc_w<0>));
+	map(0x00580000, 0x00580001).rw(FUNC(roland_sc8850_state::uipc_r<1>), FUNC(roland_sc8850_state::uipc_w<1>));
+	map(0x00900000, 0x00903fff).rw(m_master, FUNC(roland_xp_device::read), FUNC(roland_xp_device::write));
+	map(0x00d00000, 0x00efffff).rom().region("progrom", 0);
+	map(0x01000000, 0x0107ffff).mirror(0x00f80000).ram();
+}
+
+void roland_sc8850_state::lcdc_map(address_map &map)
+{
+	map(0x0000, 0x7fff).ram(); // TC55257 32 KB
+}
+
+// two 16 MB mask ROMs, on wave chip selects 5 and 6
+// the XP asks for a wave byte as a chip select in bits 27-24 and a 1 MB bank
+// in bits 23-20, and it is the board that decides what each of the eight
+// selects reaches.  This one gives each of them four banks, in order, so the
+// pair of 16 MB mask ROMs is a flat 32 MB: the machine's own wave table uses
+// all eight selects and never a bank above three, and every one of its
+// descriptors below 20 MB is then the same wave, at the same offset, as the
+// SC-8820's.
+void roland_sc8850_state::xp_rom_map(address_map &map)
+{
+	for (int select = 0; select < 8; select++)
+		map(select << 24, (select << 24) | 0x3fffff).rom().region("waverom", select << 22);
+}
+
+// the SC-8820 has 16 MB and 8 MB; it cannot boot far enough to say which
+// selects it uses, so it follows its sibling's
+// the SC-8820 numbers its banks straight through instead, 0 to 23 with no
+// chip select at all, so its two ROMs are one window.
+void roland_sc8850_state::sc8820_xp_rom_map(address_map &map)
+{
+	map(0x0000000, 0x17fffff).rom().region("waverom", 0x0000000);
+}
+
+
+//-------------------------------------------------
+//  the 160 x 64 graphic panel
+//-------------------------------------------------
+
+void roland_sc8850_state::lcd_palette(palette_device &palette) const
+{
+	palette.set_pen_color(0, rgb_t(0xf8, 0xc8, 0x40)); // backlight
+	palette.set_pen_color(1, rgb_t(0x20, 0x10, 0x00)); // dot on
+}
+
+
+//-------------------------------------------------
+//  machine configuration
+//-------------------------------------------------
+
+// the rear panel COMPUTER switch, a four position resistor ladder on AN0: the boot ROM sorts the ten bit
+// result, left aligned in ADDRA, into four bands at 0x3ff0, 0x7fe0 and 0xbfd0, and the firmware routes
+// MIDI by the band.  Only the MIDI position gives the two MIDI IN ports a handler table that reaches the
+// part assigner; the others hand the machine to a USB or serial host that nothing here answers.
+static INPUT_PORTS_START(sc8850)
+	// the switch matrix as the firmware reads it: the row and column of each
+	// code taken from the table at 0x00250410, its name from the one the
+	// switch and LED test prints at 0x00286410
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Map")
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("F4")
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("F3")
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("F2")
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("F1")
+	PORT_BIT(0x60, IP_ACTIVE_HIGH, IPT_UNUSED)
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Value")
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Edit")
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Drum")
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Effect")
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Shift")
+	PORT_BIT(0x70, IP_ACTIVE_HIGH, IPT_UNUSED)
+	PORT_BIT(0x80, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Preview")
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Part <")
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Down")
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Exit")
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Solo")
+	PORT_BIT(0xf0, IP_ACTIVE_HIGH, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Part >")
+	PORT_BIT(0x02, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Up")
+	PORT_BIT(0x04, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Enter")
+	PORT_BIT(0x08, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Mute")
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Dec / -")
+	PORT_BIT(0x20, IP_ACTIVE_HIGH, IPT_KEYPAD) PORT_NAME("Inc / +")
+	PORT_BIT(0xc0, IP_ACTIVE_HIGH, IPT_UNUSED)
+
+	PORT_START("VALUE")
+	PORT_BIT(0xff, 0x00, IPT_DIAL) PORT_NAME("Value Dial") PORT_SENSITIVITY(25) PORT_KEYDELTA(2) PORT_CODE_DEC(KEYCODE_LEFT) PORT_CODE_INC(KEYCODE_RIGHT)
+
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x3ff, 0x000, "Computer Switch")
+	PORT_CONFSETTING(0x000, "MIDI")
+	PORT_CONFSETTING(0x180, "PC-1")
+	PORT_CONFSETTING(0x280, "PC-2")
+	PORT_CONFSETTING(0x3ff, "USB")
+INPUT_PORTS_END
+
+// the SC-8820's panel does not go through a gate array and is not identified,
+// so it has no switch matrix for the scanner to walk
+static INPUT_PORTS_START(sc8820)
+	PORT_START("COMPUTER")
+	PORT_CONFNAME(0x3ff, 0x000, "Computer Switch")
+	PORT_CONFSETTING(0x000, "MIDI")
+	PORT_CONFSETTING(0x180, "PC-1")
+	PORT_CONFSETTING(0x280, "PC-2")
+	PORT_CONFSETTING(0x3ff, "USB")
+INPUT_PORTS_END
+
+void roland_sc8850_state::sc8850(machine_config &config)
+{
+	SH7014(config, m_maincpu, 28.224_MHz_XTAL);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc8850_state::sc8850_map);
+	m_maincpu->sci_tx_w<0>().set("mdout", FUNC(midi_port_device::write_txd));
+	m_maincpu->read_adc<0>().set(FUNC(roland_sc8850_state::computer_sw_r));
+	m_maincpu->read_porta().set(FUNC(roland_sc8850_state::porta_r));
+
+	// MIDI IN A and B are the two on-chip serial ports, MIDI OUT/THRU is SCI0's transmitter
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_maincpu, FUNC(sh7014_device::sci_rx_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_maincpu, FUNC(sh7014_device::sci_rx_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	screen_device &screen(SCREEN(config, "screen"));
+	screen.set_lcd();
+	screen.set_refresh_hz(60);
+	screen.set_screen_update("lcdc", FUNC(sed1330_device::screen_update));
+	screen.set_size(160, 64);
+	screen.set_visarea_full();
+	screen.set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(roland_sc8850_state::lcd_palette), 2);
+
+	SED1330(config, m_lcdc, 10'000'000); // SED1335F0B
+	m_lcdc->set_screen("screen");
+	m_lcdc->set_addrmap(0, &roland_sc8850_state::lcdc_map);
+
+	SPEAKER(config, "output1", 2).front();
+	SPEAKER(config, "output2", 2).front();
+
+	// the master's SDOC and SDOD lines, one AK4324 each, the frame half
+	// picking left or right
+	ROLAND_XP(config, m_master, 24.576_MHz_XTAL);
+	m_master->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc8850_state::xp_rom_map);
+	// the runtime vector table sends IRQ1 to the master's service routine and IRQ0 to the slave's
+	m_master->int_callback().set_inputline(m_maincpu, 1);
+	m_master->add_route(2, "output1", 1.0, 0);
+	m_master->add_route(3, "output1", 1.0, 1);
+	m_master->add_route(4, "output2", 1.0, 0);
+	m_master->add_route(5, "output2", 1.0, 1);
+
+	m_master->port_a_in_callback().set(FUNC(roland_sc8850_state::slave_link_r));
+	m_master->frame_callback().set(FUNC(roland_sc8850_state::pump_slave));
+
+	// the slave reaches the DACs only through the master, over SDOA, and the master's frame clocks it
+	ROLAND_XP(config, m_slave, 24.576_MHz_XTAL);
+	m_slave->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc8850_state::xp_rom_map);
+	m_slave->int_callback().set_inputline(m_maincpu, 0);
+	m_slave->set_pumped(true);
+	m_slave->port_a_in_callback().set(FUNC(roland_sc8850_state::master_link_r));
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+
+	// the EFX send leaves the slave on SDOC; the return comes back on port B
+	m_slave->port_out_callback().set(FUNC(roland_sc8850_state::lsp_serial_w));
+	m_slave->port_b_in_callback().set(FUNC(roland_sc8850_state::lsp_serial_r));
+}
+
+void roland_sc8850_state::sc8820(machine_config &config)
+{
+	SH7014(config, m_maincpu, 28.224_MHz_XTAL);
+	m_maincpu->set_addrmap(AS_PROGRAM, &roland_sc8850_state::sc8820_map);
+
+	SPEAKER(config, "output1", 2).front();
+	SPEAKER(config, "output2", 2).front();
+
+	ROLAND_XP(config, m_master, 24.576_MHz_XTAL);
+	m_master->set_addrmap(roland_xp_device::AS_WAVE, &roland_sc8850_state::sc8820_xp_rom_map);
+	m_master->int_callback().set_inputline(m_maincpu, 1);
+	// its program puts the DAC pair on the third strobe of each group, SDOD under the rotation the
+	// other machines follow, where the schematic runs the DAC from SDOC
+	m_master->add_route(4, "output1", 1.0, 0);
+	m_master->add_route(5, "output1", 1.0, 1);
+
+	ROLAND_LSP(config, m_lsp, 24.576_MHz_XTAL);
+}
+
+
+ROM_START(sc8850)
+	ROM_REGION32_BE(0x10000, "cpurom", 0)
+	// dated 08/25/1999 in its own string table; carries the flash updater
+	ROM_LOAD("roland-r01783490.ic1", 0x00000, 0x10000, CRC(4b2f36e3) SHA1(99b414c5129960e3e58af1fb147a1474ccccca84))
+
+	// M37640M8-104FP, the mask ROM member of the 7640 group; the firmware
+	// downloads its application into the SRAM beside it, so this is the
+	// USB stack and the loader that takes it
+	ROM_REGION(0x8000, "usbmcu", 0)
+	ROM_LOAD("roland-r02010212.ic4", 0x0000, 0x8000, NO_DUMP)
+
+	ROM_REGION32_BE(0x100000, "progrom", 0)
+	// "Roland XP-GS Ver.1.01" / "Roland SC-GS Version 1.00", built 11/28/2000
+	ROM_LOAD("roland-r01678145.ic9", 0x00000, 0x100000, CRC(3ef69f93) SHA1(e594de1f5be17c11ef4f4d7efd142053bbf44085))
+
+	ROM_REGION32_BE(0x200000, "toneprm", 0)
+	ROM_LOAD("roland-r01561945.ic10", 0x000000, 0x200000, CRC(390faa62) SHA1(d9af1c75b277de2258ed74982d7a754f60c0826e))
+
+	ROM_REGION(0x2000000, "waverom", ROMREGION_ERASE00)
+	ROM_LOAD("roland-r01891445-823.ic53", 0x0000000, 0x1000000, CRC(2cfe5aa2) SHA1(68655acdea37bfa73a30db64807902f525bf2215))
+	ROM_LOAD("roland-r01891456-824.ic54", 0x1000000, 0x1000000, CRC(623015b6) SHA1(b98166a1222ad32f82911fd72e7d0eb76380f80d))
+ROM_END
+
+ROM_START(sc8820)
+	ROM_REGION32_BE(0x10000, "cpurom", 0)
+	// the SC-8820's own CPU (Roland R02015367) is undumped; the SC-8850's
+	// on-chip ROM stands in for it and jumps to the SC-8850's flash base
+	ROM_LOAD("roland-r01783490.ic1", 0x00000, 0x10000, BAD_DUMP CRC(4b2f36e3) SHA1(99b414c5129960e3e58af1fb147a1474ccccca84))
+
+	// M37640E8FP here, the one time PROM member of the group
+	ROM_REGION(0x8000, "usbmcu", 0)
+	ROM_LOAD("roland-r02010623.ic2", 0x0000, 0x8000, NO_DUMP)
+
+	ROM_REGION32_BE(0x200000, "progrom", 0)
+	// program and tone parameters in one flash, built 11/28/2000
+	ROM_LOAD("roland-r01561945.ic5", 0x000000, 0x200000, CRC(352ad418) SHA1(4b23624d6317eb43dc63bf07d04bcce5c415e202))
+
+	ROM_REGION(0x1800000, "waverom", ROMREGION_ERASEFF)
+	ROM_LOAD("roland-r01891445-823.ic7", 0x0000000, 0x1000000, CRC(2cfe5aa2) SHA1(68655acdea37bfa73a30db64807902f525bf2215))
+	// reconstructed from Sound Canvas VA's embedded image, which is this
+	// machine's wave set descrambled; the chip is also stocked as IC39,
+	// Roland R02016156, a Macronix MX23C6410
+	ROM_LOAD("roland-r02121512-541.ic8", 0x1000000, 0x800000, BAD_DUMP CRC(38908222) SHA1(c89c88bba5290b6184142da27d7b6949a0ad94b8))
+ROM_END
+
+} // anonymous namespace
+
+
+SYST(1999, sc8850, 0,      0, sc8850, sc8850, roland_sc8850_state, init_sc8850, "Roland", "Sound Canvas SC-8850", MACHINE_NOT_WORKING)
+SYST(1999, sc8820, sc8850, 0, sc8820, sc8820, roland_sc8850_state, init_sc8850, "Roland", "Sound Canvas SC-8820", MACHINE_NOT_WORKING)

--- a/src/mame/roland/sc88_sub.cpp
+++ b/src/mame/roland/sc88_sub.cpp
@@ -1,0 +1,541 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/****************************************************************************
+
+    Roland SC-88 sub CPU (M38881M2, Roland R00232667) - high level emulation.
+
+    The chip is a Mitsubishi 3888 group protocol controller whose program
+    is not dumped.  On the SC-88 it receives MIDI IN A, MIDI IN B and the
+    computer port on its three UARTs, parses the streams and hands the main
+    CPU one message per interrupt through the 3888's system bus interface;
+    the main CPU scans the front panel switch matrix through the same
+    window and sends MIDI OUT data back through a ring in the dual port RAM.
+
+    System bus side of the chip (3888 group data sheet, fig. 16):
+
+      00-d7  dual port RAM         dc-df  IPC error registers (sub -> main)
+      d8-db  IPC mode registers    e0-fa  access flags
+             (main -> sub)         fd     semaphore, bit 7 = ready flag
+                                   fe/ff  port data / port control
+
+    Message protocol as reconstructed from the main CPU program (v1.04):
+
+      IPCER0  code    01-07 channel voice message, (status >> 4) - 7
+                      10-12 display exclusive (model 45), selecting the block
+                      20-bf GS exclusive (model 42), selecting the parameter block
+                      e7    continuation of an exclusive block
+                      ee/ef universal exclusive (GM on / master volume)
+      IPCER1  flags   bits 0-3 channel, bits 4-5 source (0 IN A, 1 IN B,
+                      2 computer), bit 6 more data follows, bit 7 payload
+                      is a block in the dual port RAM
+      IPCER2/3        data bytes, or block length / offset for a payload
+
+    Payload blocks are the exclusive bytes after F0 up to and including
+    the checksum (the F7 is not counted); they are guarded by block semaphore bit 0/1/2 (the source), which
+    the main CPU clears after copying the block.  Bit 7 of IPCER2 marks the
+    block as a request (RQ1) rather than a data set (DT1); the rest of the
+    byte is the length either way.
+
+    The code does not carry the address MSB directly.  It names one of the
+    parameter blocks of the address map, and for most of them the low three
+    bits are the high nibble of the address middle byte, so a block covers
+    eight of them:
+
+      20  00 0n   system            60  40 0n   patch common (A)
+      28  08 0n                     68  48 0n
+      30  08 0n / 0c 0n             70  50 0n   patch common (B)
+      40  20 0n   user tone bank    78  58 0n
+      48  28 0n                     80  41 0n   drum setup (A)
+      50  21 0n   user drum set     88  49 0n
+      58  29 0n                     90  51 0n   drum setup (B)
+                                    98  59 0n
+      a0  22 0n   user EFX          b0  23 00   user patch common
+      a8  2a 0n                     b1  24 00   user patch part
+                                    b8  2b 0n
+
+    The display messages of model 45 follow the same scheme from one block:
+
+      10  10 0n   text (00) and the ten dot pages (01-05, 64 bytes each)
+      12  10 2n   display page and display time
+
+    The low nibble of the middle byte is not in the block at all: it travels
+    in the channel field of IPCER1, which is how a request names one of the
+    sixteen parts.  b0-b4 are the exception, a run of address MSBs rather
+    than a run of middle bytes; the SC-88 has neither them nor a0/a8/b8.
+    30 answers to two addresses depending on the parameter asked for and 38
+    to none that could be found, so neither is listed below; both are
+    outside the published map.
+
+    A request is answered on MIDI OUT.  The main CPU sends through the ring
+    at 24-bf, D5 being its write pointer and D4 the sub CPU's read pointer,
+    under block semaphore bit 5.  The ring carries packets, not a byte
+    stream: a length byte followed by that many bytes of MIDI, the next
+    packet starting at the following multiple of four.  A packet may
+    straddle the wrap at c0.
+
+****************************************************************************/
+
+#include "emu.h"
+#include "sc88_sub.h"
+
+#define LOG_MSG     (1U << 1)
+#define LOG_TX      (1U << 2)
+
+#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(SC88_SUB, sc88_sub_device, "sc88_sub", "Roland SC-88 sub CPU (HLE)")
+
+namespace {
+
+constexpr u8 SOURCE_FLAGS[3] = { 0x00, 0x10, 0x20 };
+constexpr int BLOCK_SIZE = 0x24;        // dual port RAM 00-23 carries payload blocks
+constexpr int MAX_EXCLUSIVE = 0x8a;     // the main CPU's reassembly buffer
+constexpr int TX_RING_START = 0x24;
+constexpr int TX_RING_END = 0xc0;
+constexpr int TX_WRITE_PTR = 0xd5;
+constexpr int TX_READ_PTR = 0xd4;
+
+struct exclusive_block { u8 model; u8 address; u8 code; bool paged; };
+
+constexpr exclusive_block BLOCKS[] = {
+	{ 0x42, 0x00, 0x20, true }, { 0x42, 0x08, 0x28, true },
+	{ 0x42, 0x20, 0x40, true }, { 0x42, 0x28, 0x48, true },
+	{ 0x42, 0x21, 0x50, true }, { 0x42, 0x29, 0x58, true },
+	{ 0x42, 0x40, 0x60, true }, { 0x42, 0x48, 0x68, true },
+	{ 0x42, 0x50, 0x70, true }, { 0x42, 0x58, 0x78, true },
+	{ 0x42, 0x41, 0x80, true }, { 0x42, 0x49, 0x88, true },
+	{ 0x42, 0x51, 0x90, true }, { 0x42, 0x59, 0x98, true },
+	{ 0x42, 0x22, 0xa0, true }, { 0x42, 0x2a, 0xa8, true },
+	{ 0x42, 0x23, 0xb0, false }, { 0x42, 0x24, 0xb1, false }, { 0x42, 0x25, 0xb2, false },
+	{ 0x42, 0x26, 0xb3, false }, { 0x42, 0x27, 0xb4, false },
+	{ 0x42, 0x2b, 0xb8, true },
+	{ 0x45, 0x10, 0x10, true },
+};
+
+} // anonymous namespace
+
+
+//-------------------------------------------------
+//  UART receiver, one per MIDI source
+//-------------------------------------------------
+
+DEFINE_DEVICE_TYPE(SC88_SUB_RX, sc88_sub_rx_device, "sc88_sub_rx", "Roland SC-88 sub CPU UART")
+
+sc88_sub_rx_device::sc88_sub_rx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, SC88_SUB_RX, tag, owner, clock)
+	, device_serial_interface(mconfig, *this)
+	, m_byte_cb(*this)
+{
+}
+
+void sc88_sub_rx_device::device_start()
+{
+	set_data_frame(1, 8, PARITY_NONE, STOP_BITS_1);
+	set_rcv_rate(31250);
+}
+
+void sc88_sub_rx_device::device_reset()
+{
+	receive_register_reset();
+}
+
+void sc88_sub_rx_device::rcv_complete()
+{
+	receive_register_extract();
+	m_byte_cb(get_received_char());
+}
+
+
+//-------------------------------------------------
+//  sub CPU
+//-------------------------------------------------
+
+sc88_sub_device::sc88_sub_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, SC88_SUB, tag, owner, clock)
+	, m_int_cb(*this)
+	, m_keys_cb(*this, 0xff)
+	, m_tx_cb(*this)
+	, m_rx(*this, "rx%u", 0U)
+{
+}
+
+void sc88_sub_device::device_add_mconfig(machine_config &config)
+{
+	SC88_SUB_RX(config, m_rx[0], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<0>));
+	SC88_SUB_RX(config, m_rx[1], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<1>));
+	SC88_SUB_RX(config, m_rx[2], 0).byte_callback().set(FUNC(sc88_sub_device::rx_byte<2>));
+}
+
+void sc88_sub_device::device_start()
+{
+	m_deliver_timer = timer_alloc(FUNC(sc88_sub_device::deliver_timer), this);
+	m_tx_timer = timer_alloc(FUNC(sc88_sub_device::tx_timer), this);
+
+	save_item(NAME(m_dpram));
+	save_item(NAME(m_ipcm));
+	save_item(NAME(m_ipcer));
+	save_item(NAME(m_flags));
+	save_item(NAME(m_sem));
+	save_item(NAME(m_spcon));
+	save_item(NAME(m_pa));
+	save_item(NAME(m_pa_dir));
+	save_item(NAME(m_pb));
+	save_item(NAME(m_pb_dir));
+	save_item(NAME(m_int_state));
+	save_item(NAME(m_in_reset));
+	save_item(NAME(m_busy));
+	save_item(NAME(m_tx_rd));
+	save_item(NAME(m_tx_left));
+	save_item(NAME(m_tx_end));
+	save_item(NAME(m_tx_shift));
+	save_item(NAME(m_tx_bits));
+}
+
+void sc88_sub_device::device_reset()
+{
+	std::fill(std::begin(m_dpram), std::end(m_dpram), 0);
+	std::fill(std::begin(m_ipcm), std::end(m_ipcm), 0);
+	std::fill(std::begin(m_ipcer), std::end(m_ipcer), 0);
+	std::fill(std::begin(m_flags), std::end(m_flags), 0);
+	m_sem = 0x80; // ready: the sub CPU has finished its own initialisation
+	m_spcon = 0;
+	m_pa = m_pa_dir = m_pb = m_pb_dir = 0;
+	m_int_state = false;
+	m_int_cb(0);
+
+	for (source &s : m_src)
+		s = source();
+	m_queue.clear();
+	m_busy = false;
+	m_deliver_timer->adjust(attotime::never);
+
+	m_dpram[TX_READ_PTR] = m_dpram[TX_WRITE_PTR] = TX_RING_START;
+	m_tx_rd = TX_RING_START;
+	m_tx_left = 0;
+	m_tx_end = TX_RING_START;
+	m_tx_shift = 0;
+	m_tx_bits = 0;
+	m_tx_timer->adjust(attotime::never);
+	m_tx_cb(1);
+}
+
+
+//-------------------------------------------------
+//  system bus interface
+//-------------------------------------------------
+
+u8 sc88_sub_device::port_r()
+{
+	switch ((m_spcon >> 2) & 7)
+	{
+	case 0: return m_pa;
+	case 1: return m_pa_dir;
+	case 2: return m_pb;
+	case 3: return m_pb_dir;
+	case 4:
+	{
+		// P0 returns the switch matrix rows selected by the strobes on PB0-PB3
+		u8 keys = 0xff;
+		for (int row = 0; row < 4; row++)
+			if (BIT(m_pb, row))
+				keys &= m_keys_cb[row]();
+		return keys;
+	}
+	default: return 0xff;
+	}
+}
+
+void sc88_sub_device::port_w(u8 data)
+{
+	switch ((m_spcon >> 2) & 7)
+	{
+	case 0: m_pa = data; break;
+	case 1: m_pa_dir = data; break;
+	case 2: m_pb = data; break;
+	case 3: m_pb_dir = data; break;
+	default: break;
+	}
+}
+
+void sc88_sub_device::reset_w(int state)
+{
+	if (m_in_reset == !state)
+		return;
+	m_in_reset = !state;
+	if (m_in_reset)
+		reset();
+}
+
+u8 sc88_sub_device::read(offs_t offset)
+{
+	if (offset < 0xd8)
+	{
+		if (!machine().side_effects_disabled())
+			m_flags[offset >> 3] &= ~(1 << (offset & 7));
+		return m_dpram[offset];
+	}
+	if (offset < 0xdc)
+		return m_ipcm[offset & 3];
+	if (offset < 0xe0)
+	{
+		const u8 data = m_ipcer[offset & 3];
+		if (!machine().side_effects_disabled())
+		{
+			m_ipcer[offset & 3] = 0;
+			if (offset == 0xdc && m_int_state)
+			{
+				// the message has been taken; the next one may follow
+				m_int_state = false;
+				m_int_cb(0);
+				m_deliver_timer->adjust(attotime::from_usec(20));
+			}
+		}
+		return data;
+	}
+	if (offset < 0xfb)
+		return m_flags[offset - 0xe0];
+	if (offset == 0xfd)
+		return m_sem;
+	if (offset == 0xfe)
+		return port_r();
+	if (offset == 0xff)
+		return m_spcon;
+	return 0xff;
+}
+
+void sc88_sub_device::write(offs_t offset, u8 data)
+{
+	if (offset < 0xd8)
+	{
+		m_dpram[offset] = data;
+		m_flags[offset >> 3] |= 1 << (offset & 7);
+		if (offset == TX_WRITE_PTR && m_tx_timer->expire().is_never())
+			m_tx_timer->adjust(attotime::zero);
+		return;
+	}
+
+	if (offset < 0xdc)
+	{
+		m_ipcm[offset & 3] = data;
+		if (offset == 0xd8)
+			m_sem &= 0x7f;
+		LOG("%s: IPC mode register %d = %02x\n", machine().describe_context(), offset & 3, data);
+	}
+	else if (offset == 0xfd)
+	{
+		const u8 bit = 1 << (data & 7);
+		if (BIT(data, 7))
+			m_sem |= bit;
+		else
+			m_sem &= ~bit;
+		if (!m_busy && !m_queue.empty())
+			m_deliver_timer->adjust(attotime::from_usec(20));
+	}
+	else if (offset == 0xfe)
+		port_w(data);
+	else if (offset == 0xff)
+		m_spcon = data;
+}
+
+
+//-------------------------------------------------
+//  MIDI input parsing
+//-------------------------------------------------
+
+void sc88_sub_device::midi_byte(int src, u8 data)
+{
+	source &s = m_src[src];
+
+	if (data >= 0xf8)
+		return; // system realtime
+
+	if (data >= 0x80)
+	{
+		if (s.in_sysex)
+		{
+			if (data == 0xf7)
+			{
+				s.sysex.push_back(data);
+				send_sysex(src, s);
+			}
+			s.in_sysex = false;
+			s.sysex.clear();
+		}
+		if (data == 0xf0)
+		{
+			s.in_sysex = true;
+			s.status = 0;
+		}
+		else if (data < 0xf0)
+		{
+			s.status = data;
+			s.count = 0;
+		}
+		else
+			s.status = 0; // other system common messages cancel running status
+		return;
+	}
+
+	if (s.in_sysex)
+	{
+		if (s.sysex.size() < MAX_EXCLUSIVE + 8)
+			s.sysex.push_back(data);
+		return;
+	}
+	if (s.status == 0)
+		return;
+
+	s.data[s.count++] = data;
+	const int type = s.status >> 4;
+	const int length = (type == 0xc || type == 0xd) ? 1 : 2;
+	if (s.count < length)
+		return;
+	s.count = 0;
+
+	queue(type - 7, (s.status & 0x0f) | SOURCE_FLAGS[src], s.data[0], (length == 2) ? s.data[1] : 0);
+}
+
+// s.sysex holds the bytes after F0, ending with F7
+void sc88_sub_device::send_sysex(int src, source &s)
+{
+	const std::vector<u8> &x = s.sysex;
+	u8 code;
+	u8 chan = 0;
+	u8 request = 0;
+	if (x.size() >= 8 && x[0] == 0x41 && (x[2] == 0x42 || x[2] == 0x45) && (x[3] == 0x12 || x[3] == 0x11))
+	{
+		const exclusive_block *block = nullptr;
+		for (const exclusive_block &b : BLOCKS)
+			if (b.model == x[2] && b.address == x[4] && (b.paged || (x[5] & 0xf0) == 0))
+				block = &b;
+		if (!block)
+		{
+			LOGMASKED(LOG_MSG, "exclusive model %02x address %02x %02x has no block\n", x[2], x[4], x[5]);
+			return;
+		}
+		code = block->code + (block->paged ? (x[5] >> 4) : 0);
+		chan = x[5] & 0x0f;
+		request = (x[3] == 0x11) ? 0x80 : 0x00;
+	}
+	else if (x.size() >= 5 && x[0] == 0x7e)
+		code = 0xee;
+	else if (x.size() >= 5 && x[0] == 0x7f)
+		code = 0xef;
+	else
+		return;
+
+	if (x.size() > MAX_EXCLUSIVE)
+	{
+		LOGMASKED(LOG_MSG, "exclusive message of %d bytes dropped\n", int(x.size()));
+		return;
+	}
+
+	// long messages are split into blocks the main CPU reassembles; the
+	// length counts the bytes up to the checksum, not the F7
+	const size_t total = x.size() - 1;
+	for (size_t pos = 0; pos < total; pos += BLOCK_SIZE)
+	{
+		const size_t len = std::min<size_t>(BLOCK_SIZE, total - pos);
+		const bool more = pos + len < total;
+		queue(pos ? 0xe7 : code, SOURCE_FLAGS[src] | 0x80 | (more ? 0x40 : 0) | chan,
+				u8(len) | (pos ? 0 : request), 0,
+				std::vector<u8>(x.begin() + pos, x.begin() + pos + len));
+	}
+}
+
+
+//-------------------------------------------------
+//  IPC messages to the main CPU
+//-------------------------------------------------
+
+void sc88_sub_device::queue(u8 code, u8 flags, u8 d1, u8 d2, std::vector<u8> &&block)
+{
+	m_queue.push_back(message{ code, flags, d1, d2, std::move(block) });
+	if (!m_busy)
+		deliver();
+}
+
+void sc88_sub_device::deliver()
+{
+	if (m_busy || m_queue.empty())
+		return;
+
+	message &m = m_queue.front();
+	const int src = (m.flags >> 4) & 3;
+	if (!m.block.empty())
+	{
+		// the previous block of this source must have been consumed
+		if (BIT(m_sem, src))
+		{
+			m_deliver_timer->adjust(attotime::from_usec(100));
+			return;
+		}
+		std::copy(m.block.begin(), m.block.end(), &m_dpram[0]);
+		m_sem |= 1 << src;
+	}
+
+	LOGMASKED(LOG_MSG, "message %02x %02x %02x %02x%s\n", m.code, m.flags, m.d1, m.d2, m.block.empty() ? "" : " (block)");
+	m_ipcer[0] = m.code;
+	m_ipcer[1] = m.flags;
+	m_ipcer[2] = m.d1;
+	m_ipcer[3] = m.d2;
+	m_queue.pop_front();
+	m_busy = true;
+	m_int_state = true;
+	m_int_cb(1);
+}
+
+TIMER_CALLBACK_MEMBER(sc88_sub_device::deliver_timer)
+{
+	m_busy = false;
+	deliver();
+}
+
+
+//-------------------------------------------------
+//  MIDI OUT: bytes queued by the main CPU in the dual port RAM ring
+//-------------------------------------------------
+
+u8 sc88_sub_device::ring_advance(u8 offset, u8 count)
+{
+	offset += count;
+	if (offset >= TX_RING_END)
+		offset -= TX_RING_END - TX_RING_START;
+	return offset;
+}
+
+TIMER_CALLBACK_MEMBER(sc88_sub_device::tx_timer)
+{
+	if (m_tx_bits)
+	{
+		m_tx_cb(BIT(m_tx_shift, 0));
+		m_tx_shift >>= 1;
+		m_tx_bits--;
+		m_tx_timer->adjust(attotime::from_hz(31250));
+		return;
+	}
+
+	while (!m_tx_left)
+	{
+		if (m_tx_rd == m_dpram[TX_WRITE_PTR])
+			return;
+		m_tx_left = m_dpram[m_tx_rd];
+		m_tx_end = ring_advance(m_tx_rd, (m_tx_left + 4) & ~3);
+		m_tx_rd = ring_advance(m_tx_rd, 1);
+		if (!m_tx_left)
+			m_dpram[TX_READ_PTR] = m_tx_rd = m_tx_end;
+	}
+
+	const u8 data = m_dpram[m_tx_rd];
+	LOGMASKED(LOG_TX, "MIDI OUT %02x\n", data);
+	m_tx_rd = ring_advance(m_tx_rd, 1);
+	if (!--m_tx_left)
+		m_dpram[TX_READ_PTR] = m_tx_rd = m_tx_end;
+
+	// start bit, 8 data bits, stop bit
+	m_tx_shift = (u16(data) << 1) | 0x200;
+	m_tx_bits = 10;
+	m_tx_timer->adjust(attotime::zero);
+}

--- a/src/mame/roland/sc88_sub.h
+++ b/src/mame/roland/sc88_sub.h
@@ -1,0 +1,123 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/****************************************************************************
+
+    Roland SC-88 sub CPU (M38881M2, undumped): high level emulation of its
+    system bus interface and of the MIDI protocol it speaks with the main
+    CPU.
+
+****************************************************************************/
+
+#ifndef MAME_ROLAND_SC88_SUB_H
+#define MAME_ROLAND_SC88_SUB_H
+
+#pragma once
+
+#include "diserial.h"
+
+#include <deque>
+
+
+// UART receiver, one per MIDI source
+class sc88_sub_rx_device : public device_t, public device_serial_interface
+{
+public:
+	sc88_sub_rx_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+	auto byte_callback() { return m_byte_cb.bind(); }
+	using device_serial_interface::rx_w;
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void rcv_complete() override;
+private:
+	devcb_write8 m_byte_cb;
+};
+
+DECLARE_DEVICE_TYPE(SC88_SUB_RX, sc88_sub_rx_device)
+
+
+class sc88_sub_device : public device_t
+{
+public:
+	sc88_sub_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	// INTR pin: raised when a message is waiting in the IPC error registers
+	auto int_callback() { return m_int_cb.bind(); }
+	// switch matrix rows selected by the strobes on PB0-PB3
+	template <unsigned N> auto keys_callback() { return m_keys_cb[N].bind(); }
+	// serial data for the MIDI OUT connector
+	auto tx_callback() { return m_tx_cb.bind(); }
+
+	// MIDI IN A (rear) and B (front), and the RS-422/RS-232 computer port
+	template <unsigned N> void rxd_w(int state) { m_rx[N]->rx_w(state); }
+
+	// /RST, driven from the main CPU's P4-0 on the SC-88VL
+	void reset_w(int state);
+
+	// system bus window (A0-A7)
+	u8 read(offs_t offset);
+	void write(offs_t offset, u8 data);
+
+protected:
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	struct message
+	{
+		u8 code, flags, d1, d2;
+		std::vector<u8> block;
+	};
+
+	struct source
+	{
+		u8 status = 0;
+		u8 data[2]{};
+		u8 count = 0;
+		std::vector<u8> sysex;
+		bool in_sysex = false;
+	};
+
+	template <unsigned N> void rx_byte(u8 data) { midi_byte(N, data); }
+	void midi_byte(int src, u8 data);
+	void send_sysex(int src, source &s);
+	void queue(u8 code, u8 flags, u8 d1, u8 d2, std::vector<u8> &&block = {});
+	static u8 ring_advance(u8 offset, u8 count);
+	void deliver();
+	TIMER_CALLBACK_MEMBER(deliver_timer);
+	TIMER_CALLBACK_MEMBER(tx_timer);
+	u8 port_r();
+	void port_w(u8 data);
+
+	devcb_write_line m_int_cb;
+	devcb_read8::array<4> m_keys_cb;
+	devcb_write_line m_tx_cb;
+	required_device_array<sc88_sub_rx_device, 3> m_rx;
+
+	u8 m_dpram[0xd8]{};
+	u8 m_ipcm[4]{};
+	u8 m_ipcer[4]{};
+	u8 m_flags[0x1b]{};
+	u8 m_sem = 0;
+	u8 m_spcon = 0;
+	u8 m_pa = 0, m_pa_dir = 0, m_pb = 0, m_pb_dir = 0;
+	bool m_int_state = false;
+	bool m_in_reset = false;
+
+	source m_src[3];
+	std::deque<message> m_queue;
+	bool m_busy = false;
+	emu_timer *m_deliver_timer = nullptr;
+
+	u8 m_tx_rd = 0;
+	u8 m_tx_left = 0;
+	u8 m_tx_end = 0;
+	emu_timer *m_tx_timer = nullptr;
+	u16 m_tx_shift = 0;
+	int m_tx_bits = 0;
+};
+
+DECLARE_DEVICE_TYPE(SC88_SUB, sc88_sub_device)
+
+#endif // MAME_ROLAND_SC88_SUB_H

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -228,6 +228,8 @@ using util::BIT;
 #include "cpu/z80/z80dasm.h"
 #include "cpu/z8000/8000dasm.h"
 
+#include "sound/roland_xpd.h"
+
 #include "corestr.h"
 #include "ioprocs.h"
 #include "multibyte.h"
@@ -614,6 +616,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "r65c02",          le,  0, []() -> util::disasm_interface * { return new r65c02_disassembler; } },
 	{ "r65c19",          le,  0, []() -> util::disasm_interface * { return new r65c19_disassembler; } },
 	{ "r800",            le,  0, []() -> util::disasm_interface * { return new r800_disassembler; } },
+	{ "roland_xp",       be, -2, []() -> util::disasm_interface * { return new roland_xp_disassembler; } },
 	{ "romp",            be,  0, []() -> util::disasm_interface * { return new romp_disassembler; } },
 	{ "rsp",             le,  0, []() -> util::disasm_interface * { return new rsp_disassembler; } },
 	{ "rupi44",          le,  0, []() -> util::disasm_interface * { return new rupi44_disassembler; } },

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -228,6 +228,7 @@ using util::BIT;
 #include "cpu/z80/z80dasm.h"
 #include "cpu/z8000/8000dasm.h"
 
+#include "sound/roland_lspd.h"
 #include "sound/roland_xpd.h"
 
 #include "corestr.h"
@@ -616,6 +617,7 @@ static const dasm_table_entry dasm_table[] =
 	{ "r65c02",          le,  0, []() -> util::disasm_interface * { return new r65c02_disassembler; } },
 	{ "r65c19",          le,  0, []() -> util::disasm_interface * { return new r65c19_disassembler; } },
 	{ "r800",            le,  0, []() -> util::disasm_interface * { return new r800_disassembler; } },
+	{ "roland_lsp",      be, -2, []() -> util::disasm_interface * { return new roland_lsp_disassembler; } },
 	{ "roland_xp",       be, -2, []() -> util::disasm_interface * { return new roland_xp_disassembler; } },
 	{ "romp",            be,  0, []() -> util::disasm_interface * { return new romp_disassembler; } },
 	{ "rsp",             le,  0, []() -> util::disasm_interface * { return new rsp_disassembler; } },


### PR DESCRIPTION
This PR adds support for the Roland XP custom sound chip and the Roland LSP sound DSP bringing the Sound Canvas SC-88/88Pro to working status.

SC-8850 support is also added, with the system almost working fully (USB is not supported so only 32 parts can be used, and saving to user memory is not supported)

This was made possible thanks to giulioz [reverse-engineering notes](https://github.com/giulioz/roland-dsps) and Roland themselves by porting XP/LSP effects directly to native x64 and therefore giving me a rosetta stone for reconstructing the ISAs.

## Machines promoted to working:
- Sound Canvas SC-88 [superctr, giulioz]
- Sound Canvas SC-88Pro [superctr, giulioz]

## New non-working machines
- VE-GSPro Voice Expansion Board [superctr, giulioz]
- Sound Canvas SC-8850 [superctr, giulioz]
- Sound Canvas SC-8820 [superctr, giulioz]

## Other
- Add SC-88Pro control ROM dumps [Valley Bell]
- Reconstructed SC-88Pro wave ROM from VE-GSPro [superctr]

AI disclosure: Claude Fable 5, Claude Fable 5.1, Claude Opus 5