### PR TITLE
apple/maccordyceps.cpp: add pmac5200 and fix bootloop on system restart

### DIFF
--- a/src/mame/apple/capella.cpp
+++ b/src/mame/apple/capella.cpp
@@ -15,8 +15,8 @@
         Per the 6200 Developer Notes, the Capella only has D0-D4 connected, so only 5 bits
         can be read/written at a time.
 
-        - $53000007: ???
-        ROM clears it to 0
+        - $53000007: Reset?
+        ROM clears it to 0 at boot, then never touches it again. Likely a reset signal
 
         - $5300000F: RAM / control switch
             Bit 2 = Tag RAM map enable?
@@ -60,6 +60,7 @@ DEFINE_DEVICE_TYPE(CAPELLA, capella_device, "maccapella", "Apple Capella PowerPC
 
 void capella_device::map(address_map &map)
 {
+	map(0x53000000, 0x53000007).w(FUNC(capella_device::reset_w));
 	map(0x53000008, 0x5300000f).rw(FUNC(capella_device::ctrl_r), FUNC(capella_device::ctrl_w));
 	map(0x53000010, 0x53000017).rw(FUNC(capella_device::ctrl_b_r), FUNC(capella_device::ctrl_b_w));
 	map(0x53000018, 0x5300001f).rw(FUNC(capella_device::irq_ack_r), FUNC(capella_device::irq_ack_w));
@@ -110,6 +111,12 @@ void capella_device::device_reset()
 }
 
 //-------------------------------------------------
+
+void capella_device::reset_w(offs_t offset, u64 data)
+{
+	// failing to do this means system bootloops if you try to restart from macos
+	device_reset();
+}
 
 u64 capella_device::ctrl_r(offs_t offset)
 {

--- a/src/mame/apple/capella.h
+++ b/src/mame/apple/capella.h
@@ -18,10 +18,14 @@ public:
 
 	template <typename... T> void set_maincpu_tag(T &&... args) { m_maincpu.set_tag(std::forward<T>(args)...); }
 
+
 	// 68040-style interrupt priority level from the I/O controller (1-7, anything else = no interrupt)
 	void translate_ipl_state_change(int ipl);
+
 	// NMI (programmer's switch / Cuda), presented as IPL 7
 	void nmi_w(int state);
+
+	void reset_w(offs_t offset, u64 data);
 
 	u64 ctrl_r(offs_t offset);
 	void ctrl_w(offs_t offset, u64 data);

--- a/src/mame/apple/iosb.cpp
+++ b/src/mame/apple/iosb.cpp
@@ -202,7 +202,7 @@ void iosb_base::device_start()
 		else
 		{
 			fatalerror("iosb.cpp: init without 68k CPU or PowerPC-to-68k bridge device\n");
-		}	
+		}
 	}
 
 	m_6015_timer = timer_alloc(FUNC(iosb_base::mac_6015_tick), this);
@@ -546,7 +546,7 @@ u32 iosb_base::turboscsi_dma_r(offs_t offset, u32 mem_mask)
 	{
 		// The real DAFB simply holds off /DTACK here, we simulate that
 		// by rewinding and repeating the instruction until DRQ is asserted.
-		RESTART_INSTRUCTION(m_maincpu);	
+		RESTART_INSTRUCTION(m_maincpu);
 		m_maincpu->spin_until_time(attotime::from_usec(50));
 		return 0xffff;
 	}

--- a/src/mame/apple/maccordyceps.cpp
+++ b/src/mame/apple/maccordyceps.cpp
@@ -86,6 +86,8 @@ public:
 
 	void init_pmac6200();
 
+	void pmac5200(machine_config &config);
+
 private:
 	required_device<ppc603_device> m_maincpu;
 	required_device<capella_device> m_capella;
@@ -110,6 +112,11 @@ private:
 	{
 		m_capella->nmi_w(state);
 	}
+
+
+	u32 id_r(offs_t offset, u32 mem_mask);
+
+	u32 m_model_id;
 };
 
 void pmac6200_state::machine_start()
@@ -124,6 +131,18 @@ void pmac6200_state::machine_reset()
 
 void pmac6200_state::init_pmac6200()
 {
+}
+
+uint32_t pmac6200_state::id_r(offs_t offset, uint32_t mem_mask)
+{
+	// same behavior as in macpdm.cpp
+	// FIXME: Apple System Profiler only reports half the desired CPU speed
+	if (mem_mask == 0xffff'ffff)
+	{
+		return m_model_id & 0xffff;
+	}
+
+	return m_model_id;
 }
 
 /***************************************************************************
@@ -143,6 +162,7 @@ void pmac6200_state::pmac6200_map(address_map &map)
 	map(0x00000000, 0xffffffff).m(m_f108, FUNC(f108_device::map));
 	map(0x00000000, 0xffffffff).m(m_video, FUNC(valkyrie_device::map));
 	map(0x50000000, 0x53ffffff).m(m_primetimeii, FUNC(primetime_device::map));
+	map(0x5ffffffc, 0x5fffffff).r(FUNC(pmac6200_state::id_r));
 
 	// SONIC ethernet is supposed to live here. for now, pretend it's not there
 	map(0x50f0a000, 0x50f0bfff).noprw();
@@ -154,8 +174,6 @@ void pmac6200_state::pmac6200_map(address_map &map)
 	map(0xffc00000, 0xffffffff).rom().region("bootrom64", 0);
 
 	map(0x00000000, 0xffffffff).m(m_capella, FUNC(capella_device::map));
-
-	map(0x5ffffffc, 0x5fffffff).lr32(NAME([](offs_t offset) { return 0xa55a3250; }));
 }
 
 static INPUT_PORTS_START( macadb )
@@ -163,6 +181,8 @@ INPUT_PORTS_END
 
 void pmac6200_state::pmac6200(machine_config &config)
 {
+	m_model_id = 0xa55a3250;
+
 	PPC603(config, m_maincpu, 75_MHz_XTAL);
 	m_maincpu->ppcdrc_set_options(PPCDRC_COMPATIBLE_OPTIONS);
 	m_maincpu->set_bus_frequency(XTAL(75_MHz_XTAL)); // FSB freq to Capella
@@ -242,6 +262,14 @@ void pmac6200_state::pmac6200(machine_config &config)
 	m_ram->set_extra_options("8M,16M,32M,64M"); // per service manual
 }
 
+
+void pmac6200_state::pmac5200(machine_config &config)
+{
+	pmac6200(config);
+
+	m_model_id = 0xa55a3258;
+}
+
 #define PPC_MAKE_BRANCH_ALWAYS(x) \
 	ROM_FILL(x,   1, 0x48) \
 	ROM_FILL(x+1, 1, 0x00) \
@@ -274,4 +302,9 @@ ROM_END
 
 } // anonymous namespace
 
-COMP( 1995, pmac6200, 0, 0, pmac6200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 6200/75", MACHINE_NOT_WORKING)
+
+#define rom_pmac5200 rom_pmac6200
+
+//    YEAR  NAME      PARENT    COMPAT  MACHINE   INPUT   CLASS           INIT            COMPANY           FULLNAME                   FLAGS
+COMP( 1995, pmac6200, 0,        0,      pmac6200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 6200/75", MACHINE_NOT_WORKING)
+COMP( 1995, pmac5200, pmac6200, 0,      pmac5200, macadb, pmac6200_state, init_pmac6200,  "Apple Computer", "Power Macintosh 5200/75", MACHINE_NOT_WORKING)

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -1330,6 +1330,7 @@ pmac7200_120
 
 @source:apple/maccordyceps.cpp
 pmac6200
+pmac5200
 
 @source:apple/macii.cpp
 mac2fdhd


### PR DESCRIPTION
Summary of changes:
- apple/capella.cpp: Treat any write to register $53000007 as a signal to reset the Capella chip. The ROM does this once at every reboot. This fixes a bug where the system will bootloop if you pick Restart from the Finder.
- apple/maccordyceps.cpp: Add machine ID register (treated the same as macpdm.cpp) and add Power Macintosh 5200.
- apple/iosb.cpp: srccleaned.

Found one other issue, which is that System Profiler only reports half the CPU speed that the CPU is actually running at. In system profiler, macpdm.cpp is closer to its actual clock frequency but is off by 1 (reports 59 MHz instead of 60). Issue is minor so I decided not to fix it here.