### PR TITLE
i386: fix stmxcsr typo in disassembler

### DIFF
--- a/src/devices/cpu/i386/i386dasm.cpp
+++ b/src/devices/cpu/i386/i386dasm.cpp
@@ -1790,7 +1790,7 @@ const i386_disassembler::I386_OPCODE i386_disassembler::group0FAE_table[8] =
 	{"fxsave",          0,              PARAM_RM,           0,                  0               },
 	{"fxrstor",         0,              PARAM_RM,           0,                  0               },
 	{"ldmxcsr",         0,              PARAM_RM,           0,                  0               },
-	{"stmxscr",         0,              PARAM_RM,           0,                  0               },
+	{"stmxcsr",         0,              PARAM_RM,           0,                  0               },
 	{"???",             0,              0,                  0,                  0               },
 	{"lfence",          0,              0,                  0,                  0               },
 	{"mfence",          0,              0,                  0,                  0               },


### PR DESCRIPTION
According to many references, including the Intel Intrinsics Guide, it should be `stmxcsr` instead of `stmxscr`.

Kenji Mouri