### PR TITLE
namco/namcos2_sprite.cpp: Fix sprite zoom algorithm

### DIFF
--- a/src/mame/namco/namcos2.cpp
+++ b/src/mame/namco/namcos2.cpp
@@ -2163,6 +2163,10 @@ ROM_START( assault )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "atvoi1.bin",  0x000000, 0x080000, CRC(d36a649e) SHA1(30173f32c6ec9dda6b8946baa14266e828b0324e) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* ASSAULT (JAPAN) */
@@ -2214,6 +2218,10 @@ ROM_START( assaultj )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "atvoi1.bin",  0x000000, 0x080000, CRC(d36a649e) SHA1(30173f32c6ec9dda6b8946baa14266e828b0324e) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* ASSAULT PLUS (NAMCO) */
@@ -2265,6 +2273,10 @@ ROM_START( assaultp )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "atvoi1.bin",  0x000000, 0x080000, CRC(d36a649e) SHA1(30173f32c6ec9dda6b8946baa14266e828b0324e) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* BURNING FORCE */
@@ -2315,6 +2327,10 @@ ROM_START( burnforc )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "bu_voi-1.bin",  0x000000, 0x080000, CRC(99d8a239) SHA1(1ebc586048e757ac0ac68dc9cc171f4849e67cef) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 ROM_START( burnforco )
@@ -2364,6 +2380,10 @@ ROM_START( burnforco )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "bu_voi-1.bin",  0x000000, 0x080000, CRC(99d8a239) SHA1(1ebc586048e757ac0ac68dc9cc171f4849e67cef) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* COSMO GANG THE VIDEO (USA) */
@@ -2408,7 +2428,7 @@ ROM_START( cosmogng )
 	ROM_LOAD16_BYTE( "co2voi1.bin",  0x000000, 0x080000, CRC(5a301349) SHA1(e333ea5955a66ac8d7c94cd50047efaf6fa95b15) )
 	ROM_LOAD16_BYTE( "co2voi2.bin",  0x100000, 0x080000, CRC(a27cb45a) SHA1(08ccaaf43369e8358e31b213877829bdfd61479e) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6n", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
@@ -2454,7 +2474,7 @@ ROM_START( cosmogngj )
 	ROM_LOAD16_BYTE( "co1voi1.bin",  0x000000, 0x080000, CRC(b5ba8f15) SHA1(9e54b9ba1cd44353782adf337376dff9eec4e937) )
 	ROM_LOAD16_BYTE( "co1voi2.bin",  0x100000, 0x080000, CRC(b566b105) SHA1(b5530b0f3dea0135f28419044aee923d855f382c) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6n", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
@@ -2508,6 +2528,10 @@ ROM_START( dirtfoxj )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
 	ROM_LOAD( "nvram",  0x000000, 0x2000, CRC(4b9f7b06) SHA1(384496d2d80a48d31084dc316ebae3a5c1aa1ab9) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* DRAGON SABER */
@@ -2555,6 +2579,10 @@ ROM_START( dsaber )
 	ROM_LOAD( "pal16l8a.4g", 0x0000, 0x0104, CRC(660e1655) SHA1(ffb43238c5ffa3fa831975bc3cde72334c4c2540) )
 	ROM_LOAD( "pal16l8a.5f", 0x0200, 0x0104, CRC(18f43c22) SHA1(72849c5b842678bb9037541d26d4c99cdf879982) )
 	ROM_LOAD( "pal12l10.8d", 0x0400, 0x0040, CRC(e2379249) SHA1(ad4cdf2e0fd1304a135022eeafa2f61c5f5789cd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 
@@ -2603,6 +2631,10 @@ ROM_START( dsabera )
 	ROM_LOAD( "pal16l8a.4g", 0x0000, 0x0104, CRC(660e1655) SHA1(ffb43238c5ffa3fa831975bc3cde72334c4c2540) )
 	ROM_LOAD( "pal16l8a.5f", 0x0200, 0x0104, CRC(18f43c22) SHA1(72849c5b842678bb9037541d26d4c99cdf879982) )
 	ROM_LOAD( "pal12l10.8d", 0x0400, 0x0040, CRC(e2379249) SHA1(ad4cdf2e0fd1304a135022eeafa2f61c5f5789cd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* DRAGON SABER (JAPAN) */
@@ -2650,6 +2682,10 @@ ROM_START( dsaberj )
 	ROM_LOAD( "pal16l8a.4g", 0x0000, 0x0104, CRC(660e1655) SHA1(ffb43238c5ffa3fa831975bc3cde72334c4c2540) )
 	ROM_LOAD( "pal16l8a.5f", 0x0200, 0x0104, CRC(18f43c22) SHA1(72849c5b842678bb9037541d26d4c99cdf879982) )
 	ROM_LOAD( "pal12l10.8d", 0x0400, 0x0040, CRC(e2379249) SHA1(ad4cdf2e0fd1304a135022eeafa2f61c5f5789cd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP (REV E) */
@@ -2695,6 +2731,10 @@ ROM_START( finallap )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v1",  0x000000, CRC(86b21996) SHA1(833ffde729199c81e472fb88ed5b7f4ce08a83d6) )
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v2",  0x100000, CRC(6a164647) SHA1(3162457beccccdb416994ebd32fb83b13eb719e0) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP (revision D) */
@@ -2740,6 +2780,10 @@ ROM_START( finallapd )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v1",  0x000000, CRC(86b21996) SHA1(833ffde729199c81e472fb88ed5b7f4ce08a83d6) )
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v2",  0x100000, CRC(6a164647) SHA1(3162457beccccdb416994ebd32fb83b13eb719e0) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP (revision C) */
@@ -2785,6 +2829,10 @@ ROM_START( finallapc )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v1",  0x000000, CRC(86b21996) SHA1(833ffde729199c81e472fb88ed5b7f4ce08a83d6) )
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v2",  0x100000, CRC(6a164647) SHA1(3162457beccccdb416994ebd32fb83b13eb719e0) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP (Rev C - Japan) */
@@ -2830,6 +2878,10 @@ ROM_START( finallapjc )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v1",  0x000000, CRC(86b21996) SHA1(833ffde729199c81e472fb88ed5b7f4ce08a83d6) )
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v2",  0x100000, CRC(6a164647) SHA1(3162457beccccdb416994ebd32fb83b13eb719e0) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP  (REV B - JAPAN) */
@@ -2875,6 +2927,10 @@ ROM_START( finallapjb )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v1",  0x000000, CRC(86b21996) SHA1(833ffde729199c81e472fb88ed5b7f4ce08a83d6) )
 	NAMCOS2_DATA_LOAD_E_128K( "fl1-v2",  0x100000, CRC(6a164647) SHA1(3162457beccccdb416994ebd32fb83b13eb719e0) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 ROM_START( finalap2 )
@@ -2928,6 +2984,10 @@ ROM_START( finalap2 )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
 	ROM_LOAD( "finalap2.nv",  0x000000, 0x2000, CRC(c7ae5d0a) SHA1(9527e44accec0ec9d1990138d1b0bfc71957cc8a) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP 2 (Japan) */
@@ -2982,6 +3042,10 @@ ROM_START( finalap2j )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
 	ROM_LOAD( "finalap2.nv",  0x000000, 0x2000, CRC(c7ae5d0a) SHA1(9527e44accec0ec9d1990138d1b0bfc71957cc8a) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP 2 (Japan, rev B) */
@@ -3036,6 +3100,10 @@ ROM_START( finalap2jb )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
 	ROM_LOAD( "finalap2.nv",  0x000000, 0x2000, CRC(c7ae5d0a) SHA1(9527e44accec0ec9d1990138d1b0bfc71957cc8a) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* FINAL LAP 3 WORLD (REV. C) */
@@ -3088,7 +3156,7 @@ ROM_START( finalap3 ) // this set displays MOTION (Ver. 3) in the test mode menu
 	ROM_LOAD16_BYTE( "flt_voi-1.3m",  0x000000, 0x080000, CRC(4fc7c0ba) SHA1(bbfd1764fd79087bba5e6199e8916c28bed4d3f4) )
 	ROM_LOAD16_BYTE( "flt_voi-2.3l",  0x100000, 0x080000, CRC(409c62df) SHA1(0c2f088168f1f92f2f767ea47522c0e8f4a10265) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6r", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
@@ -3146,7 +3214,7 @@ ROM_START( finalap3a )
 	ROM_LOAD16_BYTE( "flt_voi-1.3m",  0x000000, 0x080000, CRC(4fc7c0ba) SHA1(bbfd1764fd79087bba5e6199e8916c28bed4d3f4) )
 	ROM_LOAD16_BYTE( "flt_voi-2.3l",  0x100000, 0x080000, CRC(409c62df) SHA1(0c2f088168f1f92f2f767ea47522c0e8f4a10265) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6r", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x20000, "unknown", 0 ) /* unknown rom */
@@ -3154,6 +3222,7 @@ ROM_START( finalap3a )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
 	ROM_LOAD( "finalap3.nv",  0x000000, 0x2000, CRC(efbc6274) SHA1(f542012e467027b7bd5d7102096ff91d8c9adee3) )
+
 ROM_END
 
 
@@ -3207,7 +3276,7 @@ ROM_START( finalap3j )
 	ROM_LOAD16_BYTE( "flt_voi-1.3m",  0x000000, 0x080000, CRC(4fc7c0ba) SHA1(bbfd1764fd79087bba5e6199e8916c28bed4d3f4) )
 	ROM_LOAD16_BYTE( "flt_voi-2.3l",  0x100000, 0x080000, CRC(409c62df) SHA1(0c2f088168f1f92f2f767ea47522c0e8f4a10265) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6r", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
@@ -3264,7 +3333,7 @@ ROM_START( finalap3jc )
 	ROM_LOAD16_BYTE( "flt_voi-1.3m",  0x000000, 0x080000, CRC(4fc7c0ba) SHA1(bbfd1764fd79087bba5e6199e8916c28bed4d3f4) )
 	ROM_LOAD16_BYTE( "flt_voi-2.3l",  0x100000, 0x080000, CRC(409c62df) SHA1(0c2f088168f1f92f2f767ea47522c0e8f4a10265) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6r", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration */
@@ -3320,7 +3389,7 @@ ROM_START( finalap3bl ) // bootleg set
 	ROM_LOAD16_BYTE( "fltvoi1",  0x000000, 0x080000, CRC(4fc7c0ba) SHA1(bbfd1764fd79087bba5e6199e8916c28bed4d3f4) )
 	ROM_LOAD16_BYTE( "fltvoi2",  0x100000, 0x080000, CRC(409c62df) SHA1(0c2f088168f1f92f2f767ea47522c0e8f4a10265) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* zoom */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* zoom */
 	ROM_LOAD( "04544191.6r", 0, 0x2000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* default settings, including calibration and machine ID code that passes protection */
@@ -3376,6 +3445,10 @@ ROM_START( finehour )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "fh1_vo1.bin",  0x000000, 0x080000, CRC(07560fc7) SHA1(76f3855f5a4567dc65d513e37072072c2a011e7e) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /*
@@ -3596,6 +3669,10 @@ ROM_START( fourtrax )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "fx_voi-1.3m", 0x000000, 0x080000, CRC(6173364f) SHA1(cc426f49b7e87b11f1f51e8e10db7cad87ffb44d) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 ROM_START( fourtraxj )
@@ -3655,6 +3732,10 @@ ROM_START( fourtraxj )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "fx_voi-1.3m", 0x000000, 0x080000, CRC(6173364f) SHA1(cc426f49b7e87b11f1f51e8e10db7cad87ffb44d) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* This is a strange set, it's based on the fx2 set, but with one of the 68k pair modified (21 bytes changed) and a unique GFX ROM
@@ -3725,6 +3806,10 @@ ROM_START( fourtraxa )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "fx_voi-1.3m", 0x000000, 0x080000, CRC(6173364f) SHA1(cc426f49b7e87b11f1f51e8e10db7cad87ffb44d) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* MARVEL LAND (JAPAN) */
@@ -3771,6 +3856,10 @@ ROM_START( marvland )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "mv1-voi1.bin",  0x000000, 0x080000, CRC(de5cac09) SHA1(2d73e54c4f159e52db2c403a59d6c137cce6f53e) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* MARVEL LAND (USA) */
@@ -3819,6 +3908,10 @@ ROM_START( marvlandup )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "mv1-voi1.bin",  0x000000, 0x080000, BAD_DUMP CRC(de5cac09) SHA1(2d73e54c4f159e52db2c403a59d6c137cce6f53e) ) // either undumped, or PCB was wrongly populated with JP samples ROM?
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* METAL HAWK */
@@ -3877,7 +3970,7 @@ ROM_START( metlhawk )
 	ROM_LOAD16_BYTE( "mhvoi-1.bin",  0x000000, 0x080000, CRC(2723d137) SHA1(f67334f8e456ae9e6aee39f0cf5e73449838f37f) )
 	ROM_LOAD16_BYTE( "mhvoi-2.bin",  0x100000, 0x080000, CRC(dbc92d91) SHA1(a8c50f607d5283c8bd9688d2149b811e7ddb77dd) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* sprite zoom lookup table */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
 	ROM_LOAD( "mh5762.7p",    0x00000,  0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x0500, "plds", 0 )
@@ -3945,7 +4038,7 @@ ROM_START( metlhawkj )
 	ROM_LOAD16_BYTE( "mhvoi-1.bin",  0x000000, 0x080000, CRC(2723d137) SHA1(f67334f8e456ae9e6aee39f0cf5e73449838f37f) )
 	ROM_LOAD16_BYTE( "mhvoi-2.bin",  0x100000, 0x080000, CRC(dbc92d91) SHA1(a8c50f607d5283c8bd9688d2149b811e7ddb77dd) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* sprite zoom lookup table */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
 	ROM_LOAD( "mh5762.7p",    0x00000,  0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION( 0x0500, "plds", 0 )
@@ -4007,6 +4100,10 @@ ROM_START( mirninja )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "mn_voi1.bin",  0x000000, 0x080000, CRC(2ca3573c) SHA1(b2af101730de4ccc68acc1ed143c21a8c81f64db) )
 	ROM_LOAD16_BYTE( "mn_voi2.bin",  0x100000, 0x080000, CRC(466c3b47) SHA1(9c282ffda8b0620ae60789c81c6e36c086a9a335) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 ROM_START( mirninjaa )
@@ -4058,6 +4155,10 @@ ROM_START( mirninjaa )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "mn_voi1.bin",  0x000000, 0x080000, CRC(2ca3573c) SHA1(b2af101730de4ccc68acc1ed143c21a8c81f64db) )
 	ROM_LOAD16_BYTE( "mn_voi2.bin",  0x100000, 0x080000, CRC(466c3b47) SHA1(9c282ffda8b0620ae60789c81c6e36c086a9a335) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* ORDYNE */
@@ -4112,7 +4213,7 @@ ROM_START( ordyne )
 	ROM_LOAD16_BYTE( "or_voi1.voice1",  0x000000, 0x080000, CRC(369e0bca) SHA1(2a921bb373dd043bd7b2a30e5e46ec3b8b3b5c8d) )
 	ROM_LOAD16_BYTE( "or_voi2.voice2",  0x100000, 0x080000, CRC(9f4cd7b5) SHA1(10941dd5ab3846c0cb2543655944eaec742f8f21) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* sprite zoom lookup table */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
 	ROM_LOAD( "lh5762.6n",    0x00000,  0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
@@ -4168,7 +4269,7 @@ ROM_START( ordyneje )
 	ROM_LOAD16_BYTE( "or_voi1.voice1",  0x000000, 0x080000, CRC(369e0bca) SHA1(2a921bb373dd043bd7b2a30e5e46ec3b8b3b5c8d) )
 	ROM_LOAD16_BYTE( "or_voi2.voice2",  0x100000, 0x080000, CRC(9f4cd7b5) SHA1(10941dd5ab3846c0cb2543655944eaec742f8f21) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* sprite zoom lookup table */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
 	ROM_LOAD( "lh5762.6n",    0x00000,  0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
@@ -4224,7 +4325,7 @@ ROM_START( ordynej )
 	ROM_LOAD16_BYTE( "or_voi1.voice1",  0x000000, 0x080000, CRC(369e0bca) SHA1(2a921bb373dd043bd7b2a30e5e46ec3b8b3b5c8d) )
 	ROM_LOAD16_BYTE( "or_voi2.voice2",  0x100000, 0x080000, CRC(9f4cd7b5) SHA1(10941dd5ab3846c0cb2543655944eaec742f8f21) )
 
-	ROM_REGION( 0x2000, "zoomlut", 0 ) /* sprite zoom lookup table */
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
 	ROM_LOAD( "lh5762.6n",    0x00000,  0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
@@ -4281,6 +4382,10 @@ ROM_START( phelios )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ps_voi-1.voice1",  0x000000, 0x080000, CRC(f67376ed) SHA1(b54257aad34c6ad03d5b040e6a5dda94a48b6780) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* PHELIOS (Japan) */
@@ -4336,6 +4441,10 @@ ROM_START( pheliosj )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ps_voi-1.voice1",  0x000000, 0x080000, CRC(f67376ed) SHA1(b54257aad34c6ad03d5b040e6a5dda94a48b6780) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* ROLLING THUNDER 2 */
@@ -4379,6 +4488,10 @@ ROM_START( rthun2 )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "rts_voi1.3m",  0x000000, 0x080000, CRC(e42027cd) SHA1(fa3a81118c7f112289c27023236dec2e9cbc78b5) )
 	ROM_LOAD16_BYTE( "rts_voi2.3l",  0x100000, 0x080000, CRC(0c4c2b66) SHA1(7723cbef755439a66d026015596fe1547ccd65b1) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* ROLLING THUNDER 2 (Japan) */
@@ -4422,6 +4535,10 @@ ROM_START( rthun2j )
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "rts_voi1.3m",  0x000000, 0x080000, CRC(e42027cd) SHA1(fa3a81118c7f112289c27023236dec2e9cbc78b5) )
 	ROM_LOAD16_BYTE( "rts_voi2.3l",  0x100000, 0x080000, CRC(0c4c2b66) SHA1(7723cbef755439a66d026015596fe1547ccd65b1) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	/* stuff below isn't used but loaded because it was on the board .. */
 	ROM_REGION( 0x0950, "plds", 0 )
@@ -4671,6 +4788,10 @@ ROM_START( sws )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ss_voi1.bin",  0x000000, 0x080000, CRC(503e51b7) SHA1(2e159fcc9bb0bef9a3476ae233bc8d61fabbb4bd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* SUPER WORLD STADIUM 92 */
@@ -4714,6 +4835,10 @@ ROM_START( sws92 )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ss_voi1.bin",  0x000000, 0x080000, CRC(503e51b7) SHA1(2e159fcc9bb0bef9a3476ae233bc8d61fabbb4bd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* SUPER WORLD STADIUM 92 */
@@ -4759,6 +4884,10 @@ ROM_START( sws92g )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ss_voi1.bin",  0x000000, 0x080000, CRC(503e51b7) SHA1(2e159fcc9bb0bef9a3476ae233bc8d61fabbb4bd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* SUPER WORLD STADIUM 93 */
@@ -4802,6 +4931,10 @@ ROM_START( sws93 )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
 	ROM_LOAD16_BYTE( "ss_voi1.bin",  0x000000, 0x080000, CRC(503e51b7) SHA1(2e159fcc9bb0bef9a3476ae233bc8d61fabbb4bd) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* SUZUKA 8 HOURS (World?) */
@@ -5057,6 +5190,10 @@ ROM_START( valkyrie )
 
 	ROM_REGION( 0x2000, "nvram", 0 ) /* game doesn't auto initialize nvram properly */
 	ROM_LOAD( "valkyrie.nv",  0x000000, 0x2000, CRC(d5ce4069) SHA1(ce01ebbbd8d4e03a7b8e0fa50296d6cc1a978800) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* KYUUKAI DOUCHUUKI */
@@ -5104,6 +5241,10 @@ ROM_START( kyukaidk )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 )    /* Sound voices */
 	ROM_LOAD16_BYTE( "ky1_v1.bin", 0x000000, 0x080000, CRC(5ff81aec) SHA1(0535eda474de0a4aa3b48649b04afe2b7a8619c9) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* KYUUKAI DOUCHUUKI (OLD) */
@@ -5151,6 +5292,10 @@ ROM_START( kyukaidko )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 )    /* Sound voices */
 	ROM_LOAD16_BYTE( "ky1_v1.bin", 0x000000, 0x080000, CRC(5ff81aec) SHA1(0535eda474de0a4aa3b48649b04afe2b7a8619c9) )
+
+	ROM_REGION( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom lookup table */
+	// from ordyne, not dumped from this hardware
+	ROM_LOAD( "lh5762.6n", 0x00000, 0x002000, BAD_DUMP CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 ROM_END
 
 /* GOLLY GHOST */
@@ -5189,7 +5334,7 @@ ROM_START( gollygho )
 	ROM_REGION16_BE( 0x200000, "data_rom", ROMREGION_ERASEFF ) /* Shared data roms */
 	/* All DAT ROM sockets unpopulated on PCB */
 
-	ROM_REGION16_BE( 0x2000, "zoomlut", 0 ) /* sprite zoom */
+	ROM_REGION16_BE( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom */
 	ROM_LOAD( "04544191.6n",  0x000000, 0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -5235,7 +5380,7 @@ ROM_START( bubbletr ) /* All labels were hand written and included the rom size,
 	NAMCOS2_DATA_LOAD_E_128K( "bt1_dat0.13s",   0x000000, CRC(1001a14e) SHA1(7017a33f0447fb6013d4e246dcdfcd064af87812) ) /* dated 4/24 */
 	NAMCOS2_DATA_LOAD_O_128K( "bt1_dat1.13p",   0x000000, CRC(7de6a839) SHA1(e6a3fd5b789dc061ec504570984cf61a6af7818f) ) /* dated 4/24 */
 
-	ROM_REGION16_BE( 0x2000, "zoomlut", 0 ) /* sprite zoom */
+	ROM_REGION16_BE( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom */
 	ROM_LOAD( "04544191.6n",  0x000000, 0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */
@@ -5281,7 +5426,7 @@ ROM_START( bubbletrj )
 	NAMCOS2_DATA_LOAD_E_128K( "bt1_dat0.13s",   0x000000, CRC(1001a14e) SHA1(7017a33f0447fb6013d4e246dcdfcd064af87812) )
 	NAMCOS2_DATA_LOAD_O_128K( "bt1_dat1.13p",   0x000000, CRC(7de6a839) SHA1(e6a3fd5b789dc061ec504570984cf61a6af7818f) )
 
-	ROM_REGION16_BE( 0x2000, "zoomlut", 0 ) /* sprite zoom */
+	ROM_REGION16_BE( 0x2000, "s2sprite:scalelut", 0 ) /* sprite zoom */
 	ROM_LOAD( "04544191.6n",  0x000000, 0x002000, CRC(90db1bf6) SHA1(dbb9e50a8efc3b4012fcf587cc87da9ef42a1b80) )
 
 	ROM_REGION16_BE( 0x200000, "c140", ROMREGION_ERASE00 ) /* Sound voices */

--- a/src/mame/namco/namcos2_sprite.cpp
+++ b/src/mame/namco/namcos2_sprite.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:David Haywood, Phil Stroffolino
+// copyright-holders:David Haywood, Phil Stroffolino, Ernesto Corvi, Juergen Buchmueller, Alex Pasadyn, Aaron Giles, Nicola Salmoria
 
 /*
     Namco System 2 Sprites - found on Namco System 2 video board (standard type)
@@ -19,9 +19,6 @@
     Device used by the following drivers:
     namco/namcos2.cpp (all games EXCEPT Steel Gunner, Steel Gunner 2, Lucky & Wild, Suzuka 8 Hours,
     Suzuka 8 Hours 2 which use the newer Namco NB1 style sprites, see shared/namco_c355spr.cpp).
-
-    TODO:
-    - Hook up zoom table ROM for vertical zooming ("zoomlut" region in namco/namcos2.cpp)
 */
 
 #include "emu.h"
@@ -32,28 +29,30 @@ DEFINE_DEVICE_TYPE(NAMCOS2_SPRITE_FINALLAP, namcos2_sprite_finallap_device, "nam
 DEFINE_DEVICE_TYPE(NAMCOS2_SPRITE_METALHAWK, namcos2_sprite_metalhawk_device, "namcos2_sprite_metalhawk", "Namco System 2 Sprites (C106,C134,C135,C146) (Metal Hawk)")
 
 namcos2_sprite_device::namcos2_sprite_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE, tag, owner, clock)
+	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE, tag, owner, clock, 0x7ff)
 {
 }
 
-namcos2_sprite_device::namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock) :
+namcos2_sprite_device::namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u16 xmask) :
 	device_t(mconfig, type, tag, owner, clock),
 	device_gfx_interface(mconfig, *this),
 	device_video_interface(mconfig, *this),
 	m_spriteram(*this, finder_base::DUMMY_TAG),
+	m_scalelut_region(*this, "scalelut"),
 	m_pri_cb(*this),
-	m_mix_cb(*this)
+	m_mix_cb(*this),
+	m_xmask(xmask)
 {
 }
 
 
 namcos2_sprite_metalhawk_device::namcos2_sprite_metalhawk_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE_METALHAWK, tag, owner, clock)
+	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE_METALHAWK, tag, owner, clock, 0x3ff)
 {
 }
 
 namcos2_sprite_finallap_device::namcos2_sprite_finallap_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock) :
-	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE_FINALLAP, tag, owner, clock)
+	namcos2_sprite_device(mconfig, NAMCOS2_SPRITE_FINALLAP, tag, owner, clock, 0x7ff)
 {
 }
 
@@ -70,102 +69,54 @@ void namcos2_sprite_device::device_start()
 
 /**************************************************************************************/
 
-void namcos2_sprite_device::zdrawgfxzoom(
-		bitmap_ind16 &dest_bmp,const rectangle &clip,gfx_element *gfx,
-		u32 code,u32 color,bool flipx,bool flipy,int sx,int sy,
-		int scalex, int scaley, u32 prival)
+void namcos2_sprite_device::draw_single_sprite(
+		bitmap_ind16 &bitmap, const rectangle &clip, gfx_element *gfx,
+		u32 code, u32 color, bool flipx, bool flipy, int sx, int sy,
+		int sizex, int sizey, u32 prival)
 {
-	if (!scalex || !scaley) return;
-	if (dest_bmp.bpp() == 16)
+	const u8 *const gfxdata = gfx->get_data(code % gfx->elements());
+	const u16 pal = gfx->granularity() * (color % gfx->colors());
+
+	const u8 offsxor = flipx ? (gfx->width() - 1) : 0;
+	const u16 lutbank = (flipy ? 0x1000 : 0) | sizey;
+
+	for (int y = 0; y <= sizey; y++)
 	{
-		if (gfx)
+		const int yy = (sy + y) & 0x1ff;
+
+		if (yy >= clip.min_y && yy <= clip.max_y)
 		{
-			const int sprite_screen_height = (scaley * gfx->height() + 0x8000) >> 16;
-			const int sprite_screen_width = (scalex * gfx->width() + 0x8000) >> 16;
-			if (sprite_screen_width && sprite_screen_height)
+			int dy = m_scalelut_region[lutbank | (y << 6)];
+			if (dy > 0x1f)
+				continue;
+			int xx = sx & m_xmask;
+			int siz = 0;
+			int offs = 0;
+
+			if (gfx->height() < 32) dy >>= 1;
+			const u8 *const src = &gfxdata[dy * gfx->rowbytes()];
+
+			for (int x = gfx->width() << 1; x > 0; x--)
 			{
-				const u8 *source_base = gfx->get_data(code % gfx->elements());
-				const u16 pal = gfx->granularity() * (color % gfx->colors());
+				if (xx >= clip.min_x && xx <= clip.max_x)
+				{
+					const u8 c = src[(offs >> 1) ^ offsxor];
 
-				// compute sprite increment per screen pixel
-				int dx = (gfx->width() << 16) / sprite_screen_width;
-				int dy = (gfx->height() << 16) / sprite_screen_height;
+					if (c != 0xff)
+						bitmap.pix(yy, xx) = ((prival & 0xf) << 12) | ((pal + c) & 0xfff);
+				}
+				offs++;
 
-				int ex = sx + sprite_screen_width;
-				int ey = sy + sprite_screen_height;
-
-				int x_index_base;
-				int y_index;
-
-				if (flipx)
+				siz += 1 + sizex;
+				if (siz >= 0x40)
 				{
-					x_index_base = (sprite_screen_width - 1) * dx;
-					dx = -dx;
-				}
-				else
-				{
-					x_index_base = 0;
-				}
-
-				if (flipy)
-				{
-					y_index = (sprite_screen_height - 1) * dy;
-					dy = -dy;
-				}
-				else
-				{
-					y_index = 0;
-				}
-
-				if (sx < clip.min_x)
-				{
-					// clip left
-					int pixels = clip.min_x - sx;
-					sx += pixels;
-					x_index_base += pixels * dx;
-				}
-				if (sy < clip.min_y)
-				{
-					// clip top
-					int pixels = clip.min_y - sy;
-					sy += pixels;
-					y_index += pixels * dy;
-				}
-				if (ex > clip.max_x + 1)
-				{
-					// clip right
-					int pixels = ex - clip.max_x - 1;
-					ex -= pixels;
-				}
-				if (ey > clip.max_y + 1)
-				{
-					// clip bottom
-					int pixels = ey - clip.max_y - 1;
-					ey -= pixels;
-				}
-
-				// skip if inner loop doesn't draw anything
-				if (ex > sx)
-				{
-					for (int y = sy; y < ey; y++)
-					{
-						u8 const *const source = source_base + (y_index >> 16) * gfx->rowbytes();
-						u16 *const dest = &dest_bmp.pix(y);
-						int x_index = x_index_base;
-						for (int x = sx; x < ex; x++)
-						{
-							const u8 c = source[x_index >> 16];
-							if (c != 0xff)
-								dest[x] = ((prival & 0xf) << 12) | ((pal + c) & 0xfff);
-							x_index += dx;
-						}
-						y_index += dy;
-					}
+					xx = (xx + (siz >> 6)) & m_xmask;
+					siz &= 0x3f;
 				}
 			}
 		}
 	}
-} /* zdrawgfxzoom */
+}
 
 void namcos2_sprite_device::copybitmap(screen_device &screen, bitmap_ind16 &dest_bmp, const rectangle &clip)
 {
@@ -275,45 +226,38 @@ void namcos2_sprite_device::draw_sprites(const rectangle &cliprect, int control)
 		const u16 word3   = m_spriteram[offset + (loop * 4) + 3];
 		const u16 word0   = m_spriteram[offset + (loop * 4) + 0];
 		const u16 word1   = m_spriteram[offset + (loop * 4) + 1];
-		const int sizey   = ((word0 >> 10) & 0x003f) + 1;
+		const int sizey   = (word0 >> 10) & 0x003f;
+		const int sizex = (word3 >> 10) & 0x003f;
 
-		u32 sprn;
-		bool is_32;
-
-		get_tilenum_and_size(word0, word1, sprn, is_32);
-
-		int sizex = (word3 >> 10) & 0x003f;
-		if (!is_32) sizex >>= 1;
-
-		if ((sizey - 1) && sizex)
+		if (sizey && sizex)
 		{
-			const int scalex = (sizex << 16) / (is_32 ? 0x20 : 0x10);
-			const int scaley = (sizey << 16) / (is_32 ? 0x20 : 0x10);
-			if (scalex && scaley)
-			{
-				const u32 prival = m_pri_cb(word3 & 0xf);
-				const u16 offset4 = m_spriteram[offset + (loop * 4) + 2];
-				const u32 color  = (word3 >> 4) & 0x000f;
-				const int ypos   = (0x1ff - (word0 & 0x01ff)) - 0x50 + 0x02;
-				const int xpos   = (offset4 & 0x07ff) - 0x50 + 0x07;
-				const bool flipy = BIT(word1, 15);
-				const bool flipx = BIT(word1, 14);
+			u32 sprn;
+			bool is_32;
 
-				if (!is_32)
-					sgfx->set_source_clip(BIT(word1, 0) ? 16 : 0, 16, BIT(word1, 1) ? 16 : 0, 16);
-				else
-					sgfx->set_source_clip(0, 32, 0, 32);
+			get_tilenum_and_size(word0, word1, sprn, is_32);
 
-				zdrawgfxzoom(
-						m_renderbitmap,
-						cliprect,
-						sgfx,
-						sprn, color,
-						flipx, flipy,
-						xpos, ypos,
-						scalex, scaley,
-						prival);
-			}
+			const u32 prival = m_pri_cb(word3 & 0xf);
+			const u16 offset4 = m_spriteram[offset + (loop * 4) + 2];
+			const u32 color  = (word3 >> 4) & 0x000f;
+			const int ypos   = (0x1ff - (word0 & 0x01ff)) - 0x50 + 0x02;
+			const int xpos   = (offset4 & 0x07ff) - 0x50 + 0x07;
+			const bool flipy = BIT(word1, 15);
+			const bool flipx = BIT(word1, 14);
+
+			if (!is_32)
+				sgfx->set_source_clip(BIT(word1, 0) ? 16 : 0, 16, BIT(word1, 1) ? 16 : 0, 16);
+			else
+				sgfx->set_source_clip(0, 32, 0, 32);
+
+			draw_single_sprite(
+					m_renderbitmap,
+					cliprect,
+					sgfx,
+					sprn, color,
+					flipx, flipy,
+					xpos, ypos,
+					sizex, sizey,
+					prival);
 		}
 	}
 } /* draw_sprites */
@@ -353,10 +297,10 @@ void namcos2_sprite_metalhawk_device::draw_sprites(const rectangle &cliprect, in
 	{
 		const u16 ypos  = m_spriteram[(loop * 8) + 0];
 		const u16 xpos  = m_spriteram[(loop * 8) + 3];
-		const int sizey = ((ypos >> 10) & 0x003f) + 1;
-		const int sizex =  (xpos >> 10) & 0x003f;
+		const int sizey = (ypos >> 10) & 0x003f;
+		const int sizex = (xpos >> 10) & 0x003f;
 
-		if ((sizey - 1) && sizex)
+		if (sizey && sizex)
 		{
 			const u16 attrs = m_spriteram[(loop * 8) + 7];
 
@@ -371,8 +315,6 @@ void namcos2_sprite_metalhawk_device::draw_sprites(const rectangle &cliprect, in
 			int sy           = (0x1ff - (ypos & 0x01ff)) - 0x50 + 0x02;
 			const bool flipx = BIT(flags, 1);
 			const bool flipy = BIT(flags, 2);
-			const int scalex = (sizex << 16) / (0x20);//(sizex << 16) / (is_bigsprite ? 0x20 : 0x10); correct formula?
-			const int scaley = (sizey << 16) / (is_bigsprite ? 0x20 : 0x10);
 
 			/* swap xy */
 			const int rgn = (flags & 0x0001);
@@ -385,23 +327,23 @@ void namcos2_sprite_metalhawk_device::draw_sprites(const rectangle &cliprect, in
 				{
 					sx -= (0x20 - sizex) / 0x8;
 				}
-				if (sizey < 0x20)
+				if (sizey < 0x1f)
 				{
-					sy += (0x20 - sizey) / 0xc;
+					sy += (0x20 - (sizey + 1)) / 0xc;
 				}
 				sgfx->set_source_clip(0, 32, 0, 32);
 			}
 			else
 				sgfx->set_source_clip(BIT(tile, 0) ? 16 : 0, 16, BIT(tile, 1) ? 16 : 0, 16);
 
-			zdrawgfxzoom(
+			draw_single_sprite(
 					m_renderbitmap,
 					cliprect,
 					sgfx,
 					sprn, color,
 					flipx, flipy,
 					sx, sy,
-					scalex, scaley,
+					sizex, sizey,
 					prival);
 		}
 	}

--- a/src/mame/namco/namcos2_sprite.h
+++ b/src/mame/namco/namcos2_sprite.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:David Haywood
+// copyright-holders:David Haywood, Phil Stroffolino, Ernesto Corvi, Juergen Buchmueller, Alex Pasadyn, Aaron Giles, Nicola Salmoria
 
 #ifndef MAME_NAMCO_NAMCOS2_SPRITE_H
 #define MAME_NAMCO_NAMCOS2_SPRITE_H
@@ -43,7 +43,7 @@ public:
 	bitmap_ind16 &screen_bitmap() { return m_screenbitmap; }
 
 protected:
-	namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+	namcos2_sprite_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u16 xmask);
 
 	// device_t implementation
 	virtual void device_start() override ATTR_COLD;
@@ -58,15 +58,18 @@ protected:
 
 	template <class BitmapClass> void draw_common(screen_device &screen, BitmapClass &bitmap, const rectangle &cliprect, int control);
 
-	void zdrawgfxzoom(bitmap_ind16 &dest_bmp, const rectangle &clip, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, int scalex, int scaley, u32 prival);
+	void draw_single_sprite(bitmap_ind16 &bitmap, const rectangle &clip, gfx_element *gfx, u32 code, u32 color, bool flipx, bool flipy, int sx, int sy, int sizex, int sizey, u32 prival);
 
 	required_shared_ptr<u16> m_spriteram;
+	required_region_ptr<u8> m_scalelut_region;
 
 	ns2_priority_delegate m_pri_cb;
 	ns2_mix_delegate m_mix_cb;
 
 	bitmap_ind16 m_renderbitmap;
 	bitmap_ind16 m_screenbitmap;
+
+	u16 m_xmask;
 };
 
 class namcos2_sprite_finallap_device : public namcos2_sprite_device


### PR DESCRIPTION
Use scalelut region for zoom y calculation

Hardware is evolution of pole position hardware (namco/polepos.cpp), so I copied and modified for namcos2 sprite hardware (namco/namcos2_sprite.cpp).

Differences:
- Padding/"Ignored" bytes: 0x80 (polepos) vs 0xff (namcos2_sprite)
- namcos2_sprite has vertical flip feature, scale LUT region accessed to top half when flipped.
- scale LUT is twice as large for handle vertical flip in namcos2_sprite

scalelut is from ordyne, when not dumped from hardware. (should be dumped from these hardwares?)

AI disclosure: analysis assisted with Cursor Grok 4.6