### PR TITLE
cpu/we32000: Corrected several mnemonics in the WE32100 disassembler

### DIFF
--- a/src/devices/cpu/we32000/we32100d.cpp
+++ b/src/devices/cpu/we32000/we32100d.cpp
@@ -381,13 +381,13 @@ offs_t we32100_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 		}
 		else if (!BIT(op, 0))
 		{
-			util::stream_format(stream, "%-8s0x%08x,", BIT(op, 4) ? "SPOPRT" : "SPOPRD", swapendian_int32(opcodes.r32(pc)));
+			util::stream_format(stream, "%-8s0x%08x,", BIT(op, 2) ? "SPOPRT" : "SPOPRD", swapendian_int32(opcodes.r32(pc)));
 			pc += 4;
 			dasm_src(stream, pc, opcodes);
 		}
 		else
 		{
-			util::stream_format(stream, "%-8s0x%08x,", BIT(op, 4) ? "SPOPT2" : "SPOPD2", swapendian_int32(opcodes.r32(pc)));
+			util::stream_format(stream, "%-8s0x%08x,", BIT(op, 2) ? "SPOPT2" : "SPOPD2", swapendian_int32(opcodes.r32(pc)));
 			pc += 4;
 			dasm_src(stream, pc, opcodes);
 			stream << ",";
@@ -620,7 +620,7 @@ offs_t we32100_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 		}
 		else
 		{
-			util::stream_format(stream, "%-8s", BIT(op, 0) ? "BCC" : "BCC");
+			util::stream_format(stream, "%-8s", BIT(op, 0) ? "BCCB" : "BCCH");
 			dasm_bdisp(stream, pc, opcodes, BIT(op, 0));
 		}
 		flags |= STEP_COND;
@@ -643,7 +643,7 @@ offs_t we32100_disassembler::disassemble(std::ostream &stream, offs_t pc, const 
 	case 0x60:
 		if (!BIT(op, 1))
 		{
-			stream << "RVS";
+			stream << "RVC";
 			flags |= STEP_OUT;
 		}
 		else


### PR DESCRIPTION
I was reading through the WE32100 disassembler and noticed that the branch case for opcode group 0x50 formats `BIT(op, 0) ? "BCC" : "BCC"`, so both displacement forms print the same text. Every other conditional branch in that switch appends B or H, and 0x52/0x53 are BCCH/BCCB (BGEUH/BGEUB under the other spelling of the same condition). Looking at the neighbouring cases turned up two more mistakes:

* Opcode 0x60 prints "RVS", which is the mnemonic for 0x68. The branches decoded in the same group are BVCH/BVCB, so 0x60 is RVC. As it stands RVC never appears and RVS is printed for two different opcodes.
* SPOPRT/SPOPT2 are selected with `BIT(op, 4)`, but this case only ever sees opcodes 0x00-0x07, so bit 4 is always clear there. Opcodes 0x06 and 0x07 consequently disassemble as SPOPRD and SPOPD2, and the SPOPRT/SPOPT2 spellings are unreachable. Bit 2 is what separates 0x06/0x07 from 0x02/0x03.

I cross-checked the three opcode values against the WE32100 opcode table in SIMH's 3B2 simulator, which agrees: 0x52 BCCH, 0x53 BCCB, 0x60 RVC, 0x06 SPOPRT, 0x07 SPOPT2.

To check the behaviour I compiled `we32100d.cpp` on its own against `disasmintf.cpp` and `strformat.cpp` with a small driver that feeds it one opcode at a time, and dumped all 256 opcodes before and after. Before the change 0x52, 0x53, 0x60, 0x06 and 0x07 come out as BCC, BCC, RVS, SPOPRD and SPOPD2; after it they come out as BCCH, BCCB, RVC, SPOPRT and SPOPT2, and the opcodes I did not touch (0x02, 0x03, 0x5b, 0x63, 0x68) are unchanged. That standalone build is all I was able to do here, since I have no SDL development packages on this machine for a full MAME build; the change is four literals and one bit index in a single file, with no interface change.

I have no WE32100 system to run, and the CPU core is still a skeleton, so this only affects debugger and unidasm output.

Per the contributing guidelines: this change was prepared with AI assistance, using Claude Opus 5 through Claude Code.
