### PR TITLE
dsbz80: supply uart clock from parent model(1|2|3) device

### DIFF
--- a/src/mame/sega/dsbz80.cpp
+++ b/src/mame/sega/dsbz80.cpp
@@ -11,7 +11,6 @@
 
 #include "emu.h"
 #include "dsbz80.h"
-#include "machine/clock.h"
 
 #include <algorithm>
 
@@ -53,10 +52,6 @@ void dsbz80_device::device_add_mconfig(machine_config &config)
 	I8251(config, m_uart, 4'000'000);
 	m_uart->rxrdy_handler().set_inputline(m_ourcpu, INPUT_LINE_IRQ0);
 	m_uart->txd_handler().set(FUNC(dsbz80_device::output_txd));
-
-	clock_device &uart_clock(CLOCK(config, "uart_clock", 500'000)); // 16 times 31.25MHz (standard Sega/MIDI sound data rate)
-	uart_clock.signal_handler().set("uart", FUNC(i8251_device::write_rxc));
-	uart_clock.signal_handler().append("uart", FUNC(i8251_device::write_txc));
 }
 
 //**************************************************************************

--- a/src/mame/sega/dsbz80.cpp
+++ b/src/mame/sega/dsbz80.cpp
@@ -131,6 +131,12 @@ void dsbz80_device::device_stop()
 	m_decoder.reset();
 }
 
+void dsbz80_device::uart_clock_w(int state)
+{
+	m_uart->write_rxc(state);
+	m_uart->write_txc(state);
+}
+
 void dsbz80_device::write_txd(int state)
 {
 	m_uart->write_rxd(state);

--- a/src/mame/sega/dsbz80.h
+++ b/src/mame/sega/dsbz80.h
@@ -28,8 +28,8 @@ public:
 
 	void set_clock(clock_device *uart_clock)
 	{
-		uart_clock->signal_handler().append("uart", FUNC(i8251_device::write_rxc));
-		uart_clock->signal_handler().append("uart", FUNC(i8251_device::write_txc));
+		uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
+		uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_txc));
 	}
 
 	void write_txd(int state);

--- a/src/mame/sega/dsbz80.h
+++ b/src/mame/sega/dsbz80.h
@@ -26,11 +26,7 @@ public:
 	// configuration
 	auto rxd_handler() { return m_rxd_handler.bind(); }
 
-	void set_clock(clock_device *uart_clock)
-	{
-		uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
-		uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_txc));
-	}
+	void uart_clock_w(int state);
 
 	void write_txd(int state);
 

--- a/src/mame/sega/dsbz80.h
+++ b/src/mame/sega/dsbz80.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "cpu/z80/z80.h"
+#include "machine/clock.h"
 #include "machine/i8251.h"
 #include "sound/mpeg_audio.h"
 
@@ -24,6 +25,12 @@ public:
 
 	// configuration
 	auto rxd_handler() { return m_rxd_handler.bind(); }
+
+	void set_clock(clock_device *uart_clock)
+	{
+		uart_clock->signal_handler().append("uart", FUNC(i8251_device::write_rxc));
+		uart_clock->signal_handler().append("uart", FUNC(i8251_device::write_txc));
+	}
 
 	void write_txd(int state);
 

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -1922,6 +1922,7 @@ void model1_state::swa(machine_config &config)
 	m_dsbz80->set_clock(m_m1uart_clock);
 	m_dsbz80->add_route(0, "mpeg", 1.0, 0);
 	m_dsbz80->add_route(1, "mpeg", 1.0, 1);
+	m_m1uart_clock->signal_handler().append(m_dsbz80, FUNC(dsbz80_device::uart_clock_w));
 
 	// Apparently m1audio has to filter out commands the DSB shouldn't see
 	m_m1audio->rxd_handler().append(m_dsbz80, FUNC(dsbz80_device::write_txd));

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -599,7 +599,6 @@ Notes:
 #include "model1io2.h"
 
 #include "cpu/i386/i386.h"
-#include "machine/clock.h"
 #include "machine/nvram.h"
 
 #include "speaker.h"
@@ -1854,9 +1853,9 @@ void model1_state::model1(machine_config &config)
 	m_m1uart->rxrdy_handler().set(FUNC(model1_state::sound_ready_w));
 	m_m1uart->txrdy_handler().set(FUNC(model1_state::sound_ready_w));
 
-	clock_device &m1uart_clock(CLOCK(config, "m1uart_clock", 16_MHz_XTAL / 2 / 16)); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
-	m1uart_clock.signal_handler().set(m_m1uart, FUNC(i8251_device::write_txc));
-	m1uart_clock.signal_handler().append(m_m1uart, FUNC(i8251_device::write_rxc));
+	CLOCK(config, m_m1uart_clock, 16_MHz_XTAL / 2 / 16); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
+	m_m1uart_clock->signal_handler().set(m_m1uart, FUNC(i8251_device::write_txc));
+	m_m1uart_clock->signal_handler().append(m_m1uart, FUNC(i8251_device::write_rxc));
 }
 
 void model1_state::vf(machine_config &config)
@@ -1920,6 +1919,7 @@ void model1_state::swa(machine_config &config)
 
 	SPEAKER(config, "mpeg", 2).front();
 	DSBZ80(config, m_dsbz80);
+	m_dsbz80->set_clock(m_m1uart_clock);
 	m_dsbz80->add_route(0, "mpeg", 1.0, 0);
 	m_dsbz80->add_route(1, "mpeg", 1.0, 1);
 

--- a/src/mame/sega/model1.cpp
+++ b/src/mame/sega/model1.cpp
@@ -1919,7 +1919,6 @@ void model1_state::swa(machine_config &config)
 
 	SPEAKER(config, "mpeg", 2).front();
 	DSBZ80(config, m_dsbz80);
-	m_dsbz80->set_clock(m_m1uart_clock);
 	m_dsbz80->add_route(0, "mpeg", 1.0, 0);
 	m_dsbz80->add_route(1, "mpeg", 1.0, 1);
 	m_m1uart_clock->signal_handler().append(m_dsbz80, FUNC(dsbz80_device::uart_clock_w));

--- a/src/mame/sega/model1.h
+++ b/src/mame/sega/model1.h
@@ -13,6 +13,7 @@
 
 #include "cpu/mb86233/mb86233.h"
 #include "cpu/v60/v60.h"
+#include "machine/clock.h"
 #include "machine/i8251.h"
 #include "machine/gen_fifo.h"
 #include "machine/mb8421.h"
@@ -35,6 +36,7 @@ public:
 		, m_dpram(*this, "dpram")
 		, m_m1audio(*this, M1AUDIO_TAG)
 		, m_m1uart(*this, "m1uart")
+		, m_m1uart_clock(*this, "m1uart_clock")
 		, m_m1comm(*this, "m1comm")
 		, m_dsbz80(*this, "dsbz80")
 		, m_tgp_copro(*this, "tgp_copro")
@@ -234,6 +236,7 @@ protected:
 	required_device<mb8421_device> m_dpram;
 	required_device<segam1audio_device> m_m1audio;  // Model 1 standard sound board
 	required_device<i8251_device> m_m1uart;
+	required_device<clock_device> m_m1uart_clock;
 	optional_device<m1comm_device> m_m1comm;        // Model 1 communication board
 	optional_device<dsbz80_device> m_dsbz80;        // Digital Sound Board
 	optional_device<mb86233_device> m_tgp_copro;

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -81,7 +81,6 @@
 #include "cpu/i960/i960.h"
 #include "cpu/m68000/m68000.h"
 #include "cpu/z80/z80.h"
-#include "machine/clock.h"
 #include "machine/cxd1095.h"
 #include "machine/eepromser.h"
 #include "machine/mb8421.h"
@@ -2542,9 +2541,9 @@ void model2_state::model2_scsp(machine_config &config)
 	m_uart->rxrdy_handler().set(FUNC(model2_state::sound_ready_w));
 	m_uart->txrdy_handler().set(FUNC(model2_state::sound_ready_w));
 
-	clock_device &uart_clock(CLOCK(config, "uart_clock", 500000)); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
-	uart_clock.signal_handler().set(m_uart, FUNC(i8251_device::write_txc));
-	uart_clock.signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
+	CLOCK(config, m_uart_clock, 500'000); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
+	m_uart_clock->signal_handler().set(m_uart, FUNC(i8251_device::write_txc));
+	m_uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
 }
 
 /* original Model 2 */
@@ -3030,6 +3029,7 @@ void model2c_state::stcc(machine_config &config)
 	io.an_port_callback<2>().set_ioport("BRAKE");
 
 	DSBZ80(config, m_dsbz80);
+	m_dsbz80->set_clock(m_uart_clock);
 	m_dsbz80->add_route(0, "speaker", 1.0, 0);
 	m_dsbz80->add_route(1, "speaker", 1.0, 1);
 

--- a/src/mame/sega/model2.cpp
+++ b/src/mame/sega/model2.cpp
@@ -3029,11 +3029,11 @@ void model2c_state::stcc(machine_config &config)
 	io.an_port_callback<2>().set_ioport("BRAKE");
 
 	DSBZ80(config, m_dsbz80);
-	m_dsbz80->set_clock(m_uart_clock);
 	m_dsbz80->add_route(0, "speaker", 1.0, 0);
 	m_dsbz80->add_route(1, "speaker", 1.0, 1);
 
 	m_uart->txd_handler().append(m_dsbz80, FUNC(dsbz80_device::write_txd));
+	m_uart_clock->signal_handler().append(m_dsbz80, FUNC(dsbz80_device::uart_clock_w));
 }
 
 void model2c_state::waverunr(machine_config &config)

--- a/src/mame/sega/model2.h
+++ b/src/mame/sega/model2.h
@@ -19,6 +19,7 @@
 #include "cpu/mb86233/mb86233.h"
 #include "cpu/sharc/sharc.h"
 #include "cpu/mb86235/mb86235.h"
+#include "machine/clock.h"
 #include "machine/eepromser.h"
 #include "machine/gen_fifo.h"
 #include "machine/i8251.h"
@@ -58,6 +59,7 @@ public:
 		m_dsb2(*this, "dsb2"),
 		m_m1audio(*this, M1AUDIO_TAG),
 		m_uart(*this, "uart"),
+		m_uart_clock(*this, "uart_clock"),
 		m_m2comm(*this, "m2comm"),
 		m_audiocpu(*this, "audiocpu"),
 		m_copro_fifo_in(*this, "copro_fifo_in"),
@@ -119,6 +121,7 @@ protected:
 	optional_device<dsb2_device> m_dsb2;            // 68k-based MPEG Digital Sound Board
 	optional_device<segam1audio_device> m_m1audio;  // Model 1 standard sound board
 	required_device<i8251_device> m_uart;
+	required_device<clock_device> m_uart_clock;
 	optional_device<m2comm_device> m_m2comm;        // Model 2 communication board
 	optional_device<cpu_device> m_audiocpu;
 	required_device<generic_fifo_u32_device> m_copro_fifo_in;

--- a/src/mame/sega/model3.cpp
+++ b/src/mame/sega/model3.cpp
@@ -724,7 +724,6 @@ JP4/5/6/7 - Jumpers to configure ROMs
 #include "cpu/m68000/m68000.h"
 #include "cpu/z80/kl5c80a16.h"
 #include "315_5296.h"
-#include "machine/clock.h"
 #include "machine/eepromser.h"
 #include "machine/53c810.h"
 #include "machine/nvram.h"
@@ -6376,9 +6375,9 @@ void model3_state::add_base_devices(machine_config &config)
 	I8251(config, m_uart, 8000000); // uPD71051
 	m_uart->txd_handler().set(m_scsp1, FUNC(scsp_device::midi_in));
 
-	clock_device &uart_clock(CLOCK(config, "uart_clock", 500000)); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
-	uart_clock.signal_handler().set(m_uart, FUNC(i8251_device::write_txc));
-	uart_clock.signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
+	CLOCK(config, m_uart_clock, 500'000); // 16 times 31.25kHz (standard Sega/MIDI sound data rate)
+	m_uart_clock->signal_handler().set(m_uart, FUNC(i8251_device::write_txc));
+	m_uart_clock->signal_handler().append(m_uart, FUNC(i8251_device::write_rxc));
 
 	SEGA_BILLBOARD(config, m_billboard);
 
@@ -6467,6 +6466,7 @@ void model3_state::scud(machine_config &config)
 	model3_15(config);
 
 	DSBZ80(config, m_dsbz80);
+	m_dsbz80->set_clock(m_uart_clock);
 	m_dsbz80->add_route(0, "speaker", 1.0, 0);
 	m_dsbz80->add_route(1, "speaker", 1.0, 1);
 

--- a/src/mame/sega/model3.cpp
+++ b/src/mame/sega/model3.cpp
@@ -6466,11 +6466,11 @@ void model3_state::scud(machine_config &config)
 	model3_15(config);
 
 	DSBZ80(config, m_dsbz80);
-	m_dsbz80->set_clock(m_uart_clock);
 	m_dsbz80->add_route(0, "speaker", 1.0, 0);
 	m_dsbz80->add_route(1, "speaker", 1.0, 1);
 
 	m_uart->txd_handler().append(m_dsbz80, FUNC(dsbz80_device::write_txd));
+	m_uart_clock->signal_handler().append(m_dsbz80, FUNC(dsbz80_device::uart_clock_w));
 }
 
 void model3_state::lostwsga(machine_config &config)

--- a/src/mame/sega/model3.h
+++ b/src/mame/sega/model3.h
@@ -9,6 +9,7 @@
 #include "video/poly.h"
 #include "bus/scsi/scsi.h"
 #include "machine/53c810.h"
+#include "machine/clock.h"
 #include "machine/eepromser.h"
 #include "machine/i8251.h"
 #include "sound/scsp.h"
@@ -129,6 +130,7 @@ public:
 		m_dsbz80(*this, "dsbz80"),
 		m_dsb2(*this, "dsb2"),
 		m_uart(*this, "uart"),
+		m_uart_clock(*this, "uart_clock"),
 		m_soundram(*this, "soundram"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
@@ -218,6 +220,7 @@ private:
 	optional_device<dsbz80_device> m_dsbz80;    // Z80-based MPEG Digital Sound Board
 	optional_device<dsb2_device> m_dsb2;        // 68k-based MPEG Digital Sound Board
 	required_device<i8251_device> m_uart;
+	required_device<clock_device> m_uart_clock;
 	required_shared_ptr<uint16_t> m_soundram;
 
 	required_device<gfxdecode_device> m_gfxdecode;


### PR DESCRIPTION
Dsbz80 would always instantiate its own 500hz ``clock_device`` when its parent already had a ``clock_device`` with the very same configuration. This PR makes it so that it connects to the parent clock_device rather than duplicating its own.

Benchmark results:
```
Benchmarking swa (model 1)
169.65% -> 185.45% (15.80%)
173.84% -> 183.91% (10.07%)
172.77% -> 185.75% (12.98%)

Benchmarking stcc (model 2)
113.66% -> 116.24% (2.58%)
111.67% -> 116.94% (5.27%)
113.10% -> 117.75% (4.65%)

Benchmarking scud (model 3)
91.91% -> 96.73% (4.82%)
93.83% -> 96.11% (2.28%)
92.15% -> 96.00% (3.85%)
```