### PR TITLE
video/zeus2.cpp: improve depth and blending

### DIFF
--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1870,15 +1870,12 @@ void zeus2_renderer::render_poly_8bit(int32_t scanline, const extent_t& extent, 
 			//curDepthVal = object.zbuf_min;
 			curDepthVal = 0xffffff;
 		} else if (object.depth_min_enable) {
-			curDepthVal = curz + object.zbuf_min;
+			// Render reg 0x15 is a floor on the depth value, not a per-object bias
+			curDepthVal = std::max(curz, object.zbuf_min);
 		}
 		else {
 			curDepthVal = curz;
 		}
-		//if (curz < object.zbuf_min)
-		//  curDepthVal = object.zbuf_min;
-		//else
-		//  curDepthVal = curz;
 		if (curDepthVal < 0)
 			curDepthVal = 0;
 		bool depth_pass = true;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1772,10 +1772,12 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 	//extra.depth_test_enable &= !(m_state->m_renderRegs[0x14] & 0x008000);
 	extra.depth_write_enable = !(m_state->m_renderRegs[0x14] & 0x001000);
 	extra.depth_clear_enable = (m_state->m_renderRegs[0x14] & 0x000c00);
-	// 021e0e = blend with texture alpha for type 2, 020202 blend src / dst alpha
-	extra.blend_enable = ((m_state->m_renderRegs[0x40] == 0x020202) || (m_state->m_renderRegs[0x40] == 0x021e0e && (texmode & 0x3) == 2));
+	// 021e0e = blend, gated on type 2 here but not by the game.  Otherwise bit 17 turns the pixel
+	// ALU on and the second byte picks the destination factor, 0x02 taking it from reg 0x0d.
+	extra.blend_enable = ((m_state->m_renderRegs[0x40] & 0x02ff00) == 0x020200 || (m_state->m_renderRegs[0x40] == 0x021e0e && (texmode & 0x3) == 2));
+	// The low byte picks the source factor: 0x02 scales it by reg 0x0c, 0x04 takes it at unity.
 	// Clamp translucency (1.8 fixed, 0x100=1.0) to 0x100: scale8() takes a uint8_t, so >=0x100 would truncate to near-black.
-	extra.srcAlpha = std::min<uint32_t>(m_state->m_renderRegs[0x0c], 0x100);
+	extra.srcAlpha = ((m_state->m_renderRegs[0x40] & 0xff) == 0x04) ? 0x100 : std::min<uint32_t>(m_state->m_renderRegs[0x0c], 0x100);
 	extra.dstAlpha = std::min<uint32_t>(m_state->m_renderRegs[0x0d], 0x100);
 	extra.texture_alpha = false;
 	extra.texture_rgb555 = false;

--- a/src/devices/video/zeus2.cpp
+++ b/src/devices/video/zeus2.cpp
@@ -1794,8 +1794,6 @@ void zeus2_renderer::zeus2_draw_quad(const uint32_t *databuffer, uint32_t texdat
 			extra.get_texel = m_state->get_texel_8bit_2x2_alpha;
 			extra.texture_alpha = true;
 			extra.get_alpha = m_state->get_alpha_8bit_2x2_alpha;
-			extra.depth_test_enable = false;
-			extra.depth_write_enable = false;
 		}
 		else {
 			extra.texture_rgb555 = true;


### PR DESCRIPTION
This PR fixes Midway Zeus 2 depth and blending in three ways:

**1. Render register 0x15 is a depth floor, not a per-object bias**

render_poly_8bit added reg 0x15 to every pixel's depth. Two surfaces carry different values, so the add reorders surfaces whose own z already separates them and drops the nearer one along the line where they meet. Clamping with `std::max` instead is what the register name and the commented-out code beside it always described.

This fixes the dark strokes across the announcer's face in The Grid, and the tower lamps that were drawing as flat black holes.

**2. Alpha-textured quads are depth-tested**

Quads using an 8-bit texel plus embedded alpha had their depth test and depth write forced off, overriding the reg 0x14 decode above. The Grid programs that register for those quads itself. On 87% of them in the arena it asks for the test with the write disabled, which is exactly what the decode already produces.

This fixes shadows and the arena's neon glows drawing over any wall in front of them.

**3. The blend mode register is decoded field by field, not matched whole**

Reg 0x40 was compared whole against a single value, so every other blend mode the games program drew opaque. It is really a set of fields. Bit 17 enables the pixel ALU, and a byte each picks the destination and the source factor, so testing those fields picks up the mode Cruis'n Exotica's car select uses and still leaves the opaque modes opaque. The source factor field asks for unity there, which matters because the game sets only the destination register and leaves the source one holding whatever the previous mode put in it. The field meanings were read off the games' own blend mode setters.

This fixes the Cruis'n Exotica car-select floor, which now picks up the floodlight reflections from above.

Master // PR
<img width="375" alt="master_crusnexo_carselect" src="https://github.com/user-attachments/assets/d4e745d0-0efb-4c46-bdde-2f779bc29148" /><img width="375" alt="pr_crusnexo_carselect" src="https://github.com/user-attachments/assets/143d36d2-c080-4364-adfb-fb6ed5e1a659" />

<img width="375" alt="master_thegrid_fighter_glow" src="https://github.com/user-attachments/assets/4714e0a6-742b-4436-b617-f4b43053f033" /><img width="375" alt="pr_thegrid_fighter_glow" src="https://github.com/user-attachments/assets/7902d21f-29f2-441f-bc36-f1a805725e96" />

<img width="375"  alt="master_thegrid_tower" src="https://github.com/user-attachments/assets/c0012136-f5fe-4bb1-8b29-703cfe8b8657" /><img width="375"  alt="pr_thegrid_tower" src="https://github.com/user-attachments/assets/f26b243b-8a18-4b8e-992a-faf51f1fffad" />

<img width="375" alt="master_thegrid_announcer_face_zoom" src="https://github.com/user-attachments/assets/f775c541-8346-4e0b-8d3c-9fc09f54ed88" /><img width="375"  alt="pr_thegrid_announcer_face_zoom" src="https://github.com/user-attachments/assets/bddf73ed-d560-41cd-aa6b-a4d126569705" />

Assisted by Claude Opus 5. Human polished and regression tested on Cruis'n Exotica, The Grid and Skins Game.
