### PR TITLE
New WORKING: Roland Sound Brush SB-55

### DIFF
--- a/src/devices/cpu/nec/v25.cpp
+++ b/src/devices/cpu/nec/v25.cpp
@@ -22,9 +22,9 @@
     Timer implementation is incomplete: polling is not implemented
     (reading any of the registers just returns the last value written)
 
-    Serial interface and DMA functions not implemented.
-    Note that these functions differ considerably between
-    the V25/35 and the V25+/35+.
+    The serial interface implements asynchronous mode only; I/O interface
+    mode is not emulated.  Note that the serial interface and the DMA
+    controller differ considerably between the V25/35 and the V25+/35+.
 
     Make internal RAM into a real RAM region, and use an
     internal address map (remapped when IDB is written to)
@@ -42,6 +42,8 @@
 //#define VERBOSE (...)
 
 #include "logmacro.h"
+
+#include <bit>
 
 typedef uint8_t BOOLEAN;
 typedef uint8_t BYTE;
@@ -71,6 +73,7 @@ v25_common_device::v25_common_device(const machine_config &mconfig, device_type 
 	, m_p2_out(*this)
 	, m_dma_read(*this, 0xffff)
 	, m_dma_write(*this)
+	, m_txd_handler(*this)
 	, m_tc_handler(*this)
 	, m_prefetch_size(prefetch_size)
 	, m_prefetch_cycles(prefetch_cycles)
@@ -105,6 +108,187 @@ device_memory_interface::space_config_vector v25_common_device::memory_space_con
 TIMER_CALLBACK_MEMBER(v25_common_device::v25_timer_callback)
 {
 	m_pending_irq |= param;
+}
+
+static const uint32_t s_serial_irq[2][3] =
+{
+	{ INTSER0, INTSR0, INTST0 },
+	{ INTSER1, INTSR1, INTST1 }
+};
+
+attotime v25_common_device::serial_bit_time(unsigned n) const
+{
+	const unsigned brg = m_brg[n] ? m_brg[n] : 256;
+	return clocks_to_attotime(uint64_t(m_PCK) * (2 << (m_scc[n] & 0x0f)) * brg);
+}
+
+unsigned v25_common_device::serial_data_bits(unsigned n) const
+{
+	return BIT(m_scm[n], 3) ? 8 : 7;
+}
+
+// PRTY1:PRTY0 selects no parity, a parity bit fixed at zero, odd parity or even parity
+static uint8_t v25_parity_bit(uint8_t mode, uint8_t data)
+{
+	if (mode < 2)
+		return 0;
+	const unsigned ones = std::popcount(data);
+	return (mode == 3) ? (ones & 1) : ((ones & 1) ^ 1);
+}
+
+void v25_common_device::scm_w(unsigned n, uint8_t d)
+{
+	const uint8_t old = m_scm[n];
+	m_scm[n] = d;
+
+	if (!BIT(d, 0))
+	{
+		if (BIT(d, 0) != BIT(old, 0))
+			logerror("%06x: SCM%u set to %02x: I/O interface mode not emulated\n", PC(), n, d);
+		return;
+	}
+
+	if (!BIT(d, 6) && BIT(old, 6))
+	{
+		m_rx_timer[n]->adjust(attotime::never);
+		m_rx_count[n] = 0;
+	}
+
+	if (!BIT(d, 7) && BIT(old, 7))
+	{
+		m_tx_timer[n]->adjust(attotime::never);
+		m_tx_count[n] = 0;
+		m_tx_pending[n] = false;
+		m_txd_handler[n](1);
+	}
+	else if (BIT(d, 7) && !BIT(old, 7))
+		serial_tx_enabled(n);
+}
+
+// Appendix A.3 of the user's manual has it that enabling transmission, by setting TxRDY or
+// by taking CTS low, raises a transmission completion interrupt of its own.  Firmware that
+// keeps its output in a queue relies on it: it appends a byte, sets TxRDY, and leaves the
+// handler to move the first byte into the transmit buffer.
+void v25_common_device::serial_tx_enabled(unsigned n)
+{
+	if (!BIT(m_scm[n], 7) || !BIT(m_scm[n], 0) || m_cts_state[n])
+		return;
+
+	if (m_tx_pending[n])
+		serial_load_tx(n);
+	else if (!m_tx_count[n])
+		m_pending_irq |= s_serial_irq[n][2];
+}
+
+uint8_t v25_common_device::rxb_r(unsigned n)
+{
+	if (!machine().side_effects_disabled())
+		m_rx_full[n] = false;
+	return m_rxb[n];
+}
+
+void v25_common_device::txb_w(unsigned n, uint8_t d)
+{
+	m_txb[n] = d;
+	m_tx_pending[n] = true;
+	if (!m_tx_count[n])
+		serial_load_tx(n);
+}
+
+// the frame is shifted out LSB first below a run of ones, so that the line idles high
+// once it has emptied
+void v25_common_device::serial_load_tx(unsigned n)
+{
+	if (!BIT(m_scm[n], 7) || !BIT(m_scm[n], 0) || m_cts_state[n])
+		return;
+
+	const unsigned bits = serial_data_bits(n);
+	const uint8_t data = m_txb[n] & make_bitmask<uint8_t>(bits);
+	const uint8_t parity = BIT(m_scm[n], 4, 2);
+
+	uint16_t frame = uint16_t(data) << 1;
+	unsigned length = 1 + bits;
+	if (parity)
+		frame |= uint16_t(v25_parity_bit(parity, data)) << length++;
+	frame |= 0xffff << length;
+	length += BIT(m_scm[n], 2) ? 2 : 1;
+
+	m_tx_shift[n] = frame;
+	m_tx_count[n] = length;
+	m_tx_pending[n] = false;
+
+	m_txd_handler[n](BIT(frame, 0));
+	m_tx_timer[n]->adjust(serial_bit_time(n), n);
+}
+
+TIMER_CALLBACK_MEMBER(v25_common_device::serial_tx_callback)
+{
+	const unsigned n = param;
+
+	m_tx_shift[n] >>= 1;
+	if (--m_tx_count[n])
+	{
+		m_txd_handler[n](BIT(m_tx_shift[n], 0));
+		m_tx_timer[n]->adjust(serial_bit_time(n), n);
+		return;
+	}
+
+	m_txd_handler[n](1);
+	m_pending_irq |= s_serial_irq[n][2];
+
+	if (m_tx_pending[n])
+		serial_load_tx(n);
+}
+
+void v25_common_device::serial_rxd_w(unsigned n, int state)
+{
+	const uint8_t level = state ? 1 : 0;
+	if (m_rxd_state[n] == level)
+		return;
+	m_rxd_state[n] = level;
+
+	// a start bit is only looked for between frames; the first sample sits one and a
+	// half bits into it, so that it and the rest land in the middle of their cells
+	if (!level && BIT(m_scm[n], 6) && BIT(m_scm[n], 0) && !m_rx_count[n])
+	{
+		m_rx_shift[n] = 0;
+		m_rx_count[n] = 1;
+		m_rx_timer[n]->adjust(serial_bit_time(n) * 3 / 2, n);
+	}
+}
+
+TIMER_CALLBACK_MEMBER(v25_common_device::serial_rx_callback)
+{
+	const unsigned n = param;
+	const unsigned bits = serial_data_bits(n);
+	const uint8_t parity = BIT(m_scm[n], 4, 2);
+
+	if (m_rx_count[n] <= bits + (parity ? 1 : 0))
+	{
+		m_rx_shift[n] |= uint16_t(m_rxd_state[n]) << (m_rx_count[n] - 1);
+		m_rx_count[n]++;
+		m_rx_timer[n]->adjust(serial_bit_time(n), n);
+		return;
+	}
+
+	const uint8_t data = m_rx_shift[n] & make_bitmask<uint16_t>(bits);
+
+	// the last sample is the stop bit: a low one is a framing error, and a byte still
+	// unread in the buffer is an overrun
+	uint8_t error = 0;
+	if (!m_rxd_state[n])
+		error |= 0x02;
+	if (m_rx_full[n])
+		error |= 0x01;
+	if (parity > 1 && BIT(m_rx_shift[n], bits) != v25_parity_bit(parity, data))
+		error |= 0x04;
+
+	m_rxb[n] = data;
+	m_rx_full[n] = true;
+	m_sce[n] = error;
+	m_rx_count[n] = 0;
+
+	m_pending_irq |= s_serial_irq[n][error ? 0 : 1];
 }
 
 void v25_common_device::prefetch()
@@ -228,6 +412,17 @@ void v25_common_device::device_reset()
 		m_scc[i] = 0;
 		m_brg[i] = 0;
 		m_sce[i] = 0;
+		m_txb[i] = 0;
+		m_rxb[i] = 0;
+		m_tx_shift[i] = 0;
+		m_tx_count[i] = 0;
+		m_tx_pending[i] = false;
+		m_rx_shift[i] = 0;
+		m_rx_count[i] = 0;
+		m_rx_full[i] = false;
+		m_tx_timer[i]->adjust(attotime::never);
+		m_rx_timer[i]->adjust(attotime::never);
+		m_txd_handler[i](1);
 	}
 
 	m_dmam[0] = m_dmam[1] = 0;
@@ -729,15 +924,33 @@ void v25_common_device::device_start()
 	for (i = 0; i < 4; i++)
 		m_timers[i] = timer_alloc(FUNC(v25_common_device::v25_timer_callback), this);
 
+	for (i = 0; i < 2; i++)
+	{
+		m_tx_timer[i] = timer_alloc(FUNC(v25_common_device::serial_tx_callback), this);
+		m_rx_timer[i] = timer_alloc(FUNC(v25_common_device::serial_rx_callback), this);
+	}
+
 	std::fill_n(&m_dmarq_state[0], 2, 0);
+	std::fill_n(&m_rxd_state[0], 2, 1);
+	std::fill_n(&m_cts_state[0], 2, 0);
 	std::fill_n(&m_intp_state[0], 3, 0);
 	std::fill_n(&m_ems[0], 3, 0);
 	std::fill_n(&m_srms[0], 2, 0);
 	std::fill_n(&m_stms[0], 2, 0);
 	std::fill_n(&m_tmms[0], 3, 0);
 
+	save_item(NAME(m_txb));
+	save_item(NAME(m_rxb));
+	save_item(NAME(m_tx_shift));
+	save_item(NAME(m_tx_count));
+	save_item(NAME(m_tx_pending));
+	save_item(NAME(m_rx_shift));
+	save_item(NAME(m_rx_count));
+	save_item(NAME(m_rx_full));
 	save_item(NAME(m_dmarq_state));
 	save_item(NAME(m_dmarq_edge));
+	save_item(NAME(m_rxd_state));
+	save_item(NAME(m_cts_state));
 	save_item(NAME(m_intp_state));
 
 	save_item(NAME(m_ip));

--- a/src/devices/cpu/nec/v25.cpp
+++ b/src/devices/cpu/nec/v25.cpp
@@ -71,6 +71,7 @@ v25_common_device::v25_common_device(const machine_config &mconfig, device_type 
 	, m_p2_out(*this)
 	, m_dma_read(*this, 0xffff)
 	, m_dma_write(*this)
+	, m_tc_handler(*this)
 	, m_prefetch_size(prefetch_size)
 	, m_prefetch_cycles(prefetch_cycles)
 	, m_chip_type(chip_type)
@@ -230,6 +231,7 @@ void v25_common_device::device_reset()
 	}
 
 	m_dmam[0] = m_dmam[1] = 0;
+	m_dmarq_edge[0] = m_dmarq_edge[1] = false;
 	m_dma_channel = -1;
 	m_last_dma_channel = 0;
 
@@ -491,6 +493,37 @@ void v25_common_device::external_int()
 	}
 }
 
+// Single step and burst mode start from the TDMA bit; the modes that move bytes between
+// memory and I/O start from the DMARQ pin instead, one transfer per rising edge or, in
+// demand release mode, for as long as the pin is held high.
+void v25_common_device::dmarq_state_w(unsigned n, int state)
+{
+	const uint8_t level = state ? 1 : 0;
+	if (m_dmarq_state[n] == level)
+		return;
+	m_dmarq_state[n] = level;
+	if (level)
+		m_dmarq_edge[n] = true;
+}
+
+bool v25_common_device::dma_requested(unsigned n) const
+{
+	if (!BIT(m_dmam[n], 3))
+		return false;
+
+	switch (BIT(m_dmam[n], 5, 3))
+	{
+	case 0: case 4:
+		return BIT(m_dmam[n], 2);
+	case 1: case 2:
+		return m_dmarq_state[n] != 0;
+	case 5: case 6:
+		return m_dmarq_edge[n];
+	default:
+		return false;
+	}
+}
+
 void v25_common_device::dma_process()
 {
 	uint16_t sar = m_internal_ram[m_dma_channel * 4];
@@ -501,6 +534,9 @@ void v25_common_device::dma_process()
 
 	uint32_t saddr = ((uint32_t(sarh_darh) & 0xff00) << 4) + sar;
 	uint32_t daddr = ((uint32_t(sarh_darh) & 0x00ff) << 12) + dar;
+
+	if (dmamode > 4)
+		m_dmarq_edge[m_dma_channel] = false;
 
 	switch (dmamode & 3)
 	{
@@ -584,6 +620,9 @@ void v25_common_device::dma_process()
 	uint16_t tc = --m_internal_ram[m_dma_channel * 4 + 3];
 	if (tc == 0)
 	{
+		// the TC pin marks the last transfer for the device on the other end
+		m_tc_handler[m_dma_channel](1);
+		m_tc_handler[m_dma_channel](0);
 		m_dmam[m_dma_channel] &= 0xf0; // disable channel
 		m_pending_irq |= m_dma_channel ? INTD1 : INTD0; // request interrupt
 	}
@@ -690,12 +729,15 @@ void v25_common_device::device_start()
 	for (i = 0; i < 4; i++)
 		m_timers[i] = timer_alloc(FUNC(v25_common_device::v25_timer_callback), this);
 
+	std::fill_n(&m_dmarq_state[0], 2, 0);
 	std::fill_n(&m_intp_state[0], 3, 0);
 	std::fill_n(&m_ems[0], 3, 0);
 	std::fill_n(&m_srms[0], 2, 0);
 	std::fill_n(&m_stms[0], 2, 0);
 	std::fill_n(&m_tmms[0], 3, 0);
 
+	save_item(NAME(m_dmarq_state));
+	save_item(NAME(m_dmarq_edge));
 	save_item(NAME(m_intp_state));
 
 	save_item(NAME(m_ip));
@@ -941,9 +983,9 @@ void v25_common_device::execute_run()
 			(this->*s_nec_instruction[fetchop()])();
 		do_prefetch();
 
-		if ((m_dmam[0] & 0x0c) == 0x0c || (m_dmam[1] & 0x0c) == 0x0c)
+		if (dma_requested(0) || dma_requested(1))
 		{
-			if ((m_dmam[1 - m_last_dma_channel] & 0x0c) == 0x0c)
+			if (dma_requested(1 - m_last_dma_channel))
 				m_dma_channel = 1 - m_last_dma_channel;
 			else
 				m_dma_channel = m_last_dma_channel;

--- a/src/devices/cpu/nec/v25.h
+++ b/src/devices/cpu/nec/v25.h
@@ -45,11 +45,24 @@ public:
 	auto dma0_write_cb() { return m_dma_write[0].bind(); }
 	auto dma1_write_cb() { return m_dma_write[1].bind(); }
 
+	template <unsigned N> auto txd_handler() { return m_txd_handler[N].bind(); }
 	template <unsigned N> auto tc_handler() { return m_tc_handler[N].bind(); }
 
 	template <unsigned N> void dmarq_w(int state) { dmarq_state_w(N, state); }
+	template <unsigned N> void rxd_w(int state) { serial_rxd_w(N, state); }
+	template <unsigned N> void cts_w(int state)
+	{
+		const uint8_t level = state ? 1 : 0;
+		if (m_cts_state[N] == level)
+			return;
+		m_cts_state[N] = level;
+		if (!level)
+			serial_tx_enabled(N);
+	}
 
 	TIMER_CALLBACK_MEMBER(v25_timer_callback);
+	TIMER_CALLBACK_MEMBER(serial_tx_callback);
+	TIMER_CALLBACK_MEMBER(serial_rx_callback);
 
 protected:
 	// construction/destruction
@@ -135,6 +148,18 @@ private:
 	uint8_t   m_scc[2];
 	uint8_t   m_brg[2];
 	uint8_t   m_sce[2];
+	uint8_t   m_txb[2];
+	uint8_t   m_rxb[2];
+	uint16_t  m_tx_shift[2];
+	uint8_t   m_tx_count[2];
+	bool      m_tx_pending[2];
+	uint16_t  m_rx_shift[2];
+	uint8_t   m_rx_count[2];
+	bool      m_rx_full[2];
+	uint8_t   m_rxd_state[2];
+	uint8_t   m_cts_state[2];
+	emu_timer *m_tx_timer[2];
+	emu_timer *m_rx_timer[2];
 
 	// DMA related
 	uint8_t   m_dmac[2];
@@ -169,6 +194,7 @@ private:
 	devcb_read16::array<2> m_dma_read;
 	devcb_write16::array<2> m_dma_write;
 
+	devcb_write_line::array<2> m_txd_handler;
 	devcb_write_line::array<2> m_tc_handler;
 
 	int32_t   m_cur_cycles;
@@ -235,6 +261,18 @@ private:
 	void exic2_w(uint8_t d);
 	void dmarq_state_w(unsigned n, int state);
 	bool dma_requested(unsigned n) const;
+	attotime serial_bit_time(unsigned n) const;
+	unsigned serial_data_bits(unsigned n) const;
+	void serial_rxd_w(unsigned n, int state);
+	void serial_load_tx(unsigned n);
+	void serial_tx_enabled(unsigned n);
+	uint8_t rxb_r(unsigned n);
+	void txb_w(unsigned n, uint8_t d);
+	void scm_w(unsigned n, uint8_t d);
+	uint8_t rxb0_r();
+	void txb0_w(uint8_t d);
+	uint8_t rxb1_r();
+	void txb1_w(uint8_t d);
 	uint8_t srms0_r();
 	void srms0_w(uint8_t d);
 	uint8_t stms0_r();

--- a/src/devices/cpu/nec/v25.h
+++ b/src/devices/cpu/nec/v25.h
@@ -267,7 +267,9 @@ private:
 	void tm1_w(uint16_t d);
 	uint16_t md1_r();
 	void md1_w(uint16_t d);
+	uint8_t tmc0_r();
 	void tmc0_w(uint8_t d);
+	uint8_t tmc1_r();
 	void tmc1_w(uint8_t d);
 	uint8_t tmms_r(offs_t a);
 	void tmms_w(offs_t a, uint8_t d);

--- a/src/devices/cpu/nec/v25.h
+++ b/src/devices/cpu/nec/v25.h
@@ -45,6 +45,10 @@ public:
 	auto dma0_write_cb() { return m_dma_write[0].bind(); }
 	auto dma1_write_cb() { return m_dma_write[1].bind(); }
 
+	template <unsigned N> auto tc_handler() { return m_tc_handler[N].bind(); }
+
+	template <unsigned N> void dmarq_w(int state) { dmarq_state_w(N, state); }
+
 	TIMER_CALLBACK_MEMBER(v25_timer_callback);
 
 protected:
@@ -135,6 +139,8 @@ private:
 	// DMA related
 	uint8_t   m_dmac[2];
 	uint8_t   m_dmam[2];
+	uint8_t   m_dmarq_state[2];
+	bool      m_dmarq_edge[2];
 	int8_t    m_dma_channel;
 	int8_t    m_last_dma_channel;
 
@@ -162,6 +168,8 @@ private:
 
 	devcb_read16::array<2> m_dma_read;
 	devcb_write16::array<2> m_dma_write;
+
+	devcb_write_line::array<2> m_tc_handler;
 
 	int32_t   m_cur_cycles;
 	uint8_t   m_prefetch_size;
@@ -225,6 +233,8 @@ private:
 	void exic1_w(uint8_t d);
 	uint8_t exic2_r();
 	void exic2_w(uint8_t d);
+	void dmarq_state_w(unsigned n, int state);
+	bool dma_requested(unsigned n) const;
 	uint8_t srms0_r();
 	void srms0_w(uint8_t d);
 	uint8_t stms0_r();

--- a/src/devices/cpu/nec/v25sfr.cpp
+++ b/src/devices/cpu/nec/v25sfr.cpp
@@ -51,8 +51,8 @@ void v25_common_device::ida_sfr_map(address_map &map)
 	map(0x182, 0x183).rw(FUNC(v25_common_device::md0_r), FUNC(v25_common_device::md0_w));
 	map(0x188, 0x189).rw(FUNC(v25_common_device::tm1_r), FUNC(v25_common_device::tm1_w));
 	map(0x18a, 0x18b).rw(FUNC(v25_common_device::md1_r), FUNC(v25_common_device::md1_w));
-	map(0x190, 0x190).w(FUNC(v25_common_device::tmc0_w));
-	map(0x191, 0x191).w(FUNC(v25_common_device::tmc1_w));
+	map(0x190, 0x190).rw(FUNC(v25_common_device::tmc0_r), FUNC(v25_common_device::tmc0_w));
+	map(0x191, 0x191).rw(FUNC(v25_common_device::tmc1_r), FUNC(v25_common_device::tmc1_w));
 	map(0x194, 0x196).rw(FUNC(v25_common_device::tmms_r), FUNC(v25_common_device::tmms_w));
 	map(0x19c, 0x19c).rw(FUNC(v25_common_device::tmic0_r), FUNC(v25_common_device::tmic0_w));
 	map(0x19d, 0x19d).rw(FUNC(v25_common_device::tmic1_r), FUNC(v25_common_device::tmic1_w));
@@ -484,6 +484,11 @@ void v25_common_device::md1_w(uint16_t d)
 		m_MD1 = d;
 }
 
+uint8_t v25_common_device::tmc0_r()
+{
+	return m_TMC0;
+}
+
 void v25_common_device::tmc0_w(uint8_t d)
 {
 	m_TMC0 = d;
@@ -523,6 +528,11 @@ void v25_common_device::tmc0_w(uint8_t d)
 			m_timers[1]->adjust(attotime::never);
 		}
 	}
+}
+
+uint8_t v25_common_device::tmc1_r()
+{
+	return m_TMC1;
 }
 
 void v25_common_device::tmc1_w(uint8_t d)

--- a/src/devices/cpu/nec/v25sfr.cpp
+++ b/src/devices/cpu/nec/v25sfr.cpp
@@ -619,13 +619,13 @@ void v25_common_device::dmam0_w(uint8_t d)
 			BIT(d, 5) ? "I/O" : "memory",
 			BIT(d, 6) ? "I/O" : "memory",
 			BIT(d, 4) ? "words" : "bytes");
-	if (BIT(d, 2))
+	if (BIT(d, 3))
 	{
 		uint16_t sar = m_internal_ram[0];
 		uint16_t dar = m_internal_ram[1];
 		uint16_t sarh_darh = m_internal_ram[2];
 		uint16_t tc = m_internal_ram[3];
-		logerror("        DMA enabled%s (%04x:%04x -> %04x:%04x, %u %s)\n", BIT(d, 3) ? " and triggered" : "",
+		logerror("        DMA enabled%s (%04x:%04x -> %04x:%04x, %u %s)\n", BIT(d, 2) ? " and triggered" : "",
 			sarh_darh & 0xff00, sar,
 			(sarh_darh & 0x00ff) << 8, dar,
 			tc, BIT(d, 4) ? "words" : "bytes");
@@ -663,13 +663,13 @@ void v25_common_device::dmam1_w(uint8_t d)
 			BIT(d, 5) ? "I/O" : "memory",
 			BIT(d, 6) ? "I/O" : "memory",
 			BIT(d, 4) ? "words" : "bytes");
-	if (BIT(d, 2))
+	if (BIT(d, 3))
 	{
 		uint16_t sar = m_internal_ram[4];
 		uint16_t dar = m_internal_ram[5];
 		uint16_t sarh_darh = m_internal_ram[6];
 		uint16_t tc = m_internal_ram[7];
-		logerror("        DMA enabled%s (%04x:%04x -> %04x:%04x, %u %s)\n", BIT(d, 3) ? " and triggered" : "",
+		logerror("        DMA enabled%s (%04x:%04x -> %04x:%04x, %u %s)\n", BIT(d, 2) ? " and triggered" : "",
 			sarh_darh & 0xff00, sar,
 			(sarh_darh & 0x00ff) << 8, dar,
 			tc, BIT(d, 4) ? "words" : "bytes");

--- a/src/devices/cpu/nec/v25sfr.cpp
+++ b/src/devices/cpu/nec/v25sfr.cpp
@@ -29,6 +29,8 @@ void v25_common_device::ida_sfr_map(address_map &map)
 	map(0x14c, 0x14c).rw(FUNC(v25_common_device::exic0_r), FUNC(v25_common_device::exic0_w));
 	map(0x14d, 0x14d).rw(FUNC(v25_common_device::exic1_r), FUNC(v25_common_device::exic1_w));
 	map(0x14e, 0x14e).rw(FUNC(v25_common_device::exic2_r), FUNC(v25_common_device::exic2_w));
+	map(0x160, 0x160).r(FUNC(v25_common_device::rxb0_r));
+	map(0x162, 0x162).w(FUNC(v25_common_device::txb0_w));
 	map(0x165, 0x165).rw(FUNC(v25_common_device::srms0_r), FUNC(v25_common_device::srms0_w));
 	map(0x166, 0x166).rw(FUNC(v25_common_device::stms0_r), FUNC(v25_common_device::stms0_w));
 	map(0x168, 0x168).rw(FUNC(v25_common_device::scm0_r), FUNC(v25_common_device::scm0_w));
@@ -38,6 +40,8 @@ void v25_common_device::ida_sfr_map(address_map &map)
 	map(0x16c, 0x16c).rw(FUNC(v25_common_device::seic0_r), FUNC(v25_common_device::seic0_w));
 	map(0x16d, 0x16d).rw(FUNC(v25_common_device::sric0_r), FUNC(v25_common_device::sric0_w));
 	map(0x16e, 0x16e).rw(FUNC(v25_common_device::stic0_r), FUNC(v25_common_device::stic0_w));
+	map(0x170, 0x170).r(FUNC(v25_common_device::rxb1_r));
+	map(0x172, 0x172).w(FUNC(v25_common_device::txb1_w));
 	map(0x175, 0x175).rw(FUNC(v25_common_device::srms1_r), FUNC(v25_common_device::srms1_w));
 	map(0x176, 0x176).rw(FUNC(v25_common_device::stms1_r), FUNC(v25_common_device::stms1_w));
 	map(0x178, 0x178).rw(FUNC(v25_common_device::scm1_r), FUNC(v25_common_device::scm1_w));
@@ -267,8 +271,17 @@ uint8_t v25_common_device::scm0_r()
 
 void v25_common_device::scm0_w(uint8_t d)
 {
-	logerror("%06x: SCM0 set to %02x\n", PC(), d);
-	m_scm[0] = d;
+	scm_w(0, d);
+}
+
+uint8_t v25_common_device::rxb0_r()
+{
+	return rxb_r(0);
+}
+
+void v25_common_device::txb0_w(uint8_t d)
+{
+	txb_w(0, d);
 }
 
 uint8_t v25_common_device::scc0_r()
@@ -295,9 +308,7 @@ void v25_common_device::brg0_w(uint8_t d)
 
 uint8_t v25_common_device::sce0_r()
 {
-	if (!machine().side_effects_disabled())
-		logerror("%06x: Warning: read back SCE0\n",PC());
-	return m_sce[0];
+	return m_sce[0] | (m_rxd_state[0] ? 0x80 : 0x00);
 }
 
 uint8_t v25_common_device::seic0_r()
@@ -363,8 +374,17 @@ uint8_t v25_common_device::scm1_r()
 
 void v25_common_device::scm1_w(uint8_t d)
 {
-	logerror("%06x: SCM1 set to %02x\n", PC(), d);
-	m_scm[1] = d;
+	scm_w(1, d);
+}
+
+uint8_t v25_common_device::rxb1_r()
+{
+	return rxb_r(1);
+}
+
+void v25_common_device::txb1_w(uint8_t d)
+{
+	txb_w(1, d);
 }
 
 uint8_t v25_common_device::scc1_r()
@@ -391,9 +411,7 @@ void v25_common_device::brg1_w(uint8_t d)
 
 uint8_t v25_common_device::sce1_r()
 {
-	if (!machine().side_effects_disabled())
-		logerror("%06x: Warning: read back SCE1\n",PC());
-	return m_sce[1];
+	return m_sce[1] | (m_rxd_state[1] ? 0x80 : 0x00);
 }
 
 uint8_t v25_common_device::seic1_r()

--- a/src/devices/cpu/nec/v25sfr.cpp
+++ b/src/devices/cpu/nec/v25sfr.cpp
@@ -325,24 +325,22 @@ void v25_common_device::seic0_w(uint8_t d)
 
 uint8_t v25_common_device::sric0_r()
 {
-	return read_irqcontrol(INTSR0, m_priority_ints0);
+	return read_irqcontrol(INTSR0, 7);
 }
 
 void v25_common_device::sric0_w(uint8_t d)
 {
 	write_irqcontrol(INTSR0, d);
-	m_priority_ints0 = d & 0x7;
 }
 
 uint8_t v25_common_device::stic0_r()
 {
-	return read_irqcontrol(INTST0, m_priority_ints0);
+	return read_irqcontrol(INTST0, 7);
 }
 
 void v25_common_device::stic0_w(uint8_t d)
 {
 	write_irqcontrol(INTST0, d);
-	m_priority_ints0 = d & 0x7;
 }
 
 uint8_t v25_common_device::srms1_r()
@@ -428,24 +426,22 @@ void v25_common_device::seic1_w(uint8_t d)
 
 uint8_t v25_common_device::sric1_r()
 {
-	return read_irqcontrol(INTSR1, m_priority_ints1);
+	return read_irqcontrol(INTSR1, 7);
 }
 
 void v25_common_device::sric1_w(uint8_t d)
 {
 	write_irqcontrol(INTSR1, d);
-	m_priority_ints1 = d & 0x7;
 }
 
 uint8_t v25_common_device::stic1_r()
 {
-	return read_irqcontrol(INTST1, m_priority_ints1);
+	return read_irqcontrol(INTST1, 7);
 }
 
 void v25_common_device::stic1_w(uint8_t d)
 {
 	write_irqcontrol(INTST1, d);
-	m_priority_ints1 = d & 0x7;
 }
 
 uint16_t v25_common_device::tm0_r()

--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -3695,8 +3695,11 @@ void hd63266f_device::start_command(int cmd)
 		break;
 	}
 
-	// execute the command immediately if there's no motor on delay
-	if(motor_on_counter == 0) {
+	// execute the command immediately if there's no motor on delay.  The delay is counted
+	// in index pulses, and a drive holding no disk never gives any, so a drive that reports
+	// itself not ready has to be let through to fail on its own.
+	if(motor_on_counter == 0 || !get_ready(command[1] & 3)) {
+		motor_on_counter = 0;
 		upd765_family_device::start_command(cmd);
 	} else
 		delayed_command = cmd;

--- a/src/mame/layout/roland_sb55.lay
+++ b/src/mame/layout/roland_sb55.lay
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<!--
+license:CC0-1.0
+copyright-holders:superctr
+
+Roland Sound Brush SB-55 front panel.  Three seven-segment digits and seven indicators
+share one scanned matrix with the sixteen buttons; the STANDBY switch and its lamp are
+the fifth return and the eighth segment of the same matrix, and the DISK lamp is lit while
+the drive's head is loaded.  The display is mounted upside down on the real panel,
+with its points above the digits, so the three digits are turned over here to match.
+Seven of the buttons carry an indicator of their own.  Units are 0.1 mm.
+-->
+<mamelayout version="2">
+
+	<element name="panel"><rect><color red="0.22" green="0.22" blue="0.23"/></rect></element>
+	<element name="bezel"><rect><color red="0.02" green="0.02" blue="0.02"/></rect></element>
+	<element name="trim"><rect><color red="0.30" green="0.30" blue="0.32"/></rect></element>
+	<element name="slot"><rect><color red="0.10" green="0.10" blue="0.11"/></rect></element>
+
+	<element name="button" defstate="0">
+		<rect state="0"><color red="0.07" green="0.07" blue="0.07"/></rect>
+		<rect state="1"><color red="0.32" green="0.32" blue="0.32"/></rect>
+	</element>
+	<element name="button_round" defstate="0">
+		<disk state="0"><color red="0.07" green="0.07" blue="0.07"/></disk>
+		<disk state="1"><color red="0.32" green="0.32" blue="0.32"/></disk>
+	</element>
+
+	<!-- D401 beside the STANDBY switch and D24 over the drive are amber in the service
+	     notes' part list.  The seven built into the buttons are not listed there: PLAY is
+	     green, REC red, and the other five amber. -->
+	<element name="led_amber" defstate="0">
+		<disk state="0"><color red="0.24" green="0.13" blue="0.02"/></disk>
+		<disk state="1"><color red="1.0" green="0.62" blue="0.10"/></disk>
+	</element>
+	<element name="led_red" defstate="0">
+		<disk state="0"><color red="0.26" green="0.04" blue="0.03"/></disk>
+		<disk state="1"><color red="1.0" green="0.18" blue="0.12"/></disk>
+	</element>
+	<element name="led_green" defstate="0">
+		<disk state="0"><color red="0.04" green="0.20" blue="0.06"/></disk>
+		<disk state="1"><color red="0.20" green="1.0" blue="0.35"/></disk>
+	</element>
+	<element name="digit" defstate="0">
+		<led7seg><color red="1.0" green="0.18" blue="0.12"/></led7seg>
+	</element>
+
+	<element name="midi_jack">
+		<disk><color red="0.12" green="0.12" blue="0.13"/></disk>
+		<disk><bounds x="0.12" y="0.12" width="0.76" height="0.76"/><color red="0.04" green="0.04" blue="0.04"/></disk>
+	</element>
+
+	<element name="label_power"><text string="POWER"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_standby"><text string="STANDBY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_midiin2"><text string="MIDI IN 2"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_brand"><text string="Roland"><color red="0.90" green="0.90" blue="0.90"/></text></element>
+	<element name="label_brush"><text string="SOUND Brush"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_eject"><text string="EJECT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_disk"><text string="DISK"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+
+	<element name="label_song"><text string="SONG"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_prog"><text string="PROG"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_set"><text string="SET"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_tempo"><text string="TEMPO"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_rnd"><text string="RND"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_clear"><text string="CLEAR"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_pause"><text string="PAUSE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_rec"><text string="REC"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_single"><text string="SINGLE"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_rept"><text string="REPT"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_stop"><text string="STOP"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_play"><text string="PLAY"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_rew"><text string="REW"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="label_ff"><text string="FF"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+
+	<element name="arrow_l"><text string="&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_r"><text string="&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_ll"><text string="&lt;&lt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+	<element name="arrow_rr"><text string="&gt;&gt;"><color red="0.85" green="0.85" blue="0.85"/></text></element>
+
+	<view name="Front Panel">
+		<bounds x="0" y="0" width="2180" height="500"/>
+		<element ref="panel"><bounds x="0" y="0" width="2180" height="500"/></element>
+
+		<!-- power and the front MIDI jack -->
+		<element ref="label_power"><bounds x="40" y="40" width="180" height="26"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x10"><bounds x="45" y="75" width="150" height="50"/></element>
+		<element name="led7" ref="led_amber"><bounds x="205" y="92" width="18" height="18"/></element>
+		<element ref="label_standby"><bounds x="35" y="133" width="200" height="24"/></element>
+		<element ref="midi_jack"><bounds x="60" y="290" width="120" height="120"/></element>
+		<element ref="label_midiin2"><bounds x="30" y="418" width="180" height="24"/></element>
+
+		<!-- disk slot -->
+		<element ref="trim"><bounds x="280" y="150" width="900" height="160"/></element>
+		<element ref="slot"><bounds x="295" y="165" width="870" height="90"/></element>
+		<element ref="button"><bounds x="980" y="270" width="170" height="55"/></element>
+		<element ref="label_eject"><bounds x="985" y="332" width="160" height="24"/></element>
+		<element ref="label_brand"><bounds x="600" y="55" width="260" height="50"/></element>
+		<element ref="label_brush"><bounds x="290" y="345" width="330" height="36"/></element>
+
+		<!-- the display, turned over as the panel has it -->
+		<element ref="bezel"><bounds x="1230" y="80" width="290" height="150"/></element>
+		<element name="digit2" ref="digit"><bounds x="1255" y="100" width="70" height="110"/><orientation rotate="180"/></element>
+		<element name="digit1" ref="digit"><bounds x="1340" y="100" width="70" height="110"/><orientation rotate="180"/></element>
+		<element name="digit0" ref="digit"><bounds x="1425" y="100" width="70" height="110"/><orientation rotate="180"/></element>
+		<element ref="label_disk"><bounds x="1230" y="290" width="130" height="26"/></element>
+		<element name="led_disk" ref="led_amber"><bounds x="1275" y="330" width="20" height="20"/></element>
+
+		<!-- the sixteen buttons, four panel rows of four.  The scan lines are the columns
+		     taken right to left, so the leftmost button of each row is KEY3.  SONG and
+		     TEMPO name the pair of arrows beneath them. -->
+		<element ref="label_song"><bounds x="1570" y="40" width="265" height="24"/></element>
+		<element ref="label_prog"><bounds x="1860" y="40" width="120" height="24"/></element>
+		<element ref="label_set"><bounds x="2005" y="40" width="120" height="24"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x08"><bounds x="1570" y="70" width="120" height="50"/></element>
+		<element ref="arrow_l"><bounds x="1605" y="82" width="50" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x08"><bounds x="1715" y="70" width="120" height="50"/></element>
+		<element ref="arrow_r"><bounds x="1750" y="82" width="50" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x08"><bounds x="1860" y="70" width="120" height="50"/></element>
+		<element name="led3" ref="led_amber"><bounds x="1910" y="85" width="20" height="20"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x08"><bounds x="2005" y="70" width="120" height="50"/></element>
+
+		<element ref="label_tempo"><bounds x="1570" y="140" width="265" height="24"/></element>
+		<element ref="label_rnd"><bounds x="1860" y="140" width="120" height="24"/></element>
+		<element ref="label_clear"><bounds x="2005" y="140" width="120" height="24"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x04"><bounds x="1570" y="170" width="120" height="50"/></element>
+		<element ref="arrow_l"><bounds x="1605" y="182" width="50" height="26"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x04"><bounds x="1715" y="170" width="120" height="50"/></element>
+		<element ref="arrow_r"><bounds x="1750" y="182" width="50" height="26"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x04"><bounds x="1860" y="170" width="120" height="50"/></element>
+		<element name="led4" ref="led_amber"><bounds x="1910" y="185" width="20" height="20"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x04"><bounds x="2005" y="170" width="120" height="50"/></element>
+
+		<element ref="label_pause"><bounds x="1570" y="240" width="120" height="24"/></element>
+		<element ref="label_rec"><bounds x="1715" y="240" width="120" height="24"/></element>
+		<element ref="label_single"><bounds x="1860" y="240" width="120" height="24"/></element>
+		<element ref="label_rept"><bounds x="2005" y="240" width="120" height="24"/></element>
+		<element ref="button_round" inputtag="KEY3" inputmask="0x02"><bounds x="1595" y="272" width="70" height="70"/></element>
+		<element name="led0" ref="led_amber"><bounds x="1620" y="297" width="20" height="20"/></element>
+		<element ref="button_round" inputtag="KEY2" inputmask="0x02"><bounds x="1740" y="272" width="70" height="70"/></element>
+		<element name="led1" ref="led_red"><bounds x="1765" y="297" width="20" height="20"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x02"><bounds x="1860" y="282" width="120" height="50"/></element>
+		<element name="led5" ref="led_amber"><bounds x="1910" y="297" width="20" height="20"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x02"><bounds x="2005" y="282" width="120" height="50"/></element>
+		<element name="led6" ref="led_amber"><bounds x="2055" y="297" width="20" height="20"/></element>
+
+		<element ref="label_stop"><bounds x="1570" y="360" width="120" height="24"/></element>
+		<element ref="label_play"><bounds x="1715" y="360" width="120" height="24"/></element>
+		<element ref="label_rew"><bounds x="1860" y="360" width="120" height="24"/></element>
+		<element ref="label_ff"><bounds x="2005" y="360" width="120" height="24"/></element>
+		<element ref="button" inputtag="KEY3" inputmask="0x01"><bounds x="1570" y="390" width="120" height="50"/></element>
+		<element ref="button" inputtag="KEY2" inputmask="0x01"><bounds x="1715" y="390" width="120" height="50"/></element>
+		<element name="led2" ref="led_green"><bounds x="1765" y="405" width="20" height="20"/></element>
+		<element ref="button" inputtag="KEY1" inputmask="0x01"><bounds x="1860" y="390" width="120" height="50"/></element>
+		<element ref="arrow_ll"><bounds x="1895" y="402" width="50" height="26"/></element>
+		<element ref="button" inputtag="KEY0" inputmask="0x01"><bounds x="2005" y="390" width="120" height="50"/></element>
+		<element ref="arrow_rr"><bounds x="2040" y="402" width="50" height="26"/></element>
+	</view>
+</mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -40343,6 +40343,9 @@ s50
 s550
 w30
 
+@source:roland/roland_sb55.cpp
+sb55
+
 @source:roland/roland_sc55.cpp
 sc55
 sc155

--- a/src/mame/roland/roland_sb55.cpp
+++ b/src/mame/roland/roland_sb55.cpp
@@ -1,0 +1,452 @@
+// license:BSD-3-Clause
+// copyright-holders:superctr
+/*************************************************************************************************
+
+    Roland Sound Brush SB-55
+
+    A MIDI file player from 1991, sold beside the SC-55: a 3.5" floppy drive, a three digit
+    LED display and sixteen transport buttons, with no tone generator of its own.  Disks are
+    MS-DOS format and hold Standard MIDI Files.  The infrared remote control is the SC-55's
+    card remote, whose SONG, TEMPO and transport keys the Sound Brush answers.
+
+
+    Main board (from the service notes, Apr. 1991, PCB 22925988 1/4):
+
+    X1 16.000 MHz crystal (CPU), X2 455 kHz (remote decoder)
+    IC2  uPD70320GJ-8-589  NEC V25, ROMless
+    IC10 27C512            64K program EPROM
+    IC9  HM65256BFP        32K SRAM, lithium battery backed
+    IC8  BR2816A           2K x 8 parallel EEPROM
+    IC18 HD63266F          floppy disk controller, uPD765 command set
+    IC5  M54513P           LED segment driver, from port 0
+    IC6  M54581P           LED common and switch row driver, from P14-P17
+    IC7  74HC541           switch matrix read buffer onto the data bus
+    IC4  BU3910F           remote control decoder, the same part as the SC-55's IC31
+    IC3  PC410             photocoupler, MIDI IN 2 on the front
+    IC21 M51953AL          reset
+
+    The V25's A19 and A18 pick the chip, so every device is mirrored across its quarter of
+    the 1 MB space: RAM at 00000, the EEPROM at 80000 and the EPROM at C0000, which is where
+    the reset vector at FFFF0 sends the CPU.  A14 and A15 split the I/O space, which holds
+    only the floppy controller at 0000 and the switch buffer at 4000.
+
+    The panel is one matrix scanned from the CPU's ports.  P14-P17 drive four common lines
+    through IC6, one low at a time; port 0 drives eight segment lines through IC5.  Commons
+    0 to 2 carry the three digits of the display and common 3 the seven indicator lamps and,
+    on the eighth segment, the STANDBY lamp of its own little board.  IC5 drives the display
+    in its own order, a to g and then the point, from bit 7 down.
+
+    The display is mounted upside down: its points stand above the digits rather than below,
+    and its commons run from the right of the panel.  The firmware's font at C000:FBB0 is
+    drawn the other way up to suit, and the layout turns the three digits over again.
+
+    The same four commons drive the switch matrix, whose five returns come back through IC7,
+    and the firmware numbers a key common * 5 + return.  The commons are the panel's columns
+    taken right to left and the returns its rows taken bottom to top, so that the four keys
+    of the bottom row are 0, 5, 10 and 15 and the top row's are 3, 8, 13 and 18.  Return 4
+    is not part of the panel: it carries the drive's DISK CHANGE line on common 0, the
+    footswitch jack on common 1 and the STANDBY switch on common 3.  IC11A gates DISK CHANGE
+    with common 0 and pulls the return low through D3, so the machine reads the drive's own
+    latch as a key, and that is how it notices a disk taken out or put in while it is in
+    standby.  The footswitch is the one return the firmware inverts for itself, so an open
+    jack reads low.
+
+    The machine holds itself in standby at common 3 return 4, with the display blank and
+    only the STANDBY lamp lit, and the same key takes it out again, as does the remote's
+    POWER key.  From standby, holding SET, PROG and STOP and then pressing PLAY enters the
+    service mode, which shows "tSt".
+
+    The firmware will not take a combination of keys while anything else at all is down, and
+    the one thing it excuses is the footswitch.
+
+    MIDI IN 1 on the rear is the V25's serial channel 0, MIDI IN 2 on the front is channel 1,
+    and MIDI OUT is channel 0's transmitter; MIDI THRU echoes IN 1 in hardware.  The floppy
+    controller's interrupt is INTP0 and its DMA request drives DMARQ0, so sectors move through
+    the CPU's own DMA channel 0 in one transfer mode.  P26 runs the drive motor, and the drive
+    answers with READY, which is how the machine finds out whether it still holds a disk when
+    it comes out of standby.  The controller's head load line is the drive's IN USE and, through
+    Q1, the DISK lamp over the slot, so the lamp shows an access and not a disk.  The remote
+    decoder puts a key number of 0 to 19 on port T and pulses INTP1.
+
+    The machine reads its disk, walks the FAT and the directory, takes the title out of
+    the Standard MIDI File and sends it to a Sound Canvas as a GS display sysex, and then
+    plays the song out of MIDI OUT.  It takes only the timebases it was built for -- 24,
+    48, 96, 192 and 384 ticks to the quarter note, and 60, 120, 240 and 480 -- and shows
+    "noP" for any other.  A song number is shown on the two right hand digits, with the
+    point of the middle one lit beside it.
+
+    It records too, by the owner's manual's own combination: hold PAUSE and press REC, which
+    takes the next free song number, and then PLAY.  STOP writes what came in at MIDI IN to
+    the disk as a format 0 file at 96 ticks to the quarter note.
+
+    TODO:
+    - the service mode waits for a disk it then reads and writes, and what it wants on
+      one is not known; the service notes' own test menu is not reached
+    - P23 to P25 carry more drive lines the firmware drives directly and nothing here takes
+    - MIDI THRU is not wired; MAME has no hardware echo of an input port
+
+*************************************************************************************************/
+
+#include "emu.h"
+
+#include "bus/midi/midiinport.h"
+#include "bus/midi/midioutport.h"
+#include "cpu/nec/v25.h"
+#include "imagedev/floppy.h"
+#include "machine/nvram.h"
+#include "machine/upd765.h"
+
+#include "roland_sb55.lh"
+
+
+namespace {
+
+class sb55_state : public driver_device
+{
+public:
+	sb55_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_fdc(*this, "fdc")
+		, m_floppy(*this, "fdc:0")
+		, m_keys(*this, "KEY%u", 0U)
+		, m_eeprom(*this, "eeprom", 0x800, ENDIANNESS_LITTLE)
+		, m_digit(*this, "digit%u", 0U)
+		, m_led(*this, "led%u", 0U)
+		, m_led_disk(*this, "led_disk")
+	{
+	}
+
+	void sb55(machine_config &config);
+
+	DECLARE_INPUT_CHANGED_MEMBER(remote_key);
+
+protected:
+	virtual void machine_start() override ATTR_COLD;
+	virtual void machine_reset() override ATTR_COLD;
+
+private:
+	void mem_map(address_map &map) ATTR_COLD;
+	void io_map(address_map &map) ATTR_COLD;
+
+	u8 eeprom_r(offs_t offset) { return m_eeprom[offset]; }
+	void eeprom_w(offs_t offset, u8 data) { m_eeprom[offset] = data; }
+
+	void floppy_changed(floppy_image_device *floppy, bool loaded);
+	void drive_w(u8 data);
+	void update_ready();
+
+	void head_load_w(int state);
+	void fdc_irq_w(int state);
+	TIMER_CALLBACK_MEMBER(head_unload) { m_head_load = false; m_led_disk = 0; }
+
+	u8 switches_r();
+	void segments_w(u8 data);
+	void scan_w(u8 data);
+	void update_display();
+
+	required_device<v25_device> m_maincpu;
+	required_device<hd63266f_device> m_fdc;
+	required_device<floppy_connector> m_floppy;
+	required_ioport_array<4> m_keys;
+	memory_share_creator<u8> m_eeprom;
+	output_finder<3> m_digit;
+	output_finder<8> m_led;
+	output_finder<> m_led_disk;
+
+	emu_timer *m_unload_timer = nullptr;
+
+	u8 m_scan = 0xff;
+	u8 m_segments = 0;
+	u8 m_remote_key = 0xff;
+	bool m_disk = false;
+	bool m_motor = false;
+	bool m_head_load = false;
+};
+
+
+void sb55_state::machine_start()
+{
+	floppy_image_device *const floppy = m_floppy->get_device();
+	m_fdc->set_floppy(floppy);
+	m_fdc->set_rate(250000);
+	if (floppy != nullptr)
+	{
+		floppy->setup_load_cb(floppy_image_device::load_cb(
+				[this] (floppy_image_device *floppy) { floppy_changed(floppy, true); }));
+		floppy->setup_unload_cb(floppy_image_device::unload_cb(
+				[this] (floppy_image_device *floppy) { floppy_changed(floppy, false); }));
+		m_disk = floppy->exists();
+	}
+	m_unload_timer = timer_alloc(FUNC(sb55_state::head_unload), this);
+	update_ready();
+
+	save_item(NAME(m_scan));
+	save_item(NAME(m_segments));
+	save_item(NAME(m_remote_key));
+	save_item(NAME(m_disk));
+	save_item(NAME(m_motor));
+	save_item(NAME(m_head_load));
+}
+
+void sb55_state::machine_reset()
+{
+	m_scan = 0xff;
+	m_segments = 0;
+	m_remote_key = 0xff;
+	m_motor = false;
+	m_unload_timer->reset();
+	m_head_load = false;
+	m_led_disk = 0;
+	update_ready();
+}
+
+
+// MAME's own ready comes up two index pulses after the motor, which is later than the
+// firmware looks, so the controller takes it as an external line driven from here instead
+void sb55_state::update_ready()
+{
+	m_fdc->ready_w(!(m_disk && m_motor));
+}
+
+// the image is still counted as present while its unload callback runs, so the drive says
+// here which way it went
+void sb55_state::floppy_changed(floppy_image_device *floppy, bool loaded)
+{
+	m_disk = loaded;
+	update_ready();
+}
+
+// P26 runs the drive's motor
+void sb55_state::drive_w(u8 data)
+{
+	if (m_motor == !BIT(data, 6))
+		return;
+	m_motor = !BIT(data, 6);
+	update_ready();
+}
+
+// the controller loads the head for a transfer and drops it again a head unload time after
+// the command ends, and the lamp goes out with it.  MAME's controller only ever loads the
+// head, so the interrupt that ends the command starts that time here; the firmware leaves
+// the unload time at the longest the chip has.
+void sb55_state::head_load_w(int state)
+{
+	if (!state)
+		return;
+	m_unload_timer->reset();
+	m_head_load = true;
+	m_led_disk = 1;
+}
+
+void sb55_state::fdc_irq_w(int state)
+{
+	if (state && m_head_load)
+		m_unload_timer->adjust(attotime::from_msec(256));
+}
+
+
+//-------------------------------------------------
+//  the panel matrix
+//-------------------------------------------------
+
+// one common line is held low at a time; rows 0 to 2 are the digits, row 3 the indicators.
+// The segments come off the bus the other way round from the order a seven segment element
+// wants them, and the layout has the digits upside down as the panel does.
+void sb55_state::update_display()
+{
+	for (int row = 0; row < 4; row++)
+	{
+		if (BIT(m_scan, 4 + row))
+			continue;
+
+		if (row < 3)
+			m_digit[row] = bitswap<8>(m_segments, 0, 1, 2, 3, 4, 5, 6, 7);
+		else
+			for (int bit = 0; bit < 8; bit++)
+				m_led[bit] = BIT(m_segments, bit);
+	}
+}
+
+void sb55_state::segments_w(u8 data)
+{
+	m_segments = data;
+	update_display();
+}
+
+void sb55_state::scan_w(u8 data)
+{
+	m_scan = data;
+	update_display();
+}
+
+// IC7 puts the five switch returns on the low bits of the bus; the three it leaves open
+// read back high through the pull-ups.  The drive's DISK CHANGE shares the fifth return
+// with the footswitch and the standby switch, and holds it low from the moment a disk is
+// taken out until the drive steps with one in again.
+u8 sb55_state::switches_r()
+{
+	floppy_image_device *const floppy = m_floppy->get_device();
+	u8 data = 0xff;
+	for (int row = 0; row < 4; row++)
+	{
+		if (BIT(m_scan, 4 + row))
+			continue;
+		u8 keys = m_keys[row]->read();
+		if (row == 0 && (floppy == nullptr || !floppy->dskchg_r()))
+			keys &= ~0x10;
+		data &= keys;
+	}
+	return data;
+}
+
+
+//-------------------------------------------------
+//  the remote control decoder
+//-------------------------------------------------
+
+// IC4 decodes a key number onto port T and pulses INTP1; the firmware reads port T in the
+// handler, so the number has to stand while the line is taken
+INPUT_CHANGED_MEMBER(sb55_state::remote_key)
+{
+	if (!newval)
+		return;
+
+	m_remote_key = param;
+	m_maincpu->set_input_line(NEC_INPUT_LINE_INTP1, ASSERT_LINE);
+	m_maincpu->set_input_line(NEC_INPUT_LINE_INTP1, CLEAR_LINE);
+}
+
+
+//-------------------------------------------------
+//  address maps
+//-------------------------------------------------
+
+void sb55_state::mem_map(address_map &map)
+{
+	map(0x00000, 0x07fff).mirror(0x38000).ram().share("nvram");
+	map(0x80000, 0x807ff).mirror(0x3f800).rw(FUNC(sb55_state::eeprom_r), FUNC(sb55_state::eeprom_w));
+	map(0xc0000, 0xcffff).mirror(0x30000).rom().region("progrom", 0);
+}
+
+void sb55_state::io_map(address_map &map)
+{
+	map(0x0000, 0x0002).mirror(0x3ffc).m(m_fdc, FUNC(hd63266f_device::map));
+	map(0x4000, 0x4000).mirror(0x3fff).r(FUNC(sb55_state::switches_r));
+}
+
+
+//-------------------------------------------------
+//  machine configuration
+//-------------------------------------------------
+
+static INPUT_PORTS_START( sb55 )
+	// The four scan lines are the panel's columns, taken right to left, and the five returns
+	// its rows, taken bottom to top; the firmware numbers a key scan * 5 + return.  The fifth
+	// return carries the disk sensor, the footswitch jack and the standby switch.
+	PORT_START("KEY0")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Fast Forward")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Repeat")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Clear")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Set")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_UNUSED) // the drive's DISK CHANGE, driven below
+	PORT_BIT(0xe0, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY1")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Rewind")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Single")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Random")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Program")
+	// the firmware inverts this return, and only this one, so an open jack reads low
+	PORT_BIT(0x10, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Start/Stop Footswitch")
+	PORT_BIT(0xe0, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY2")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Play")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Record")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Tempo >")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Song >")
+	PORT_BIT(0xf0, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("KEY3")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Stop")
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Pause")
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Tempo <")
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Song <")
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("Power")
+	PORT_BIT(0xe0, IP_ACTIVE_LOW, IPT_UNUSED)
+
+	PORT_START("REMOTE")
+	PORT_BIT(0x000001, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote All")     PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 0)
+	PORT_BIT(0x000002, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Mute")    PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 1)
+	PORT_BIT(0x000004, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Power")   PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 3)
+	PORT_BIT(0x000008, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Part <")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 4)
+	PORT_BIT(0x000010, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Part >")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 5)
+	PORT_BIT(0x000020, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Inst <")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 6)
+	PORT_BIT(0x000040, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Inst >")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 7)
+	PORT_BIT(0x000080, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Level <") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 8)
+	PORT_BIT(0x000100, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Level >") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 9)
+	PORT_BIT(0x000200, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Reverb <") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 10)
+	PORT_BIT(0x000400, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Reverb >") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 11)
+	PORT_BIT(0x000800, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Song <")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 12)
+	PORT_BIT(0x001000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Song >")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 13)
+	PORT_BIT(0x002000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Tempo <") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 14)
+	PORT_BIT(0x004000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Tempo >") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 15)
+	PORT_BIT(0x008000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Stop")    PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 16)
+	PORT_BIT(0x010000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Play")    PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 17)
+	PORT_BIT(0x020000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Rewind")  PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 18)
+	PORT_BIT(0x040000, IP_ACTIVE_HIGH, IPT_OTHER) PORT_NAME("Remote Fast Forward") PORT_CHANGED_MEMBER(DEVICE_SELF, FUNC(sb55_state::remote_key), 19)
+INPUT_PORTS_END
+
+static void sb55_floppies(device_slot_interface &device)
+{
+	device.option_add("35dd", FLOPPY_35_DD);
+}
+
+void sb55_state::sb55(machine_config &config)
+{
+	V25(config, m_maincpu, 16_MHz_XTAL);
+	m_maincpu->set_addrmap(AS_PROGRAM, &sb55_state::mem_map);
+	m_maincpu->set_addrmap(AS_IO, &sb55_state::io_map);
+	m_maincpu->p0_out_cb().set(FUNC(sb55_state::segments_w));
+	m_maincpu->p1_out_cb().set(FUNC(sb55_state::scan_w));
+	m_maincpu->p2_out_cb().set(FUNC(sb55_state::drive_w));
+	m_maincpu->pt_in_cb().set([this] () { return m_remote_key; });
+	m_maincpu->dma0_read_cb().set(m_fdc, FUNC(hd63266f_device::dma_r));
+	m_maincpu->dma0_write_cb().set(m_fdc, FUNC(hd63266f_device::dma_w));
+	m_maincpu->tc_handler<0>().set(m_fdc, FUNC(hd63266f_device::tc_line_w));
+	m_maincpu->txd_handler<0>().set("mdout", FUNC(midi_port_device::write_txd));
+
+	NVRAM(config, "nvram", nvram_device::DEFAULT_ALL_0); // HM65256 (IC9) + lithium battery
+	// BR2816A (IC8).  A blank part reads as FF and the firmware then rejects its own
+	// settings and stops at an error; zeroed, it writes its defaults over them instead.
+	NVRAM(config, "eeprom", nvram_device::DEFAULT_ALL_0);
+
+	HD63266F(config, m_fdc, 16_MHz_XTAL);
+	m_fdc->intrq_wr_callback().set_inputline(m_maincpu, NEC_INPUT_LINE_INTP0);
+	m_fdc->intrq_wr_callback().append(FUNC(sb55_state::fdc_irq_w));
+	m_fdc->drq_wr_callback().set(m_maincpu, FUNC(v25_device::dmarq_w<0>));
+	m_fdc->hdl_wr_callback().set(FUNC(sb55_state::head_load_w));
+	m_fdc->set_ready_line_connected(false);
+	m_fdc->set_select_lines_connected(false);
+
+	FLOPPY_CONNECTOR(config, m_floppy, sb55_floppies, "35dd", floppy_image_device::default_pc_floppy_formats);
+
+	midi_port_device &mdin(MIDI_PORT(config, "mdin", midiin_slot, "midiin"));
+	mdin.rxd_handler().set(m_maincpu, FUNC(v25_device::rxd_w<0>));
+	midi_port_device &mdin2(MIDI_PORT(config, "mdin2", midiin_slot, "midiin"));
+	mdin2.rxd_handler().set(m_maincpu, FUNC(v25_device::rxd_w<1>));
+	MIDI_PORT(config, "mdout", midiout_slot, "midiout");
+
+	config.set_default_layout(layout_roland_sb55);
+}
+
+ROM_START( sb55 )
+	ROM_REGION( 0x10000, "progrom", 0 )
+	ROM_LOAD( "roland_sb-55_v1.03.ic10", 0x0000, 0x10000, CRC(c1798080) SHA1(5184c61132798e86b140c36329130fd14f3024ea) )
+ROM_END
+
+} // anonymous namespace
+
+
+SYST( 1991, sb55, 0, 0, sb55, sb55, sb55_state, empty_init, "Roland", "Sound Brush SB-55", MACHINE_NO_SOUND_HW )


### PR DESCRIPTION
A MIDI player that goes with the SC-55 and can also record to 3.5inch double density floppy disks.

I wish I had a dump of the demo disk, but for now you can create your own disks using this script https://gist.github.com/superctr/c80709f36e44d050967c72f6a3cb9768

The upd765 fix might need a second look by someone more competent. I'm not sure if it could break something else.

One known issue: the SB-55 struggles with certain MIDIs causing tempo slowdowns. Partially this is due to incorrect V25 instruction timings, will be dealt with in a separate PR.

AI disclosure: Claude Opus 5 was used for this.