### PR TITLE
osd: Keep the primary monitor at the front of the monitor list

### DIFF
--- a/src/osd/modules/monitor/monitor_common.cpp
+++ b/src/osd/modules/monitor/monitor_common.cpp
@@ -43,7 +43,11 @@ std::shared_ptr<osd_monitor_info> monitor_module_base::monitor_from_handle(std::
 
 void monitor_module_base::add_monitor(std::shared_ptr<osd_monitor_info> monitor)
 {
-	list().push_back(monitor);
+	if (monitor->is_primary())
+		list().insert(list().begin(), monitor);
+	else
+		list().push_back(monitor);
+
 	m_monitor_index[monitor->oshandle()] = monitor;
 }
 


### PR DESCRIPTION
The primary monitor isn't always the first monitor. This commit special cases the primary monitor and sorts it into the front of the monitor list, so that "screen auto" opens on the primary monitor.

Fixes #7922 and maybe also #12431 and #7532
