### PR TITLE
CD-i: Attenuation Table

### DIFF
--- a/src/mame/philips/cdicdic.cpp
+++ b/src/mame/philips/cdicdic.cpp
@@ -447,12 +447,10 @@ void cdicdic_device::play_audio_sector(const uint8_t coding, const uint8_t *data
 		}
 
 		int16_t sampleL = 0, sampleR = 0, outL = 0, outR = 0;
-		// Attenuation is logarithmic (decibels).
-		// Floats are not chip accurate, but the formula is correct.
-		float scaleLL = powf(10.0f, -m_atten[0] / 20.0f);
-		float scaleLR = powf(10.0f, -m_atten[1] / 20.0f);
-		float scaleRR = powf(10.0f, -m_atten[2] / 20.0f);
-		float scaleRL = powf(10.0f, -m_atten[3] / 20.0f);
+		const float scaleLL = m_atten[0] / 255.0f;
+		const float scaleLR = m_atten[1] / 255.0f;
+		const float scaleRR = m_atten[2] / 255.0f;
+		const float scaleRL = m_atten[3] / 255.0f;
 		for (uint16_t i = 0; i < 18 * 28 * num_samples; i++)
 		{
 			sampleL = m_samples[0][i];
@@ -1386,7 +1384,7 @@ void cdicdic_device::device_reset()
 	m_dmadac[0]->enable(1);
 	m_dmadac[1]->enable(1);
 
-	std::fill_n(m_atten, 4, 0);
+	std::fill_n(m_atten, 4, 0xff);
 	std::fill_n(m_xa_last, 4, 0);
 }
 

--- a/src/mame/philips/cdislavehle.cpp
+++ b/src/mame/philips/cdislavehle.cpp
@@ -33,6 +33,20 @@ TODO:
 // device type definition
 DEFINE_DEVICE_TYPE(CDI_SLAVE_HLE, cdislave_hle_device, "cdislavehle", "CD-i Mono-I Slave HLE")
 
+namespace {
+
+const u8 s_attenuation_table[46] =
+{
+	0xff, 0xe4, 0xcb, 0xb5, 0xa2, 0x90, 0x80, 0x72,
+	0x66, 0x5b, 0x51, 0x48, 0x40, 0x39, 0x33, 0x2e,
+	0x29, 0x24, 0x20, 0x1d, 0x1a, 0x17, 0x14, 0x12,
+	0x10, 0x0e, 0x0d, 0x0b, 0x0a, 0x09, 0x08, 0x07,
+	0x06, 0x06, 0x05, 0x05, 0x04, 0x04, 0x03, 0x03,
+	0x03, 0x02, 0x02, 0x02, 0x02, 0x01,
+};
+
+}
+
 
 //**************************************************************************
 //  MEMBER FUNCTIONS
@@ -233,10 +247,21 @@ void cdislave_hle_device::slave_w(offs_t offset, uint16_t data)
 					{
 						case 0xc0: case 0xc1: case 0xc2: case 0xc3: case 0xc4: case 0xc5: case 0xc6: case 0xc7:
 						case 0xc8: case 0xc9: case 0xca: case 0xcb: case 0xcc: case 0xcd: case 0xce: case 0xcf:
-							m_atten_w((((u32)m_in_buf[1]) << 24) | (((u32)m_in_buf[2]) << 16) | (((u32)m_in_buf[3]) << 8) | (((u32)m_in_buf[4])));
+						{
+							u32 gains = 0;
+							for (int i = 1; i <= 4; i++)
+							{
+								gains <<= 8;
+								if (m_in_buf[i] < std::size(s_attenuation_table))
+								{
+									gains |= s_attenuation_table[m_in_buf[i]];
+								}
+							}
+							m_atten_w(gains);
 							m_in_index = 0;
 							m_in_count = 0;
 							break;
+						}
 						case 0xf0: // Set Front Panel LCD
 							memset(m_in_buf + 1, 0, 16);
 							m_in_count = 17;


### PR DESCRIPTION
Reverse engineering revealed the attenuation lookup table is in the slave, not the CDIC. This exchanges the powf approximation for the actual lookup table values.

The result is <0.5% difference in volume.