### PR TITLE
Quizard: Fixes boot

### DIFF
--- a/src/devices/machine/scc68070.cpp
+++ b/src/devices/machine/scc68070.cpp
@@ -711,13 +711,18 @@ TIMER_CALLBACK_MEMBER(scc68070_device::tx_callback)
 		m_uart.transmit_pointer--;
 
 		m_uart.status_register |= USR_TXRDY;
-		m_uart_tx_int = true;
-		update_ipl();
 	}
 
 	if (m_uart.transmit_pointer < 0)
 	{
 		m_uart.status_register |= USR_TXEMT | USR_TXRDY;
+	}
+
+	const bool tx_ready = (m_uart.status_register & USR_TXRDY) != 0;
+	if (tx_ready != m_uart_tx_int)
+	{
+		m_uart_tx_int = tx_ready;
+		update_ipl();
 	}
 }
 
@@ -1402,6 +1407,11 @@ void scc68070_device::uth_w(uint8_t data)
 	uart_tx(data);
 	m_uart.transmit_holding_register = data;
 	m_uart.status_register &= ~USR_TXRDY;
+	if (m_uart_tx_int)
+	{
+		m_uart_tx_int = false;
+		update_ipl();
+	}
 }
 
 uint8_t scc68070_device::urh_r()

--- a/src/mame/philips/cdi.cpp
+++ b/src/mame/philips/cdi.cpp
@@ -213,7 +213,7 @@ void quizard_state::machine_reset()
 	cdi_state::machine_reset();
 
 	m_boot_press = false;
-	m_boot_timer->adjust(attotime::from_seconds(13), 1);
+	m_boot_timer->adjust(attotime::from_seconds(22), 1);
 	m_mcu_p3 = 0x05; // RTS|RXD
 }
 


### PR DESCRIPTION
With these changes, Quizard boots again (tested on Austria 1.0).

I'm not 100% sure that these changes are right, however the system boots Quizard now. As more accuracy comes to the devices, these changes and hacks that were used to make Quizard run may be determined to be inaccurate.