### PR TITLE
acorn/riscpc: add quadrature mouse

### DIFF
--- a/src/devices/machine/arm_iomd.cpp
+++ b/src/devices/machine/arm_iomd.cpp
@@ -41,7 +41,7 @@ enum keyboard_status_register : u8
 //**************************************************************************
 
 // device type definition
-DEFINE_DEVICE_TYPE(ARM_IOMD, arm_iomd_device, "arm_iomd", "ARM IOMD controller")
+DEFINE_DEVICE_TYPE(ARM_IOMD20, arm_iomd20_device, "arm_iomd20", "ARM IOMD20 controller")
 // TODO: ssfindo.cpp actually uses a Cirrus Logic 7500FE, is it rebadged?
 DEFINE_DEVICE_TYPE(ARM7500FE_IOMD, arm7500fe_iomd_device, "arm_7500fe_soc", "ARM 7500FE SoC")
 
@@ -54,7 +54,7 @@ DEFINE_DEVICE_TYPE(ARM7500FE_IOMD, arm7500fe_iomd_device, "arm_7500fe_soc", "ARM
 //  arm_iomd_device - constructor
 //-------------------------------------------------
 
-void arm_iomd_device::base_map(address_map &map)
+void arm_iomd_device::map(address_map &map)
 {
 	// I/O
 	map(0x000, 0x003).rw(FUNC(arm_iomd_device::iocr_r), FUNC(arm_iomd_device::iocr_w));
@@ -93,8 +93,6 @@ void arm_iomd_device::base_map(address_map &map)
 	map(0x094, 0x097).r(FUNC(arm_iomd_device::id_r<0>));
 	map(0x098, 0x09b).r(FUNC(arm_iomd_device::id_r<1>));
 	map(0x09c, 0x09f).r(FUNC(arm_iomd_device::version_r));
-	// mouse
-//  map(0x0a0, 0x0a3) // ...
 
 	// I/O control
 //  map(0x0c4, 0x0c7).rw(FUNC(arm_iomd_device::iotcr_r), FUNC(arm_iomd_device::iotcr_w));
@@ -126,17 +124,18 @@ void arm_iomd_device::base_map(address_map &map)
 //  TODO: iomd2 has extra regs in 0x200-0x3ff area, others NOPs / mirrors?
 }
 
-void arm_iomd_device::map(address_map &map)
+void arm_iomd20_device::map(address_map &map)
 {
-	arm_iomd_device::base_map(map);
+	arm_iomd_device::map(map);
+
 //  map(0x088, 0x08b).rw(FUNC(arm_iomd_device::dramcr_r), FUNC(arm_iomd_device::dramcr_w));
 	// VRAM control
 //  map(0x08c, 0x08f).rw(FUNC(arm_iomd_device::vrefcr_r), FUNC(arm_iomd_device::vrefcr_w));
 	// flyback line size
 //  map(0x090, 0x093).rw(FUNC(arm_iomd_device::fsize_r), FUNC(arm_iomd_device::fsize_w));
 	// quadrature mouse control
-//  map(0x0a0, 0x0a3).rw(FUNC(arm_iomd_device::mousex_r), FUNC(arm_iomd_device::mousex_w));
-//  map(0x0a4, 0x0a7).rw(FUNC(arm_iomd_device::mousey_r), FUNC(arm_iomd_device::mousey_w));
+	map(0x0a0, 0x0a3).rw(FUNC(arm_iomd20_device::mouse_r<0>), FUNC(arm_iomd20_device::mouse_w<0>));
+	map(0x0a4, 0x0a7).rw(FUNC(arm_iomd20_device::mouse_r<1>), FUNC(arm_iomd20_device::mouse_w<1>));
 	// DACK timing control
 //  map(0x0c0, 0x0c3).rw(FUNC(arm_iomd_device::dmatcr_r), FUNC(arm_iomd_device::dmatcr_w));
 	// DMA external control
@@ -174,8 +173,10 @@ arm_iomd_device::arm_iomd_device(const machine_config &mconfig, device_type type
 {
 }
 
-arm_iomd_device::arm_iomd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: arm_iomd_device(mconfig, ARM_IOMD, tag, owner, clock)
+arm_iomd20_device::arm_iomd20_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: arm_iomd_device(mconfig, ARM_IOMD20, tag, owner, clock)
+	, m_mouse_pos{}
+	, m_mouse_flag{}
 {
 	m_id = 0xd4e7;
 	m_version = 0;
@@ -183,7 +184,7 @@ arm_iomd_device::arm_iomd_device(const machine_config &mconfig, const char *tag,
 
 void arm7500fe_iomd_device::map(address_map &map)
 {
-	arm_iomd_device::base_map(map);
+	arm_iomd_device::map(map);
 
 	map(0x00c, 0x00f).rw(FUNC(arm7500fe_iomd_device::iolines_r), FUNC(arm7500fe_iomd_device::iolines_w));
 	// master clock controls
@@ -238,10 +239,25 @@ arm7500fe_iomd_device::arm7500fe_iomd_device(const machine_config &mconfig, cons
 //  configuration addiitons
 //-------------------------------------------------
 
+template <unsigned Axis, unsigned Signal> void arm_iomd20_device::mouse_pos_w(int state)
+{
+	if (m_mouse_flag[Axis] == bool(Signal))
+		// signal 0 leads, negative
+		m_mouse_pos[Axis]--;
+	else
+		// signal 1 leads, positive
+		m_mouse_pos[Axis]++;
+
+	m_mouse_flag[Axis] = !m_mouse_flag[Axis];
+}
+
+template void arm_iomd20_device::mouse_pos_w<0U, 0U>(int state);
+template void arm_iomd20_device::mouse_pos_w<0U, 1U>(int state);
+template void arm_iomd20_device::mouse_pos_w<1U, 0U>(int state);
+template void arm_iomd20_device::mouse_pos_w<1U, 1U>(int state);
+
 void arm_iomd_device::device_add_mconfig(machine_config &config)
 {
-	//TODO: hookup mouse quadrature interface here ...
-
 	AT_SSRT(config, m_ssrt);
 	m_ssrt->rp().set(FUNC(arm_iomd_device::kbd_rxp_w));
 	m_ssrt->rx().set(FUNC(arm_iomd_device::kbd_rxf_w));
@@ -252,7 +268,7 @@ void arm7500fe_iomd_device::device_add_mconfig(machine_config &config)
 {
 	arm_iomd_device::device_add_mconfig(config);
 
-	//TODO: ... replace quadrature mouse with AUX PS/2
+	// TODO: add AUX PS/2 mouse
 }
 
 //-------------------------------------------------
@@ -297,6 +313,14 @@ void arm_iomd_device::device_start()
 	save_pointer(NAME(m_sndbuffer_ok), std::size(m_sndbuffer_ok));
 
 	// TODO: jumps to EASI space at $0c0016xx for RiscPC if POR is on?
+}
+
+void arm_iomd20_device::device_start()
+{
+	arm_iomd_device::device_start();
+
+	save_item(NAME(m_mouse_pos));
+	save_item(NAME(m_mouse_flag));
 }
 
 void arm7500fe_iomd_device::device_start()
@@ -471,6 +495,16 @@ void arm_iomd_device::kbd_txe_w(int state)
 		m_kbdsr &= ~KSR_TXE;
 		irqrq_w<IRQB>(0x40);
 	}
+}
+
+template <unsigned Axis> u32 arm_iomd20_device::mouse_r()
+{
+	return u32(m_mouse_pos[Axis]);
+}
+
+template <unsigned Axis> void arm_iomd20_device::mouse_w(u32 data)
+{
+	m_mouse_pos[Axis] = u16(data);
 }
 
 u32 arm7500fe_iomd_device::msedat_r()

--- a/src/devices/machine/arm_iomd.h
+++ b/src/devices/machine/arm_iomd.h
@@ -76,7 +76,6 @@ protected:
 
 	TIMER_CALLBACK_MEMBER(timer_elapsed);
 
-	void base_map(address_map &map) ATTR_COLD;
 	u16 m_id;
 	u8 m_version;
 
@@ -192,6 +191,33 @@ private:
 //  constexpr u8 dmaid_mask = 0x1f;
 };
 
+class arm_iomd20_device : public arm_iomd_device
+{
+public:
+	// construction/destruction
+	arm_iomd20_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void map(address_map &map) override ATTR_COLD;
+
+	// quadrature mouse input lines
+	void mousex0_w(int state) { mouse_pos_w<0U, 0U>(state); }
+	void mousex1_w(int state) { mouse_pos_w<0U, 1U>(state); }
+	void mousey0_w(int state) { mouse_pos_w<1U, 0U>(state); }
+	void mousey1_w(int state) { mouse_pos_w<1U, 1U>(state); }
+
+protected:
+	virtual void device_start() override ATTR_COLD;
+
+private:
+	template <unsigned Axis, unsigned Signal> void mouse_pos_w(int state);
+
+	template <unsigned Axis> u32 mouse_r();
+	template <unsigned Axis> void mouse_w(u32 data);
+
+	u16 m_mouse_pos[2];
+	bool m_mouse_flag[2];
+};
+
 class arm7500fe_iomd_device : public arm_iomd_device
 {
 public:
@@ -226,7 +252,7 @@ private:
 };
 
 // device type definition
-DECLARE_DEVICE_TYPE(ARM_IOMD, arm_iomd_device)
+DECLARE_DEVICE_TYPE(ARM_IOMD20, arm_iomd20_device)
 DECLARE_DEVICE_TYPE(ARM7500FE_IOMD, arm7500fe_iomd_device)
 
 

--- a/src/devices/machine/quadmouse.cpp
+++ b/src/devices/machine/quadmouse.cpp
@@ -14,7 +14,7 @@
 DEFINE_DEVICE_TYPE(QUADENCODER, quadencoder_device, "quadencoder", "Generic quadature encoder support")
 DEFINE_DEVICE_TYPE(QUADMOUSE, quadmouse_device, "quadmouse", "Generic quadrature mouse support")
 
-static INPUT_PORTS_START(quadmouse)
+INPUT_PORTS_START(quadmouse)
 	PORT_START("x")
 	PORT_BIT(0xf000, IP_ACTIVE_HIGH, IPT_UNUSED)
 	PORT_BIT(0x0fff, 0, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_CHANGED_MEMBER("encoder_x", FUNC(quadencoder_device::changed), 0)

--- a/src/devices/machine/quadmouse.cpp
+++ b/src/devices/machine/quadmouse.cpp
@@ -105,7 +105,12 @@ TIMER_CALLBACK_MEMBER(quadencoder_device::tick)
 }
 
 quadmouse_device::quadmouse_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, QUADMOUSE, tag, owner, clock),
+	quadmouse_device(mconfig, QUADMOUSE, tag, owner, clock)
+{
+}
+
+quadmouse_device::quadmouse_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
 	m_enc_x(*this, "encoder_x"),
 	m_enc_y(*this, "encoder_y"),
 	m_port_x(*this, "x"),

--- a/src/devices/machine/quadmouse.h
+++ b/src/devices/machine/quadmouse.h
@@ -61,7 +61,9 @@ public:
 	bool right_r()  { return m_enc_x->pl_r(); }
 
 protected:
-	// device-level overrides
+	quadmouse_device(const machine_config &mconfig, device_type type,const char *tag, device_t *owner, uint32_t clock);
+
+	// device_t overrides
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual void device_start() override;
 

--- a/src/mame/acorn/riscpc.cpp
+++ b/src/mame/acorn/riscpc.cpp
@@ -26,7 +26,7 @@ Notes:
 **************************************************************************************************/
 
 #include "emu.h"
-
+#include "riscpc_mouse.h"
 #include "bus/pc_kbd/pc_kbdc.h"
 #include "bus/pc_kbd/keyboards.h"
 #include "bus/rs232/hlemouse.h"
@@ -70,7 +70,7 @@ public:
 		, m_kbdc(*this, "kbdc")
 		, m_screen(*this, "screen")
 		, m_i2cmem(*this, "i2cmem")
-		, m_mouse(*this, "MOUSE")
+		, m_misc(*this, "MISC")
 	{ }
 
 	void rpc700(machine_config &config);
@@ -82,6 +82,7 @@ public:
 
 private:
 	void base_config(machine_config &config);
+	void quad_mouse(machine_config &config);
 
 	required_device<cpu_device> m_maincpu;
 	required_device<arm_vidc20_device> m_vidc;
@@ -91,7 +92,7 @@ private:
 	required_device<pc_kbdc_device> m_kbdc;
 	required_device<screen_device> m_screen;
 	required_device<i2cmem_device> m_i2cmem;
-	required_ioport m_mouse;
+	required_ioport m_misc;
 
 	virtual void machine_reset() override ATTR_COLD;
 	virtual void machine_start() override ATTR_COLD;
@@ -172,7 +173,7 @@ void riscpc_state::a7000_map(address_map &map)
 //  map(0x03070000, 0x0307ffff) //podule space 4,5,6,7
 	map(0x03200000, 0x032001ff).m(m_iomd, FUNC(arm_iomd_device::map));
 //	map(0x03240000, 0x032400ff) a7000p -bios 0 (podule mirror?)
-	map(0x03310000, 0x03310003).portr(m_mouse);
+	map(0x03310000, 0x03310003).portr(m_misc);
 //  map(0x033a0004, 0x033a0004) // topbanan, joystick?
 
 	map(0x03400000, 0x037fffff).w(m_vidc, FUNC(arm_vidc20_device::write));
@@ -188,21 +189,22 @@ void riscpc_state::riscpc_map(address_map &map)
 {
 	a7000_map(map);
 	map(0x02000000, 0x027fffff).mirror(0x00800000).ram(); // VRAM
+	map(0x03210400, 0x03210400).r("mouse", FUNC(riscpc_mouse_device::buttons_r)); // TODO: monitor ID bit
 }
 
 
 /* Input ports */
 static INPUT_PORTS_START( a7000 )
-	PORT_START("MOUSE")
+	PORT_START("MISC")
 	// for debugging we leave video and sound HWs as options, eventually slotify them
 	PORT_CONFNAME( 0x01, 0x00, "Monitor Type" )
 	PORT_CONFSETTING(    0x00, "VGA" )
 	PORT_CONFSETTING(    0x01, "TV Screen" )
 	PORT_BIT( 0x0e, IP_ACTIVE_LOW, IPT_UNUSED )
 	// TODO: unmap for non-quadrature mouse variants
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("Mouse Right")   PORT_CODE(MOUSECODE_BUTTON3)
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("Mouse Center")  PORT_CODE(MOUSECODE_BUTTON2)
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Mouse Left")    PORT_CODE(MOUSECODE_BUTTON1)
+	//PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_NAME("Mouse Right")   PORT_CODE(MOUSECODE_BUTTON3)
+	//PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_NAME("Mouse Center")  PORT_CODE(MOUSECODE_BUTTON2)
+	//PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_NAME("Mouse Left")    PORT_CODE(MOUSECODE_BUTTON1)
 	// TODO: understand condition where this occurs
 	PORT_CONFNAME( 0x80, 0x00, "CMOS Reset bit" )
 	PORT_CONFSETTING(    0x00, DEF_STR( Off ) )
@@ -358,6 +360,16 @@ void riscpc_state::base_config(machine_config &config)
 	SOFTWARE_LIST(config, "flop_list").set_compatible("archimedes");
 }
 
+void riscpc_state::quad_mouse(machine_config &config)
+{
+	// TODO: figure out which x/y directions are positive/negative
+	riscpc_mouse_device &mouse(RISCPC_MOUSE(config, "mouse"));
+	mouse.write_right().set(m_iomd, FUNC(arm_iomd20_device::mousex0_w));
+	mouse.write_left().set(m_iomd, FUNC(arm_iomd20_device::mousex1_w));
+	mouse.write_up().set(m_iomd, FUNC(arm_iomd20_device::mousey0_w));
+	mouse.write_down().set(m_iomd, FUNC(arm_iomd20_device::mousey1_w));
+}
+
 void riscpc_state::rpc600(machine_config &config)
 {
 	constexpr XTAL cpuxtal(60_MHz_XTAL/2);
@@ -365,8 +377,9 @@ void riscpc_state::rpc600(machine_config &config)
 	ARM610(config, m_maincpu, cpuxtal);
 	m_maincpu->set_addrmap(AS_PROGRAM, &riscpc_state::riscpc_map);
 
-	ARM_IOMD(config, m_iomd, cpuxtal);
+	ARM_IOMD20(config, m_iomd, cpuxtal);
 	base_config(config);
+	quad_mouse(config);
 }
 
 void riscpc_state::rpc700(machine_config &config)
@@ -375,8 +388,9 @@ void riscpc_state::rpc700(machine_config &config)
 	ARM710A(config, m_maincpu, cpuxtal);
 	m_maincpu->set_addrmap(AS_PROGRAM, &riscpc_state::riscpc_map);
 
-	ARM_IOMD(config, m_iomd, cpuxtal);
+	ARM_IOMD20(config, m_iomd, cpuxtal);
 	base_config(config);
+	quad_mouse(config);
 }
 
 void riscpc_state::a7000(machine_config &config)
@@ -419,8 +433,9 @@ void riscpc_state::sarpc(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &riscpc_state::riscpc_map);
 
 	// TODO: bump me up, check VIDC clocks
-	ARM_IOMD(config, m_iomd, cpuxtal * 44);
+	ARM_IOMD20(config, m_iomd, cpuxtal * 44);
 	base_config(config);
+	quad_mouse(config);
 }
 
 void riscpc_state::sarpc_j233(machine_config &config)
@@ -431,8 +446,9 @@ void riscpc_state::sarpc_j233(machine_config &config)
 	SA110(config, m_maincpu, cpuxtal * 64);
 	m_maincpu->set_addrmap(AS_PROGRAM, &riscpc_state::riscpc_map);
 
-	ARM_IOMD(config, m_iomd, cpuxtal * 64);
+	ARM_IOMD20(config, m_iomd, cpuxtal * 64);
 	base_config(config);
+	quad_mouse(config);
 }
 
 // TODO: BIOS revisions are identical for all computers, may warrant a dummy MACHINE_IS_BIOS_ROOT romset to hold them all instead.

--- a/src/mame/acorn/riscpc_mouse.cpp
+++ b/src/mame/acorn/riscpc_mouse.cpp
@@ -5,7 +5,6 @@
  * Acorn Risc PC Mouse
  *
  * TODO:
- *  - inherit x/y ports from quadmouse_device
  *  - slotify
  */
 
@@ -37,14 +36,8 @@ u8 riscpc_mouse_device::buttons_r()
 }
 
 static INPUT_PORTS_START(riscpc_mouse)
-	// FIXME: include X/Y ports from quadmouse_device?
-	PORT_START("x")
-	PORT_BIT(0xf000, IP_ACTIVE_HIGH, IPT_UNUSED)
-	PORT_BIT(0x0fff, 0, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_CHANGED_MEMBER("encoder_x", FUNC(quadencoder_device::changed), 0)
-
-	PORT_START("y")
-	PORT_BIT(0xf000, IP_ACTIVE_HIGH, IPT_UNUSED)
-	PORT_BIT(0x0fff, 0, IPT_MOUSE_Y) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_CHANGED_MEMBER("encoder_y", FUNC(quadencoder_device::changed), 0)
+	INPUT_PORTS_EXTERN(quadmouse);
+	PORT_INCLUDE(quadmouse)
 
 	PORT_START("buttons")
 	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_BUTTON3) PORT_NAME("Mouse Right")   PORT_CODE(MOUSECODE_BUTTON3)

--- a/src/mame/acorn/riscpc_mouse.cpp
+++ b/src/mame/acorn/riscpc_mouse.cpp
@@ -1,0 +1,60 @@
+// license:BSD-3-Clause
+// copyright-holders:Patrick Mackinlay
+
+/*
+ * Acorn Risc PC Mouse
+ *
+ * TODO:
+ *  - inherit x/y ports from quadmouse_device
+ *  - slotify
+ */
+
+#include "emu.h"
+#include "riscpc_mouse.h"
+
+//#define VERBOSE (LOG_GENERAL)
+#include "logmacro.h"
+
+riscpc_mouse_device::riscpc_mouse_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)
+	: quadmouse_device(mconfig, RISCPC_MOUSE, tag, owner, clock)
+	, m_buttons(*this, "buttons")
+{
+}
+
+void riscpc_mouse_device::device_start()
+{
+	quadmouse_device::device_start();
+}
+
+void riscpc_mouse_device::device_reset()
+{
+	quadmouse_device::device_reset();
+}
+
+u8 riscpc_mouse_device::buttons_r()
+{
+	return m_buttons->read();
+}
+
+static INPUT_PORTS_START(riscpc_mouse)
+	// FIXME: include X/Y ports from quadmouse_device?
+	PORT_START("x")
+	PORT_BIT(0xf000, IP_ACTIVE_HIGH, IPT_UNUSED)
+	PORT_BIT(0x0fff, 0, IPT_MOUSE_X) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_CHANGED_MEMBER("encoder_x", FUNC(quadencoder_device::changed), 0)
+
+	PORT_START("y")
+	PORT_BIT(0xf000, IP_ACTIVE_HIGH, IPT_UNUSED)
+	PORT_BIT(0x0fff, 0, IPT_MOUSE_Y) PORT_SENSITIVITY(100) PORT_KEYDELTA(0) PORT_CHANGED_MEMBER("encoder_y", FUNC(quadencoder_device::changed), 0)
+
+	PORT_START("buttons")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_BUTTON3) PORT_NAME("Mouse Right")   PORT_CODE(MOUSECODE_BUTTON3)
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_BUTTON2) PORT_NAME("Mouse Center")  PORT_CODE(MOUSECODE_BUTTON2)
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_BUTTON1) PORT_NAME("Mouse Left")    PORT_CODE(MOUSECODE_BUTTON1)
+INPUT_PORTS_END
+
+ioport_constructor riscpc_mouse_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(riscpc_mouse);
+}
+
+DEFINE_DEVICE_TYPE(RISCPC_MOUSE, riscpc_mouse_device, "riscpc_mouse", "Acorn Risc PC Mouse")

--- a/src/mame/acorn/riscpc_mouse.h
+++ b/src/mame/acorn/riscpc_mouse.h
@@ -1,0 +1,29 @@
+// license:BSD-3-Clause
+// copyright-holders:Patrick Mackinlay
+#ifndef MAME_ACORN_RISCPC_MOUSE_H
+#define MAME_ACORN_RISCPC_MOUSE_H
+
+#pragma once
+
+#include "machine/quadmouse.h"
+
+class riscpc_mouse_device
+	: public quadmouse_device
+{
+public:
+	riscpc_mouse_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock = 0);
+
+	u8 buttons_r();
+
+protected:
+	virtual ioport_constructor device_input_ports() const override ATTR_COLD;
+	virtual void device_start() override ATTR_COLD;
+	virtual void device_reset() override ATTR_COLD;
+
+private:
+	required_ioport m_buttons;
+};
+
+DECLARE_DEVICE_TYPE(RISCPC_MOUSE, riscpc_mouse_device)
+
+#endif // MAME_ACORN_RISCPC_MOUSE_H


### PR DESCRIPTION
Some minor refactoring and added the quadrature mouse. The axes/buttons show up in the memory map at the right places, but nothing reads them at the moment. Axes might be inverted.