### PR TITLE
gaelco/lotoplay.cpp: Z80 sets are devices for programming Loto-Plays, not Loto-Plays

### DIFF
--- a/src/mame/gaelco/lotoplay.cpp
+++ b/src/mame/gaelco/lotoplay.cpp
@@ -104,7 +104,7 @@ ROM_START(lotoplayb)
 	ROM_LOAD("lp_vii_sch_mostra_11302_68705p3s.bin", 0x0000, 0x0800, CRC(61b426d3) SHA1(b66dc6c382a04d8cdbaee342f179ce80abfd3c71))
 ROM_END
 
-// Different PCB than the previous sets
+// Different PCB than the previous sets, instead of a LEDs roulette uses a 7-segments 1 digit display
 ROM_START(lotoplayc)
 	ROM_REGION(0x0800, "maincpu", 0)
 	ROM_LOAD("multn.bin", 0x0000, 0x0800, CRC(20a0e0d0) SHA1(832ed64dfa5f5f150f0e9918b40e9fb4e8e4260d))

--- a/src/mame/gaelco/lotoplay.cpp
+++ b/src/mame/gaelco/lotoplay.cpp
@@ -41,7 +41,8 @@
  |        |__|  |__|      |__|                |
  |____________________________________________|
 
- There is another type of PCB  with a Z80 (exact model unknown) and a external ROM.
+ Gaelco had a custom hardware for programming M68705-based Loto-Play devices,
+ with a Z80 and two AY-3-8910. The M68705 ROM was embedded on the Z80 ROM.
 
 *******************************************************************************/
 
@@ -50,6 +51,8 @@
 #include "cpu/m6805/m68705.h"
 #include "cpu/pic16c5x/pic16c5x.h"
 #include "cpu/z80/z80.h"
+
+#include "speaker.h"
 
 namespace
 {
@@ -77,16 +80,23 @@ INPUT_PORTS_END
 void lotoplay_state::lotoplay_p3(machine_config &config)
 {
 	M68705P3(config, m_maincpu, 3'579'545); // MC68705P3S, unknown clock
+
+	SPEAKER(config, "mono").front_center();
 }
 
 void lotoplay_state::lotoplay_pic(machine_config &config)
 {
 	PIC16C54(config, m_maincpu, 4_MHz_XTAL); // PIC16C54
+
+	SPEAKER(config, "mono").front_center();
 }
 
 void lotoplay_state::lotoplay_z80(machine_config &config)
 {
 	Z80(config, m_maincpu, 4'000'000); // unknown clock
+
+	//AY8910(config, m_ay[0], 4'000'000 / 2); // unknown clock
+	//AY8910(config, m_ay[1], 4'000'000 / 2); // unknown clock
 }
 
 
@@ -107,6 +117,12 @@ ROM_START(lotoplayb)
 	ROM_LOAD("lp_vii_sch_mostra_11302_68705p3s.bin", 0x0000, 0x0800, CRC(61b426d3) SHA1(b66dc6c382a04d8cdbaee342f179ce80abfd3c71))
 ROM_END
 
+// Different PCB than the previous sets
+ROM_START(lotoplayc)
+	ROM_REGION(0x0800, "maincpu", 0)
+	ROM_LOAD("multn.bin", 0x0000, 0x0800, CRC(20a0e0d0) SHA1(832ed64dfa5f5f150f0e9918b40e9fb4e8e4260d))
+ROM_END
+
 
 // Sets with PIC16C54.
 
@@ -116,31 +132,35 @@ ROM_START(lotoplayp)
 ROM_END
 
 
-// Sets with Z80.
+// Devices for programming MC68705-based Loto-Play boards. The MC68705 ROM is at 0x1000 on each Z80 ROM
 
 ROM_START(lotoplayz)
 	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplay' image: CRC(112645cd) SHA1(f2ad6b2fbec36d0bfe034d7bfb036ef6bf4ee395)
 	ROM_LOAD("grab._lp_sp_ultima_27c64.bin",         0x0000, 0x2000, CRC(980e14ac) SHA1(3f6dc75a8cb3fe38941b8a7900ecccdafabc14e9))
 ROM_END
 
 ROM_START(lotoplayza)
 	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplaya' image: CRC(9b77603c) SHA1(6799b930f9805332bf20c6146b044222fe49d243)
 	ROM_LOAD("grab._lp_s_3b4c_27c64.bin",            0x0000, 0x2000, CRC(556e2c35) SHA1(612f160592fd122e5a91914618e19eade5b52c3e))
 ROM_END
 
 ROM_START(lotoplayzb)
 	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplayc' image: CRC(20a0e0d0) SHA1(832ed64dfa5f5f150f0e9918b40e9fb4e8e4260d)
 	ROM_LOAD("multn_0.0_27c64.bin",                  0x0000, 0x2000, CRC(e74bce2a) SHA1(66a09f5df3a27b0c4bc964b19450734b736dc768))
 ROM_END
 
 
 } // anonymous namespace
 
-//    YEAR   NAME        PARENT    MACHINE       INPUT     CLASS           INIT        ROT   COMPANY              FULLNAME                      FLAGS
-GAME( 1988?, lotoplay,   0,        lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 1)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1988?, lotoplaya,  lotoplay, lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 2)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1988?, lotoplayb,  lotoplay, lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 3)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayp,  lotoplay, lotoplay_pic, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (PIC16C54)",       MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayz,  lotoplay, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (Z80, set 1)",     MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayza, lotoplay, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (Z80, set 2)",     MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayzb, lotoplay, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (Z80, set 3)",     MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+//    YEAR   NAME        PARENT     MACHINE       INPUT     CLASS           INIT        ROT   COMPANY              FULLNAME                                FLAGS
+GAME( 1988?, lotoplay,   0,         lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 1)",           MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplaya,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 2)",           MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplayb,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 3)",           MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplayc,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 4)",           MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayp,  lotoplay,  lotoplay_pic, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (PIC16C54)",                 MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayz,  0,         lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 1)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayza, lotoplayz, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 2)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayzb, lotoplayz, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 3)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )

--- a/src/mame/gaelco/lotoplay.cpp
+++ b/src/mame/gaelco/lotoplay.cpp
@@ -41,16 +41,12 @@
  |        |__|  |__|      |__|                |
  |____________________________________________|
 
- Gaelco had a custom hardware for programming M68705-based Loto-Play devices,
- with a Z80 and two AY-3-8910. The M68705 ROM was embedded on the Z80 ROM.
-
 *******************************************************************************/
 
 #include "emu.h"
 
 #include "cpu/m6805/m68705.h"
 #include "cpu/pic16c5x/pic16c5x.h"
-#include "cpu/z80/z80.h"
 
 #include "speaker.h"
 
@@ -68,7 +64,6 @@ public:
 
 	void lotoplay_p3(machine_config &config);
 	void lotoplay_pic(machine_config &config);
-	void lotoplay_z80(machine_config &config);
 
 protected:
 	required_device<cpu_device> m_maincpu;
@@ -89,14 +84,6 @@ void lotoplay_state::lotoplay_pic(machine_config &config)
 	PIC16C54(config, m_maincpu, 4_MHz_XTAL); // PIC16C54
 
 	SPEAKER(config, "mono").front_center();
-}
-
-void lotoplay_state::lotoplay_z80(machine_config &config)
-{
-	Z80(config, m_maincpu, 4'000'000); // unknown clock
-
-	//AY8910(config, m_ay[0], 4'000'000 / 2); // unknown clock
-	//AY8910(config, m_ay[1], 4'000'000 / 2); // unknown clock
 }
 
 
@@ -132,35 +119,11 @@ ROM_START(lotoplayp)
 ROM_END
 
 
-// Devices for programming MC68705-based Loto-Play boards. The MC68705 ROM is at 0x1000 on each Z80 ROM
-
-ROM_START(lotoplayz)
-	ROM_REGION(0x2000, "maincpu", 0)
-	// holds the 'lotoplay' image: CRC(112645cd) SHA1(f2ad6b2fbec36d0bfe034d7bfb036ef6bf4ee395)
-	ROM_LOAD("grab._lp_sp_ultima_27c64.bin",         0x0000, 0x2000, CRC(980e14ac) SHA1(3f6dc75a8cb3fe38941b8a7900ecccdafabc14e9))
-ROM_END
-
-ROM_START(lotoplayza)
-	ROM_REGION(0x2000, "maincpu", 0)
-	// holds the 'lotoplaya' image: CRC(9b77603c) SHA1(6799b930f9805332bf20c6146b044222fe49d243)
-	ROM_LOAD("grab._lp_s_3b4c_27c64.bin",            0x0000, 0x2000, CRC(556e2c35) SHA1(612f160592fd122e5a91914618e19eade5b52c3e))
-ROM_END
-
-ROM_START(lotoplayzb)
-	ROM_REGION(0x2000, "maincpu", 0)
-	// holds the 'lotoplayc' image: CRC(20a0e0d0) SHA1(832ed64dfa5f5f150f0e9918b40e9fb4e8e4260d)
-	ROM_LOAD("multn_0.0_27c64.bin",                  0x0000, 0x2000, CRC(e74bce2a) SHA1(66a09f5df3a27b0c4bc964b19450734b736dc768))
-ROM_END
-
-
 } // anonymous namespace
 
-//    YEAR   NAME        PARENT     MACHINE       INPUT     CLASS           INIT        ROT   COMPANY              FULLNAME                                FLAGS
-GAME( 1988?, lotoplay,   0,         lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 1)",           MACHINE_NOT_WORKING )
-GAME( 1988?, lotoplaya,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 2)",           MACHINE_NOT_WORKING )
-GAME( 1988?, lotoplayb,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 3)",           MACHINE_NOT_WORKING )
-GAME( 1988?, lotoplayc,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 4)",           MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayp,  lotoplay,  lotoplay_pic, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (PIC16C54)",                 MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayz,  0,         lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 1)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayza, lotoplayz, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 2)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
-GAME( 1990?, lotoplayzb, lotoplayz, lotoplay_z80, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 3)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+//    YEAR   NAME        PARENT     MACHINE       INPUT     CLASS           INIT        ROT   COMPANY              FULLNAME                      FLAGS
+GAME( 1988?, lotoplay,   0,         lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 1)", MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplaya,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 2)", MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplayb,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 3)", MACHINE_NOT_WORKING )
+GAME( 1988?, lotoplayc,  lotoplay,  lotoplay_p3,  lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (MC68705, set 4)", MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayp,  lotoplay,  lotoplay_pic, lotoplay, lotoplay_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play (PIC16C54)",       MACHINE_NOT_WORKING )

--- a/src/mame/gaelco/lotoplay_prog.cpp
+++ b/src/mame/gaelco/lotoplay_prog.cpp
@@ -1,0 +1,75 @@
+// license:BSD-3-Clause
+// copyright-holders:
+
+/********************************************************************
+
+ Skeleton driver for Gaelco programming devices for M68705-based "Loto-Play" PCBs.
+ The M68705 ROM is embedded on the Z80 ROM.
+
+********************************************************************/
+
+#include "emu.h"
+
+#include "cpu/z80/z80.h"
+
+#include "sound/ay8910.h"
+
+namespace
+{
+
+class lotoplay_prog_state : public driver_device
+{
+public:
+	lotoplay_prog_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_ay(*this, "ay%u", 1U)
+	{
+	}
+
+	void lotoplay_prog(machine_config &config) ATTR_COLD;
+
+private:
+	required_device<cpu_device> m_maincpu;
+	required_device_array<ay8910_device, 2> m_ay;
+};
+
+INPUT_PORTS_START(lotoplay_prog)
+INPUT_PORTS_END
+
+void lotoplay_prog_state::lotoplay_prog(machine_config &config)
+{
+	Z80(config, m_maincpu, 4'000'000); // unknown clock
+
+	AY8910(config, m_ay[0], 4'000'000 / 2); // unknown clock
+	AY8910(config, m_ay[1], 4'000'000 / 2); // unknown clock
+}
+
+
+// Devices for programming MC68705-based Loto-Play boards. The MC68705 ROM is at 0x1000 on each Z80 ROM
+
+ROM_START(lotoplayz)
+	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplay' image: CRC(112645cd) SHA1(f2ad6b2fbec36d0bfe034d7bfb036ef6bf4ee395)
+	ROM_LOAD("grab._lp_sp_ultima_27c64.bin", 0x0000, 0x2000, CRC(980e14ac) SHA1(3f6dc75a8cb3fe38941b8a7900ecccdafabc14e9))
+ROM_END
+
+ROM_START(lotoplayza)
+	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplaya' image: CRC(9b77603c) SHA1(6799b930f9805332bf20c6146b044222fe49d243)
+	ROM_LOAD("grab._lp_s_3b4c_27c64.bin",    0x0000, 0x2000, CRC(556e2c35) SHA1(612f160592fd122e5a91914618e19eade5b52c3e))
+ROM_END
+
+ROM_START(lotoplayzb)
+	ROM_REGION(0x2000, "maincpu", 0)
+	// holds the 'lotoplayc' image: CRC(20a0e0d0) SHA1(832ed64dfa5f5f150f0e9918b40e9fb4e8e4260d)
+	ROM_LOAD("multn_0.0_27c64.bin",          0x0000, 0x2000, CRC(e74bce2a) SHA1(66a09f5df3a27b0c4bc964b19450734b736dc768))
+ROM_END
+
+
+} // anonymous namespace
+
+//    YEAR   NAME        PARENT     MACHINE        INPUT          CLASS                INIT        ROT   COMPANY              FULLNAME                                FLAGS
+GAME( 1990?, lotoplayz,  0,         lotoplay_prog, lotoplay_prog, lotoplay_prog_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 1)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayza, lotoplayz, lotoplay_prog, lotoplay_prog, lotoplay_prog_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 2)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )
+GAME( 1990?, lotoplayzb, lotoplayz, lotoplay_prog, lotoplay_prog, lotoplay_prog_state, empty_init, ROT0, "Gaelco / Covielsa", "Loto-Play programming device (set 3)", MACHINE_NO_SOUND_HW | MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -19584,6 +19584,7 @@ goldartuk
 lotoplay
 lotoplaya
 lotoplayb
+lotoplayc
 lotoplayp
 lotoplayz
 lotoplayza

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -19586,6 +19586,8 @@ lotoplaya
 lotoplayb
 lotoplayc
 lotoplayp
+
+@source:gaelco/lotoplay_prog.cpp
 lotoplayz
 lotoplayza
 lotoplayzb


### PR DESCRIPTION
Now "lotoplayzx" sets (the programming devices) are on a separate source file.
Also added a new MC68705 set and put the speaker on all sets that have one.


New systems marked not working
------------------------------
Loto-Play programming device (set 1) [Javier Valero, Josep Quingles, Recreativas.org]


New clones marked not working
-----------------------------
Loto-Play (MC68705, set 4) [Javier Valero, Josep Quingles, Recreativas.org]
