### PR TITLE
floppy: fix/extend hard-sectored variant handling in the core

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -421,10 +421,10 @@ void floppy_image_device::add_variant(uint32_t variant)
 	} else if (m_sectoring_type == floppy_image::H16) {
 		switch (variant) {
 		case floppy_image::SSSD:
-			actual_variant = floppy_image::SSDD16;
+			actual_variant = floppy_image::SSSD16;
 			break;
 		case floppy_image::SSDD:
-			actual_variant = floppy_image::SSSD16;
+			actual_variant = floppy_image::SSDD16;
 			break;
 		case floppy_image::SSQD:
 			actual_variant = floppy_image::SSQD16;
@@ -952,6 +952,7 @@ bool floppy_image_device::twosid_r()
 	case floppy_image::SSDD16:
 	case floppy_image::SSDD32:
 	case floppy_image::SSQD:
+	case floppy_image::SSQD10:
 	case floppy_image::SSQD16:
 		return true;
 	case 0:

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -48,11 +48,27 @@ void floppy_image::set_variant(uint32_t _variant)
 
 	uint32_t sectors;
 	switch(variant) {
+	case SSSD10:
+	case SSDD10:
+	case SSQD10:
+	case DSSD10:
+	case DSDD10:
+	case DSQD10:
+		sectors = 10;
+		break;
+	case SSSD16:
 	case SSDD16:
 	case SSQD16:
+	case DSSD16:
 	case DSDD16:
 	case DSQD16:
 		sectors = 16;
+		break;
+	case SSSD32:
+	case SSDD32:
+	case DSSD32:
+	case DSDD32:
+		sectors = 32;
 		break;
 	default:
 		sectors = 0;


### PR DESCRIPTION
- flopimg: set_variant only knew five of the 16-sector variants, so every other hard-sectored variant was given no sector holes at all.  Cover the 10, 16 and 32 hard-sector variants for both sides and all densities.
- imagedev/floppy: add_variant mapped SSSD to SSDD16 and SSDD to SSSD16 for H16 sectoring - the two cases were swapped.
- imagedev/floppy: twosid_r omitted SSQD10, so single-sided quad-density 10-sector media reported as double-sided.