### PR TITLE
Add Macintosh Cordyceps (Power Mac x200) stub driver

### DIFF
--- a/src/mame/apple/capella.cpp
+++ b/src/mame/apple/capella.cpp
@@ -1,3 +1,5 @@
+// license:BSD-3-Clause
+// copyright-holders:wurthless-elektroniks
 /****************************************************************************
 
     Apple "Capella" (343S1181) PowerPC-to-68k bus bridge

--- a/src/mame/apple/capella.cpp
+++ b/src/mame/apple/capella.cpp
@@ -56,7 +56,7 @@ DEFINE_DEVICE_TYPE(CAPELLA, capella_device, "maccapella", "Apple Capella PowerPC
 void capella_device::map(address_map &map)
 {
     map(0x53000008, 0x5300000f).rw(FUNC(capella_device::ctrl_r), FUNC(capella_device::ctrl_w));
-    
+    map(0x53000010, 0x53000017).rw(FUNC(capella_device::ctrl_b_r), FUNC(capella_device::ctrl_b_w));
     map(0x53000018, 0x5300001f).rw(FUNC(capella_device::irq_ack_r), FUNC(capella_device::irq_ack_w));
     map(0x53000020, 0x53000027).r(FUNC(capella_device::ipl_lines_r));
 }
@@ -74,6 +74,8 @@ void capella_device::device_add_mconfig(machine_config &config)
 capella_device::capella_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, CAPELLA, tag, owner, clock),
 	m_maincpu(*this, finder_base::DUMMY_TAG),
+    m_ctrl_reg(0),
+    m_ctrl_reg_b(0),
     m_last_pending_irq(-1),
     m_ipl_lines(7)
 {
@@ -94,6 +96,7 @@ void capella_device::device_start()
 void capella_device::device_reset()
 {
     m_last_pending_irq = -1;
+    m_ctrl_reg_b = 0; // CPU bootloops otherwise
 }
 
 
@@ -107,6 +110,16 @@ u64 capella_device::ctrl_r(offs_t offset)
 void capella_device::ctrl_w(offs_t offset, u64 data)
 {
     m_ctrl_reg = data & 0x1f;
+}
+
+u64 capella_device::ctrl_b_r(offs_t offset)
+{
+    return m_ctrl_reg_b & 0x1F;
+}
+
+void capella_device::ctrl_b_w(offs_t offset, u64 data)
+{
+    m_ctrl_reg_b = data & 0x1f;
 }
 
 u64 capella_device::ipl_lines_r(offs_t offset)

--- a/src/mame/apple/capella.cpp
+++ b/src/mame/apple/capella.cpp
@@ -37,6 +37,9 @@
         before sending them off to the 68k emulator.
         See https://github.com/elliotnunn/NanoKernel/blob/master/ExternalInts.s, ExtIntHandlerCordyceps
 
+    The 6260 developer notes mention a "M7 bit" in the Capella that, when toggled, acts as a ROM switch.
+    This isn't really needed to start the system; it's enough to map the ROM where it should go.
+
     Die shot (very sparsely populated):
     https://siliconpr0n.org/archive/doku.php?id=bercovici:vlsi:vy16669-apple-343s1181-a-capella&s[]=capella
 
@@ -54,7 +57,7 @@ void capella_device::map(address_map &map)
 {
     map(0x53000008, 0x5300000f).rw(FUNC(capella_device::ctrl_r), FUNC(capella_device::ctrl_w));
     
-    map(0x53000018, 0x5300001f).r(FUNC(capella_device::irq_ack_r)).nopw();
+    map(0x53000018, 0x5300001f).rw(FUNC(capella_device::irq_ack_r), FUNC(capella_device::irq_ack_w));
     map(0x53000020, 0x53000027).r(FUNC(capella_device::ipl_lines_r));
 }
 
@@ -71,7 +74,8 @@ void capella_device::device_add_mconfig(machine_config &config)
 capella_device::capella_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, CAPELLA, tag, owner, clock),
 	m_maincpu(*this, finder_base::DUMMY_TAG),
-    m_last_pending_irq(-1)
+    m_last_pending_irq(-1),
+    m_ipl_lines(7)
 {
 }
 
@@ -107,20 +111,28 @@ void capella_device::ctrl_w(offs_t offset, u64 data)
 
 u64 capella_device::ipl_lines_r(offs_t offset)
 {
-    // TODO: actually return the real IPL state.
-    // the bootrom will hang if it doesn't get an interrupt when it expects
-    return 7;
+    return m_ipl_lines;
 }
 
 u64 capella_device::irq_ack_r(offs_t offset)
 {
-    m_last_pending_irq = -1;
     m_maincpu->set_input_line(PPC_IRQ, CLEAR_LINE);
- 
     return 0;
 }
 
-void capella_device::set_ipl_lines(int ipl)
+void capella_device::irq_ack_w(offs_t offset, u64 data)
+{
+    m_maincpu->set_input_line(PPC_IRQ, CLEAR_LINE);
+
+    // functionality guessed
+    if (!(1 <= m_last_pending_irq && m_last_pending_irq <= 7)) {
+        m_ipl_lines = 7;
+        return;
+    }
+    m_ipl_lines = ~m_last_pending_irq & 7;
+}
+
+void capella_device::translate_ipl_state_change(int ipl)
 {
     // should only see IRQs 1, 2, 4 from primetime and NMI 7 from the CUDA
     if (!(1 <= ipl && ipl <= 7)) {
@@ -129,6 +141,5 @@ void capella_device::set_ipl_lines(int ipl)
     }
 
     m_last_pending_irq = ipl;
-    
-    // actual way to fire the IRQ is unclear; CPU always seems to get hung up
+    m_maincpu->set_input_line(PPC_IRQ, ASSERT_LINE);
 }

--- a/src/mame/apple/capella.cpp
+++ b/src/mame/apple/capella.cpp
@@ -1,0 +1,134 @@
+/****************************************************************************
+
+    Apple "Capella" (343S1181) PowerPC-to-68k bus bridge
+    This handles bus translation on the Cordyceps (Power Macintosh x200/x300) board.
+    
+    Memory map based on how the 6200 bootrom behaves:
+
+    - $51xxxxxx: Cache RAM, 64 bits wide (on ROM/L2 card)
+
+    - $52xxxxxx: Tag RAM (2x8k SRAMs on motherboard), 8 bit accesses only (ROM accesses $52000007, $5200000F, etc.)
+
+    - $53xxxxxx: Capella registers
+        Per the 6200 Developer Notes, the Capella only has D0-D4 connected, so only 5 bits
+        can be read/written at a time.
+
+        - $53000007: ???
+        ROM clears it to 0
+
+        - $5300000F: RAM / control switch
+            Bit 2 = Tag RAM map enable?
+            Bit 1 = L2 cache map enable?
+            Bit 0 = ?
+
+        - $53000017: ???
+        ROM sets then clears bit 0; also clears bit 5
+        68k routine at 0x125c checks bit 3; if 0, it sets it and exits,
+        otherwise it falls through to an A-trap (0xA092 / _EgretDispatch),
+        and the machine seems to reboot then.
+        Note that for non-Cordyceps machines, that routine instead checks bit 2
+
+        - $5300001f: IRQ acknowledge
+        ROM does: read, eieio, write 0, eieio, read twice, isync.
+
+        - $53000027: 68040 IPL line state
+        This is right off the bus, so they have to be inverted for processing.
+        Cordyceps-specific IRQ handler at 0x0315840 inverts these bits with XOR 7
+        before sending them off to the 68k emulator.
+        See https://github.com/elliotnunn/NanoKernel/blob/master/ExternalInts.s, ExtIntHandlerCordyceps
+
+    Die shot (very sparsely populated):
+    https://siliconpr0n.org/archive/doku.php?id=bercovici:vlsi:vy16669-apple-343s1181-a-capella&s[]=capella
+
+****************************************************************************/
+
+
+#include "emu.h"
+#include "capella.h"
+
+DEFINE_DEVICE_TYPE(CAPELLA, capella_device, "maccapella", "Apple Capella PowerPC-to-68040 bridge")
+
+//-------------------------------------------------
+
+void capella_device::map(address_map &map)
+{
+    map(0x53000008, 0x5300000f).rw(FUNC(capella_device::ctrl_r), FUNC(capella_device::ctrl_w));
+    
+    map(0x53000018, 0x5300001f).r(FUNC(capella_device::irq_ack_r)).nopw();
+    map(0x53000020, 0x53000027).r(FUNC(capella_device::ipl_lines_r));
+}
+
+//-------------------------------------------------
+
+void capella_device::device_add_mconfig(machine_config &config)
+{
+}
+
+//-------------------------------------------------
+//  capella_device - constructor
+//-------------------------------------------------
+
+capella_device::capella_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, CAPELLA, tag, owner, clock),
+	m_maincpu(*this, finder_base::DUMMY_TAG),
+    m_last_pending_irq(-1)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void capella_device::device_start()
+{
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void capella_device::device_reset()
+{
+    m_last_pending_irq = -1;
+}
+
+
+//-------------------------------------------------
+
+u64 capella_device::ctrl_r(offs_t offset)
+{
+    return m_ctrl_reg & 0x1F;
+}
+
+void capella_device::ctrl_w(offs_t offset, u64 data)
+{
+    m_ctrl_reg = data & 0x1f;
+}
+
+u64 capella_device::ipl_lines_r(offs_t offset)
+{
+    // TODO: actually return the real IPL state.
+    // the bootrom will hang if it doesn't get an interrupt when it expects
+    return 7;
+}
+
+u64 capella_device::irq_ack_r(offs_t offset)
+{
+    m_last_pending_irq = -1;
+    m_maincpu->set_input_line(PPC_IRQ, CLEAR_LINE);
+ 
+    return 0;
+}
+
+void capella_device::set_ipl_lines(int ipl)
+{
+    // should only see IRQs 1, 2, 4 from primetime and NMI 7 from the CUDA
+    if (!(1 <= ipl && ipl <= 7)) {
+        m_maincpu->set_input_line(PPC_IRQ, CLEAR_LINE);
+        return;
+    }
+
+    m_last_pending_irq = ipl;
+    
+    // actual way to fire the IRQ is unclear; CPU always seems to get hung up
+}

--- a/src/mame/apple/capella.h
+++ b/src/mame/apple/capella.h
@@ -1,0 +1,48 @@
+
+#ifndef MAME_APPLE_CAPELLA_H
+#define MAME_APPLE_CAPELLA_H
+
+#pragma once
+
+
+#include "cpu/powerpc/ppc.h"
+
+class capella_device :  public device_t
+{
+public:
+	// construction/destruction
+	capella_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// interface routines
+	virtual void map(address_map &map) ATTR_COLD;
+
+	template <typename... T> void set_maincpu_tag(T &&... args) { m_maincpu.set_tag(std::forward<T>(args)...); }
+
+
+    void set_ipl_lines(int ipl);
+
+	u64 ctrl_r(offs_t offset);
+	void ctrl_w(offs_t offset, u64 data);
+
+    u64 ipl_lines_r(offs_t offset);
+    u64 irq_ack_r(offs_t offset);
+
+	TIMER_CALLBACK_MEMBER(fire_delayed_irq);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+	virtual void device_add_mconfig(machine_config &config) override ATTR_COLD;
+
+private:
+	required_device<ppc_device> m_maincpu;
+
+	int m_last_pending_irq;
+	u8 m_ctrl_reg;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(CAPELLA, capella_device)
+
+#endif // MAME_APPLE_CAPELLA_H

--- a/src/mame/apple/capella.h
+++ b/src/mame/apple/capella.h
@@ -24,6 +24,10 @@ public:
 	u64 ctrl_r(offs_t offset);
 	void ctrl_w(offs_t offset, u64 data);
 
+	u64 ctrl_b_r(offs_t offset);
+	void ctrl_b_w(offs_t offset, u64 data);
+
+
     u64 ipl_lines_r(offs_t offset);
 
     u64 irq_ack_r(offs_t offset);
@@ -40,9 +44,10 @@ protected:
 private:
 	required_device<ppc_device> m_maincpu;
 
+	u8 m_ctrl_reg;
+	u8 m_ctrl_reg_b;
 	int m_last_pending_irq;
 	u8 m_ipl_lines;
-	u8 m_ctrl_reg;
 };
 
 // device type definition

--- a/src/mame/apple/capella.h
+++ b/src/mame/apple/capella.h
@@ -19,13 +19,15 @@ public:
 	template <typename... T> void set_maincpu_tag(T &&... args) { m_maincpu.set_tag(std::forward<T>(args)...); }
 
 
-    void set_ipl_lines(int ipl);
+    void translate_ipl_state_change(int ipl);
 
 	u64 ctrl_r(offs_t offset);
 	void ctrl_w(offs_t offset, u64 data);
 
     u64 ipl_lines_r(offs_t offset);
+
     u64 irq_ack_r(offs_t offset);
+	void irq_ack_w(offs_t offset, u64 data);
 
 	TIMER_CALLBACK_MEMBER(fire_delayed_irq);
 
@@ -39,6 +41,7 @@ private:
 	required_device<ppc_device> m_maincpu;
 
 	int m_last_pending_irq;
+	u8 m_ipl_lines;
 	u8 m_ctrl_reg;
 };
 

--- a/src/mame/apple/f108.cpp
+++ b/src/mame/apple/f108.cpp
@@ -127,7 +127,7 @@ void f108_device::device_reset()
 
 	// put ROM mirror at 0
 	address_space &space = m_maincpu->space(AS_PROGRAM);
-	const u32 memory_size = std::min((u32)0x3fffff, m_rom_size);
+	const u32 memory_size = std::min((u32)0x400000, m_rom_size);
 	const u32 memory_end = memory_size - 1;
 	offs_t memory_mirror = memory_end & ~(memory_size - 1);
 

--- a/src/mame/apple/f108.cpp
+++ b/src/mame/apple/f108.cpp
@@ -53,24 +53,12 @@ void f108_device::device_add_mconfig(machine_config &config)
 	m_ata->irq_handler().set(FUNC(f108_device::ata_irq_w));
 
 	NSCSI_BUS(config, m_scsibus);
-	NSCSI_CONNECTOR(config, "scsi:0", mac_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsi:1", mac_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsi:2", mac_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsi:3").option_set("cdrom", NSCSI_CDROM_APPLE).machine_config(
-		[](device_t *device)
-		{
-			device->subdevice<cdda_device>("cdda")->add_route(0, "^^^primetimeii:speaker", 1.0, 0);
-			device->subdevice<cdda_device>("cdda")->add_route(1, "^^^primetimeii:speaker", 1.0, 1);
-		});
-	NSCSI_CONNECTOR(config, "scsi:4", mac_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsi:5", mac_scsi_devices, nullptr);
-	NSCSI_CONNECTOR(config, "scsi:6", mac_scsi_devices, nullptr);
+	// ... bus devices to be populated by drivers ...
+
 	NCR53C96(config, m_ncr1, 40_MHz_XTAL);
 	m_scsibus->set_external_device(7, m_ncr1);
 	m_ncr1->set_busmd(ncr53c96_device::BUSMD_1);
 
-	SOFTWARE_LIST(config, "hdd_list").set_original("mac_hdd");
-	SOFTWARE_LIST(config, "cd_list").set_original("mac_cdrom").set_filter("MC68040");
 
 	SCC85C30(config, m_scc, 31.3344_MHz_XTAL/4);
 	m_scc->configure_channels(3'686'400, 3'686'400, 3'686'400, 3'686'400);

--- a/src/mame/apple/iosb.cpp
+++ b/src/mame/apple/iosb.cpp
@@ -539,7 +539,6 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 		{
 			m68k_cpu->restart_this_instruction();
 		}
-		m_maincpu->retry_access();
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return 0xffff;
 	}

--- a/src/mame/apple/iosb.cpp
+++ b/src/mame/apple/iosb.cpp
@@ -39,6 +39,13 @@
 static constexpr u32 C7M  = 7833600;
 static constexpr u32 C15M = (C7M * 2);
 
+// same pattern as in amiga/amiga.cpp, but macro'd
+#define RESTART_INSTRUCTION(x) \
+		if (auto *const musashi = dynamic_cast<m68000_musashi_device *>(&*x)) \
+			musashi->restart_this_instruction(); \
+		else \
+			x->retry_access(); \
+
 //**************************************************************************
 //  DEVICE DEFINITIONS
 //**************************************************************************
@@ -186,12 +193,16 @@ void iosb_base::device_start()
 {
 	if (!m_capella)
 	{
-		m68000_musashi_device* m68k_maincpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu);
-		if (!m68k_maincpu)
+		// if Capella (or some other bridge chip) is not present,
+		// we *MUST* be talking directly to a 680x0
+		if (auto *const musashi = dynamic_cast<m68000_musashi_device *>(&*m_maincpu))
 		{
-			fatalerror("iosb init without 68k CPU or PowerPC-to-68k bridge device\n");
+			musashi->set_emmu_enable(true);
 		}
-		m68k_maincpu->set_emmu_enable(true);
+		else
+		{
+			fatalerror("iosb.cpp: init without 68k CPU or PowerPC-to-68k bridge device\n");
+		}	
 	}
 
 	m_6015_timer = timer_alloc(FUNC(iosb_base::mac_6015_tick), this);
@@ -310,7 +321,7 @@ void iosb_base::field_interrupts()
 	{
 		if (m_capella)
 		{
-			m_capella->set_ipl_lines(-1);
+			m_capella->translate_ipl_state_change(-1);
 		}
 		else
 		{
@@ -323,7 +334,7 @@ void iosb_base::field_interrupts()
 	{
 		if (m_capella)
 		{
-			m_capella->set_ipl_lines(take_interrupt);
+			m_capella->translate_ipl_state_change(take_interrupt);
 		}
 		else
 		{
@@ -535,11 +546,7 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 	{
 		// The real DAFB simply holds off /DTACK here, we simulate that
 		// by rewinding and repeating the instruction until DRQ is asserted.
-		m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
-		if (m68k_cpu)
-		{
-			m68k_cpu->restart_this_instruction();
-		}
+		RESTART_INSTRUCTION(m_maincpu);	
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return 0xffff;
 	}
@@ -558,11 +565,7 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 		{
 			// The real DAFB simply holds off /DTACK here, we simulate that
 			// by rewinding and repeating the instruction until DRQ is asserted.
-			m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
-			if (m68k_cpu)
-			{
-				m68k_cpu->restart_this_instruction();
-			}
+			RESTART_INSTRUCTION(m_maincpu);
 			m_maincpu->spin_until_time(attotime::from_usec(50));
 			return 0xffff;
 		}
@@ -588,11 +591,7 @@ void iosb_base::turboscsi_dma_w(offs_t offset, u32 data, u32 mem_mask)
 
 	if (!m_drq)
 	{
-		m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
-		if (m68k_cpu)
-		{
-			m68k_cpu->restart_this_instruction();
-		}
+		RESTART_INSTRUCTION(m_maincpu);
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return;
 	}
@@ -606,11 +605,7 @@ void iosb_base::turboscsi_dma_w(offs_t offset, u32 data, u32 mem_mask)
 		m_scsi_second_half = true;
 		if (!m_drq)
 		{
-			m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
-			if (m68k_cpu)
-			{
-				m68k_cpu->restart_this_instruction();
-			}
+			RESTART_INSTRUCTION(m_maincpu);
 			m_maincpu->spin_until_time(attotime::from_usec(50));
 			return;
 		}

--- a/src/mame/apple/iosb.cpp
+++ b/src/mame/apple/iosb.cpp
@@ -124,6 +124,7 @@ iosb_base::iosb_base(const machine_config &mconfig, device_type type, const char
 	m_pa4(*this, 0),
 	m_pa6(*this, 0),
 	m_maincpu(*this, finder_base::DUMMY_TAG),
+	m_capella(*this, finder_base::DUMMY_TAG),
 	m_ncr(*this, finder_base::DUMMY_TAG),
 	m_via1(*this, "via1"),
 	m_via2(*this, "via2"),
@@ -183,7 +184,14 @@ primetimeii_device::primetimeii_device(const machine_config &mconfig, const char
 
 void iosb_base::device_start()
 {
-	m_maincpu->set_emmu_enable(true);
+	if (!m_capella)
+	{
+		m68000_musashi_device* m68k_maincpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu);
+		if (!m68k_maincpu)
+		{
+			fatalerror("iosb init without 68k CPU or PowerPC-to-68k bridge device\n");
+		}
+	}
 
 	m_6015_timer = timer_alloc(FUNC(iosb_base::mac_6015_tick), this);
 	m_6015_timer->adjust(attotime::never);
@@ -296,15 +304,30 @@ void iosb_base::field_interrupts()
 		take_interrupt = 1;
 	}
 
+
 	if (m_last_taken_interrupt > -1)
 	{
-		m_maincpu->set_input_line(m_last_taken_interrupt, CLEAR_LINE);
+		if (m_capella)
+		{
+			m_capella->set_ipl_lines(-1);
+		}
+		else
+		{
+			m_maincpu->set_input_line(m_last_taken_interrupt, CLEAR_LINE);
+		}
 		m_last_taken_interrupt = -1;
 	}
 
 	if (take_interrupt > -1)
 	{
-		m_maincpu->set_input_line(take_interrupt, ASSERT_LINE);
+		if (m_capella)
+		{
+			m_capella->set_ipl_lines(take_interrupt);
+		}
+		else
+		{
+			m_maincpu->set_input_line(take_interrupt, ASSERT_LINE);
+		}
 		m_last_taken_interrupt = take_interrupt;
 	}
 }
@@ -511,7 +534,12 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 	{
 		// The real DAFB simply holds off /DTACK here, we simulate that
 		// by rewinding and repeating the instruction until DRQ is asserted.
-		m_maincpu->restart_this_instruction();
+		m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
+		if (m68k_cpu)
+		{
+			m68k_cpu->restart_this_instruction();
+		}
+		m_maincpu->retry_access();
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return 0xffff;
 	}
@@ -530,7 +558,11 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 		{
 			// The real DAFB simply holds off /DTACK here, we simulate that
 			// by rewinding and repeating the instruction until DRQ is asserted.
-			m_maincpu->restart_this_instruction();
+			m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
+			if (m68k_cpu)
+			{
+				m68k_cpu->restart_this_instruction();
+			}
 			m_maincpu->spin_until_time(attotime::from_usec(50));
 			return 0xffff;
 		}
@@ -556,7 +588,11 @@ void iosb_base::turboscsi_dma_w(offs_t offset, u32 data, u32 mem_mask)
 
 	if (!m_drq)
 	{
-		m_maincpu->restart_this_instruction();
+		m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
+		if (m68k_cpu)
+		{
+			m68k_cpu->restart_this_instruction();
+		}
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return;
 	}
@@ -570,7 +606,11 @@ void iosb_base::turboscsi_dma_w(offs_t offset, u32 data, u32 mem_mask)
 		m_scsi_second_half = true;
 		if (!m_drq)
 		{
-			m_maincpu->restart_this_instruction();
+			m68000_musashi_device* m68k_cpu = dynamic_cast<m68000_musashi_device *>(&m_maincpu); 
+			if (m68k_cpu)
+			{
+				m68k_cpu->restart_this_instruction();
+			}
 			m_maincpu->spin_until_time(attotime::from_usec(50));
 			return;
 		}

--- a/src/mame/apple/iosb.cpp
+++ b/src/mame/apple/iosb.cpp
@@ -191,6 +191,7 @@ void iosb_base::device_start()
 		{
 			fatalerror("iosb init without 68k CPU or PowerPC-to-68k bridge device\n");
 		}
+		m68k_maincpu->set_emmu_enable(true);
 	}
 
 	m_6015_timer = timer_alloc(FUNC(iosb_base::mac_6015_tick), this);

--- a/src/mame/apple/iosb.h
+++ b/src/mame/apple/iosb.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "capella.h"
 #include "macrtc.h"
 
 #include "cpu/m68000/m68040.h"
@@ -42,6 +43,7 @@ public:
 
 	template <typename... T> void set_maincpu_tag(T &&... args) { m_maincpu.set_tag(std::forward<T>(args)...); }
 	template <typename... T> void set_scsi_tag(T &&... args) { m_ncr.set_tag(std::forward<T>(args)...); }
+	template <typename... T> void set_capella_tag(T &&... args) { m_capella.set_tag(std::forward<T>(args)...); }
 
 	void pb3_w(int state) { m_adb_interrupt = state; }
 	void cb1_w(int state);  // ADB clock
@@ -76,13 +78,15 @@ protected:
 	devcb_write_line m_cb1, m_cb2, m_dfac_clock_w, m_dfac_data_w, m_dfac_latch_w;
 	devcb_read_line m_pa1, m_pa2, m_pa4, m_pa6;
 
-	required_device<m68000_musashi_device> m_maincpu;
+	required_device<cpu_device> m_maincpu;
+	optional_device<capella_device> m_capella;
 	required_device<ncr53c96_device> m_ncr;
 	required_device<via6522_device> m_via1;
 	required_device<quadra_pseudovia_device> m_via2;
 	required_device<asc_base_device> m_asc;
 	required_device<applefdintf_device> m_fdc;
 	required_device_array<floppy_connector, 2> m_floppy;
+
 
 	u16 m_iosb_regs[0x20];
 

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -48,6 +48,8 @@
 
 #include "bus/adb/adb.h"
 #include "bus/adb/cards.h"
+#include "bus/nscsi/cd.h"
+#include "bus/nscsi/devices.h"
 #include "bus/nubus/cards.h"
 #include "bus/nubus/nubus.h"
 #include "cpu/powerpc/ppc.h"
@@ -179,6 +181,16 @@ void pmac6200_state::pmac6200(machine_config &config)
 	m_f108->set_primetimeii_tag("primetimeii");
     m_f108->set_rom_tag("bootrom");
     m_f108->write_ata_irq().set(m_primetimeii, FUNC(primetimeii_device::ata_irq_w));
+
+	// attach no SCSI devices for the time being
+	NSCSI_CONNECTOR(config, "f108:scsi:0", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:1", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:2", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:3", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:4", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:5", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:6", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:7", mac_scsi_devices, nullptr);
 
 	PRIMETIMEII(config, m_primetimeii, 75_MHz_XTAL / 2); // guessed
 	m_primetimeii->set_maincpu_tag("maincpu");

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -12,12 +12,15 @@
 	successor to the 6100, reviewers opened it up and quickly found that
 	it was really a Quadra 630 with a PowerPC 603 grafted onto it,
 	with the expected performance bottlenecks making it perform worse
-	than its predecessor.
+	than its predecessor. Add to that the overall cheapness of the
+	case, poor software support by Mac OS, and unstable clock generators
+	causing freezes on early production boards, and this machine became
+	a perennial contender in the discussion of "worst Mac ever made".
 
-    The often-cited Low End Mac articles listing the issues with the Power Mac 6200
-    mention that the 68k bus is split into "Left 32" and "Right 32" halves.
-    This might really be referring to how the Quadra 630 bus is split into a fast half
-	and a slow half for I/O.
+	The later 5260/100 and 5260/120 upgrade the CPU to a 603e and substitute
+	the PrimeTime II for the PrimeTime III, which adds 16-bit audio.
+	It is not to be confused with the 6360/160, which is a complete redesign
+	and has nothing to do with the Cordyceps architecture.
 
 	The Capella bridge chip, as well as the existence of other PowerPC-to-68k bridge chips,
 	will warrant a cleanup/refactor of some other 68k Mac drivers and devices
@@ -28,7 +31,7 @@
 	but eventually the boot hangs.
 	
 	Machine IDs:
-	pmac5200: 0x3258, 0x325E, 0x3259, 0x325C, 0x325D
+	pmac5200: 0x3258, 0x3259, 0x325C, 0x325D, 0x325E
 	pmac6200: 0x3250, 0x3251, 0x3254, 0x3255, 0x3256
 
 ****************************************************************************/
@@ -106,7 +109,7 @@ private:
 		if (state)
 		{
 			// guessed; NMI on 68000 series is all /IPLx lines low (IRQ level 7)
-			m_capella->set_ipl_lines(0);
+			m_capella->translate_ipl_state_change(7);
 		}
 	}
 };
@@ -163,10 +166,11 @@ INPUT_PORTS_END
 void pmac6200_state::pmac6200(machine_config &config)
 {
 	PPC603(config, m_maincpu, 75_MHz_XTAL);
-
+	m_maincpu->ppcdrc_set_options(PPCDRC_COMPATIBLE_OPTIONS);
     m_maincpu->set_bus_frequency(XTAL(75_MHz_XTAL)); // FSB freq to Capella
 	m_maincpu->set_addrmap(AS_PROGRAM, &pmac6200_state::pmac6200_map);
-
+	config.set_perfect_quantum(m_maincpu); // chimes of death without it
+	
 	CAPELLA(config, m_capella, 75_MHz_XTAL);
 	m_capella->set_maincpu_tag("maincpu");
 
@@ -198,7 +202,7 @@ void pmac6200_state::pmac6200(machine_config &config)
 	m_cuda->nmi_callback().set(FUNC(pmac6200_state::nmi_irq));
 	m_adbbus->out_adb_callback().set(m_cuda, FUNC(cuda_device::set_adb_line));
 	m_adbbus->out_poweron_callback().set(m_cuda, FUNC(cuda_device::set_adb_power));
-	config.set_perfect_quantum(m_maincpu);
+
 
 	input_merger_device &sda_merger(INPUT_MERGER_ALL_HIGH(config, "sda"));
 	sda_merger.output_handler().append(m_cuda, FUNC(cuda_device::set_iic_sda));

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -278,4 +278,4 @@ ROM_END
 
 } // anonymous namespace
 
-COMP( 1995, pmac6200, 0, 0, pmac6200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 6200", MACHINE_NOT_WORKING)
+COMP( 1995, pmac6200, 0, 0, pmac6200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 6200/75", MACHINE_NOT_WORKING)

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -1,9 +1,9 @@
-
-
+// license:BSD-3-Clause
+// copyright-holders:wurthless-elektroniks, R. Belmont
 /****************************************************************************
 
     Power Macintosh x200/x300 "Cordyceps" hardware
-    Heavily based on maccquadra630.cpp
+    Heavily based on maccquadra630.cpp by R. Belmont
 
 	The bootrom calls this board "Cordyceps" ("Boot Cordyceps 6")
 	but the Apple codenames "Crusader" and "Elixir" are better known.

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -1,0 +1,265 @@
+
+
+/****************************************************************************
+
+    Power Macintosh x200/x300 "Cordyceps" hardware
+    Heavily based on maccquadra630.cpp
+
+	The bootrom calls this board "Cordyceps" ("Boot Cordyceps 6")
+	but the Apple codenames "Crusader" and "Elixir" are better known.
+
+	This machine is an Apple fan "favorite". Ostensibly positioned as the
+	successor to the 6100, reviewers opened it up and quickly found that
+	it was really a Quadra 630 with a PowerPC 603 grafted onto it,
+	with the expected performance bottlenecks making it perform worse
+	than its predecessor.
+
+    The often-cited Low End Mac articles listing the issues with the Power Mac 6200
+    mention that the 68k bus is split into "Left 32" and "Right 32" halves.
+    This might really be referring to how the Quadra 630 bus is split into a fast half
+	and a slow half for I/O.
+
+	The Capella bridge chip, as well as the existence of other PowerPC-to-68k bridge chips,
+	will warrant a cleanup/refactor of some other 68k Mac drivers and devices
+	to fully support PowerPC accelerators. But we can hack around that for now.
+
+	Driver status:
+	Gets past POST (with hacks) and runs some initial device configuration,
+	but eventually the boot hangs.
+	
+	Machine IDs:
+	pmac5200: 0x3258, 0x325E, 0x3259, 0x325C, 0x325D
+	pmac6200: 0x3250, 0x3251, 0x3254, 0x3255, 0x3256
+
+****************************************************************************/
+
+#include "emu.h"
+
+#include "capella.h"
+#include "cuda.h"
+#include "dfac2.h"
+#include "f108.h"
+#include "iosb.h"
+#include "mactoolbox.h"
+#include "valkyrie.h"
+
+#include "bus/adb/adb.h"
+#include "bus/adb/cards.h"
+#include "bus/nubus/cards.h"
+#include "bus/nubus/nubus.h"
+#include "cpu/powerpc/ppc.h"
+#include "machine/input_merger.h"
+#include "machine/ram.h"
+#include "machine/timer.h"
+
+#include "softlist_dev.h"
+
+#define C32M 31.3344_MHz_XTAL
+
+namespace { // anonymous namespace
+
+class pmac6200_state : public driver_device
+{
+public:
+	pmac6200_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_capella(*this, "capella"),
+		m_f108(*this, "f108"),
+		m_primetimeii(*this, "primetimeii"),
+		m_dfac2(*this, "dfac2"),
+		m_video(*this, "valkyrie"),
+		m_adbbus(*this, "adb"),
+		m_cuda(*this, "cuda"),
+		m_ram(*this, RAM_TAG)
+	{
+	}
+
+	void pmac6200(machine_config &config);
+
+	void pmac6200_map(address_map &map) ATTR_COLD;
+
+	void init_pmac6200();
+
+private:
+	required_device<ppc603_device> m_maincpu;
+	required_device<capella_device> m_capella;
+	required_device<f108_device> m_f108;
+	required_device<primetimeii_device> m_primetimeii;
+	required_device<dfac2_device> m_dfac2;
+	required_device<valkyrie_device> m_video;
+	required_device<adb_bus_device> m_adbbus;
+	required_device<cuda_device> m_cuda;
+	required_device<ram_device> m_ram;
+
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+
+	void cuda_reset_w(int state)
+	{
+		m_maincpu->set_input_line(INPUT_LINE_HALT, state);
+		m_maincpu->set_input_line(INPUT_LINE_RESET, state);
+	}
+
+	void nmi_irq(int state)
+	{
+		if (state)
+		{
+			// guessed; NMI on 68000 series is all /IPLx lines low (IRQ level 7)
+			m_capella->set_ipl_lines(0);
+		}
+	}
+};
+
+void pmac6200_state::machine_start()
+{
+	m_f108->set_ram_info(m_ram->pointer<u32>(), m_ram->size());
+}
+
+void pmac6200_state::machine_reset()
+{
+	m_maincpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
+}
+
+void pmac6200_state::init_pmac6200()
+{
+}
+
+/***************************************************************************
+    ADDRESS MAPS
+***************************************************************************/
+
+// [info 20d28] Box PowerMac 6200 (was Carnation 16) decoder 14 (djMEMC/MEMCjr/F108)
+// VIA mask 00000000 VIA match 00000000 ID 3250
+// [decoder @ 000218de] Screen physical f9001000 logical 32-bit f9001000 logical 24-bit 00000000
+// ROM @ 40800000
+// diag ROM @ 58000000 VIA1 @ 50f00000 SCC Read @ 50f0c020 
+// SCC Write @ 50f0c020 IWM/SWIM @ 50f1e000 VIA2 @ 50f02000 ASC @ 50f14000 VDAC @ 50f24000 
+// SONIC @ 50f0a000 SCSI96 1 @ 50f10000 Patch ROM @ 5ff00000 
+void pmac6200_state::pmac6200_map(address_map &map)
+{
+	// 68040 bus includes main RAM, with the expected bottlenecks
+    map(0x00000000, 0xffffffff).m(m_f108, FUNC(f108_device::map));
+	map(0x00000000, 0xffffffff).m(m_video, FUNC(valkyrie_device::map));
+	map(0x50000000, 0x53ffffff).m(m_primetimeii, FUNC(primetime_device::map));
+	
+	// SONIC ethernet is supposed to live here. for now, pretend it's not there
+	map(0x50f0a000, 0x50f0bfff).noprw();
+
+	// Capella-mapped devices in 64-bit address space
+	map(0x40000000, 0x403fffff).rom().region("bootrom64", 0); // HACK: should be mirrored, but doing
+	map(0x40800000, 0x40bfffff).rom().region("bootrom64", 0); // .mirror(0x0fc00000) crashes the bootrom
+
+	map(0xffc00000, 0xffffffff).rom().region("bootrom64", 0);
+
+	map(0x00000000, 0xffffffff).m(m_capella, FUNC(capella_device::map));
+
+	map(0x5ffffffc, 0x5fffffff).lr32(NAME([](offs_t offset) { return 0xa55a3250; }));
+}
+
+static INPUT_PORTS_START( macadb )
+INPUT_PORTS_END
+
+void pmac6200_state::pmac6200(machine_config &config)
+{
+	PPC603(config, m_maincpu, 75_MHz_XTAL);
+
+    m_maincpu->set_bus_frequency(XTAL(75_MHz_XTAL)); // FSB freq to Capella
+	m_maincpu->set_addrmap(AS_PROGRAM, &pmac6200_state::pmac6200_map);
+
+	CAPELLA(config, m_capella, 75_MHz_XTAL);
+	m_capella->set_maincpu_tag("maincpu");
+
+	F108(config, m_f108, 75_MHz_XTAL / 2); // 68040 bus speed is 37.5 MHz, half of FSB frequency
+	m_f108->set_maincpu_tag("maincpu");
+	m_f108->set_primetimeii_tag("primetimeii");
+    m_f108->set_rom_tag("bootrom");
+    m_f108->write_ata_irq().set(m_primetimeii, FUNC(primetimeii_device::ata_irq_w));
+
+	PRIMETIMEII(config, m_primetimeii, 75_MHz_XTAL / 2); // guessed
+	m_primetimeii->set_maincpu_tag("maincpu");
+	m_primetimeii->set_scsi_tag("f108:ncr53c96");
+	m_primetimeii->set_capella_tag("capella");
+
+	VALKYRIE(config, m_video, C32M); // TODO: confirm on real hardware
+	m_video->write_irq().set(m_primetimeii, FUNC(primetime_device::via2_irq_w<0x40>));
+
+	ADB_BUS(config, m_adbbus);
+	ADB_CONNECTOR(config, "adb:0", adb_devices, "hle_keyboard");
+	ADB_CONNECTOR(config, "adb:1", adb_devices, "hle_mouse");
+
+	CUDA_V2XX(config, m_cuda, XTAL(32'768));
+	m_cuda->zero_default_pram(); 
+	m_cuda->set_default_bios_tag("341s0060");
+	m_cuda->reset_callback().set(FUNC(pmac6200_state::cuda_reset_w));
+	m_cuda->linechange_callback().set(m_adbbus, FUNC(adb_bus_device::adb_host_line_w));
+	m_cuda->via_clock_callback().set(m_primetimeii, FUNC(primetime_device::cb1_w));
+	m_cuda->via_data_callback().set(m_primetimeii, FUNC(primetime_device::cb2_w));
+	m_cuda->nmi_callback().set(FUNC(pmac6200_state::nmi_irq));
+	m_adbbus->out_adb_callback().set(m_cuda, FUNC(cuda_device::set_adb_line));
+	m_adbbus->out_poweron_callback().set(m_cuda, FUNC(cuda_device::set_adb_power));
+	config.set_perfect_quantum(m_maincpu);
+
+	input_merger_device &sda_merger(INPUT_MERGER_ALL_HIGH(config, "sda"));
+	sda_merger.output_handler().append(m_cuda, FUNC(cuda_device::set_iic_sda));
+
+	m_cuda->iic_sda_callback().set(sda_merger, FUNC(input_merger_device::in_w<0>));
+	m_cuda->iic_sda_callback().append(m_video, FUNC(valkyrie_device::sda_write));
+	m_cuda->iic_scl_callback().set(m_video, FUNC(valkyrie_device::scl_write));
+
+	m_video->sda_callback().set(sda_merger, FUNC(input_merger_device::in_w<1>));
+
+	APPLE_DFAC2(config, m_dfac2, 22257);
+	m_dfac2->sda_callback().set(sda_merger, FUNC(input_merger_device::in_w<2>));
+	m_cuda->iic_scl_callback().append(m_dfac2, FUNC(dfac2_device::scl_write));
+	m_cuda->iic_sda_callback().append(m_dfac2, FUNC(dfac2_device::sda_write));
+
+	m_primetimeii->pb3_callback().set(m_cuda, FUNC(cuda_device::get_treq));
+	m_primetimeii->pb4_callback().set(m_cuda, FUNC(cuda_device::set_byteack));
+	m_primetimeii->pb5_callback().set(m_cuda, FUNC(cuda_device::set_tip));
+	m_primetimeii->write_cb2().set(m_cuda, FUNC(cuda_device::set_via_data));
+
+	// per the Apple Developer Notes, the PDS expansion card only appears at fe.
+	// note that this PDS implementation is broken on real hardware because
+	// of the use of a PowerPC chip, so accelerators will cause problems.
+	// 
+	// TODO: PDS is to be added later because of said 68k/PPC incompatibility.
+	
+	RAM(config, m_ram);
+	m_ram->set_default_size("8M");
+	m_ram->set_extra_options("8M,16M,32M,64M"); // per service manual
+}
+
+#define PPC_MAKE_BRANCH_ALWAYS(x) \
+	ROM_FILL(x,   1, 0x48) \
+	ROM_FILL(x+1, 1, 0x00) \
+	// .
+
+#define PPC_ASSEMBLE_NOP(x) \
+	ROM_FILL(x,   1, 0x7f) \
+	ROM_FILL(x+1, 1, 0xff) \
+	ROM_FILL(x+2, 1, 0xfb) \
+	ROM_FILL(x+3, 1, 0x78) \
+	// .
+
+ROM_START( pmac6200 )
+	// bootrom is on the 64-bit PowerPC bus, so it should be loaded in a 64-bit space
+    ROM_REGION64_BE(0x400000, "bootrom64", 0)
+	ROM_LOAD( "63abfd3f.bin", 0x000000, 0x400000, CRC(2f47a6ea) SHA1(0b34d7c692594695b39719c3bf21808985f89f2c) )
+
+	// HACK: the bootrom tells the Capella to map in cache/tag RAMs and then tests them, failing if they're bad.
+	// we skip these tests for now; if it turns out these are never touched again,
+	// then these hacks can probably stay here...
+	PPC_MAKE_BRANCH_ALWAYS(0x3051b0) // skip checksum mismatch panic
+	PPC_ASSEMBLE_NOP(0x30529c)		 // NOP out call to cache/tag RAM tests
+	PPC_MAKE_BRANCH_ALWAYS(0x3052a4) // avoid panic case after patched-out routine
+	
+	// this is here to keep the F108 happy
+	// TODO: confirm on real hardware if the 68k side can see the bootrom
+    ROM_REGION32_BE(0x400000, "bootrom", 0)
+	ROM_FILL(0, 0x400000, 0)
+ROM_END
+
+} // anonymous namespace
+
+COMP( 1995, pmac6200, 0, 0, pmac6200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 6200", MACHINE_NOT_WORKING)

--- a/src/mame/apple/macquadra630.cpp
+++ b/src/mame/apple/macquadra630.cpp
@@ -45,6 +45,8 @@
 
 #include "bus/adb/adb.h"
 #include "bus/adb/cards.h"
+#include "bus/nscsi/cd.h"
+#include "bus/nscsi/devices.h"
 #include "bus/nubus/cards.h"
 #include "bus/nubus/nubus.h"
 #include "cpu/m68000/m68040.h"
@@ -164,6 +166,22 @@ void quadra630_state::macqd630(machine_config &config)
 	m_f108->set_primetimeii_tag("primetimeii");
 	m_f108->set_rom_tag("bootrom");
 	m_f108->write_ata_irq().set(m_primetimeii, FUNC(primetimeii_device::ata_irq_w));
+
+	NSCSI_CONNECTOR(config, "f108:scsi:0", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:1", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:2", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:3").option_set("cdrom", NSCSI_CDROM_APPLE).machine_config(
+		[](device_t *device)
+		{
+			device->subdevice<cdda_device>("cdda")->add_route(0, "^^^primetimeii:speaker", 1.0, 0);
+			device->subdevice<cdda_device>("cdda")->add_route(1, "^^^primetimeii:speaker", 1.0, 1);
+		});
+	NSCSI_CONNECTOR(config, "f108:scsi:4", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:5", mac_scsi_devices, nullptr);
+	NSCSI_CONNECTOR(config, "f108:scsi:6", mac_scsi_devices, nullptr);
+
+	SOFTWARE_LIST(config, "hdd_list").set_original("mac_hdd");
+	SOFTWARE_LIST(config, "cd_list").set_original("mac_cdrom").set_filter("MC68040");
 
 	PRIMETIMEII(config, m_primetimeii, 33_MHz_XTAL);
 	m_primetimeii->set_maincpu_tag("maincpu");

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -1328,6 +1328,9 @@ pmac7200_90
 pmac7200_100
 pmac7200_120
 
+@source:apple/maccordyceps.cpp
+pmac6200
+
 @source:apple/macii.cpp
 mac2fdhd
 macii


### PR DESCRIPTION
This is an early PR that stubs in support for the Power Mac x200 series, which the bootrom refers to as "Cordyceps". It is rough around the edges and is in need of feedback, so I'm expecting change requests.

New machines marked NOT WORKING:
- pmac6200: Power Macintosh 6200

Summary of changes:
- apple/f108.cpp: Change maximum ROM mask from 0x3fffff to 0x400000, as it doesn't correctly work with 4 MiB ROMs
- apple/capella.cpp: Rudimentary support for the "Capella" PowerPC-to-68040 bus bridge chip
- apple/maccordyceps.cpp: Stub driver heavily based off macquadra630.cpp
- apple/iosb.cpp: Graft on Capella support and change maincpu tag to be more abstract, so that the Primetime II device can work with a 680x0 or a Capella bridge device

Stuff to discuss:
- The iosb.cpp changes are super hacky and I haven't really tested them on the 68k machine drivers. However this driver, and the other PowerPC upgrades for 68k machines (and also the Powerbook Duo 2300c with its recycled 68k chipset), will require these downstream devices to be refactored so that they can work with either a 68k CPU or a bridge chip.

- IRQ translation in the Capella chip is fairly obvious, with an IRQ acknowledge register and a register containing the 68k IPL lines state, but how IRQs actually fire is still a mystery. If IRQs don't fire how the bootrom expects, then the machine locks up. Right now the Capella code pretends interrupts never happen, and that at least gets the bootrom past the initial POST, but it hangs on the gray cross-hatched screen.

- f108.cpp requires there to be an address space for a 32-bit bootrom, but the PowerPC accesses the bootrom 64 bits at a time. Right now I give the PowerPC a "bootrom64" and hand the F108 an empty 4 MB bootrom, and things seem to work. Maybe the standard Mac ROM switch should be moved to a generic reusable handler for the 68k machines?

- I'm not sure if maccordyceps.cpp would be better off unified with macquadra630.cpp, as it's very similar hardware. For now though I think it would be better to keep them separate, so Cordyceps changes don't break the Quadra driver.
