### PR TITLE
ti99: add configurable Gigacart cartridge boards

### DIFF
--- a/scripts/src/tests.lua
+++ b/scripts/src/tests.lua
@@ -66,6 +66,7 @@ project("mametests")
 		MAME_DIR .. "tests/lib/util/corestr.cpp",
 		MAME_DIR .. "tests/lib/util/options.cpp",
 		MAME_DIR .. "tests/emu/attotime.cpp",
+		MAME_DIR .. "tests/emu/gigacart.cpp",
 		MAME_DIR .. "tests/emu/video/rgbutil.cpp",
 	}
 

--- a/scripts/ti99_gigacart_check.lua
+++ b/scripts/ti99_gigacart_check.lua
@@ -1,0 +1,41 @@
+-- license:BSD-3-Clause
+-- Run with -autoboot_script and GIGACART_CHECKSUMS pointing to a local text
+-- file containing BANK SUM hex pairs. Each sum covers all 4096 big-endian
+-- words, modulo 65536. No game-specific reference data is distributed here.
+-- Debugger memory access bypasses the TI's wait-state sequencing; ordinary
+-- Lua space reads/writes do not initiate a complete datamux transaction.
+local machine = manager.machine
+local cpu = machine.devices[':maincpu']
+local symbols = emu.symbol_table(machine)
+local mem = {read_u16=function(self,a) return symbols:memory_value(':maincpu','p',a,2,true) end, write_u16=function(self,a,v) symbols:set_memory_value(':maincpu','p',a,2,v,true) end}
+local cart = machine.devices[':gromport:single:cartridge']
+local oldpc = cpu.state['PC'].value
+local checked = 0
+local reference = assert(os.getenv('GIGACART_CHECKSUMS'), 'Set GIGACART_CHECKSUMS to a local full-bank checksum reference')
+for line in io.lines(reference) do
+  local b,s = line:match('^(%x+)%s+(%x%x%x%x)')
+  if b then
+    local bank,expected = tonumber(b,16),tonumber(s,16)
+    assert(bank == checked and bank < 0x100000, 'Expected consecutive banks starting at zero')
+    mem:write_u16(0x6000 + (bank & 0xfff)*2, ((bank >> 12) & 255) << 8)
+    local sum = 0
+    for addr=0x6000,0x7ffe,2 do sum = (sum + mem:read_u16(addr)) & 0xffff end
+    assert(sum == expected, string.format('bank %04X expected %04X got %04X',bank,expected,sum))
+    checked = checked+1
+  end
+end
+assert(checked > 0, 'No checksum rows found')
+mem:write_u16(0x6000, 0x0102)
+assert(emu.item(cart.items['0/m_rom_page']):read(0)==0x1000, 'TI word write order')
+local state = machine:buffer_save()
+local gromaddr = emu.item(cart.items['0/m_grom_address'])
+local savedgrom = gromaddr:read(0)
+gromaddr:write(0, 0x8081)
+mem:write_u16(0x7ffe, 0x0300)
+assert(emu.item(cart.items['0/m_rom_page']):read(0)~=0x1000)
+assert(machine:buffer_load(state))
+assert(emu.item(cart.items['0/m_rom_page']):read(0)==0x1000, 'saved bank latch')
+assert(gromaddr:read(0)==savedgrom, 'saved GROM address and page')
+assert(cpu.state['PC'].value == oldpc)
+print('PASS: '..checked..' full-bank checksums, TI word write ordering, bank and GROM save/restore')
+machine:exit()

--- a/src/devices/bus/ti99/gromport/cartridges.cpp
+++ b/src/devices/bus/ti99/gromport/cartridges.cpp
@@ -14,6 +14,7 @@
 ***************************************************************************/
 #include "emu.h"
 #include "cartridges.h"
+#include "gigacart.h"
 
 #include "fileio.h"
 
@@ -60,7 +61,10 @@ enum
 	PCB_PAGED377,
 	PCB_PAGEDCRU,
 	PCB_GROMEMU,
-	PCB_PAGED7
+	PCB_PAGED7,
+	PCB_GIGACART_ROM,
+	PCB_GIGACART_GROM,
+	PCB_GIGACART_CPLD
 };
 
 static char const *const pcbdefs[] =
@@ -77,6 +81,9 @@ static char const *const pcbdefs[] =
 	"pagedcru",     // PCB_PAGEDCRU
 	"gromemu",      // PCB_GROMEMU
 	"paged7",       // PCB_PAGED7
+	"gigacart-rom",
+	"gigacart-grom",
+	"gigacart-cpld",
 	nullptr
 };
 
@@ -90,6 +97,9 @@ static const pcb_type sw_pcbdefs[] =
 	{ PCB_MBX, "mbx" },
 	{ PCB_GROMEMU, "gromemu" },
 	{ PCB_PAGED7, "paged7" },
+	{ PCB_GIGACART_ROM, "gigacart-rom" },
+	{ PCB_GIGACART_GROM, "gigacart-grom" },
+	{ PCB_GIGACART_CPLD, "gigacart-cpld" },
 	{ 0, nullptr}
 };
 
@@ -114,9 +124,42 @@ ti99_cartridge_device::ti99_cartridge_device(const machine_config &mconfig, cons
 {
 }
 
+bool ti99_cartridge_device::is_gigacart() const
+{
+	return m_pcbtype >= PCB_GIGACART_ROM && m_pcbtype <= PCB_GIGACART_CPLD;
+}
+
+std::string ti99_cartridge_device::validate_gigacart()
+{
+	auto feature = [this](char const *name) -> char const * {
+		if (loaded_through_softlist()) return get_feature(name);
+		auto const entry = m_rpk->m_features.find(name);
+		return entry == m_rpk->m_features.end() ? nullptr : entry->second.c_str();
+	};
+	auto length = [this](char const *region, char const *socket) -> uint64_t {
+		return loaded_through_softlist() ? get_software_region_length(region) : m_rpk->get_resource_length(socket);
+	};
+	char const *width = feature("bank_data_bits");
+	if (!width || !gigacart::parse_width(width, m_bank_data_bits))
+		return "Gigacart requires bank_data_bits from 1 through 8";
+	char const *initial = feature("initial_bank");
+	if (!gigacart::parse_initial(initial ? initial : "first", m_bank_data_bits, m_initial_bank))
+		return "Gigacart initial_bank must be first, last, or a decimal bank within the declared range";
+	uint64_t const size = length("rom", "rom_socket");
+	if (!gigacart::valid_size(size, m_bank_data_bits))
+		return "Gigacart ROM must contain a power-of-two number of whole 8 KiB banks within the declared capacity";
+	if (size > std::numeric_limits<size_t>::max()) return "Gigacart ROM exceeds this build's host address space";
+	uint64_t const grom = length("grom", "grom_socket");
+	if (m_pcbtype == PCB_GIGACART_GROM ? (grom == 0 || grom > 0xa000 || (grom & 0x1fff)) : grom != 0)
+		return "Gigacart GROM socket does not match the selected boot hardware";
+	if (length("ram", "ram_socket") || length("nvram", "rom2_socket") || length("rom2", "rom2_socket"))
+		return "Gigacart does not support cartridge RAM or a second ROM socket";
+	return {};
+}
+
 void ti99_cartridge_device::prepare_cartridge()
 {
-	int rom1_length = 0;
+	uint64_t rom1_length = 0;
 	int rom2_length = 0;
 
 	uint8_t* gromdump_ptr;
@@ -165,7 +208,7 @@ void ti99_cartridge_device::prepare_cartridge()
 	}
 
 	rom1_length = loaded_through_softlist() ? get_software_region_length("rom") : m_rpk->get_resource_length("rom_socket");
-	if (rom1_length > 32*1048576)
+	if (!is_gigacart() && rom1_length > 32*1048576)
 	{
 		LOGMASKED(LOG_WARN, "Cartridge ROM size exceeds 32 MiB; truncated.\n");
 		rom1_length = 32*1048576;
@@ -243,7 +286,7 @@ void ti99_cartridge_device::prepare_cartridge()
 		if (m_pcb->get_maximum_bank_count() > 1)
 			LOGMASKED(LOG_CONFIG, "ROM bank mask=0x%04x\n", m_pcb->m_rom_mask);
 
-		if (m_rom_size > m_pcb->get_maximum_bank_count() * m_pcb->get_bank_size())
+		if (m_rom_size > uint64_t(m_pcb->get_maximum_bank_count()) * m_pcb->get_bank_size())
 			LOGMASKED(LOG_WARN, "WARNING: ROM dump exceeds the banking range of this cartridge type.\n");
 	}
 	else
@@ -324,6 +367,8 @@ std::pair<std::error_condition, std::string> ti99_cartridge_device::call_load()
 		LOGMASKED(LOG_CONFIG, "Using softlists\n");
 		int i = 0;
 		const char* pcb = get_feature("pcb");
+		m_pcbtype = 0;
+		if (!pcb) return { image_error::INVALIDIMAGE, "Missing cartridge PCB type" };
 		do
 		{
 			if (strcmp(pcb, sw_pcbdefs[i].name)==0)
@@ -348,8 +393,19 @@ std::pair<std::error_condition, std::string> ti99_cartridge_device::call_load()
 		m_pcbtype = m_rpk->get_type();
 	}
 
+	if (is_gigacart())
+	{
+		std::string const error = validate_gigacart();
+		if (!error.empty()) { m_rpk.reset(); return { image_error::INVALIDIMAGE, error }; }
+	}
+
 	switch (m_pcbtype)
 	{
+	case PCB_GIGACART_ROM:
+	case PCB_GIGACART_GROM:
+	case PCB_GIGACART_CPLD:
+		m_pcb = std::make_unique<ti99_gigacart_cartridge>();
+		break;
 	case PCB_STANDARD:
 		LOGMASKED(LOG_CONFIG, "Standard PCB\n");
 		m_pcb = std::make_unique<ti99_standard_cartridge>();
@@ -400,7 +456,10 @@ std::pair<std::error_condition, std::string> ti99_cartridge_device::call_load()
 		break;
 	}
 
-	prepare_cartridge();
+	if (!m_pcb) return { image_error::INVALIDIMAGE, "Unsupported cartridge PCB type" };
+	try { prepare_cartridge(); }
+	catch (std::bad_alloc const &) { m_pcb.reset(); m_rpk.reset(); return { std::errc::not_enough_memory, "Cannot allocate cartridge ROM" }; }
+	if (is_gigacart()) m_rom_page = m_initial_bank;
 	m_pcb->set_cartridge(this);
 	m_pcb->set_tag(tag());
 	m_connector->insert();
@@ -478,7 +537,7 @@ void ti99_cartridge_device::set_gromlines(line_state mline, line_state moline, l
 {
 	if (m_pcb != nullptr)
 	{
-		if (m_pcbtype == PCB_GROMEMU)
+		if (m_pcbtype == PCB_GROMEMU || m_pcbtype == PCB_GIGACART_CPLD)
 		{
 			m_grom_selected = (gsq == ASSERT_LINE);
 			m_grom_read_mode = (mline == ASSERT_LINE);
@@ -1518,6 +1577,53 @@ void ti99_gromemu_cartridge::gromemuwrite(offs_t offset, uint8_t data)
 
 
 /****************************************************************************
+    Hardware reference: Mike Brent (Tursi)'s Gigacart project:
+    https://github.com/tursilion/gigacart
+    Runtime CPLD: cart/cpld.seahorseCELoad/design.vhd
+    Related GROM-emulation background: https://github.com/tursilion/ubergrom
+    Jon Guidry supplied cartridge hardware observations and dump validation.
+
+    Gigacart: address-selected low 12 bank bits plus 1-8 low data bits.
+    Tursi's runtime CPLD uses two data bits. On the TI-99/4A each CPU word
+    write reaches us twice, low byte first. Both byte writes latch the bank.
+    The CPLD boot variant exposes the final 256 flash bytes as GROM page 4,
+    independently of the ROM bank. It has an 8-bit wrapping address register
+    and leaves address readback to the real console GROMs.
+****************************************************************************/
+
+void ti99_gigacart_cartridge::readz(offs_t offset, uint8_t *value)
+{
+	if (romspace_selected())
+		*value = m_rom_ptr[gigacart::image_offset(rom_page(), offset, m_cart->m_rom_size)];
+	else if (m_cart->m_pcbtype == PCB_GIGACART_GROM)
+		gromreadz(value);
+	else if (m_cart->m_pcbtype == PCB_GIGACART_CPLD && m_cart->m_grom_selected
+		&& m_cart->m_grom_read_mode && !m_cart->m_grom_address_mode)
+	{
+		if ((m_cart->m_grom_address & 0xff00) == 0x8000)
+			*value = m_rom_ptr[m_cart->m_rom_size - 256 + (m_cart->m_grom_address & 255)];
+		if (!m_cart->machine().side_effects_disabled())
+			m_cart->m_grom_address = (m_cart->m_grom_address & 0xff00) | ((m_cart->m_grom_address + 1) & 255);
+	}
+}
+
+void ti99_gigacart_cartridge::write(offs_t offset, uint8_t data)
+{
+	if (romspace_selected())
+		// Keep the physical latch; image mirroring is applied only on reads.
+		m_cart->m_rom_page = gigacart::select(offset, data, m_cart->m_bank_data_bits);
+	else if (m_cart->m_pcbtype == PCB_GIGACART_GROM)
+		gromwrite(data);
+	else if (m_cart->m_pcbtype == PCB_GIGACART_CPLD && m_cart->m_grom_selected
+		&& !m_cart->m_grom_read_mode && m_cart->m_grom_address_mode)
+	{
+		// Hardware shifts every address byte; only the preceding byte's page
+		// bits are retained. There is no first/second-byte flip-flop.
+		m_cart->m_grom_address = ((m_cart->m_grom_address & 0xe0) == 0x80 ? 0x8000 : 0) | data;
+	}
+}
+
+/****************************************************************************
 
     RPK loader
 
@@ -1557,7 +1663,7 @@ uint8_t* ti99_cartridge_device::rpk::get_contents_of_socket(const char *socket_n
 /*
     Deliver the length of the contents of the socket by name of the socket.
 */
-int ti99_cartridge_device::rpk::get_resource_length(const char *socket_name)
+uint64_t ti99_cartridge_device::rpk::get_resource_length(const char *socket_name)
 {
 	auto socket = m_sockets.find(socket_name);
 	if (socket == m_sockets.end()) return 0;
@@ -1600,12 +1706,12 @@ void ti99_cartridge_device::rpk::close()
     not a network socket)
 ***************************************************************/
 
-ti99_cartridge_device::ti99_rpk_socket::ti99_rpk_socket(const char* id, int length, std::vector<uint8_t> &&contents, std::string &&pathname)
+ti99_cartridge_device::ti99_rpk_socket::ti99_rpk_socket(const char* id, uint64_t length, std::vector<uint8_t> &&contents, std::string &&pathname)
 	: m_id(id), m_length(length), m_contents(std::move(contents)), m_pathname(std::move(pathname))
 {
 }
 
-ti99_cartridge_device::ti99_rpk_socket::ti99_rpk_socket(const char* id, int length, std::vector<uint8_t> &&contents)
+ti99_cartridge_device::ti99_rpk_socket::ti99_rpk_socket(const char* id, uint64_t length, std::vector<uint8_t> &&contents)
 	: ti99_rpk_socket(id, length, std::move(contents), "")
 {
 }
@@ -1613,12 +1719,12 @@ ti99_cartridge_device::ti99_rpk_socket::ti99_rpk_socket(const char* id, int leng
 /*
     Load a rom resource and put it in a pcb socket instance.
 */
-std::error_condition ti99_cartridge_device::rpk_load_rom_resource(const rpk_socket &socket, std::unique_ptr<ti99_rpk_socket> &result)
+std::error_condition ti99_cartridge_device::rpk_load_rom_resource(const rpk_socket &socket, std::unique_ptr<ti99_rpk_socket> &result, uint64_t max_length)
 {
 	LOGMASKED(LOG_RPK, "[RPK handler] Loading ROM contents for socket '%s' from file %s\n", socket.id(), socket.filename());
 
 	std::vector<uint8_t> contents;
-	std::error_condition err =  socket.read_file(contents);
+	std::error_condition err = socket.read_file(contents, max_length);
 	if (err)
 		return err;
 
@@ -1684,16 +1790,35 @@ std::error_condition ti99_cartridge_device::rpk_open(emu_options &options, util:
 
 	// specify the PCB
 	newrpk->m_type = file->pcb_type() + 1;
+	newrpk->m_features = file->pcb_features();
 	LOGMASKED(LOG_RPK, "[RPK handler] Cartridge says it has PCB type '%s'\n", pcbdefs[file->pcb_type()]);
 
+	bool const giga = newrpk->m_type >= PCB_GIGACART_ROM && newrpk->m_type <= PCB_GIGACART_CPLD;
+	unsigned bits = 0;
+	if (giga)
+	{
+		auto const width = newrpk->m_features.find("bank_data_bits");
+		if (width == newrpk->m_features.end() || !gigacart::parse_width(width->second, bits))
+			return rpk_reader::error::INVALID_LAYOUT;
+		auto const initial = newrpk->m_features.find("initial_bank");
+		uint32_t bank;
+		if (initial != newrpk->m_features.end() && !gigacart::parse_initial(initial->second, bits, bank))
+			return rpk_reader::error::INVALID_LAYOUT;
+	}
 	for (const rpk_socket &socket : file->sockets())
 	{
+		if (giga && (socket.type() != rpk_socket::socket_type::ROM
+			|| (socket.id() != "rom_socket" && !(newrpk->m_type == PCB_GIGACART_GROM && socket.id() == "grom_socket"))
+			|| newrpk->m_sockets.count(socket.id())))
+			return rpk_reader::error::INVALID_LAYOUT;
 		std::unique_ptr<ti99_rpk_socket> ti99_socket;
 
 		switch (socket.type())
 		{
 		case rpk_socket::socket_type::ROM:
-			err = rpk_load_rom_resource(socket, ti99_socket);
+			err = rpk_load_rom_resource(socket, ti99_socket, giga
+				? (socket.id() == "grom_socket" ? 0xa000 : uint64_t(gigacart::bank_count(bits)) * 8192)
+				: ~uint64_t(0));
 			if (err)
 				return err;
 			newrpk->add_socket(socket.id().c_str(), std::move(ti99_socket));

--- a/src/devices/bus/ti99/gromport/cartridges.h
+++ b/src/devices/bus/ti99/gromport/cartridges.h
@@ -16,6 +16,7 @@
 #include "emuopts.h"
 
 #include "utilfwd.h"
+#include <map>
 
 
 // declared in formats/rpk.h
@@ -32,6 +33,7 @@ class ti99_cartridge_device : public device_t, public device_cartrom_image_inter
 	friend class ti99_gkracker_device;
 	friend class ti99_cartridge_pcb;
 	friend class ti99_gromemu_cartridge;
+	friend class ti99_gigacart_cartridge;
 
 public:
 	ti99_cartridge_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
@@ -63,6 +65,8 @@ protected:
 	void call_unload() override;
 
 	void prepare_cartridge();
+	bool is_gigacart() const;
+	std::string validate_gigacart();
 
 	// device_image_interface
 	bool is_reset_on_load() const noexcept override       { return false; }
@@ -77,7 +81,7 @@ private:
 	class rpk;
 
 	static std::error_condition rpk_open(emu_options &options, util::random_read &stream, const char *system_name, std::unique_ptr<rpk> &result);
-	static std::error_condition rpk_load_rom_resource(const rpk_socket &socket, std::unique_ptr<ti99_rpk_socket> &result);
+	static std::error_condition rpk_load_rom_resource(const rpk_socket &socket, std::unique_ptr<ti99_rpk_socket> &result, uint64_t max_length);
 	static std::unique_ptr<ti99_rpk_socket> rpk_load_ram_resource(emu_options &options, const rpk_socket &socket, const char *system_name);
 
 	class rpk
@@ -89,12 +93,13 @@ private:
 
 		int         get_type(void) { return m_type; }
 		uint8_t*      get_contents_of_socket(const char *socket_name);
-		int         get_resource_length(const char *socket_name);
+		uint64_t    get_resource_length(const char *socket_name);
 		void        close();
 
 	private:
 		emu_options&            m_options;      // need this to find the path to the nvram files
 		int                     m_type;
+		std::map<std::string, std::string> m_features;
 		//const char*             m_system_name;  // need this to find the path to the nvram files
 		std::unordered_map<std::string,std::unique_ptr<ti99_rpk_socket>> m_sockets;
 
@@ -104,12 +109,12 @@ private:
 	class ti99_rpk_socket
 	{
 	public:
-		ti99_rpk_socket(const char *id, int length, std::vector<uint8_t> &&contents);
-		ti99_rpk_socket(const char *id, int length, std::vector<uint8_t> &&contents, std::string &&pathname);
+		ti99_rpk_socket(const char *id, uint64_t length, std::vector<uint8_t> &&contents);
+		ti99_rpk_socket(const char *id, uint64_t length, std::vector<uint8_t> &&contents, std::string &&pathname);
 		~ti99_rpk_socket() {}
 
 		const char*     id() { return m_id; }
-		int             get_content_length() { return m_length; }
+		uint64_t        get_content_length() { return m_length; }
 		uint8_t*          get_contents() { return &m_contents[0]; }
 		bool            persistent_ram() { return !m_pathname.empty(); }
 		const char*     get_pathname() { return m_pathname.c_str(); }
@@ -117,7 +122,7 @@ private:
 
 	private:
 		const char*     m_id;
-		uint32_t          m_length;
+		uint64_t          m_length;
 		std::vector<uint8_t> m_contents;
 		const std::string m_pathname;
 	};
@@ -126,7 +131,9 @@ private:
 	int     get_index_from_tagname();
 
 	// Common static cartridge states (no need to save in state)
-	uint32_t    m_rom_size;
+	uint64_t    m_rom_size;
+	unsigned    m_bank_data_bits = 0;
+	uint32_t    m_initial_bank = 0;
 	uint32_t    m_ram_size;
 	bool        m_has_buffered_ram;
 
@@ -327,6 +334,14 @@ public:
 };
 
 /********************** GROM emulation cartridge  ************************************/
+
+class ti99_gigacart_cartridge : public ti99_cartridge_pcb
+{
+public:
+	void readz(offs_t offset, uint8_t *value) override;
+	void write(offs_t offset, uint8_t data) override;
+	const int get_maximum_bank_count() override { return 1 << 20; }
+};
 
 class ti99_gromemu_cartridge : public ti99_cartridge_pcb
 {

--- a/src/devices/bus/ti99/gromport/gigacart.h
+++ b/src/devices/bus/ti99/gromport/gigacart.h
@@ -1,0 +1,49 @@
+// license:BSD-3-Clause
+// copyright-holders:Jon Guidry
+#ifndef MAME_BUS_TI99_GROMPORT_GIGACART_H
+#define MAME_BUS_TI99_GROMPORT_GIGACART_H
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace bus::ti99::gromport::gigacart {
+
+// Geometry is independent of boot hardware and the installed ROM capacity.
+constexpr uint32_t bank_count(unsigned data_bits) { return 1U << (12 + data_bits); }
+constexpr uint32_t select(uint16_t address, uint8_t data, unsigned data_bits)
+{
+	return ((uint32_t(data) & ((1U << data_bits) - 1)) << 12) | ((address >> 1) & 0x0fff);
+}
+constexpr uint64_t image_offset(uint32_t bank, uint16_t address, uint64_t size)
+{
+	return (uint64_t(bank) * 8192 + (address & 0x1fff)) & (size - 1);
+}
+constexpr bool valid_size(uint64_t size, unsigned data_bits)
+{
+	return size >= 8192 && !(size & (size - 1)) && size <= uint64_t(bank_count(data_bits)) * 8192;
+}
+inline bool parse_width(std::string_view value, unsigned &bits)
+{
+	if (value.size() != 1 || value[0] < '1' || value[0] > '8') return false;
+	bits = value[0] - '0';
+	return true;
+}
+inline bool parse_initial(std::string_view value, unsigned bits, uint32_t &bank)
+{
+	bank = 0;
+	if (value == "first") return true;
+	if (value == "last") { bank = bank_count(bits) - 1; return true; }
+	if (value.empty()) return false;
+	for (char ch : value)
+	{
+		if (ch < '0' || ch > '9') return false;
+		bank = bank * 10 + ch - '0';
+		if (bank >= bank_count(bits)) return false;
+	}
+	return true;
+}
+
+} // namespace bus::ti99::gromport::gigacart
+#endif

--- a/src/lib/formats/rpk.cpp
+++ b/src/lib/formats/rpk.cpp
@@ -42,12 +42,15 @@ DTD:
     <!ATTLIST ram file CDATA #IMPLIED>
     <!ATTLIST ram length CDATA #REQUIRED>
     <!ATTLIST pcb type CDATA #REQUIRED>
+    <!ATTLIST pcb bank_data_bits CDATA #IMPLIED>
+    <!ATTLIST pcb initial_bank CDATA #IMPLIED>
     <!ATTLIST socket id ID #REQUIRED>
     <!ATTLIST socket uses IDREF #REQUIRED>
 
 ***************************************************************************/
 
 #include "rpk.h"
+#include "ioprocs.h"
 #include "xmlfile.h"
 
 
@@ -178,6 +181,13 @@ std::error_condition rpk_reader::read(util::archive_file::ptr &&zipfile, rpk_fil
 
 	// create the rpk_file object
 	rpk_file::ptr file = std::make_unique<rpk_file>(std::move(zipfile), pcb_type);
+
+	// Optional board configuration. Board-specific validation belongs to the device.
+	for (char const *name : { "bank_data_bits", "initial_bank" })
+	{
+		std::string const *value = pcb_node->get_attribute_string_ptr(name);
+		if (value) file->m_pcb_features.emplace(name, *value);
+	}
 
 	// find the sockets and load their respective resource
 	for (util::xml::data_node const *socket_node = pcb_node->get_first_child(); socket_node; socket_node = socket_node->get_next_sibling())
@@ -394,12 +404,17 @@ rpk_socket::~rpk_socket()
 //  read_file
 //-------------------------------------------------
 
-std::error_condition rpk_socket::read_file(std::vector<std::uint8_t> &result) const
+std::error_condition rpk_socket::read_file(std::vector<std::uint8_t> &result, std::uint64_t max_length) const
 {
 	// find the file
 	if (m_rpk.zipfile().search(m_filename, false) < 0)
 		return rpk_reader::error::INVALID_FILE_REF;
+	if (m_rpk.zipfile().current_uncompressed_length() > max_length)
+		return std::errc::file_too_large;
 
+	// Check before narrowing to size_t (notably for ZIP64 ROM images).
+	if (m_rpk.zipfile().current_uncompressed_length() > result.max_size())
+		return std::errc::not_enough_memory;
 	// prepare a buffer
 	result.clear();
 	try
@@ -412,7 +427,7 @@ std::error_condition rpk_socket::read_file(std::vector<std::uint8_t> &result) co
 	}
 
 	// read the file
-	std::error_condition const ziperr = m_rpk.zipfile().decompress(&result[0], m_rpk.zipfile().current_uncompressed_length());
+	std::error_condition const ziperr = m_rpk.zipfile().decompress(result.data(), m_rpk.zipfile().current_uncompressed_length());
 	if (ziperr)
 		return ziperr;
 
@@ -420,7 +435,14 @@ std::error_condition rpk_socket::read_file(std::vector<std::uint8_t> &result) co
 	if (m_hashes.has_value())
 	{
 		util::hash_collection actual_hashes;
-		actual_hashes.compute(&result[0], result.size(), m_hashes->hash_types().c_str());
+		// The pointer overload takes a 32-bit length. Use the streaming overload
+		// so a ZIP64 cartridge is hashed in full, including bytes above 4 GiB.
+		auto input = util::ram_read(result.data(), result.size());
+		if (!input) return std::errc::not_enough_memory;
+		size_t actual;
+		auto const err = actual_hashes.compute(*input, 0, result.size(), actual, m_hashes->hash_types().c_str());
+		if (err) return err;
+		if (actual != result.size()) return std::errc::io_error;
 
 		if (actual_hashes != m_hashes)
 			return rpk_reader::error::INVALID_FILE_REF; // Hash check failed

--- a/src/lib/formats/rpk.h
+++ b/src/lib/formats/rpk.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <list>
 #include <optional>
+#include <map>
 
 
 /***************************************************************************
@@ -54,7 +55,7 @@ public:
 	std::uint32_t length() const noexcept { assert(m_type == socket_type::RAM || m_type == socket_type::PERSISTENT_RAM); return m_length; }
 
 	// methods
-	std::error_condition read_file(std::vector<std::uint8_t> &result) const;
+	std::error_condition read_file(std::vector<std::uint8_t> &result, std::uint64_t max_length = ~std::uint64_t(0)) const;
 
 private:
 	rpk_file &                              m_rpk;
@@ -84,11 +85,13 @@ public:
 
 	// accessors
 	int pcb_type() const { return m_pcb_type; }
+	const std::map<std::string, std::string> &pcb_features() const { return m_pcb_features; }
 	const std::list<rpk_socket> &sockets() const { return m_sockets; }
 
 private:
 	util::archive_file::ptr     m_zipfile;
 	int                         m_pcb_type;
+	std::map<std::string, std::string> m_pcb_features;
 	std::list<rpk_socket>       m_sockets;
 
 	// accesors

--- a/tests/emu/gigacart.cpp
+++ b/tests/emu/gigacart.cpp
@@ -1,0 +1,57 @@
+// license:BSD-3-Clause
+// copyright-holders:Jon Guidry
+#ifdef GIGACART_STANDALONE
+#define CATCH_CONFIG_MAIN
+#endif
+#include "catch.hpp"
+#include "../../src/devices/bus/ti99/gromport/gigacart.h"
+
+using namespace bus::ti99::gromport;
+
+TEST_CASE("Gigacart bank bus and capacity", "[gigacart]")
+{
+	for (unsigned bits = 1; bits <= 8; ++bits)
+	{
+		uint32_t const count = gigacart::bank_count(bits);
+		uint64_t const size = uint64_t(count) * 8192;
+		REQUIRE(gigacart::valid_size(size, bits));
+		REQUIRE_FALSE(gigacart::valid_size(size * 2, bits));
+		for (uint32_t bank = 0; bank < count; ++bank)
+		{
+			uint16_t const address = 0x6000 | ((bank & 4095) * 2);
+			uint8_t const data = bank >> 12;
+			if (gigacart::select(address, data, bits) != bank || gigacart::select(address | 1, data, bits) != bank)
+				FAIL("Bank selection differs from bus vector");
+		}
+	}
+	REQUIRE(gigacart::select(0x6000, 0xfd, 2) == 0x1000);
+	REQUIRE(gigacart::select(0x6000, 0xfe, 2) == 0x2000);
+	REQUIRE(gigacart::select(0x7ffe, 0xff, 2) == 0x3fff);
+	// TI MOV >0102,@>6000: odd byte 02 first, then even byte 01.
+	REQUIRE(gigacart::select(0x6001, 2, 2) == 0x2000);
+	REQUIRE(gigacart::select(0x6000, 1, 2) == 0x1000);
+	REQUIRE(gigacart::image_offset(0xfffff, 0x7fff, UINT64_C(0x200000000)) == UINT64_C(0x1ffffffff));
+	REQUIRE(gigacart::image_offset(0x80000, 0x6000, UINT64_C(0x200000000)) == UINT64_C(0x100000000));
+	REQUIRE(gigacart::image_offset(0xfffff, 0x7fff, 0x4000) == 0x3fff);
+	REQUIRE_FALSE(gigacart::valid_size(0, 2));
+	REQUIRE_FALSE(gigacart::valid_size(8191, 2));
+	REQUIRE_FALSE(gigacart::valid_size(24576, 2));
+}
+
+TEST_CASE("Gigacart configuration is explicit", "[gigacart]")
+{
+	unsigned bits = 0;
+	for (auto value : { "", "0", "9", "02", "-1", "2x", " 2", "2 " })
+		REQUIRE_FALSE(gigacart::parse_width(value, bits));
+	REQUIRE(gigacart::parse_width("2", bits));
+	REQUIRE(bits == 2);
+	uint32_t bank;
+	REQUIRE(gigacart::parse_initial("first", 2, bank));
+	REQUIRE(bank == 0);
+	REQUIRE(gigacart::parse_initial("last", 2, bank));
+	REQUIRE(bank == 16383);
+	REQUIRE(gigacart::parse_initial("4096", 2, bank));
+	REQUIRE(bank == 4096);
+	for (auto value : { "", "-1", "+1", "0x10", "16384", "999999999999999999999999999" })
+		REQUIRE_FALSE(gigacart::parse_initial(value, 2, bank));
+}

--- a/tests/emu/gigacart_rpk.py
+++ b/tests/emu/gigacart_rpk.py
@@ -1,0 +1,89 @@
+# license:BSD-3-Clause
+"""Integration tests using synthetic cartridges and user-supplied console ROMs."""
+from pathlib import Path
+import argparse, subprocess, zipfile, json, re
+from concurrent.futures import ThreadPoolExecutor
+p=argparse.ArgumentParser(description='Exercise Gigacart RPK validation and bank reads in a built TI-99 MAME.')
+p.add_argument('--mame',type=Path,required=True)
+p.add_argument('--rompath',type=Path,required=True)
+p.add_argument('--output',type=Path,required=True)
+a=p.parse_args()
+root=a.mame.resolve().parent
+folder=a.output.resolve()
+folder.mkdir(parents=True,exist_ok=True)
+cases=[]
+def case(name, pcb='gigacart-rom', attrs='bank_data_bits="2"', romsize=8192, sockets=None, good=False):
+    if sockets is None: sockets=[('rom_socket','rom','rom')]
+    resources=[]; links=[]
+    for socket,res,kind in sockets:
+        resources.append(f'<{kind} id="{res}" file="{res}.bin"'+(' length="8192"' if kind=='ram' else '')+'/>')
+        links.append(f'<socket id="{socket}" uses="{res}"/>')
+    xml=f'<romset><resources>{"".join(resources)}</resources><configuration><pcb type="{pcb}" {attrs}>{"".join(links)}</pcb></configuration></romset>'
+    path=folder/(name+'.rpk')
+    with zipfile.ZipFile(path,'w',compression=zipfile.ZIP_DEFLATED) as z:
+        z.writestr('layout.xml',xml)
+        for res in set(r for _,r,k in sockets if k=='rom'):
+            data=bytearray(romsize if res=='rom' else 8192)
+            if res=='rom':
+                for bank in range(len(data)//8192):
+                    offset=bank*8192+8190
+                    data[offset:offset+2]=((bank^0x5aa5)&0xffff).to_bytes(2,'big')
+            z.writestr(res+'.bin',data)
+    width = re.search(r'bank_data_bits="([1-8])"',attrs)
+    cases.append((name,path,good,int(width[1]) if width else None,romsize,attrs))
+for bits in range(1,9): case(f'width-{bits}',attrs=f'bank_data_bits="{bits}"',good=True)
+for value in ['', 'bank_data_bits="0"','bank_data_bits="9"','bank_data_bits="02"','bank_data_bits="2x"']:
+    case(f'bad-width-{len(cases)}',attrs=value)
+case('bad-initial',attrs='bank_data_bits="2" initial_bank="16384"')
+case('empty-initial',attrs='bank_data_bits="2" initial_bank=""')
+case('initial-last',attrs='bank_data_bits="8" initial_bank="last"',good=True)
+case('initial-number',attrs='bank_data_bits="2" initial_bank="4096"',good=True)
+case('short-rom',romsize=8191)
+case('empty-rom',romsize=0)
+case('not-power-two',romsize=24576)
+case('oversize',attrs='bank_data_bits="1"',romsize=128*1024*1024)
+case('cpld',pcb='gigacart-cpld',good=True)
+case('grom',pcb='gigacart-grom',sockets=[('rom_socket','rom','rom'),('grom_socket','grom','rom')],good=True)
+case('missing-grom',pcb='gigacart-grom')
+case('unexpected-grom',pcb='gigacart-cpld',sockets=[('rom_socket','rom','rom'),('grom_socket','grom','rom')])
+case('unexpected-ram',sockets=[('rom_socket','rom','rom'),('ram_socket','ram','ram')])
+case('ram-as-rom',sockets=[('rom_socket','rom','ram')])
+case('duplicate-socket',sockets=[('rom_socket','rom','rom'),('rom_socket','other','rom')])
+case('unknown-socket',sockets=[('rom_socket','rom','rom'),('wrong_socket','other','rom')])
+case('legacy-standard',pcb='standard',attrs='',good=True)
+case('legacy-paged',pcb='paged',attrs='',romsize=16384,good=True)
+case('legacy-inverted',pcb='paged379i',attrs='',romsize=131072,good=True)
+case('legacy-noninverted',pcb='paged377',attrs='',romsize=131072,good=True)
+def run(item):
+    name,path,good,bits,romsize,attrs=item
+    cfg=folder/name
+    cfg.mkdir(exist_ok=True)
+    cmd=[str(a.mame.resolve()),'ti99_4a','-rompath',str(a.rompath.resolve()),'-cart',str(path),
+         '-video','none','-sound','none','-nothrottle','-skip_gameinfo','-seconds_to_run','1','-cfg_directory',str(cfg)]
+    if good and bits:
+        initial=re.search(r'initial_bank="([^"]*)"',attrs)
+        initial=initial[1] if initial else 'first'
+        initial=0 if initial=='first' else (1<<(12+bits))-1 if initial=='last' else int(initial)
+        lua=cfg/'check.lua'
+        lua.write_text(f'''local m=manager.machine
+local c=m.devices[':gromport:single:cartridge']
+local bank=emu.item(c.items['0/m_rom_page'])
+assert(bank:read(0)=={initial}, 'initial bank')
+local symbols=emu.symbol_table(m)
+local mem={{read_u16=function(self,a) return symbols:memory_value(':maincpu','p',a,2,true) end,write_u16=function(self,a,v) symbols:set_memory_value(':maincpu','p',a,2,v,true) end}}
+mem:write_u16(0x7ffe,0xff00)
+assert(bank:read(0)=={(1<<(12+bits))-1}, 'configured physical bank width')
+assert(mem:read_u16(0x7ffe)=={((romsize//8192-1)^0x5aa5)&0xffff}, 'mirrored ROM read')
+print('BANK ASSERTIONS PASSED')
+m:exit()
+''')
+        cmd.extend(['-autoboot_delay','0','-autoboot_script',str(lua)])
+    r=subprocess.run(cmd,cwd=root,capture_output=True,text=True,timeout=60)
+    (folder/(name+'.log')).write_text(r.stdout+r.stderr)
+    result={'case':name,'expected_load':good,'exit':r.returncode,'pass':r.returncode==(0 if good else 4) and (not(good and bits) or 'BANK ASSERTIONS PASSED' in r.stdout)}
+    print(json.dumps(result),flush=True)
+    return result
+with ThreadPoolExecutor(max_workers=2) as pool: results=list(pool.map(run,cases))
+(folder/'results.json').write_text(json.dumps(results,indent=2))
+assert all(r['pass'] for r in results)
+print(f'PASS: {len(results)} RPK load/rejection cases')


### PR DESCRIPTION
This change adds Gigacart support to MAME, including ROM-only, separate-GROM, and CPLD boot variants. It supports address/data bank selection, an explicit bank-data width, and an initial-bank setting. It also includes synthetic mapper and RPK tests, plus a generic checksum tool that accepts an external reference file.

Dragon’s Lair provides the tested two-data-bit, 128 MiB implementation. Configurations using three through eight data bits have synthetic tests but have not been validated against physical hardware. Tursi’s [CPLD notes](https://github.com/tursilion/gigacart/blob/main/cart/CPLD%20Notes.txt) describe an alternate 512 MiB configuration and a theoretical maximum of 8 GiB using all eight data bits.

Mike Brent (Tursi)’s [Gigacart repository](https://github.com/tursilion/gigacart) is the primary hardware reference, particularly the [runtime CPLD implementation](https://github.com/tursilion/gigacart/blob/main/cart/cpld.seahorseCELoad/design.vhd). His [UberGROM project](https://github.com/tursilion/ubergrom) supplies the related GROM-emulation background. The Gigacart CPLD source also credits Ralph’s FinalGROM99 address-increment idea.

I have a long history with TI-99 cartridge boards. I designed the original 16 KiB and 64 KiB boards, starting with the inverted 74LS379-based 16 KiB boards in 2009 and the `.9` image convention. My later 64 KiB boards used a 74LS378 with some lines unused, and I moved to non-inverted banking in response to user preference.

Jim Fetzner added two lines to my 64 KiB design for a 128 KiB EPROM and manufactured those boards for me when I lacked capacity. He subsequently extended the same circuit to support a fully banked 512 KiB EPROM using all the available lines on the 74LS378, then used the 74LS377 for 2 MiB boards. Jim’s 2 MiB board was the largest conventional parallel-ROM cartridge board in this lineage.

In 2014, Tursi, Jim, and I collaborated on the UberGROM board, combining a 512 KiB 39SF040 flash ROM with an ATmega1284P to simulate GROM.

The traditional TI “write-to-ROM” banking method derives the bank number from the address of a write to the cartridge ROM window. With 12 address-derived bank bits, this method can select 4,096 banks of 8 KiB, giving a theoretical capacity of 32 MiB. That is the banking method’s capacity, rather than the size of a board we produced.

For Dragon’s Lair, Tursi extended this method by adding two bits from the TI data bus to the 12 address-derived bank bits. The resulting 14-bit bank number selects 16,384 banks of 8 KiB, providing the required 128 MiB. His CPLD also presents a small GROM boot shim stored in the final 256 bytes of the flash ROM. See the [Gigacart CPLD source](https://github.com/tursilion/gigacart/blob/main/cart/cpld.seahorseCELoad/design.vhd).

I supplied hardware knowledge, cartridge observations, the ROM dump, and real-system test results, including technical input relayed from AtariAge. OpenAI Codex (GPT-6) assisted with implementation, debugging, and emulator testing. These acknowledgments do not imply that the other community members reviewed this patch.

Validation was performed together with the separate TMS9901 interrupt fix, based on upstream commit `e7f900f5`:

- Full debug emulator build.
- 49 standalone assertions and 33 RPK test cases.
- All 16,384 full-bank checksums checked against the external reference file.
- Bank and GROM save-state restoration.
- Successful completion of Dragonostics.
- A complete 194-move Practice run through Daphne’s rescue and the return to the intro.

Audio output was disabled during automated testing, so these results do not establish audio fidelity. A manual play through was performed to test audio and verify functionality via the practice run and to also run Dragonostics.  The upstream aggregate unit-test target references removed RGB files; the Gigacart unit tests were compiled and run standalone.