### PR TITLE
swp30: iir2 register order, and a leak in the dpcm accumulator

### DIFF
--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -622,7 +622,10 @@ void swp30_device::streaming_block::dpcm_step(u8 input)
 	m_dpcm_s2 = m_dpcm_s3;
 
 	s32 delta = m_dpcm_delta + dpcm_expand[input];
-	s32 sample = m_dpcm_s3 + (delta << scale);
+	s32 acc = m_dpcm_s3;
+	if(mode != 3)
+		acc -= s32((s64(acc) * 3) >> 7);
+	s32 sample = acc + (delta << scale);
 
 	if(sample < -0x8000) {
 		sample = -0x8000;

--- a/src/devices/sound/swp30.cpp
+++ b/src/devices/sound/swp30.cpp
@@ -155,11 +155,11 @@ TODOs:
   aaaaaa 100011  MEG/Data         cccc cccc cccc cccc                      constant index 6*a + 1
   cccccc 100100  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR1 a0
   aaaaaa 100101  MEG/Data         cccc cccc cccc cccc                      constant index 6*a + 2
-  cccccc 100110  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR1 a1
+  cccccc 100110  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR2 b1
   aaaaaa 100111  MEG/Data         cccc cccc cccc cccc                      constant index 6*a + 3
-  cccccc 101000  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR1 b1
+  cccccc 101000  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR2 a1
   aaaaaa 101001  MEG/Data         cccc cccc cccc cccc                      constant index 6*a + 4
-  cccccc 101010  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR1 a0
+  cccccc 101010  AWM2/IIR         vvvv vvvv vvvv vvvv                      IIR2 a0
   aaaaaa 101011  MEG/Data         cccc cccc cccc cccc                      constant index 6*a + 5
 
 
@@ -1970,8 +1970,8 @@ void swp30_device::map(address_map &map)
 	rchan(map, 0x20).rw(FUNC(swp30_device::a1_r<0>), FUNC(swp30_device::a1_w<0>));
 	rchan(map, 0x22).rw(FUNC(swp30_device::b1_r<0>), FUNC(swp30_device::b1_w<0>));
 	rchan(map, 0x24).rw(FUNC(swp30_device::a0_r<0>), FUNC(swp30_device::a0_w<0>));
-	rchan(map, 0x26).rw(FUNC(swp30_device::a1_r<1>), FUNC(swp30_device::a1_w<1>));
-	rchan(map, 0x28).rw(FUNC(swp30_device::b1_r<1>), FUNC(swp30_device::b1_w<1>));
+	rchan(map, 0x26).rw(FUNC(swp30_device::b1_r<1>), FUNC(swp30_device::b1_w<1>));
+	rchan(map, 0x28).rw(FUNC(swp30_device::a1_r<1>), FUNC(swp30_device::a1_w<1>));
 	rchan(map, 0x2a).rw(FUNC(swp30_device::a0_r<1>), FUNC(swp30_device::a0_w<1>));
 	// 2c-2f missing
 


### PR DESCRIPTION
Two swp30 fixes found by recording a real MU2000 over s/pdif and comparing it
against the emulation note by note. Measurements are in the commit messages;
this is the summary.

### 1. iir2's a1 and b1 registers are swapped

Slots 0x26 and 0x28 are registered as a1 then b1, but the table above the IIR1
block says the second filter takes b1 first:

```
//   cccccc 100110   IIR2 b1
//   cccccc 101000   IIR2 a1
```

Read the current way, the mu2000 firmware programs a feedback coefficient of
-20591 — -2.51 in Q13, well outside the unit circle. The filter diverges, the
output alternates sign and grows 2.5x per sample until it saturates, and the
voice becomes a constant-amplitude 22.05 kHz square wave about twenty times
louder than anything else on the chip. The dac clips and the rest of the mix
disappears under it. Swapped, the three registers read a0=2.70, a1=-2.51,
b1=0.818 — a stable one-pole with a dc gain of 1.04.

On a 27-track sequence reaching 31 simultaneous notes, the fraction of 50 ms
blocks where consecutive samples alternate in sign goes from 100.0% to 21.7%
(ordinary music), and the peak from 32768 (clipped) to 23529.

### 2. The dpcm accumulator leaks in compressor modes 0-2

The reconstruction is an integrator with no bound. Mode 0-2 samples in the
mu2000 wave rom have a systematically positive delta stream, so it ramps into
the clamp within a fifth of a second and the voice becomes a dc offset with the
waveform riding on top. Trumpet (gm 57) splits at midi 51/52; the sample used
from 52 up is mode 2 and its 5086 delta bytes sum to +3119. The sample used
from 51 down is mode 3 and its loop sums to exactly 0, so that mode does not
leak — the encoder clearly targets a decoder that behaves differently per mode.

Leak fitted against the hardware, one note each side of the split, no effects:

| leak | h1/h2 | h1/h3 | rms error over 15 harmonics | below 30 Hz |
|---|---|---|---|---|
| hardware | 0.7357 | 1.3410 | — | 0.13% |
| none | 0.8782 | 1.5637 | 0.041 | 27.12% |
| 2/256 | 0.7466 | 1.3827 | 0.006 | 11.20% |
| **3/128** | 0.7295 | 1.3446 | **0.002** | 5.32% |
| 4/256 | 0.7071 | 1.2948 | 0.005 | 3.07% |

0.002 is closer than the mode 3 sample manages (0.003), and mode 3 output is
unchanged bit for bit. The 5.3% still below 30 Hz against the hardware's 0.13%
is not accounted for; a stronger leak trades that against the harmonic fit and
comes out worse.

### Left out: the meg register write wraps instead of saturating

Not in this PR because it needs a matching drc change I cannot test, but it is
the same family of bug and it is audible, so it seems worth reporting.

`p` is 42-bit and the destination register is 24-bit. In the `dm` case 6 and
`dr` paths the dither is added before the shift, so a `p` sitting on the
positive clamp `0x3fffffffff` can be pushed past it, and `(p >> 15) & 0xffffff`
then reads back as `0x800000` — the most negative value. The distortion
insertion effect deliberately runs `p` into the clamp (it amplifies by ~1593x
and averages five stages that saturate at different points to build a
piecewise soft clipper), so this bites hard: tracing 1000 samples, pc 0x0d0 is
positive-saturated 71.5% of the time and pc 0x0d3, which reads that register,
is negative-saturated 94.2% of the time. The effect output becomes dc.

Clamping to [-0x800000, 0x7fffff] instead of masking fixes it. Against the
hardware, on a C4 through the distortion insertion:

```
                dc     largest peak    rms
  before    +182.1     0 Hz (190)    189.0
  after       -1.7   261 Hz  (47)    146.0
  hardware   -16.2   262 Hz  (63)    127.4
```

The drc emits the same wrapping sequence (`UML_DSAR` by 7 then `UML_SAR` by 8),
so fixing only the interpreter would leave the default path unchanged. I have
no way to build and test a uml change here, so I have left both halves out.
Happy to add them if you want it.

### Reproducing

Both were found with headless runs and a midi file:

```
mame mu2000 -bios v200 -midiin1 song.mid -wavwrite out.wav \
    -seconds_to_run 30 -video none
```

The hardware side was recorded from the machine's s/pdif output while the same
file was played to it over usb midi, so the two can be lined up note for note.
The wave roms used were dumped from the author's own MU2000 and match the
hashes already registered for `mu2000`.
