### PR TITLE
CD-i: Play Music CDs

### DIFF
--- a/src/mame/philips/cdislavehle.cpp
+++ b/src/mame/philips/cdislavehle.cpp
@@ -132,6 +132,20 @@ uint16_t cdislave_hle_device::slave_r(offs_t offset)
 	return 0xff;
 }
 
+uint8_t cdislave_hle_device::disc_type()
+{
+	if (!m_cdrom->exists())
+		return 0x00;
+
+	const cdrom_file::toc &toc = m_cdrom->get_toc();
+	for (uint32_t i = 0; i < toc.numtrks; i++)
+	{
+		if (toc.tracks[i].trktype != cdrom_file::CD_TRACK_AUDIO)
+			return 0x02;
+	}
+	return 0x01;
+}
+
 void cdislave_hle_device::set_mouse_position()
 {
 	m_device_mouse_x = ((m_in_buf[1] & 0x70) << 3) | (m_in_buf[2] & 0x7f);
@@ -284,7 +298,7 @@ void cdislave_hle_device::slave_w(offs_t offset, uint16_t data)
 					switch (m_in_buf[0])
 					{
 						case 0xb0: // Request Disc Status
-							prepare_readback(attotime::from_hz(4), 3, 4, 0xb0, 0x00, 0x02, 0x15, 0xb0);
+							prepare_readback(attotime::from_hz(4), 3, 4, 0xb0, 0x00, disc_type(), 0x15, 0xb0);
 							break;
 						//case 0xb1: // Request Disc Base
 							//prepare_readback(attotime::from_hz(10000), 3, 4, 0xb1, 0x00, 0x00, 0x00, 0xb1);
@@ -381,6 +395,7 @@ cdislave_hle_device::cdislave_hle_device(const machine_config &mconfig, const ch
 	, m_dmadac(*this, ":dac%u", 1U)
 	, m_atten_w(*this)
 	, m_testplug_cb(*this, 0)
+	, m_cdrom(*this, ":cdrom")
 {
 }
 

--- a/src/mame/philips/cdislavehle.h
+++ b/src/mame/philips/cdislavehle.h
@@ -20,6 +20,7 @@ TODO:
 
 #pragma once
 
+#include "imagedev/cdromimg.h"
 #include "sound/dmadac.h"
 
 //**************************************************************************
@@ -59,6 +60,7 @@ protected:
 private:
 	void prepare_readback(const attotime &delay, uint8_t channel, uint8_t count, uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t cmd);
 	void set_mouse_position();
+	uint8_t disc_type();
 
 	devcb_write_line m_int_callback;
 	devcb_read16 m_read_mousex;
@@ -68,6 +70,7 @@ private:
 	required_device_array<dmadac_sound_device, 2> m_dmadac;
 	devcb_write32 m_atten_w;
 	devcb_read_line m_testplug_cb;
+	required_device<cdrom_image_device> m_cdrom;
 
 	struct channel_state
 	{


### PR DESCRIPTION
This adds a small disc-type check to the CD-i Slave HLE. This allows it to recognize music CDs, which triggers the CD player mode.

Fixes #15832

<img width="1232" height="1025" alt="image" src="https://github.com/user-attachments/assets/279cd628-aea7-4a25-bb56-7caac25b55c1" />
