### PR TITLE
mcs48.cpp: add one character to flags string specifier (from 11 to 12…

### DIFF
--- a/src/devices/cpu/mcs48/mcs48.cpp
+++ b/src/devices/cpu/mcs48/mcs48.cpp
@@ -1194,7 +1194,7 @@ void mcs48_cpu_device::device_start()
 	state_add(STATE_GENPC,     "GENPC",     m_pc).mask(0xfff).noshow();
 	state_add(STATE_GENPCBASE, "CURPC",     m_prevpc).mask(0xfff).noshow();
 	state_add(MCS48_SP,        "SP",        m_psw).mask(0x7).noshow();
-	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_psw).noshow().formatstr("%11s");
+	state_add(STATE_GENFLAGS,  "GENFLAGS",  m_psw).noshow().formatstr("%12s");
 	state_add(MCS48_A,         "A",         m_a);
 	state_add(MCS48_TC,        "TC",        m_timer);
 	state_add(MCS48_TPRE,      "TPRE",      m_prescaler).mask(0x1f);


### PR DESCRIPTION
…), stack bit 0 was not shown.


Was working with an i8039 and noticed that stack bit 0 wasn't being shown in the debugger.


"%c%c%c %c%c%c%c%c%c%c%c" comes out to 12 characters

void mcs48_cpu_device::state_string_export(const device_state_entry &entry, std::string &str) const
{
        switch (entry.index())
        {
                case STATE_GENFLAGS:
                        str = string_format("%c%c%c %c%c%c%c%c%c%c%c",
                                m_irq_state  ? 'I':'.',
                                m_a11        ? 'M':'.',
                                m_f1         ? '1':'.',
                                m_psw & 0x80 ? 'C':'.',
                                m_psw & 0x40 ? 'A':'.',
                                m_psw & 0x20 ? '0':'.',
                                m_psw & 0x10 ? 'B':'.',
                                m_psw & 0x08 ? '?':'.',
                                m_psw & 0x04 ? 's':'.',
                                m_psw & 0x02 ? 's':'.',
                                m_psw & 0x01 ? 's':'.');
                        break;
        }
}
