### PR TITLE
st2302u_bbl_spi.cpp - improved sound further, allowed toumapet & qpet to boot [anonymous]

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -4304,6 +4304,18 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/machine/xn297l.h,MACHINES["XN297L"] = true
+---------------------------------------------------
+
+if MACHINES["XN297L"] then
+	files {
+		MAME_DIR .. "src/devices/machine/xn297l.cpp",
+		MAME_DIR .. "src/devices/machine/xn297l.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/machine/ym2148.h,MACHINES["YM2148"] = true
 ---------------------------------------------------
 

--- a/src/devices/cpu/m6502/st2204.cpp
+++ b/src/devices/cpu/m6502/st2204.cpp
@@ -692,6 +692,8 @@ void st2204_device::common_map(address_map &map)
 	map(0x004c, 0x004c).rw(FUNC(st2204_device::pl_r), FUNC(st2204_device::pl_w));
 	// PCL is listed as write-only in ST2202 specification, but DynamiDesk suggests otherwise
 	map(0x004e, 0x004e).rw(FUNC(st2204_device::pcl_r), FUNC(st2204_device::pcl_w));
+	map(0x0050, 0x0050).rw(FUNC(st2204_device::sdatal_r), FUNC(st2204_device::sdatal_w));
+	map(0x0051, 0x0051).rw(FUNC(st2204_device::sdatah_r), FUNC(st2204_device::sdatah_w));
 	map(0x0052, 0x0052).rw(FUNC(st2204_device::sctr_r), FUNC(st2204_device::sctr_w));
 	map(0x0053, 0x0053).rw(FUNC(st2204_device::sckr_r), FUNC(st2204_device::sckr_w));
 	map(0x0054, 0x0054).rw(FUNC(st2204_device::ssr_r), FUNC(st2204_device::ssr_w));

--- a/src/devices/cpu/m6502/st2205u.cpp
+++ b/src/devices/cpu/m6502/st2205u.cpp
@@ -103,21 +103,24 @@ st2302u_device::st2302u_device(const machine_config &mconfig, const char *tag, d
 
 void st2205u_base_device::sound_stream_update(sound_stream &stream)
 {
+	constexpr int OUTPUT_SCALE = 0x200 * 0x3f * 4;
+	sound_stream::sample_t output = 0.0F;
 	for (int channel = 0; channel < 4; channel++)
-	{
-		// The four channels are mixed into one 10-bit output, so retain enough headroom for their sum.
-		const int output = !BIT(m_psgc, 0) && BIT(m_psgc, channel + 4)
-				? m_psg_output[channel] * (m_psg_vol[channel] & 0x3f)
-				: 0;
+		if (!BIT(m_psgc, 0) && BIT(m_psgc, channel + 4))
+			output += sound_stream::sample_t(double(m_psg_output[channel] * (m_psg_vol[channel] & 0x3f)) / OUTPUT_SCALE);
 
-		for (int sample = 0; sample < stream.samples(); sample++)
-			stream.put_int(channel, sample, output, 0x200 * 0x3f * 4);
+	// The four channels are mixed internally and output mode 3 selects the current DAC rather than PWM.
+	const bool current_dac = BIT(m_psgc, 1, 2) == 3;
+	for (int sample = 0; sample < stream.samples(); sample++)
+	{
+		stream.put(PSG_OUTPUT_PWM, sample, current_dac ? 0.0F : output);
+		stream.put(PSG_OUTPUT_CURRENT_DAC, sample, current_dac ? output : 0.0F);
 	}
 }
 
 void st2205u_base_device::base_init(std::unique_ptr<mi_st2xxx> &&intf)
 {
-	m_stream = stream_alloc(0, 4, 48000);
+	m_stream = stream_alloc(0, PSG_OUTPUT_COUNT, 48000);
 
 	m_timer_12bit[0] = timer_alloc(FUNC(st2205u_device::t0_interrupt), this);
 	m_timer_12bit[1] = timer_alloc(FUNC(st2205u_device::t1_interrupt), this);
@@ -1316,6 +1319,8 @@ void st2205u_device::int_map(address_map &map)
 	map(0x004c, 0x004c).w(FUNC(st2205u_device::lpal_w));
 	map(0x004e, 0x004e).rw(FUNC(st2205u_device::pl_r), FUNC(st2205u_device::pl_w));
 	map(0x004f, 0x004f).rw(FUNC(st2205u_device::pcl_r), FUNC(st2205u_device::pcl_w));
+	map(0x0050, 0x0050).rw(FUNC(st2205u_device::sdatal_r), FUNC(st2205u_device::sdatal_w));
+	map(0x0051, 0x0051).rw(FUNC(st2205u_device::sdatah_r), FUNC(st2205u_device::sdatah_w));
 	map(0x0052, 0x0052).rw(FUNC(st2205u_device::sctr_r), FUNC(st2205u_device::sctr_w));
 	map(0x0053, 0x0053).rw(FUNC(st2205u_device::sckr_r), FUNC(st2205u_device::sckr_w));
 	map(0x0054, 0x0054).rw(FUNC(st2205u_device::ssr_r), FUNC(st2205u_device::ssr_w));
@@ -1344,6 +1349,8 @@ void st2302u_device::int_map(address_map &map)
 	map(0x0008, 0x000d).rw(FUNC(st2302u_device::pctrl_r), FUNC(st2302u_device::pctrl_w));
 	map(0x000e, 0x000e).rw(FUNC(st2302u_device::pfc_r), FUNC(st2302u_device::pfc_w));
 	map(0x000f, 0x000f).rw(FUNC(st2302u_device::pfd_r), FUNC(st2302u_device::pfd_w));
+	map(0x0010, 0x0010).rw(FUNC(st2302u_device::sdatal_r), FUNC(st2302u_device::sdatal_w));
+	map(0x0011, 0x0011).rw(FUNC(st2302u_device::sdatah_r), FUNC(st2302u_device::sdatah_w));
 	map(0x0012, 0x0012).rw(FUNC(st2302u_device::sctr_r), FUNC(st2302u_device::sctr_w));
 	map(0x0013, 0x0013).rw(FUNC(st2302u_device::sckr_r), FUNC(st2302u_device::sckr_w));
 	map(0x0014, 0x0014).rw(FUNC(st2302u_device::ssr_r), FUNC(st2302u_device::ssr_w));

--- a/src/devices/cpu/m6502/st2205u.h
+++ b/src/devices/cpu/m6502/st2205u.h
@@ -16,6 +16,13 @@
 class st2205u_base_device : public st2xxx_device, public device_sound_interface
 {
 public:
+	enum : unsigned
+	{
+		PSG_OUTPUT_PWM,
+		PSG_OUTPUT_CURRENT_DAC,
+		PSG_OUTPUT_COUNT
+	};
+
 	enum {
 		ST_BTC = ST_BDIV + 1,
 		ST_T0C,

--- a/src/devices/cpu/m6502/st2xxx.cpp
+++ b/src/devices/cpu/m6502/st2xxx.cpp
@@ -49,6 +49,7 @@ st2xxx_device::st2xxx_device(const machine_config &mconfig, device_type type, co
 	, m_data_config("data", ENDIANNESS_LITTLE, 8, data_bits, 0)
 	, m_in_port_cb(*this, 0xff)
 	, m_out_port_cb(*this)
+	, m_spi_exchange_cb(*this)
 	, m_prr_mask(data_bits <= 14 ? 0 : ((u16(1) << (data_bits - 14)) - 1) | (has_banked_ram ? 0x8000 : 0))
 	, m_drr_mask(data_bits <= 15 ? 0 : ((u16(1) << (data_bits - 15)) - 1) | (has_banked_ram ? 0x8000 : 0))
 	, m_pdata{0}
@@ -84,6 +85,12 @@ st2xxx_device::st2xxx_device(const machine_config &mconfig, device_type type, co
 	, m_sckr(0)
 	, m_ssr(0)
 	, m_smod(0)
+	, m_sdata_tx(0)
+	, m_sdata_rx(0)
+	, m_spi_pending_rx(0)
+	, m_spi_busy(false)
+	, m_spi_tx_pending(false)
+	, m_spi_timer(nullptr)
 	, m_uctr(0)
 	, m_usr(0)
 	, m_irctr(0)
@@ -201,9 +208,16 @@ void st2xxx_device::save_common_registers()
 	}
 	if (st2xxx_has_spi())
 	{
+		m_spi_exchange_cb.resolve();
+		m_spi_timer = timer_alloc(FUNC(st2xxx_device::spi_complete), this);
 		save_item(NAME(m_sctr));
 		save_item(NAME(m_sckr));
 		save_item(NAME(m_ssr));
+		save_item(NAME(m_sdata_tx));
+		save_item(NAME(m_sdata_rx));
+		save_item(NAME(m_spi_pending_rx));
+		save_item(NAME(m_spi_busy));
+		save_item(NAME(m_spi_tx_pending));
 		if (st2xxx_spi_iis())
 			save_item(NAME(m_smod));
 	}
@@ -272,6 +286,13 @@ void st2xxx_device::device_reset()
 	m_sckr = 0;
 	m_ssr = 0;
 	m_smod = 0;
+	m_sdata_tx = 0;
+	m_sdata_rx = 0;
+	m_spi_pending_rx = 0;
+	m_spi_busy = false;
+	m_spi_tx_pending = false;
+	if (m_spi_timer != nullptr)
+		m_spi_timer->adjust(attotime::never);
 
 	// reset UART and BRG
 	m_uctr = 0;
@@ -802,11 +823,105 @@ u8 st2xxx_device::sctr_r()
 
 void st2xxx_device::sctr_w(u8 data)
 {
-	// TXEMP on wakeup?
+	// TODO: Slave operation, external SS/data-ready signals, collision/mode-fault
+	// status and IIS mode are not implemented.
+
+	// Enabling SPI resets its internal state and leaves the transmit buffer empty.
 	if (!BIT(m_sctr, 7) && BIT(data, 7))
-		m_ssr |= 0x20;
+	{
+		m_spi_timer->adjust(attotime::never);
+		m_sdata_tx = 0;
+		m_sdata_rx = 0;
+		m_spi_pending_rx = 0;
+		m_spi_busy = false;
+		m_spi_tx_pending = false;
+		m_ssr = 0x20;
+	}
+	else if (BIT(m_sctr, 7) && !BIT(data, 7))
+	{
+		m_spi_timer->adjust(attotime::never);
+		m_spi_pending_rx = 0;
+		m_spi_busy = false;
+		m_spi_tx_pending = false;
+		m_ssr &= ~0x10;
+	}
 
 	m_sctr = data;
+
+	// A word loaded in slave mode begins shifting if the interface is changed to master mode.
+	if (BIT(m_sctr, 7) && BIT(m_sctr, 0) && !m_spi_busy && m_spi_tx_pending)
+		spi_start();
+}
+
+u8 st2xxx_device::sdatal_r()
+{
+	if (!machine().side_effects_disabled())
+		m_ssr &= ~0x42;
+	return u8(m_sdata_rx);
+}
+
+void st2xxx_device::sdatal_w(u8 data)
+{
+	m_sdata_tx = (m_sdata_tx & 0xff00) | data;
+	m_spi_tx_pending = true;
+	m_ssr &= ~0x20;
+
+	if (BIT(m_sctr, 7) && BIT(m_sctr, 0) && !m_spi_busy)
+		spi_start();
+}
+
+u8 st2xxx_device::sdatah_r()
+{
+	return m_sdata_rx >> 8;
+}
+
+void st2xxx_device::sdatah_w(u8 data)
+{
+	m_sdata_tx = (m_sdata_tx & 0x00ff) | u16(data) << 8;
+}
+
+void st2xxx_device::spi_start()
+{
+	assert(BIT(m_sctr, 7));
+	assert(BIT(m_sctr, 0));
+	assert(!m_spi_busy);
+	assert(m_spi_tx_pending);
+
+	u8 const bits = (m_sckr & 0x0f) + 1;
+	u16 const mask = bits == 16 ? 0xffff : (u16(1) << bits) - 1;
+	m_spi_pending_rx = m_spi_exchange_cb.isnull() ? mask : m_spi_exchange_cb(m_sdata_tx & mask, bits) & mask;
+	m_spi_tx_pending = false;
+	m_spi_busy = true;
+	m_ssr |= 0x30;
+
+	// The transmit request occurs when the shift register takes the buffered word.
+	m_ireq |= 0x0100;
+	update_irq_state();
+
+	unsigned const clocks = bits * (2U << ((m_sckr >> 4) & 0x07));
+	m_spi_timer->adjust(cycles_to_attotime(clocks));
+}
+
+TIMER_CALLBACK_MEMBER(st2xxx_device::spi_complete)
+{
+	m_spi_busy = false;
+	m_ssr &= ~0x10;
+
+	bool const overrun = BIT(m_ssr, 6);
+	if (overrun)
+		m_ssr |= 0x02;
+	m_sdata_rx = m_spi_pending_rx;
+	m_ssr |= 0x40;
+
+	if (BIT(m_sctr, 6) || (overrun && BIT(m_sctr, 5)))
+	{
+		m_ireq |= 0x0200;
+		update_irq_state();
+	}
+
+	// A waiting transmit buffer is reloaded without a gap between words.
+	if (BIT(m_sctr, 7) && BIT(m_sctr, 0) && m_spi_tx_pending)
+		spi_start();
 }
 
 u8 st2xxx_device::sckr_r()
@@ -827,7 +942,7 @@ u8 st2xxx_device::ssr_r()
 void st2xxx_device::ssr_w(u8 data)
 {
 	// Write any value to clear
-	m_ssr = 0;
+	m_ssr = m_spi_busy ? 0x10 : 0;
 }
 
 u8 st2xxx_device::smod_r()

--- a/src/devices/cpu/m6502/st2xxx.h
+++ b/src/devices/cpu/m6502/st2xxx.h
@@ -10,6 +10,8 @@
 
 class st2xxx_device : public w65c02s_device {
 public:
+	using spi_exchange_delegate = device_delegate<u16 (u16 data, u8 bits)>;
+
 	enum {
 		ST_PAOUT = M6502_IR + 1,
 		ST_PBOUT,
@@ -83,6 +85,7 @@ public:
 	auto out_pf_callback() { return m_out_port_cb[5].bind(); }
 	auto in_pl_callback() { return m_in_port_cb[6].bind(); }
 	auto out_pl_callback() { return m_out_port_cb[6].bind(); }
+	template <typename... T> void set_spi_exchange_callback(T &&... args) { m_spi_exchange_cb.set(std::forward<T>(args)...); }
 
 protected:
 	st2xxx_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor internal_map, int data_bits, bool has_banked_ram);
@@ -138,6 +141,7 @@ protected:
 
 	TIMER_CALLBACK_MEMBER(bt_interrupt);
 	TIMER_CALLBACK_MEMBER(lcd_interrupt);
+	TIMER_CALLBACK_MEMBER(spi_complete);
 
 	u8 pdata_r(offs_t offset);
 	void pdata_w(offs_t offset, u8 data);
@@ -216,12 +220,17 @@ protected:
 
 	u8 sctr_r();
 	void sctr_w(u8 data);
+	u8 sdatal_r();
+	void sdatal_w(u8 data);
+	u8 sdatah_r();
+	void sdatah_w(u8 data);
 	u8 sckr_r();
 	void sckr_w(u8 data);
 	u8 ssr_r();
 	void ssr_w(u8 data);
 	u8 smod_r();
 	void smod_w(u8 data);
+	void spi_start();
 
 	u8 uctr_r();
 	void uctr_w(u8 data);
@@ -243,6 +252,7 @@ protected:
 
 	devcb_read8::array<7> m_in_port_cb;
 	devcb_write8::array<7> m_out_port_cb;
+	spi_exchange_delegate m_spi_exchange_cb;
 
 	const u16 m_prr_mask;
 	const u16 m_drr_mask;
@@ -287,6 +297,12 @@ protected:
 	u8 m_sckr;
 	u8 m_ssr;
 	u8 m_smod;
+	u16 m_sdata_tx;
+	u16 m_sdata_rx;
+	u16 m_spi_pending_rx;
+	bool m_spi_busy;
+	bool m_spi_tx_pending;
+	emu_timer *m_spi_timer;
 
 	u8 m_uctr;
 	u8 m_usr;

--- a/src/devices/machine/generic_spi_flash.cpp
+++ b/src/devices/machine/generic_spi_flash.cpp
@@ -1,7 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:David Haywood
 
-// HLE-like implementation for SPI Flash ROMs using byte interface rather than SPI signals
+// HLE-like implementation for SPI flash ROMs.  Most hosts use the byte
+// interface; the pin-level adapter supports software-driven SPI buses.
 
 #include "emu.h"
 #include "generic_spi_flash.h"
@@ -33,6 +34,13 @@ void generic_spi_flash_device::device_start()
 	save_item(NAME(m_spi_state_step));
 	save_item(NAME(m_spi_statusreg));
 	save_item(NAME(m_spi_configreg));
+	save_item(NAME(m_bitbang_cs));
+	save_item(NAME(m_bitbang_sck));
+	save_item(NAME(m_bitbang_si));
+	save_item(NAME(m_bitbang_so));
+	save_item(NAME(m_bitbang_input));
+	save_item(NAME(m_bitbang_output));
+	save_item(NAME(m_bitbang_bits));
 
 	m_spi_statusreg = 0;
 	m_spi_configreg = 0;
@@ -44,6 +52,14 @@ void generic_spi_flash_device::device_reset()
 	m_spi_addr = 0;
 	m_spi_state = 0;
 	m_spi_latch = 0;
+	m_spi_state_step = 0;
+	m_bitbang_cs = 1;
+	m_bitbang_sck = 0;
+	m_bitbang_si = 1;
+	m_bitbang_so = 1;
+	m_bitbang_input = 0;
+	m_bitbang_output = 0xff;
+	m_bitbang_bits = 0;
 }
 
 void generic_spi_flash_device::get_command(u8 data)
@@ -115,6 +131,13 @@ void generic_spi_flash_device::get_command(u8 data)
 		LOGMASKED(LOG_SPI, "Set SPI to COMMAND_35_RDSR2\n");
 		m_spi_state = COMMAND_35_RDSR2;
 	}
+	else if (data == COMMAND_50_VSR_WREN)
+	{
+		// TODO: Model the volatile status-register write-enable latch when
+		// software depends on it.  Current users write an already-zero status.
+		LOGMASKED(LOG_SPI, "Accept volatile status register write enable\n");
+		m_spi_state = READY_FOR_COMMAND;
+	}
 	else if (data == COMMAND_66_ENABLE_RESET)
 	{
 		LOGMASKED(LOG_SPI, "Set SPI to ENABLE_RESET\n");
@@ -162,6 +185,98 @@ void generic_spi_flash_device::get_command(u8 data)
 	}
 
 	m_spi_state_step = 0;
+}
+
+u8 generic_spi_flash_device::next_bitbang_byte() const
+{
+	switch (m_spi_state)
+	{
+	case COMMAND_03_READ:
+		if (m_spi_state_step >= 3 && m_spiptr && m_length)
+			return m_spiptr[m_spi_addr & (m_length - 1)];
+		break;
+
+	case COMMAND_05_RDSR:
+		return m_spi_state_step ? 0x00 : m_spi_statusreg;
+
+	case COMMAND_0B_FAST_READ:
+		if (m_spi_state_step >= 4 && m_spiptr && m_length)
+			return m_spiptr[m_spi_addr & (m_length - 1)];
+		break;
+
+	case COMMAND_15_RDCR:
+		return m_spi_configreg;
+
+	case COMMAND_35_RDSR2:
+		return m_spi_statusreg;
+
+	case COMMAND_9F_RDID:
+		if (m_spi_state_step < std::size(m_idbytes))
+			return m_idbytes[m_spi_state_step];
+		break;
+
+	case COMMAND_EB_4READ:
+		if (m_spi_state_step >= 6 && m_spiptr && m_length)
+			return m_spiptr[m_spi_addr & (m_length - 1)];
+		break;
+	}
+
+	return 0xff;
+}
+
+void generic_spi_flash_device::cs_w(int state)
+{
+	state = state ? 1 : 0;
+	if (m_bitbang_cs == state)
+		return;
+
+	m_bitbang_cs = state;
+	m_spi_state = READY_FOR_COMMAND;
+	m_spi_state_step = 0;
+	m_bitbang_input = 0;
+	m_bitbang_output = 0xff;
+	m_bitbang_bits = 0;
+	m_bitbang_so = 1;
+}
+
+void generic_spi_flash_device::sck_w(int state)
+{
+	state = state ? 1 : 0;
+	if (m_bitbang_sck == state)
+		return;
+
+	if (!m_bitbang_cs)
+	{
+		if (state)
+		{
+			m_bitbang_input = (m_bitbang_input << 1) | m_bitbang_si;
+			if (++m_bitbang_bits == 8)
+				write(m_bitbang_input);
+		}
+		else if (m_bitbang_bits == 8)
+		{
+			m_bitbang_input = 0;
+			m_bitbang_output = next_bitbang_byte();
+			m_bitbang_bits = 0;
+			m_bitbang_so = BIT(m_bitbang_output, 7);
+		}
+		else
+		{
+			m_bitbang_so = BIT(m_bitbang_output, 7 - m_bitbang_bits);
+		}
+	}
+
+	m_bitbang_sck = state;
+}
+
+void generic_spi_flash_device::si_w(int state)
+{
+	m_bitbang_si = state ? 1 : 0;
+}
+
+int generic_spi_flash_device::so_r() const
+{
+	return m_bitbang_cs ? 1 : m_bitbang_so;
 }
 
 void generic_spi_flash_device::process_read_command(u8 data)
@@ -474,4 +589,3 @@ bool generic_spi_flash_device::nvram_write(util::write_stream &file)
 	auto const [err, actual] = util::write(file, m_spiptr, m_length);
 	return !err;
 }
-

--- a/src/devices/machine/generic_spi_flash.cpp
+++ b/src/devices/machine/generic_spi_flash.cpp
@@ -386,7 +386,7 @@ void generic_spi_flash_device::process_sector_erase_command(u8 data)
 		LOGMASKED(LOG_SPI, "SPI set to Erase Sector with address %08x\n", m_spi_addr);
 		break;
 	default:
-		LOGMASKED(LOG_SPI, "%s unexpected byte %02x when writing sector erase address\n", data);
+		LOGMASKED(LOG_SPI, "unexpected byte %02x when writing sector erase address\n", data);
 		break;
 	}
 }

--- a/src/devices/machine/generic_spi_flash.h
+++ b/src/devices/machine/generic_spi_flash.h
@@ -19,9 +19,16 @@ public:
 		return m_spi_latch;
 	}
 
+	// SPI mode 0 pin-level interface for bit-banged hosts.
+	void cs_w(int state);
+	void sck_w(int state);
+	void si_w(int state);
+	int so_r() const;
+
 	void set_ready()
 	{
 		m_spi_state = READY_FOR_COMMAND;
+		m_spi_state_step = 0;
 	}
 
 	void write(u8 data);
@@ -67,6 +74,7 @@ private:
 		COMMAND_31_UNKNOWN = 0x31,
 
 		COMMAND_35_RDSR2 = 0x35,
+		COMMAND_50_VSR_WREN = 0x50,
 
 		COMMAND_66_ENABLE_RESET = 0x66,
 
@@ -98,6 +106,7 @@ private:
 	void process_status2_read_command(u8 data);
 	void process_status_rdid_command(u8 data);
 	void process_config_read_command(u8 data);
+	u8 next_bitbang_byte() const;
 
 	u32 m_spi_addr;
 	u8 m_spi_state;
@@ -105,6 +114,13 @@ private:
 	u8 m_spi_state_step;
 	u8 m_spi_statusreg;
 	u8 m_spi_configreg;
+	u8 m_bitbang_cs;
+	u8 m_bitbang_sck;
+	u8 m_bitbang_si;
+	u8 m_bitbang_so;
+	u8 m_bitbang_input;
+	u8 m_bitbang_output;
+	u8 m_bitbang_bits;
 
 	// config
 	u8 *m_spiptr;

--- a/src/devices/machine/xn297l.cpp
+++ b/src/devices/machine/xn297l.cpp
@@ -22,18 +22,10 @@ DEFINE_DEVICE_TYPE(XN297L, xn297l_device, "xn297l", "Panchip XN297L 2.4 GHz tran
 
 xn297l_device::xn297l_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
 	device_t(mconfig, XN297L, tag, owner, clock),
-	m_registers{0},
-	m_tx_fifo{{0}},
-	m_tx_length{0},
-	m_tx_no_ack{0},
 	m_tx_count(0),
-	m_rx_fifo{{0}},
-	m_rx_length{0},
-	m_rx_pipe{0},
 	m_rx_count(0),
 	m_command(CMD_NOP),
 	m_command_pos(0),
-	m_payload{0},
 	m_payload_length(0),
 	m_payload_no_ack(0),
 	m_cs(true),
@@ -44,6 +36,14 @@ xn297l_device::xn297l_device(const machine_config &mconfig, const char *tag, dev
 	m_transmitting(false),
 	m_transmit_timer(nullptr)
 {
+	std::fill(&m_registers[0][0], &m_registers[0][0] + sizeof(m_registers), 0);
+	std::fill(&m_tx_fifo[0][0], &m_tx_fifo[0][0] + sizeof(m_tx_fifo), 0);
+	std::fill(&m_rx_fifo[0][0], &m_rx_fifo[0][0] + sizeof(m_rx_fifo), 0);
+	std::fill(&m_tx_length[0], &m_tx_length[0] + sizeof(m_tx_length), 0);
+	std::fill(&m_tx_no_ack[0], &m_tx_no_ack[0] + sizeof(m_tx_no_ack), 0);
+	std::fill(&m_rx_length[0], &m_rx_length[0] + sizeof(m_rx_length), 0);
+	std::fill(&m_rx_pipe[0], &m_rx_pipe[0] + sizeof(m_rx_pipe), 0);
+	std::fill(&m_payload[0], &m_payload[0] + sizeof(m_payload), 0);
 }
 
 void xn297l_device::device_start()

--- a/src/devices/machine/xn297l.cpp
+++ b/src/devices/machine/xn297l.cpp
@@ -1,0 +1,453 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#include "emu.h"
+#include "xn297l.h"
+
+// This is a byte-oriented HLE of the host-visible SPI, register and FIFO
+// behaviour used by current drivers.  RF propagation and communication with
+// a peer are not emulated; enhanced transmissions therefore exhaust their
+// retries and set MAX_RT.
+// TODO: Retain the last successfully transmitted frame for REUSE_TX_PL and
+// implement ACK payload storage when a driver needs either feature.
+
+#define LOG_COMMAND (1U << 1)
+#define LOG_FIFO    (1U << 2)
+
+//#define VERBOSE (LOG_COMMAND | LOG_FIFO)
+#include "logmacro.h"
+
+
+DEFINE_DEVICE_TYPE(XN297L, xn297l_device, "xn297l", "Panchip XN297L 2.4 GHz transceiver")
+
+xn297l_device::xn297l_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
+	device_t(mconfig, XN297L, tag, owner, clock),
+	m_registers{0},
+	m_tx_fifo{{0}},
+	m_tx_length{0},
+	m_tx_no_ack{0},
+	m_tx_count(0),
+	m_rx_fifo{{0}},
+	m_rx_length{0},
+	m_rx_pipe{0},
+	m_rx_count(0),
+	m_command(CMD_NOP),
+	m_command_pos(0),
+	m_payload{0},
+	m_payload_length(0),
+	m_payload_no_ack(0),
+	m_cs(true),
+	m_ce(false),
+	m_reset_hold(false),
+	m_features_active(false),
+	m_tx_reuse(false),
+	m_transmitting(false),
+	m_transmit_timer(nullptr)
+{
+}
+
+void xn297l_device::device_start()
+{
+	m_transmit_timer = timer_alloc(FUNC(xn297l_device::transmit_complete), this);
+
+	save_item(NAME(m_registers));
+	save_item(NAME(m_tx_fifo));
+	save_item(NAME(m_tx_length));
+	save_item(NAME(m_tx_no_ack));
+	save_item(NAME(m_tx_count));
+	save_item(NAME(m_rx_fifo));
+	save_item(NAME(m_rx_length));
+	save_item(NAME(m_rx_pipe));
+	save_item(NAME(m_rx_count));
+	save_item(NAME(m_command));
+	save_item(NAME(m_command_pos));
+	save_item(NAME(m_payload));
+	save_item(NAME(m_payload_length));
+	save_item(NAME(m_payload_no_ack));
+	save_item(NAME(m_cs));
+	save_item(NAME(m_ce));
+	save_item(NAME(m_reset_hold));
+	save_item(NAME(m_features_active));
+	save_item(NAME(m_tx_reuse));
+	save_item(NAME(m_transmitting));
+}
+
+void xn297l_device::device_reset()
+{
+	reset_registers();
+	m_cs = true;
+	m_ce = false;
+	m_reset_hold = false;
+	m_features_active = false;
+	m_command = CMD_NOP;
+	m_command_pos = 0;
+	m_payload_length = 0;
+	m_payload_no_ack = 0;
+	m_transmitting = false;
+	m_transmit_timer->adjust(attotime::never);
+}
+
+void xn297l_device::reset_registers()
+{
+	m_features_active = false;
+	std::fill(&m_registers[0][0], &m_registers[0][0] + sizeof(m_registers), 0);
+	m_registers[REG_CONFIG][0] = 0x08;
+	m_registers[REG_EN_AA][0] = 0x01;
+	m_registers[0x02][0] = 0x01;
+	m_registers[0x03][0] = 0x03;
+	m_registers[0x04][0] = 0x03;
+	m_registers[REG_RF_CH][0] = 0x4e;
+	m_registers[0x06][0] = 0x3f;
+	std::fill_n(m_registers[REG_RX_ADDR_P0], 5, 0xe7);
+	std::fill_n(m_registers[REG_RX_ADDR_P1], 5, 0xc2);
+	m_registers[0x0c][0] = 0xc3;
+	m_registers[0x0d][0] = 0xc4;
+	m_registers[0x0e][0] = 0xc5;
+	m_registers[0x0f][0] = 0xc6;
+	std::fill_n(m_registers[REG_TX_ADDR], 5, 0xe7);
+	m_registers[0x19][0] = 0x0f;
+	const u8 rf_cal2[6] = { 0x45, 0x21, 0xef, 0x2c, 0x5a, 0x42 };
+	std::copy(std::begin(rf_cal2), std::end(rf_cal2), m_registers[0x1a]);
+	const u8 dem_cal2[3] = { 0x0b, 0xdf, 0x02 };
+	std::copy(std::begin(dem_cal2), std::end(dem_cal2), m_registers[0x1b]);
+	const u8 rf_cal[3] = { 0xf6, 0x3f, 0x5d };
+	std::copy(std::begin(rf_cal), std::end(rf_cal), m_registers[0x1e]);
+	const u8 bb_cal[5] = { 0x0a, 0x6d, 0x67, 0x9c, 0x46 };
+	std::copy(std::begin(bb_cal), std::end(bb_cal), m_registers[0x1f]);
+
+	flush_tx();
+	flush_rx();
+	m_registers[REG_STATUS][0] = 0;
+	m_registers[REG_OBSERVE_TX][0] = 0;
+}
+
+unsigned xn297l_device::register_width(u8 reg) const
+{
+	switch (reg)
+	{
+	case REG_RX_ADDR_P0:
+	case REG_RX_ADDR_P1:
+	case REG_TX_ADDR:
+	case 0x1f:
+		return 5;
+	case 0x1a:
+		return 6;
+	case 0x1b:
+	case 0x1e:
+		return 3;
+	default:
+		return 1;
+	}
+}
+
+unsigned xn297l_device::payload_limit() const
+{
+	return (m_registers[REG_FEATURE][0] & 0x18) == 0x18 ? 64 : 32;
+}
+
+unsigned xn297l_device::fifo_limit() const
+{
+	return payload_limit() == 64 ? 1 : FIFO_DEPTH;
+}
+
+u8 xn297l_device::status_r() const
+{
+	const u8 pipe = m_rx_count ? (m_rx_pipe[0] & 7) : 7;
+	return (m_registers[REG_STATUS][0] & 0x70) | (pipe << 1) | (m_tx_count >= fifo_limit());
+}
+
+u8 xn297l_device::fifo_status_r() const
+{
+	return (m_tx_reuse ? 0x40 : 0x00)
+		| (m_tx_count >= fifo_limit() ? 0x20 : 0x00)
+		| (m_tx_count ? 0x00 : 0x10)
+		| (m_rx_count >= fifo_limit() ? 0x02 : 0x00)
+		| (m_rx_count ? 0x00 : 0x01);
+}
+
+u8 xn297l_device::register_r(u8 reg, u8 offset) const
+{
+	if (offset >= register_width(reg))
+		return 0xff;
+	if (reg == REG_STATUS)
+		return status_r();
+	if (reg == REG_FIFO_STATUS)
+		return fifo_status_r();
+	return m_registers[reg][offset];
+}
+
+void xn297l_device::register_w(u8 reg, u8 offset, u8 data)
+{
+	if (offset >= register_width(reg))
+		return;
+
+	if (reg == REG_STATUS)
+	{
+		m_registers[REG_STATUS][0] &= ~(data & 0x70);
+		return;
+	}
+	if (reg == REG_OBSERVE_TX || reg == REG_FIFO_STATUS)
+		return;
+
+	switch (reg)
+	{
+	case REG_EN_AA:
+	case 0x02:
+	case 0x1c:
+		data &= 0x3f;
+		break;
+	case 0x03:
+		data &= 0x03;
+		break;
+	case REG_RF_CH:
+		data &= 0x7f;
+		m_registers[REG_OBSERVE_TX][0] &= 0x0f;
+		break;
+	case 0x11:
+	case 0x12:
+	case 0x13:
+	case 0x14:
+	case 0x15:
+	case 0x16:
+		data &= 0x7f;
+		break;
+	case REG_FEATURE:
+		data &= 0x7f;
+		break;
+	default:
+		break;
+	}
+
+	m_registers[reg][offset] = data;
+	if (reg == REG_FEATURE && !BIT(data, 5))
+		m_ce = false;
+	if (reg == REG_CONFIG && (!BIT(data, 1) || BIT(data, 0)))
+	{
+		m_transmitting = false;
+		m_transmit_timer->adjust(attotime::never);
+	}
+}
+
+void xn297l_device::flush_tx()
+{
+	m_tx_count = 0;
+	std::fill(std::begin(m_tx_length), std::end(m_tx_length), 0);
+	std::fill(std::begin(m_tx_no_ack), std::end(m_tx_no_ack), 0);
+	m_tx_reuse = false;
+	m_transmitting = false;
+	if (m_transmit_timer)
+		m_transmit_timer->adjust(attotime::never);
+}
+
+void xn297l_device::flush_rx()
+{
+	m_rx_count = 0;
+	std::fill(std::begin(m_rx_length), std::end(m_rx_length), 0);
+	std::fill(std::begin(m_rx_pipe), std::end(m_rx_pipe), 0);
+}
+
+void xn297l_device::pop_tx()
+{
+	if (!m_tx_count)
+		return;
+	for (unsigned i = 1; i < m_tx_count; ++i)
+	{
+		std::copy(std::begin(m_tx_fifo[i]), std::end(m_tx_fifo[i]), m_tx_fifo[i - 1]);
+		m_tx_length[i - 1] = m_tx_length[i];
+		m_tx_no_ack[i - 1] = m_tx_no_ack[i];
+	}
+	--m_tx_count;
+}
+
+void xn297l_device::pop_rx()
+{
+	if (!m_rx_count)
+		return;
+	for (unsigned i = 1; i < m_rx_count; ++i)
+	{
+		std::copy(std::begin(m_rx_fifo[i]), std::end(m_rx_fifo[i]), m_rx_fifo[i - 1]);
+		m_rx_length[i - 1] = m_rx_length[i];
+		m_rx_pipe[i - 1] = m_rx_pipe[i];
+	}
+	--m_rx_count;
+}
+
+void xn297l_device::start_transmit()
+{
+	if (m_transmitting || !m_ce || !m_tx_count || !BIT(m_registers[REG_CONFIG][0], 1)
+		|| BIT(m_registers[REG_CONFIG][0], 0) || BIT(m_registers[REG_STATUS][0], 4))
+		return;
+
+	m_transmitting = true;
+	const bool auto_ack = BIT(m_registers[REG_EN_AA][0], 0) && !m_tx_no_ack[0];
+	const unsigned attempts = auto_ack ? ((m_registers[0x04][0] & 0x0f) + 1) : 1;
+	const unsigned retry_delay = ((m_registers[0x04][0] >> 4) + 1) * 250;
+	const unsigned packet_time = 150 + m_tx_length[0] * 8;
+	m_transmit_timer->adjust(attotime::from_usec(packet_time * attempts + (attempts - 1) * retry_delay));
+}
+
+TIMER_CALLBACK_MEMBER(xn297l_device::transmit_complete)
+{
+	m_transmitting = false;
+	if (!m_tx_count)
+		return;
+
+	const bool auto_ack = BIT(m_registers[REG_EN_AA][0], 0) && !m_tx_no_ack[0];
+	if (auto_ack)
+	{
+		const u8 retries = m_registers[0x04][0] & 0x0f;
+		m_registers[REG_OBSERVE_TX][0] = std::min<unsigned>((m_registers[REG_OBSERVE_TX][0] & 0xf0) + 0x10, 0xf0) | retries;
+		m_registers[REG_STATUS][0] |= 0x10;
+		LOGMASKED(LOG_FIFO, "TX payload reached maximum retry count\n");
+	}
+	else
+	{
+		pop_tx();
+		m_registers[REG_STATUS][0] |= 0x20;
+		LOGMASKED(LOG_FIFO, "TX payload sent without acknowledgement\n");
+		start_transmit();
+	}
+}
+
+void xn297l_device::finish_command()
+{
+	bool const write_tx = m_command == CMD_W_TX_PAYLOAD
+		|| (m_command == CMD_W_TX_PAYLOAD_NO_ACK && m_features_active && BIT(m_registers[REG_FEATURE][0], 0));
+	if (write_tx
+		&& m_payload_length && m_tx_count < fifo_limit())
+	{
+		std::copy_n(m_payload, m_payload_length, m_tx_fifo[m_tx_count]);
+		m_tx_length[m_tx_count] = m_payload_length;
+		m_tx_no_ack[m_tx_count] = m_payload_no_ack;
+		++m_tx_count;
+		m_tx_reuse = false;
+		m_registers[REG_OBSERVE_TX][0] &= 0xf0;
+		LOGMASKED(LOG_FIFO, "Queued %u-byte TX payload%s\n", m_payload_length, m_payload_no_ack ? " without ACK" : "");
+		start_transmit();
+	}
+	else if (m_command == CMD_R_RX_PAYLOAD && m_command_pos > 1)
+	{
+		pop_rx();
+	}
+	else if (m_command == CMD_RESET && m_command_pos > 1)
+	{
+		if (m_payload[0] == 0x5a)
+		{
+			reset_registers();
+			m_ce = false;
+			m_reset_hold = true;
+		}
+		else if (m_payload[0] == 0xa5)
+		{
+			m_reset_hold = false;
+		}
+	}
+	else if (m_command == CMD_ACTIVATE && m_command_pos > 1)
+	{
+		if (m_payload[0] == 0x73)
+			m_features_active = true;
+		else if (m_payload[0] == 0x8c)
+		{
+			m_features_active = false;
+			m_tx_reuse = false;
+		}
+	}
+	else if ((m_command == CMD_CE_FSPI_ON || m_command == CMD_CE_FSPI_OFF) && m_command_pos > 1
+		&& m_payload[0] == 0x00 && BIT(m_registers[REG_FEATURE][0], 5))
+	{
+		m_ce = m_command == CMD_CE_FSPI_ON;
+		if (m_ce)
+			start_transmit();
+	}
+}
+
+void xn297l_device::cs_w(int state)
+{
+	state = state ? 1 : 0;
+	if (state == m_cs)
+		return;
+
+	if (state)
+		finish_command();
+	else
+	{
+		m_command = CMD_NOP;
+		m_command_pos = 0;
+		m_payload_length = 0;
+		m_payload_no_ack = 0;
+	}
+	m_cs = state;
+}
+
+u8 xn297l_device::transfer(u8 data)
+{
+	if (m_cs)
+		return 0xff;
+
+	if (!m_command_pos)
+	{
+		u8 const result = status_r();
+		m_command = data;
+		m_command_pos = 1;
+		LOGMASKED(LOG_COMMAND, "Command %02X (status %02X)\n", data, result);
+
+		if (m_reset_hold && data != CMD_RESET)
+			return result;
+
+		switch (data)
+		{
+		case CMD_FLUSH_TX:
+			flush_tx();
+			break;
+		case CMD_FLUSH_RX:
+			flush_rx();
+			break;
+		case CMD_REUSE_TX_PL:
+			m_tx_reuse = m_tx_count != 0;
+			break;
+		case CMD_R_RX_PL_WID:
+		case CMD_R_RX_PAYLOAD:
+		case CMD_W_TX_PAYLOAD:
+		case CMD_W_TX_PAYLOAD_NO_ACK:
+		case CMD_ACTIVATE:
+		case CMD_RESET:
+		case CMD_CE_FSPI_OFF:
+		case CMD_CE_FSPI_ON:
+		case CMD_NOP:
+			break;
+		default:
+			if ((data & 0xe0) != CMD_R_REGISTER && (data & 0xe0) != CMD_W_REGISTER && (data & 0xf8) != 0xa8)
+				logerror("%s: unknown SPI command %02X\n", machine().describe_context(), data);
+			break;
+		}
+		return result;
+	}
+	if (m_reset_hold && m_command != CMD_RESET)
+		return status_r();
+
+	const u8 pos = m_command_pos++ - 1;
+	if ((m_command & 0xe0) == CMD_R_REGISTER)
+		return register_r(m_command & 0x1f, pos);
+	if ((m_command & 0xe0) == CMD_W_REGISTER)
+	{
+		register_w(m_command & 0x1f, pos, data);
+		return status_r();
+	}
+	if (m_command == CMD_R_RX_PL_WID)
+		return m_features_active && BIT(m_registers[REG_FEATURE][0], 2) && m_rx_count ? m_rx_length[0] : 0;
+	if (m_command == CMD_R_RX_PAYLOAD)
+		return (m_rx_count && pos < m_rx_length[0]) ? m_rx_fifo[0][pos] : 0xff;
+	if (m_command == CMD_W_TX_PAYLOAD || m_command == CMD_W_TX_PAYLOAD_NO_ACK || (m_command & 0xf8) == 0xa8)
+	{
+		bool const enabled = m_command == CMD_W_TX_PAYLOAD
+			|| (m_command == CMD_W_TX_PAYLOAD_NO_ACK && m_features_active && BIT(m_registers[REG_FEATURE][0], 0))
+			|| ((m_command & 0xf8) == 0xa8 && m_features_active && BIT(m_registers[REG_FEATURE][0], 1));
+		if (enabled && m_payload_length < payload_limit())
+			m_payload[m_payload_length++] = data;
+		m_payload_no_ack = enabled && m_command == CMD_W_TX_PAYLOAD_NO_ACK;
+		return status_r();
+	}
+	if (m_payload_length < MAX_PAYLOAD)
+		m_payload[m_payload_length++] = data;
+	return status_r();
+}

--- a/src/devices/machine/xn297l.h
+++ b/src/devices/machine/xn297l.h
@@ -1,0 +1,97 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+#ifndef MAME_MACHINE_XN297L_H
+#define MAME_MACHINE_XN297L_H
+
+#pragma once
+
+
+class xn297l_device : public device_t
+{
+public:
+	xn297l_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+	static constexpr feature_type unemulated_features() { return feature::COMMS; }
+
+	// Byte-level interface for the chip's 3-wire SPI bus.
+	u8 transfer(u8 data);
+	void cs_w(int state);
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	static constexpr unsigned MAX_PAYLOAD = 64;
+	static constexpr unsigned FIFO_DEPTH = 2;
+
+	TIMER_CALLBACK_MEMBER(transmit_complete);
+
+	void reset_registers();
+	u8 register_r(u8 reg, u8 offset) const;
+	void register_w(u8 reg, u8 offset, u8 data);
+	u8 status_r() const;
+	u8 fifo_status_r() const;
+	unsigned register_width(u8 reg) const;
+	unsigned payload_limit() const;
+	unsigned fifo_limit() const;
+	void finish_command();
+	void flush_tx();
+	void flush_rx();
+	void start_transmit();
+	void pop_tx();
+	void pop_rx();
+
+	u8 m_registers[0x20][6];
+	u8 m_tx_fifo[FIFO_DEPTH][MAX_PAYLOAD];
+	u8 m_tx_length[FIFO_DEPTH];
+	u8 m_tx_no_ack[FIFO_DEPTH];
+	u8 m_tx_count;
+	u8 m_rx_fifo[FIFO_DEPTH][MAX_PAYLOAD];
+	u8 m_rx_length[FIFO_DEPTH];
+	u8 m_rx_pipe[FIFO_DEPTH];
+	u8 m_rx_count;
+
+	u8 m_command;
+	u8 m_command_pos;
+	u8 m_payload[MAX_PAYLOAD];
+	u8 m_payload_length;
+	u8 m_payload_no_ack;
+	bool m_cs;
+	bool m_ce;
+	bool m_reset_hold;
+	bool m_features_active;
+	bool m_tx_reuse;
+	bool m_transmitting;
+	emu_timer *m_transmit_timer;
+
+	static constexpr u8 CMD_R_REGISTER           = 0x00;
+	static constexpr u8 CMD_W_REGISTER           = 0x20;
+	static constexpr u8 CMD_R_RX_PL_WID          = 0x60;
+	static constexpr u8 CMD_R_RX_PAYLOAD         = 0x61;
+	static constexpr u8 CMD_W_TX_PAYLOAD         = 0xa0;
+	static constexpr u8 CMD_FLUSH_TX             = 0xe1;
+	static constexpr u8 CMD_FLUSH_RX             = 0xe2;
+	static constexpr u8 CMD_REUSE_TX_PL          = 0xe3;
+	static constexpr u8 CMD_W_TX_PAYLOAD_NO_ACK  = 0xb0;
+	static constexpr u8 CMD_ACTIVATE             = 0x50;
+	static constexpr u8 CMD_RESET                = 0x53;
+	static constexpr u8 CMD_CE_FSPI_OFF          = 0xfc;
+	static constexpr u8 CMD_CE_FSPI_ON           = 0xfd;
+	static constexpr u8 CMD_NOP                  = 0xff;
+
+	static constexpr u8 REG_CONFIG       = 0x00;
+	static constexpr u8 REG_EN_AA        = 0x01;
+	static constexpr u8 REG_RF_CH        = 0x05;
+	static constexpr u8 REG_STATUS       = 0x07;
+	static constexpr u8 REG_OBSERVE_TX   = 0x08;
+	static constexpr u8 REG_RX_ADDR_P0   = 0x0a;
+	static constexpr u8 REG_RX_ADDR_P1   = 0x0b;
+	static constexpr u8 REG_TX_ADDR      = 0x10;
+	static constexpr u8 REG_FIFO_STATUS  = 0x17;
+	static constexpr u8 REG_FEATURE      = 0x1d;
+};
+
+DECLARE_DEVICE_TYPE(XN297L, xn297l_device)
+
+#endif // MAME_MACHINE_XN297L_H

--- a/src/devices/video/st7735_lcdc.cpp
+++ b/src/devices/video/st7735_lcdc.cpp
@@ -44,7 +44,7 @@ u32 st7735_lcdc_device::render_to_bitmap(screen_device &screen, bitmap_rgb32 &bi
 			{
 				int const count = (y * 0x200) + x;
 
-				u16 const dat = m_displaybuffer[count & 0x1ffff];
+				u16 const dat = m_displaybuffer[count & 0xffff];
 
 				int const b = ((dat >> 0) & 0x1f) << 3;
 				int const g = ((dat >> 5) & 0x3f) << 2;
@@ -200,11 +200,11 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 
 			if (BIT(m_madctl, 5)) // MV
 			{
-				m_displaybuffer[((m_posx + (m_posy * 0x200))) & 0x1ffff] = m_pixellatch;
+				m_displaybuffer[((m_posx + (m_posy * 0x200))) & 0xffff] = m_pixellatch;
 			}
 			else
 			{
-				m_displaybuffer[((m_posy + ((129 - m_posx) * 0x200))) & 0x1ffff] = m_pixellatch;
+				m_displaybuffer[((m_posy + ((129 - m_posx) * 0x200))) & 0xffff] = m_pixellatch;
 			}
 
 			m_posx++;
@@ -222,9 +222,6 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 	}
 	else if (m_command == 0x36) // MADCTL (Memory Data Access Control)
 	{
-
-		// 
-
 		switch (m_commandstep)
 		{
 		case 0:
@@ -373,7 +370,7 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 
 void st7735_lcdc_device::device_start()
 {
-	m_displaybuffer = make_unique_clear<u16 []>(256 * 256 * 2);
+	m_displaybuffer = make_unique_clear<u16 []>(256 * 256);
 	m_posx = 0;
 	m_posy = 0;
 	m_posminx = 0;
@@ -388,7 +385,7 @@ void st7735_lcdc_device::device_start()
 	m_pixelbyte = 0;
 	m_pixellatch = 0;
 
-	save_pointer(NAME(m_displaybuffer), 256 * 256 * 2);
+	save_pointer(NAME(m_displaybuffer), 256 * 256);
 	save_item(NAME(m_posx));
 	save_item(NAME(m_posy));
 	save_item(NAME(m_posminx));

--- a/src/devices/video/st7735_lcdc.cpp
+++ b/src/devices/video/st7735_lcdc.cpp
@@ -13,6 +13,12 @@
 // what are the differences with ST7715 and ST7735SV? (and other models)
 // PWCTR1 has only 2 params on the SV at least
 
+// GM2/GM1/GM0 pins select between 2 modes
+// 132RGB x 152 or 128RGB x 160
+// 
+// however some of the users of this are setting slightly offset co-ordinates (+1/2 pixels)
+// that would take it beyond those bounds?
+
 
 DEFINE_DEVICE_TYPE(ST7735, st7735_lcdc_device, "st7735", "Sitronix ST7735 LCD Controller")
 
@@ -38,7 +44,7 @@ u32 st7735_lcdc_device::render_to_bitmap(screen_device &screen, bitmap_rgb32 &bi
 			{
 				int const count = (y * 0x200) + x;
 
-				u16 const dat = get_u16be(&m_displaybuffer[count * 2]);
+				u16 const dat = m_displaybuffer[count & 0x1ffff];
 
 				int const b = ((dat >> 0) & 0x1f) << 3;
 				int const g = ((dat >> 5) & 0x3f) << 2;
@@ -161,11 +167,11 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 		case 0: m_posminy = data << 8 | (m_posminy & 0xff); break;
 		case 1: m_posminy = (m_posminy & 0xff00) | data; break;
 		case 2: m_posmaxy = data << 8 | (m_posmaxy & 0xff); break;
-		case 3:
-			m_posmaxy = (m_posmaxy & 0xff00) | data; m_posy = m_posminy;
+		case 3:	m_posmaxy = (m_posmaxy & 0xff00) | data;
 			logerror("Y Min %04x Y Max %04x\n", m_posminy, m_posmaxy);
 			break;
 		}
+		m_posy = m_posminy;
 	}
 	else if (m_command == 0x2a)
 	{
@@ -174,33 +180,65 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 		case 0: m_posminx = data << 8 | (m_posminx & 0xff); break;
 		case 1: m_posminx = (m_posminx & 0xff00) | data; break;
 		case 2: m_posmaxx = data << 8 | (m_posmaxx & 0xff); break;
-		case 3:
-			m_posmaxx = (m_posmaxx & 0xff00) | data; m_posx = m_posminx << 1;
+		case 3:	m_posmaxx = (m_posmaxx & 0xff00) | data;
 			logerror("X Min %04x X Max %04x\n", m_posminx, m_posmaxx);
 			break;
 		}
+		m_posx = m_posminx;
 	}
 	else if (m_command == 0x2c)
 	{
-		m_displaybuffer[((m_posx + (m_posy * 0x400))) & 0x1ffff] = data;
+		m_pixellatch = (m_pixellatch << 8) | data;
 
-		m_posx++;
-		if (m_posx > ((m_posmaxx << 1) + 1))
+		if (m_commandstep & 1)
 		{
-			m_posx = m_posminx << 1;
-			m_posy++;
+			// dphh8630: MADCTL set to a8 (MY 1 MX 0 MV 1 ML 0 RGB 1 MH 0) (and similar devices)
+			// touma560: MADCTL set to 48 (MY 0 MX 1 MV 0 ML 0 RGB 1 MH 0)
+			// qpet:     MADCTL set to c8 (MY 1 MX 1 MV 0 ML 0 RGB 1 MH 0)
+			// toumapet: MADCTL set to 08 (MY 0 MX 0 MV 0 ML 0 RGB 1 MH 0)
+			// touma558: MADCTL set to 00 (MY 0 MX 0 MV 0 ML 0 RGB 0 MH 0) (is this being correctly set, the RGB order is the same as others?)
 
-			if (m_posy > m_posmaxy)
+			if (BIT(m_madctl, 5)) // MV
 			{
-				m_posy = m_posminy;
+				m_displaybuffer[((m_posx + (m_posy * 0x200))) & 0x1ffff] = m_pixellatch;
+			}
+			else
+			{
+				m_displaybuffer[((m_posy + ((129 - m_posx) * 0x200))) & 0x1ffff] = m_pixellatch;
+			}
+
+			m_posx++;
+			if (m_posx > m_posmaxx)
+			{
+				m_posx = m_posminx;
+				m_posy++;
+
+				if (m_posy > m_posmaxy)
+				{
+					m_posy = m_posminy;
+				}
 			}
 		}
 	}
 	else if (m_command == 0x36) // MADCTL (Memory Data Access Control)
 	{
+
+		// 
+
 		switch (m_commandstep)
 		{
-		case 0: logerror("MADCTL set to %02x\n", data); break;
+		case 0:
+		{
+			m_madctl = data;
+			u8 my = BIT(m_madctl, 7);
+			u8 mx = BIT(m_madctl, 6);
+			u8 mv = BIT(m_madctl, 5);
+			u8 ml = BIT(m_madctl, 4);
+			u8 rgb = BIT(m_madctl, 3);
+			u8 mh = BIT(m_madctl, 2);
+			logerror("MADCTL set to %02x (MY %d MX %d MV %d ML %d RGB %d MH %d)\n", data, my, mx, mv, ml, rgb, mh);
+			break;
+		}
 		default: logerror("unexpected parameter for command %02x\n", m_command); break;
 		}
 	}
@@ -335,7 +373,7 @@ void st7735_lcdc_device::lcdc_data_w(u8 data)
 
 void st7735_lcdc_device::device_start()
 {
-	m_displaybuffer = make_unique_clear<u8 []>(256 * 256 * 2);
+	m_displaybuffer = make_unique_clear<u16 []>(256 * 256 * 2);
 	m_posx = 0;
 	m_posy = 0;
 	m_posminx = 0;
@@ -346,6 +384,9 @@ void st7735_lcdc_device::device_start()
 	m_commandstep = 0;
 	m_displayon = 0;
 	m_sleep = 1;
+	m_madctl = 0;
+	m_pixelbyte = 0;
+	m_pixellatch = 0;
 
 	save_pointer(NAME(m_displaybuffer), 256 * 256 * 2);
 	save_item(NAME(m_posx));
@@ -358,6 +399,7 @@ void st7735_lcdc_device::device_start()
 	save_item(NAME(m_commandstep));
 	save_item(NAME(m_displayon));
 	save_item(NAME(m_sleep));
+	save_item(NAME(m_madctl));
 }
 
 void st7735_lcdc_device::device_reset()

--- a/src/devices/video/st7735_lcdc.h
+++ b/src/devices/video/st7735_lcdc.h
@@ -28,7 +28,7 @@ protected:
 	virtual void device_reset() override ATTR_COLD;
 
 private:
-	std::unique_ptr<u8 []> m_displaybuffer;
+	std::unique_ptr<u16 []> m_displaybuffer;
 	u16 m_posx, m_posy;
 	u16 m_posminx, m_posmaxx;
 	u16 m_posminy, m_posmaxy;
@@ -36,6 +36,9 @@ private:
 	u8 m_commandstep;
 	u8 m_displayon;
 	u8 m_sleep;
+	u8 m_madctl;
+	u16 m_pixellatch;
+	u8 m_pixelbyte;
 };
 
 #endif // MAME_VIDEO_ST7735_LCDC_H

--- a/src/mame/handheld/generalplus_gpce4.cpp
+++ b/src/mame/handheld/generalplus_gpce4.cpp
@@ -487,7 +487,7 @@ ROM_END
 
 
 // The 'Micro Arcade' units are credit card sized handheld devices
-CONS( 2017, mapacman,      0,       0,      generalplus_gpce4,   mapacman,          generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Pac-Man (Micro Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )
+CONS( 2017, mapacman,      0,       0,      generalplus_gpce4,   mapacman,          generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Pac-Man (Micro Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING | ROT90 )
 
 // The 'Tiny Arcade' units are arcade cabinets on a keyring.
 CONS( 2017, taspinv,       0,       0,      generalplus_gpce4,   generalplus_gpce4, generalplus_gpce4_mapacman_state, empty_init, "Super Impulse", "Space Invaders (Tiny Arcade)", MACHINE_NO_SOUND | MACHINE_NOT_WORKING )

--- a/src/mame/handheld/st2302u_bbl_rom.cpp
+++ b/src/mame/handheld/st2302u_bbl_rom.cpp
@@ -354,10 +354,8 @@ void st22xx_bbl338_state::st22xx_dphh8213(machine_config &config)
 	m_maincpu->in_pc_callback().set_ioport("PORTC");
 
 	SPEAKER(config, "mono").front_center();
-	m_maincpu->add_route(0, "mono", 1.00);
-	m_maincpu->add_route(1, "mono", 1.00);
-	m_maincpu->add_route(2, "mono", 1.00);
-	m_maincpu->add_route(3, "mono", 1.00);
+	m_maincpu->add_route(st2205u_base_device::PSG_OUTPUT_PWM, "mono", 1.00);
+	m_maincpu->add_route(st2205u_base_device::PSG_OUTPUT_CURRENT_DAC, "mono", 1.00);
 
 
 	SCREEN(config, m_screen).set_lcd();

--- a/src/mame/handheld/st2302u_bbl_spi.cpp
+++ b/src/mame/handheld/st2302u_bbl_spi.cpp
@@ -402,7 +402,7 @@ ROM_START(bbl380)
 	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASEFF)
 	ROM_LOAD("bbl380_st2205u.bin", 0x000000, 0x004000, NO_DUMP) // internal OTPROM BIOS (addresses are different from other sets)
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("bbl 380 180 in 1.bin", 0x000000, 0x400000, BAD_DUMP CRC(146c88da) SHA1(7f18526a6d8cf991f86febce3418d35aac9f49ad))
 	// 0x0022XX, 0x0026XX, 0x002AXX, 0x002CXX, 0x002DXX, 0x0031XX, 0x0036XX, etc. should not be FF fill
 ROM_END
@@ -411,7 +411,7 @@ ROM_START(mc_cb203)
 	ROM_REGION(0x800000, "maincpu", ROMREGION_ERASEFF)
 	ROM_LOAD("cb230_st2205u.bin", 0x000000, 0x004000, NO_DUMP) // internal OTPROM BIOS (addresses are different from other sets, including bbl380)
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("s25fl032.bin", 0x000000, 0x400000, CRC(33c4e67b) SHA1(5787db4c8ce4c2569a5f9e9054cbb1944c1b3092))
 ROM_END
 
@@ -420,28 +420,28 @@ ROM_END
 ROM_START(rhhc152)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("152_mk25q32amg_ef4016.bin", 0x000000, 0x400000, CRC(5f553895) SHA1(cd21c6ff225e0455531f6b1d9f1c66a284948516))
 ROM_END
 
 ROM_START(ragc153)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("25q32ams.bin", 0x000000, 0x400000, CRC(de328d73) SHA1(d17b97e9057be4add68b9f5a26e04c9f0a139673)) // first 0x100 bytes would read as 0xff at regular speed, but give valid looking consistent data at a slower rate
 ROM_END
 
 ROM_START(dphh8630)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x200000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("bg25q16.bin", 0x000000, 0x200000, CRC(277850d5) SHA1(740087842e1e63bf99b4ca9c1b2053361f267269))
 ROM_END
 
 ROM_START(dgun2953)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("dg160_25x32v_ef3016.bin", 0x000000, 0x400000, CRC(2e993bac) SHA1(4b310e326a47df1980aeef38aa9a59018d7fe76f))
 ROM_END
 
@@ -455,15 +455,22 @@ ROM_END
 ROM_START(supreme)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("25q32.bin", 0x000000, 0x400000, CRC(93072a3d) SHA1(9f8770839032922e64d5ddd8864441357623c45f))
 ROM_END
 
 ROM_START(throwbck)
 	INTERNAL_ROM_TYPE1
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("25q32egig.bin", 0x000000, 0x400000, CRC(959eb09d) SHA1(901738e6b6c8fdfe4ed9b268ba3ddd1444551442))
+ROM_END
+
+ROM_START(rocoball)
+	INTERNAL_ROM_TYPE1
+
+	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_LOAD("spi.bin", 0x000000, 0x800000, CRC(59894e3a) SHA1(e05c40de0c52cd8aa972f70e86c77c32cd6b93cc) )
 ROM_END
 
 // sets with 2nd version of internal ROM
@@ -471,28 +478,28 @@ ROM_END
 ROM_START(dphh8633)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("25lq032.u2", 0x000000, 0x400000, CRC(45b8609a) SHA1(d03615a68465a1a365ba07db0b352424680d62d0) )
 ROM_END
 
 ROM_START(dphh8661)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25d32h.u2", 0x000000, 0x400000, CRC(b91c1dfc) SHA1(97557d10174c74d40aba780398cb2de3974b2f24) )
 ROM_END
 
 ROM_START(retro150)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25d32sh.u2", 0x000000, 0x400000, CRC(294290aa) SHA1(078892b2bb10e347ed07273bafed486e0f52c909) )
 ROM_END
 
 ROM_START(retro150a)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("by25q32ess.bin", 0x000000, 0x400000, CRC(ef9e8091) SHA1(5b924d5fd4419956d49379a695b87435df7a1155) )
 ROM_END
 
@@ -506,7 +513,7 @@ ROM_END
 ROM_START(ppg118)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("25q32.u2", 0x000000, 0x400000, CRC(c96a30b8) SHA1(da2c41e57b852f3a6644a7cbd0d3740e1b0555dc) )
 ROM_END
 
@@ -520,19 +527,19 @@ ROM_END
 ROM_START(toumapet)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25d32sh.bin", 0x000000, 0x400000, CRC(25498f00) SHA1(c5c410e29f540d7f1fd4bbb333467f8a3eaccc15) )
 ROM_END
 
 ROM_START(touma560)
-	INTERNAL_ROM_TYPE2 // still does't boot with this one, is it different internal ROM again, or just different mappings?
+	INTERNAL_ROM_TYPE2
 
 	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("py25q64ha.bin", 0x000000, 0x800000, CRC(7974bf3c) SHA1(8467f869f86b51a86eb115e1408b30daa8f148e7) )
 ROM_END
 
 ROM_START(touma568)
-	INTERNAL_ROM_TYPE2 // still does't boot with this one, is it different internal ROM again, or just different mappings?
+	INTERNAL_ROM_TYPE2
 
 	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25q64sh.bin", 0x000000, 0x800000, CRC(32f6d834) SHA1(c0dc5b4792a6d86822a666a0f8de7380d1905505) )
@@ -541,23 +548,16 @@ ROM_END
 ROM_START(qpet)
 	INTERNAL_ROM_TYPE2
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x200000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("t25s16.bin", 0x000000, 0x200000, CRC(78a9c285) SHA1(73b0ebe1c88af79fae3357ab3cb4920d685a14f4) )
 ROM_END
 
-
-ROM_START(rocoball)
-	INTERNAL_ROM_TYPE1
-
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
-	ROM_LOAD("spi.bin", 0x000000, 0x800000, CRC(59894e3a) SHA1(e05c40de0c52cd8aa972f70e86c77c32cd6b93cc) )
-ROM_END
 
 ROM_START(tchib158)
 	ROM_REGION(0x2000, "maincpu", ROMREGION_ERASEFF)
 	ROM_LOAD("st2x_internal_tchib158.bin", 0x0000, 0x2000, NO_DUMP )
 
-	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_REGION(0x400000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25d32sh.u2", 0x000000, 0x400000, CRC(274a25ff) SHA1(4c0560ee6cb2d31edd4afdf99adf04ce8d69c6bf) )
 ROM_END
 
@@ -585,6 +585,10 @@ CONS( 201?, arcade10,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl3
 CONS( 201?, supreme,       0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Fizz Creations", "Arcade Classics Mini Handheld Arcade (Supreme 150)", MACHINE_IMPERFECT_SOUND )
 
 CONS( 201?, throwbck,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Westminster", "Throwback Pocket Video Game Console 150+ 8-Bit Games", MACHINE_IMPERFECT_SOUND )
+
+// might not be using the menu protection device, but accesses something there instead
+// could contain corrupt save data
+CONS( 2020, rocoball,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Roco Battle Ball", MACHINE_NOT_WORKING )
 
 // releases with different internal ROM
 
@@ -615,5 +619,3 @@ CONS( 2020, qpet,          0,       0,      bbl380_radio_qpet, bbl380_pet, bbl38
 
 // yet another internal ROM? (doesn't seem to boot with the ones we have)
 CONS( 2022, tchib158,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Tchibo GmbH", "Tchibo 158-in-1 Retro Game", MACHINE_NOT_WORKING )
-
-CONS( 2020, rocoball,      0,       0,      bbl380_menuprot,      bbl380_prot, bbl380_state, empty_init, "<unknown>", "Roco Battle Ball", MACHINE_NOT_WORKING )

--- a/src/mame/handheld/st2302u_bbl_spi.cpp
+++ b/src/mame/handheld/st2302u_bbl_spi.cpp
@@ -30,20 +30,19 @@
 #include "cpu/m6502/st2205u.h"
 #include "machine/bl_handhelds_menucontrol.h"
 #include "machine/generic_spi_flash.h"
+#include "machine/xn297l.h"
 #include "video/st7735_lcdc.h"
 
 #include "screen.h"
 #include "emupal.h"
 #include "speaker.h"
 
-#define LOG_BBL_SPI         (1U << 1)
-#define LOG_BBL_UNKNOWN     (1U << 2)
 
-#define LOG_ALL             (LOG_BBL_SPI | LOG_BBL_UNKNOWN)
+#define LOG_SPI (1U << 1)
 
-#define VERBOSE             (0)
-
+//#define VERBOSE (LOG_SPI)
 #include "logmacro.h"
+
 
 namespace {
 
@@ -59,12 +58,17 @@ public:
 		m_io_p2(*this, "IN1"),
 		m_menucontrol(*this, "menucontrol"),
 		m_lcdc(*this, "lcdc"),
-		m_genspi(*this, "spi")
+		m_genspi(*this, "spi"),
+		m_radio(*this, "radio")
 	{ }
 
 	void bbl380(machine_config &config) ATTR_COLD;
 	void bbl380_menuprot(machine_config &config) ATTR_COLD;
+	void bbl380_menuprot_offset(machine_config &config) ATTR_COLD;
 	void bbl380_24mhz(machine_config &config) ATTR_COLD;
+	void bbl380_radio(machine_config &config) ATTR_COLD;
+	void bbl380_radio_big(machine_config &config) ATTR_COLD;
+	void bbl380_radio_qpet(machine_config &config) ATTR_COLD;
 
 protected:
 	virtual void machine_start() override ATTR_COLD;
@@ -81,22 +85,14 @@ private:
 	required_device<screen_device> m_screen;
 
 	void output_w(u8 data);
-	void output2_w(u8 data);
+	void output2_w(offs_t, u8 data, u8 mem_mask);
+	u8 flash_portc_r(offs_t, u8 mem_mask);
+	void flash_portc_w(offs_t, u8 data, u8 mem_mask);
+	u16 spi_exchange(u16 data, u8 bits);
 
 	u8 m_output2val;
-
-	void spi10_w(u8 data);
-	void spi11_w(u8 data);
-	u8 spi10_r();
-	u8 spi11_r();
-
-	u8 m_spi10;
-	u8 m_spi11;
-
-	u8 m_spi10out;
-	u8 m_spi11out;
-
-	u8 m_spi10out_has_data;
+	bool m_radio_selected;
+	bool m_flash_selected;
 
 	required_region_ptr<u8> m_spirom;
 	required_ioport m_io_p1;
@@ -104,19 +100,27 @@ private:
 	required_device<bl_handhelds_menucontrol_device> m_menucontrol;
 	required_device<st7735_lcdc_device> m_lcdc;
 	required_device<generic_spi_flash_device> m_genspi;
-
-	u8 ff_r() { LOGMASKED(LOG_BBL_UNKNOWN, "%s reading from 0x14\n", machine().describe_context()); return 0xff; }
+	optional_device<xn297l_device> m_radio;
 };
 
 
 void bbl380_state::output_w(u8 data)
 {
-	// probably unrelated as toumapet does it mid-read and then sends invalid commands
-	m_genspi->reset();
+	// Legacy sets need this transaction reset until their flash select is hooked up.
+	// The pet hardware supplies the real flash select on PC3.
+	if (!m_radio)
+		m_genspi->reset();
 }
 
-void bbl380_state::output2_w(u8 data)
+void bbl380_state::output2_w(offs_t, u8 data, u8 mem_mask)
 {
+	if (m_radio)
+	{
+		int const cs = BIT(mem_mask, 7) ? BIT(data, 7) : 1;
+		m_radio->cs_w(cs);
+		m_radio_selected = !cs;
+	}
+
 	if ((data & 0x40) != (m_output2val & 0x40))
 	{
 		if (data & 0x40)
@@ -129,6 +133,22 @@ void bbl380_state::output2_w(u8 data)
 	m_output2val = data;
 }
 
+u8 bbl380_state::flash_portc_r(offs_t, u8)
+{
+	return m_genspi->so_r() ? 0xff : 0xfd;
+}
+
+void bbl380_state::flash_portc_w(offs_t, u8 data, u8 mem_mask)
+{
+	// The factory-test helper accesses the main flash using SPI mode 0 on
+	// PC0=SCK, PC1=SO, PC2=SI and PC3=/CS rather than the SoC SPI controller.
+	m_genspi->si_w(BIT(mem_mask, 2) ? BIT(data, 2) : 1);
+	int const cs = BIT(mem_mask, 3) ? BIT(data, 3) : 1;
+	m_genspi->cs_w(cs);
+	m_flash_selected = !cs;
+	m_genspi->sck_w(BIT(mem_mask, 0) ? BIT(data, 0) : 0);
+}
+
 u32 bbl380_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	return m_lcdc->render_to_bitmap(screen, bitmap, cliprect);
@@ -138,14 +158,8 @@ void bbl380_state::machine_start()
 {
 	// port related
 	save_item(NAME(m_output2val));
-
-	save_item(NAME(m_spi10));
-	save_item(NAME(m_spi11));
-
-	save_item(NAME(m_spi10out));
-	save_item(NAME(m_spi11out));
-
-	save_item(NAME(m_spi10out_has_data));
+	save_item(NAME(m_radio_selected));
+	save_item(NAME(m_flash_selected));
 
 	m_genspi->set_rom_ptr(memregion("spi")->base());
 	m_genspi->set_rom_size(memregion("spi")->bytes());
@@ -155,57 +169,42 @@ void bbl380_state::machine_start()
 void bbl380_state::machine_reset()
 {
 	m_output2val = 0;
+	m_radio_selected = false;
+	m_flash_selected = false;
+	if (m_radio)
+		m_radio->cs_w(1);
 
-	m_spi10 = 0;
-	m_spi11 = 0;
-
-	m_spi10out = 0;
-	m_spi11out = 0;
-
-	m_spi10out_has_data = 0;
-
-	// TODO: handle these things in the core via callbacks etc. once correct behavior is agreed upon
-	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0x0010, 0x0010, read8smo_delegate(*this, FUNC(bbl380_state::spi10_r)), write8smo_delegate(*this, FUNC(bbl380_state::spi10_w))); // SPI related
-	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0x0011, 0x0011, read8smo_delegate(*this, FUNC(bbl380_state::spi11_r)), write8smo_delegate(*this, FUNC(bbl380_state::spi11_w))); // SPI related
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0x0014, 0x0014, read8smo_delegate(*this, FUNC(bbl380_state::ff_r))); // SPI related
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x0000, 0x0000, write8smo_delegate(*this, FUNC(bbl380_state::output_w))); // Port A output hack, SPI state needs resetting on every port write here or some gfx won't copy fully eg red squares on right of parachute, Soc implementation filters writes
 }
 
-void bbl380_state::spi10_w(u8 data)
+u16 bbl380_state::spi_exchange(u16 data, u8 bits)
 {
-	m_spi10out = data;
-	m_spi10out_has_data = 1;
-	LOGMASKED(LOG_BBL_SPI, "%s: spi10_w %02x\n", machine().describe_context(), data);
-}
-
-void bbl380_state::spi11_w(u8 data)
-{
-	m_spi11out = data;
-	LOGMASKED(LOG_BBL_SPI, "%s: spi11_w %02x\n", machine().describe_context(), data);
-}
-
-u8 bbl380_state::spi10_r()
-{
-	u8 ret = m_spi10;
-
-	if (m_spi10out_has_data)
+	u16 result = 0xffff;
+	if (bits == 8 || bits == 16)
 	{
-		m_genspi->write(m_spi11out);
-		m_spi11 = m_genspi->read();
-
-		m_genspi->write(m_spi10out);
-		m_spi10out_has_data = 0;
-		m_spi10 = m_genspi->read();
+		result = 0;
+		for (int shift = bits - 8; shift >= 0; shift -= 8)
+		{
+			u8 const byte = data >> shift;
+			u8 reply;
+			if (m_radio_selected)
+				reply = m_radio->transfer(byte);
+			else if (!m_radio || m_flash_selected)
+			{
+				m_genspi->write(byte);
+				reply = m_genspi->read();
+			}
+			else
+				reply = 0xff;
+			result = (result << 8) | reply;
+		}
 	}
 
-	LOGMASKED(LOG_BBL_SPI, "%s: spi10_r returning %02x\n", machine().describe_context(), ret);
-	return ret;
-}
-
-u8 bbl380_state::spi11_r()
-{
-	LOGMASKED(LOG_BBL_SPI, "%s: spi11_r returning %02x\n", machine().describe_context(), m_spi11);
-	return m_spi11;
+	char const *const target = m_radio_selected
+		? (m_flash_selected ? " (XN297L, flash also selected)" : " (XN297L)")
+		: ((m_radio && !m_flash_selected) ? " (no device selected)" : "");
+	LOGMASKED(LOG_SPI, "%s: %u-bit SPI transfer %04x returning %04x%s\n", machine().describe_context(), bits, data, result, target);
+	return result;
 }
 
 
@@ -243,19 +242,74 @@ static INPUT_PORTS_START(bbl380_prot)
 	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_CUSTOM) PORT_READ_LINE_DEVICE_MEMBER("menucontrol", FUNC(bl_handhelds_menucontrol_device::status_r))
 INPUT_PORTS_END
 
+static INPUT_PORTS_START(bbl380_pet)
+	PORT_INCLUDE(bbl380)
+
+	PORT_MODIFY("IN0") // 3 buttons only, no side buttons?
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_BUTTON1) PORT_NAME("Select")
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_BUTTON2) PORT_NAME("Enter")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_BUTTON3) PORT_NAME("Back/Menu")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_MODIFY("IN1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_CONFNAME(0x02, 0x00, "Battery Charging")
+	PORT_CONFSETTING(0x00, "Not Charging")
+	PORT_CONFSETTING(0x02, "Charging")
+	PORT_BIT(0xec, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_UNUSED) // going low causes the software to enter a wireless receive path; source unknown
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(bbl380_pet560)
+	PORT_INCLUDE(bbl380)
+
+	PORT_MODIFY("IN0") // has side buttons
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Select") // increase selection value, left in games
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("Enter")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("Back/Menu") // right in games, back in menu
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT )  // for slider menu only
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) // ^
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_MODIFY("IN1") // no battery charging state on this one?
+	PORT_BIT(0xff, IP_ACTIVE_LOW, IPT_UNUSED)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(bbl380_pet568)
+	PORT_INCLUDE(bbl380)
+
+	PORT_MODIFY("IN0") // has side buttons
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT )  // for slider menu only
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) // ^
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_BUTTON1) PORT_NAME("Select") // left in games
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_BUTTON2) PORT_NAME("Enter")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_BUTTON3) PORT_NAME("Back/Menu") // right in games
+	PORT_CONFNAME(0x20, 0x00, "Battery Charging")
+	PORT_CONFSETTING(0x00, "Not Charging")
+	PORT_CONFSETTING(0x20, "Charging")
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_UNUSED) 
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_MODIFY("IN1")
+	PORT_BIT(0xef, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_UNUSED)
+INPUT_PORTS_END
+
 void bbl380_state::bbl380_do_maincpu_config()
 {
 	m_maincpu->set_addrmap(AS_DATA, &bbl380_state::bbl380_map);
 	m_maincpu->in_pa_callback().set_ioport("IN0");
 	m_maincpu->in_pb_callback().set_ioport("IN1");
 	m_maincpu->out_pa_callback().set(FUNC(bbl380_state::output_w));
-	//m_maincpu->spi_in_callback().set(FUNC(bbl380_state::spi_r));  // TODO, hook these up properly
-	//m_maincpu->spi_out_callback().set(FUNC(bbl380_state::spi_w));
+	m_maincpu->set_spi_exchange_callback(FUNC(bbl380_state::spi_exchange));
 
-	m_maincpu->add_route(0, "mono", 1.00);
-	m_maincpu->add_route(1, "mono", 1.00);
-	m_maincpu->add_route(2, "mono", 1.00);
-	m_maincpu->add_route(3, "mono", 1.00);
+	m_maincpu->add_route(st2205u_base_device::PSG_OUTPUT_PWM, "mono", 1.00);
 }
 
 void bbl380_state::bbl380(machine_config &config)
@@ -288,12 +342,48 @@ void bbl380_state::bbl380_menuprot(machine_config &config)
 	m_maincpu->out_pb_callback().set(FUNC(bbl380_state::output2_w));
 }
 
+void bbl380_state::bbl380_menuprot_offset(machine_config &config)
+{
+	bbl380_menuprot(config);
+	m_screen->set_size(161, 132);
+	m_screen->set_visarea(1, 161 - 1, 2, 130 - 1);
+}
+
 void bbl380_state::bbl380_24mhz(machine_config &config)
 {
 	bbl380(config);
 	ST2302U(config.replace(), m_maincpu, 24'000'000); // 24MHz clock correct for music tempo. SoC type not confirmed
 	bbl380_do_maincpu_config();
 }
+
+void bbl380_state::bbl380_radio(machine_config &config)
+{
+	bbl380_24mhz(config);
+	m_maincpu->out_pb_callback().set(FUNC(bbl380_state::output2_w));
+	m_maincpu->in_pc_callback().set(FUNC(bbl380_state::flash_portc_r));
+	m_maincpu->out_pc_callback().set(FUNC(bbl380_state::flash_portc_w));
+	XN297L(config, m_radio, 16_MHz_XTAL);
+
+	m_screen->set_size(161, 132);
+	m_screen->set_visarea(1, 129 - 1, 0, 128 - 1);
+}
+
+void bbl380_state::bbl380_radio_big(machine_config &config)
+{
+	bbl380_radio(config);
+
+	m_screen->set_size(256, 256);
+	m_screen->set_visarea(0, 160 - 1, 2, 130 - 1);
+}
+
+void bbl380_state::bbl380_radio_qpet(machine_config &config)
+{
+	bbl380_radio(config);
+
+	m_screen->set_size(160, 132);
+	m_screen->set_visarea(3, 131 - 1, 0, 128 - 1);
+}
+
 
 // internal OTPROM BIOS, dumped from dgun2953 PCB, 6000-7fff range
 #define INTERNAL_ROM_TYPE1 \
@@ -428,7 +518,7 @@ ROM_START(table108)
 ROM_END
 
 ROM_START(toumapet)
-	INTERNAL_ROM_TYPE2 // still does't boot with this one, is it different internal ROM again, or just different mappings?
+	INTERNAL_ROM_TYPE2
 
 	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("p25d32sh.bin", 0x000000, 0x400000, CRC(25498f00) SHA1(c5c410e29f540d7f1fd4bbb333467f8a3eaccc15) )
@@ -449,10 +539,18 @@ ROM_START(touma568)
 ROM_END
 
 ROM_START(qpet)
-	INTERNAL_ROM_TYPE2 // not checked if it uses this ROM type
+	INTERNAL_ROM_TYPE2
 
 	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("t25s16.bin", 0x000000, 0x200000, CRC(78a9c285) SHA1(73b0ebe1c88af79fae3357ab3cb4920d685a14f4) )
+ROM_END
+
+
+ROM_START(rocoball)
+	INTERNAL_ROM_TYPE2
+
+	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
+	ROM_LOAD("spi.bin", 0x000000, 0x800000, CRC(59894e3a) SHA1(e05c40de0c52cd8aa972f70e86c77c32cd6b93cc) )
 ROM_END
 
 ROM_START(tchib158)
@@ -496,23 +594,27 @@ CONS( 201?, retro150a,     retro150,0,      bbl380_24mhz,   bbl380, bbl380_state
 
 // these are for the Japanese market, the ROM is the same between the Pocket Game and Game Computer but the form factor is different.
 // pg118 and table108 have a screen offset issue
-CONS( 2019, pg118,         0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Pocket Game / Game Computer", "Pocket Game 118-in-1 / Game Computer 118-in-1", MACHINE_NOT_WORKING )
-CONS( 201?, table108,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Table Game Classic 108-in-1 (KTFC-001B)", MACHINE_NOT_WORKING )
+CONS( 2019, pg118,         0,       0,      bbl380_menuprot_offset,   bbl380_prot, bbl380_state, empty_init, "Pocket Game / Game Computer", "Pocket Game 118-in-1 / Game Computer 118-in-1", MACHINE_NOT_WORKING )
+CONS( 201?, table108,      0,       0,      bbl380_menuprot_offset,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Table Game Classic 108-in-1 (KTFC-001B)", MACHINE_NOT_WORKING )
 
 CONS( 201?, ppg118,        0,       0,      bbl380_24mhz,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "PPG Play Portable Game 118 Games (HH-0046)", MACHINE_NOT_WORKING )
 
 // it is unclear if dphh8633 refers to the case style, rather than the software, as the dphh8630 set was also noted as previously being found in an 8633 unit
+// 49. Crazy Dancer 62. Dancer Trace, and 69. Dancer Attack don't work properly, despite
+// working on other units in MAME and on real hardware with the same ROM as dphh8661, why?
 CONS( 201?, dphh8633,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 268-in-1 - Model 8633", MACHINE_NOT_WORKING )
-CONS( 2016, dphh8661,      0,       0,      bbl380_24mhz,   bbl380_prot, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 268-in-1 - Model 8661", MACHINE_NOT_WORKING ) // from PCP? (logo on back of console) 2016 date on PCB
+CONS( 2016, dphh8661,      0,       0,      bbl380_24mhz,      bbl380_prot, bbl380_state, empty_init, "<unknown>", "Digital Pocket Hand Held System 268-in-1 - Model 8661", MACHINE_NOT_WORKING ) // from PCP? (logo on back of console) 2016 date on PCB
+
+// The OK-550 PCB has an XN297LBW wireless transceiver.
+CONS( 2021, toumapet,      0,       0,      bbl380_radio,     bbl380_pet,    bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-550)", MACHINE_NOT_WORKING | ROT90 )
+// OK-558 is Tou ma pet Watch
+CONS( 2021, touma560,      0,       0,      bbl380_radio_big, bbl380_pet560, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-560)", MACHINE_NOT_WORKING | ROT90 )
+CONS( 2021, touma568,      0,       0,      bbl380_radio_big, bbl380_pet568, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-568)", MACHINE_NOT_WORKING | ROT90 )
+
+CONS( 2020, qpet,          0,       0,      bbl380_radio_qpet, bbl380_pet, bbl380_state, empty_init, "M&D", "Q Pet (2nd version)", MACHINE_NOT_WORKING| ROT90 ) // firmware uses the same transceiver protocol
 
 // yet another internal ROM? (doesn't seem to boot with the ones we have)
-
 CONS( 2022, tchib158,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Tchibo GmbH", "Tchibo 158-in-1 Retro Game", MACHINE_NOT_WORKING )
 
-// also has the 0xE4 XOR, also doesn't currently boot, could be yet another internal ROM
-CONS( 2021, toumapet,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-550)", MACHINE_NOT_WORKING )
-CONS( 2021, touma560,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-560)", MACHINE_NOT_WORKING )
-CONS( 2021, touma568,      0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "Shenzhen Shiji New Technology", "Tou ma Pet (OK-568)", MACHINE_NOT_WORKING )
-
-
-CONS( 2020, qpet,          0,       0,      bbl380,   bbl380, bbl380_state, empty_init, "M&D", "Q Pet (2nd version)", MACHINE_NOT_WORKING )
+// unknown if it uses the same internal ROM as other games, could be a bad dump
+CONS( 2020, rocoball,      0,       0,      bbl380_radio,      bbl380_pet, bbl380_state, empty_init, "<unknown>", "Roco Battle Ball", MACHINE_NOT_WORKING| ROT90 )

--- a/src/mame/handheld/st2302u_bbl_spi.cpp
+++ b/src/mame/handheld/st2302u_bbl_spi.cpp
@@ -547,7 +547,7 @@ ROM_END
 
 
 ROM_START(rocoball)
-	INTERNAL_ROM_TYPE2
+	INTERNAL_ROM_TYPE1
 
 	ROM_REGION(0x800000, "spi", ROMREGION_ERASEFF)
 	ROM_LOAD("spi.bin", 0x000000, 0x800000, CRC(59894e3a) SHA1(e05c40de0c52cd8aa972f70e86c77c32cd6b93cc) )
@@ -616,5 +616,4 @@ CONS( 2020, qpet,          0,       0,      bbl380_radio_qpet, bbl380_pet, bbl38
 // yet another internal ROM? (doesn't seem to boot with the ones we have)
 CONS( 2022, tchib158,      0,       0,      bbl380_menuprot,   bbl380_prot, bbl380_state, empty_init, "Tchibo GmbH", "Tchibo 158-in-1 Retro Game", MACHINE_NOT_WORKING )
 
-// unknown if it uses the same internal ROM as other games, could be a bad dump
-CONS( 2020, rocoball,      0,       0,      bbl380_radio,      bbl380_pet, bbl380_state, empty_init, "<unknown>", "Roco Battle Ball", MACHINE_NOT_WORKING| ROT90 )
+CONS( 2020, rocoball,      0,       0,      bbl380_menuprot,      bbl380_prot, bbl380_state, empty_init, "<unknown>", "Roco Battle Ball", MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -20215,6 +20215,7 @@ ragc153
 retro150
 retro150a
 rhhc152
+rocoball
 supreme
 table108
 tchib158


### PR DESCRIPTION
this is a continuation of the previous st2302u work ( https://github.com/mamedev/mame/pull/16041 ) with some tweaks from me to what I was sent.

- st2305u.cpp: treat DAC and PWM audio output paths as separate, this eliminates 'pops' after samples on ragc153 and others, which switch to DAC mode at the end of sample playback.
- st2xxx.cpp: add SPI interface
- generic_spi_flash.cpp: add support for bit-by-bit access, rather than pure byte HLE, hooked st2302u_bbl_spi.cpp up that way for toumapet.
- st7735_lcdc.cpp: added support for rotated scan mode, used by toumapet and others
- st2302u_bbl_spi.cpp: mapped inputs for toumapet, touma560, touma568 and qpet, hooked up xn297l device identified by AI
- xn297l.cpp: new device, AI coded from public specification with some manual tweaking

new NOT WORKING machine
-------
Roco Battle Ball [cyanic]

AI use disclosure: ChatGPT Codex 5.6 Sol on Max