### PR TITLE
tms9901: update synchronous interrupt output on every external clock

### DIFF
--- a/src/devices/machine/tms9901.cpp
+++ b/src/devices/machine/tms9901.cpp
@@ -514,9 +514,6 @@ void tms9901_device::phi_line(int state)
 			if (!m_clock_mode)
 				m_clock_read_register = m_decrementer_value;
 
-			// We signal the interrupt in sync with the clock line
-			signal_int();
-
 			// For the next phi assert
 			// MZ: This costs a lot of performance for a minimum of benefit.
 			if (m_poll_lines) sample_interrupt_inputs();
@@ -526,6 +523,11 @@ void tms9901_device::phi_line(int state)
 			if (m_clockdiv==32)
 				timer_clock_in(CLEAR_LINE);
 		}
+
+		// INTREQ follows the external clock, not the decrementer's /64 clock.
+		// Delaying deassertion can leave a stale interrupt request after the
+		// CPU acknowledges a peripheral and then enables interrupts.
+		signal_int();
 	}
 }
 

--- a/tests/emu/tms9901_irq.a99
+++ b/tests/emu/tms9901_irq.a99
@@ -1,0 +1,34 @@
+* license:BSD-3-Clause
+* Run from scratchpad with WP >8300 and interrupts disabled.
+* Each iteration acknowledges VDP INT2 before briefly enabling interrupts.
+* A stale INTREQ sends execution to the console handler and fails the test.
+* Vary the delay to exercise different phases of the /64 timer divider.
+       AORG >8320
+       LIMI 0
+       LWPI >8300
+       CLR R12
+       SBZ 0
+       SBZ 3
+       SBO 2
+       LI R0,>E000
+       MOVB R0,@>8C02
+       LI R0,>8100
+       MOVB R0,@>8C02
+       CLR R7
+LOOP   MOVB @>8802,R1
+WAIT   TB 2
+       JEQ WAIT
+       MOV R7,R6
+       ANDI R6,>003F
+       INC R6
+DELAY  DEC R6
+       JNE DELAY
+       MOVB @>8802,R1
+       LIMI 1
+       NOP
+       LIMI 0
+       INC R7
+       CI R7,256
+       JL LOOP
+DONE   JMP DONE
+       END

--- a/tests/emu/tms9901_irq.lua
+++ b/tests/emu/tms9901_irq.lua
@@ -1,0 +1,35 @@
+-- license:BSD-3-Clause
+-- Assemble tms9901_irq.a99 with xas99.py -R -b -o irq-test.bin.
+-- Set TMS9901_IRQ_TEST to that binary and run ti99_4a with console ROMs,
+-- -autoboot_delay 1 -autoboot_script tests/emu/tms9901_irq.lua.
+-- No cartridge or game data is required. Completion takes about 5 seconds
+-- of emulated time. The caller must check for the PASS line, not just exit 0.
+local m = manager.machine
+local cpu = m.devices[':maincpu']
+local symbols = emu.symbol_table(m)
+local file = assert(io.open(assert(os.getenv('TMS9901_IRQ_TEST')), 'rb'))
+local code = file:read('a')
+file:close()
+assert(#code == 78, 'Unexpected test binary size')
+for i = 1,#code,2 do
+    symbols:set_memory_value(':maincpu','p',0x8320+i-1,2,code:byte(i)*256+code:byte(i+1),true)
+end
+cpu.state.ST.value = 0
+cpu.state.WP.value = 0x8300
+cpu.state.PC.value = 0x8320
+local frames = 0
+emu.register_frame_done(function()
+    frames = frames+1
+    local pc = cpu.state.PC.value
+    local count = symbols:memory_value(':maincpu','p',0x830e,2,true)
+    if cpu.state.WP.value ~= 0x8300 or pc < 0x8320 or pc > 0x836e then
+        print(string.format('FAIL: stale interrupt after %d iterations; PC=%04X WP=%04X',count,pc,cpu.state.WP.value))
+        m:exit()
+    elseif count == 256 then
+        print('PASS: 256 VDP interrupt acknowledgements across 64 delay phases')
+        m:exit()
+    elseif frames > 600 then
+        print('FAIL: interrupt acknowledgement test timed out')
+        m:exit()
+    end
+end,'TMS9901 IRQ regression')


### PR DESCRIPTION
Report INTREQ changes on each external clock assertion, rather than only on the timer's divide-by-64 clock. This prevents a stale interrupt after VDP acknowledgement followed by LIMI 1 on the TI-99/4A.

Include a cartridge-free regression test. On the tested original base, it failed after three acknowledgements before the fix and passed all 256 afterward. Dragonostics then reached completion.

Developed collaboratively with Jon Guidry using OpenAI Codex (GPT-6) assistance for implementation, investigation and testing.

Revalidated on upstream e7f900f5 together with the Gigacart mapper: full debug emulator build, all 256 interrupt acknowledgements across 64 delay phases, Dragonostics completion, and a complete Practice run through rescue to the intro. Other TMS9901 systems were not run.