### PR TITLE
alfaskop41xx: make the display unit's memory size selectable with -ram

### DIFF
--- a/src/mame/ericsson/alfaskop41xx.cpp
+++ b/src/mame/ericsson/alfaskop41xx.cpp
@@ -31,6 +31,7 @@ Dansk Datahistorisk Forening - http://datamuseum.dk/
 #include "machine/mc6854.h"
 #include "machine/output_latch.h"
 #include "machine/pla.h"
+#include "machine/ram.h"
 #include "video/mc6845.h"
 
 #include "screen.h"
@@ -78,6 +79,7 @@ public:
 		, m_screen(*this, "screen")
 		, m_vram(*this, "vram")
 		, m_pla(*this, PLA1_TAG)
+		, m_ram(*this, RAM_TAG)
 		, m_chargen(*this, "chargen")
 		, m_tia_adlc(*this, "tia_adlc")
 		, m_tia_dma(*this, "tia_dma")
@@ -100,6 +102,7 @@ private:
 	required_device<screen_device> m_screen;
 	required_shared_ptr<uint8_t> m_vram;
 	required_device<pls100_device> m_pla;
+	required_device<ram_device> m_ram;
 
 	/* Video controller */
 	required_region_ptr<uint8_t> m_chargen;
@@ -178,20 +181,13 @@ private:
 void alfaskop4110_state::mem_map(address_map &map)
 {
 	map.unmap_value_high();
-	map(0x0000, 0x7fff).ram();
+	// Main memory is installed in machine_start, since how far it reaches
+	// depends on which memory board the unit has.  The video RAM keeps its
+	// own entry so that the share survives.
 	map(0x7800, 0x7fff).ram().share(m_vram); // TODO: Video RAM base address is configurable via NVRAM - this is the default
-	// The display unit was sold with two sizes of read/write memory and its
-	// operating software knows both.  The memory sizing routine in the DUOS
-	// module walks upwards two bytes at a time until an address stops
-	// answering, and then accepts a boundary of either F000 or F680; anything
-	// else stops the IPL with "MRW ERROR" on the status line.  The smaller of
-	// the two is not enough for every product: AlfaWord (4017-021) refuses to
-	// start on it and reports "Wrong Hardware configuration".
-	map(0x8000, 0xf67f).ram();
 
-	// NVRAM.  It cannot begin at F600 on a unit with the larger memory
-	// board, because that address is still read/write memory there.
-	map(0xf680, 0xf6ff).lrw8(NAME([this](offs_t offset) -> uint8_t { LOGNVRAM("nvram_r %04x: %02x\n", offset, 0); return (uint8_t) 0; }),
+	// NVRAM
+	map(0xf600, 0xf6ff).lrw8(NAME([this](offs_t offset) -> uint8_t { LOGNVRAM("nvram_r %04x: %02x\n", offset, 0); return (uint8_t) 0; }),
 				 NAME( [this](offs_t offset, uint8_t data) {    LOGNVRAM("nvram_w %04x: %02x\n", offset, data); }));
 	// TIA board
 	map(0xf700, 0xf71f).mirror(0x00).lrw8(NAME([this](offs_t offset) -> uint8_t    { LOGDMA("TIA DMA_r %04x: %02x\n", offset, 0); return m_tia_dma->read(offset); }),
@@ -317,6 +313,8 @@ void alfaskop4110_state::alfaskop4110(machine_config &config)
 	/* basic machine hardware */
 	M6800(config, m_maincpu, XTAL(19'170'000) / 18); // Verified from service manual
 	m_maincpu->set_addrmap(AS_PROGRAM, &alfaskop4110_state::mem_map);
+
+	RAM(config, m_ram).set_default_size("64K").set_extra_options("60K");
 
 	/* Interrupt controller and address modifier PLA */
 	/*
@@ -488,6 +486,20 @@ void alfaskop4110_state::machine_start()
 {
 	save_item(NAME(m_irq));
 	save_item(NAME(m_imsk));
+
+	// The display unit took one of two memory boards and its operating
+	// software knows both: the sizing routine in DUOS walks upwards two bytes
+	// at a time until an address stops answering and then accepts a boundary
+	// of either F000 or F680, stopping the IPL with "MRW ERROR" for anything
+	// else.  The smaller board is not enough for every product: AlfaWord
+	// (4017-021) reports "Wrong Hardware configuration" and restarts the unit.
+	// Above F67F sit the NVRAM, the I/O boards and the ROM, so a larger board
+	// is simply not reachable past that point.
+	address_space &space = m_maincpu->space(AS_PROGRAM);
+	u32 const top = (m_ram->size() < 0xf680) ? m_ram->size() : 0xf680;
+	space.install_ram(0x0000, 0x77ff, m_ram->pointer());
+	if (top > 0x8000)
+		space.install_ram(0x8000, top - 1, m_ram->pointer() + 0x8000);
 
 	m_poll_start_timer = timer_alloc(FUNC(alfaskop4110_state::poll_start), this);
 	m_poll_start_timer->adjust(attotime::from_msec(5000));

--- a/src/mame/ericsson/alfaskop41xx.cpp
+++ b/src/mame/ericsson/alfaskop41xx.cpp
@@ -180,10 +180,18 @@ void alfaskop4110_state::mem_map(address_map &map)
 	map.unmap_value_high();
 	map(0x0000, 0x7fff).ram();
 	map(0x7800, 0x7fff).ram().share(m_vram); // TODO: Video RAM base address is configurable via NVRAM - this is the default
-	map(0x8000, 0xefff).ram();
+	// The display unit was sold with two sizes of read/write memory and its
+	// operating software knows both.  The memory sizing routine in the DUOS
+	// module walks upwards two bytes at a time until an address stops
+	// answering, and then accepts a boundary of either F000 or F680; anything
+	// else stops the IPL with "MRW ERROR" on the status line.  The smaller of
+	// the two is not enough for every product: AlfaWord (4017-021) refuses to
+	// start on it and reports "Wrong Hardware configuration".
+	map(0x8000, 0xf67f).ram();
 
-	// NVRAM
-	map(0xf600, 0xf6ff).lrw8(NAME([this](offs_t offset) -> uint8_t { LOGNVRAM("nvram_r %04x: %02x\n", offset, 0); return (uint8_t) 0; }),
+	// NVRAM.  It cannot begin at F600 on a unit with the larger memory
+	// board, because that address is still read/write memory there.
+	map(0xf680, 0xf6ff).lrw8(NAME([this](offs_t offset) -> uint8_t { LOGNVRAM("nvram_r %04x: %02x\n", offset, 0); return (uint8_t) 0; }),
 				 NAME( [this](offs_t offset, uint8_t data) {    LOGNVRAM("nvram_w %04x: %02x\n", offset, data); }));
 	// TIA board
 	map(0xf700, 0xf71f).mirror(0x00).lrw8(NAME([this](offs_t offset) -> uint8_t    { LOGDMA("TIA DMA_r %04x: %02x\n", offset, 0); return m_tia_dma->read(offset); }),


### PR DESCRIPTION
The display unit took one of two memory boards and its own operating software knows both, but the driver only had the smaller one wired in. This makes the size selectable with `-ram`.

The evidence is in the display unit's software. DUOS, loaded from the system diskette, sizes memory by walking upwards two bytes at a time until an address stops answering, and then checks the boundary it found. In a dump of the display unit's memory the routine sits at 37F0 and reads:

```
3801  compare the boundary with F000, and branch to the error path if it differs
3812  LDX #$EFFC / STX $02C7        the smaller size
3852  LDX $02C7 / CPX #$F67C        the larger size
3887  write "MRW ERROR" to the status line and halt in a loop at 389C
```

Anything between the two is refused. Tops of F0FF, F1FF, F3FF and F5FF all give MRW ERROR at IPL, so this is not a case of extra memory being harmless.

The smaller size is not enough for every product. AlfaWord, 4017-021, tests the configuration when it starts, reports "Wrong Hardware configuration" on the status line and then restarts the display unit by loading the reset vector from FFFE and jumping through it. With the larger size it starts normally and comes up with its entry form.

Main memory now comes from a RAM device, so `-ram 64K` selects the larger board and `-ram 60K` the smaller one. Everything above F67F is the NVRAM, the I/O boards and the ROM, so the map caps there rather than wrapping, and the video RAM keeps its own entry so the share survives. 64K is the default because the system diskette is happy with either size and AlfaWord only runs on the larger one.

Checked both ways with the display unit, the communication processor and the flexible disk unit running together, booting the 4016-101 system diskette at level M306-01 and starting AlfaWord from the function menu: with `-ram 60K` AlfaWord reports the configuration error and drops back to the menu, and with `-ram 64K` it comes up with its entry form.
